### PR TITLE
Replace internal symbol map.

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef FORTRAN_LOWER_CONVERT_EXPR_H_
-#define FORTRAN_LOWER_CONVERT_EXPR_H_
+#ifndef FORTRAN_LOWER_CONVERT_EXPR_H
+#define FORTRAN_LOWER_CONVERT_EXPR_H
 
 #include "Intrinsics.h"
 
@@ -70,4 +70,4 @@ mlir::Value createSomeAddress(mlir::Location loc, AbstractConverter &converter,
 } // namespace lower
 } // namespace Fortran
 
-#endif // FORTRAN_LOWER_CONVERT_EXPR_H_
+#endif // FORTRAN_LOWER_CONVERT_EXPR_H

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -25,32 +25,9 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 
-namespace Fortran {
-namespace semantics {
-class Symbol;
-using SymbolRef = common::Reference<const Symbol>;
-} // namespace semantics
-
-namespace lower {
+namespace Fortran::lower {
 
 class AbstractConverter;
-
-/// Helper class to map front-end symbols to their MLIR representation. This
-/// provides a way to lookup the fir.alloca location of a variable, for example.
-class SymMap {
-public:
-  /// Add `symbol` to the current map and  bind to `value`.
-  void addSymbol(semantics::SymbolRef symbol, mlir::Value value);
-
-  /// Find `symbol` and return its value if it appears in the current mappings.
-  mlir::Value lookupSymbol(semantics::SymbolRef symbol);
-
-  void erase(semantics::SymbolRef sym) { symbolMap.erase(&*sym); }
-  void clear() { symbolMap.clear(); }
-
-private:
-  llvm::DenseMap<const semantics::Symbol *, mlir::Value> symbolMap;
-};
 
 //===----------------------------------------------------------------------===//
 // FirOpBuilder interface extensions
@@ -372,7 +349,6 @@ private:
   llvm::Optional<mlir::Location> currentLoc{};
 };
 
-} // namespace lower
-} // namespace Fortran
+} // namespace Fortran::lower
 
 #endif // FORTRAN_LOWER_FIRBUILDER_H

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Bridge.h"
+#include "SymbolMap.h"
 #include "flang/Lower/ConvertExpr.h"
 #include "flang/Lower/ConvertType.h"
 #include "flang/Lower/FIRBuilder.h"
@@ -380,12 +381,12 @@ private:
 
   template <typename A>
   mlir::OpBuilder::InsertPoint genWhereCondition(fir::WhereOp &where,
-						 const A *stmt) {
+                                                 const A *stmt) {
     auto cond = createLogicalExprAsI1(
         toLocation(),
         Fortran::semantics::GetExpr(
             std::get<Fortran::parser::ScalarLogicalExpr>(stmt->t)));
-        where = builder->create<fir::WhereOp>(toLocation(), cond, true);
+    where = builder->create<fir::WhereOp>(toLocation(), cond, true);
     auto insPt = builder->saveInsertionPoint();
     switchInsertionPointToWhere(where);
     return insPt;

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/ConvertExpr.h"
+#include "SymbolMap.h"
 #include "flang/Common/default-kinds.h"
 #include "flang/Common/unwrap.h"
 #include "flang/Evaluate/fold.h"
@@ -241,7 +242,7 @@ class ExprLowering {
   mlir::Value genval(const Fortran::evaluate::DescriptorInquiry &desc) {
     auto descRef = symMap.lookupSymbol(desc.base().GetLastSymbol());
     assert(descRef && "no mlir::Value associated to Symbol");
-    auto descType = descRef.getType();
+    auto descType = descRef.getAddr().getType();
     mlir::Value res{};
     switch (desc.field()) {
     case Fortran::evaluate::DescriptorInquiry::Field::Len:

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -7,22 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/FIRBuilder.h"
+#include "SymbolMap.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/ConvertType.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Semantics/symbol.h"
 #include "llvm/Support/ErrorHandling.h"
-
-void Fortran::lower::SymMap::addSymbol(Fortran::semantics::SymbolRef symbol,
-                                       mlir::Value value) {
-  symbolMap.try_emplace(&*symbol, value);
-}
-
-mlir::Value
-Fortran::lower::SymMap::lookupSymbol(Fortran::semantics::SymbolRef symbol) {
-  auto iter{symbolMap.find(&*symbol)};
-  return (iter == symbolMap.end()) ? nullptr : iter->second;
-}
 
 mlir::FuncOp Fortran::lower::FirOpBuilder::createFunction(
     mlir::Location loc, mlir::ModuleOp module, llvm::StringRef name,

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -1,0 +1,239 @@
+//===-- SymbolMap.h -- lowering internal symbol map -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_SYMBOLMAP_H
+#define FORTRAN_LOWER_SYMBOLMAP_H
+
+#include "flang/Common/idioms.h"
+#include "flang/Common/reference.h"
+#include "flang/Semantics/symbol.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
+
+namespace Fortran::lower {
+
+/// An index of ssa-values that together compose a variable referenced by a
+/// Symbol. For example, the declaration
+///
+///   CHARACTER(LEN=i) :: c(j1,j2)
+///
+/// is a single variable `c`. This variable is a two-dimensional array of
+/// CHARACTER. It has a starting address and three dynamic properties: the LEN
+/// parameter `i` a runtime value describing the length of the CHARACTER, and
+/// the `j1` and `j2` runtime values, which describe the shape of the array.
+///
+/// The lowering bridge needs to be able to record all four of these ssa-values
+/// in the lookup table to be able to correctly lower Fortran to FIR.
+struct SymIndex {
+  // For lookups that fail, have a monostate
+  using None = std::monostate;
+
+  // Capture triple notation ssa-values
+  using Triple = std::tuple<mlir::Value, mlir::Value, mlir::Value>;
+
+  // Trivial intrinsic type
+  struct Intrinsic {
+    explicit Intrinsic(mlir::Value addr) : addr{addr} {}
+    mlir::Value addr;
+  };
+
+  // Array variable that has a simple shape
+  struct Shaped {
+    explicit Shaped(mlir::Value addr, llvm::ArrayRef<mlir::Value> s)
+        : addr{addr}, shape{s.begin(), s.end()} {}
+    mlir::Value addr;
+    std::vector<mlir::Value> shape;
+  };
+
+  // Array variable that uses triple notation
+  struct FullDim {
+    explicit FullDim(mlir::Value addr, llvm::ArrayRef<Triple> s)
+        : addr{addr}, shape{s.begin(), s.end()} {}
+    mlir::Value addr;
+    std::vector<Triple> shape;
+  };
+
+  // CHARACTER type variable with its dependent type LEN parameter
+  struct Char {
+    explicit Char(mlir::Value addr, mlir::Value len) : addr{addr}, len{len} {}
+    mlir::Value addr;
+    mlir::Value len;
+  };
+
+  // CHARACTER array variable that has a simple shape
+  struct CharShaped {
+    explicit CharShaped(mlir::Value addr, mlir::Value len,
+                        llvm::ArrayRef<mlir::Value> s)
+        : addr{addr}, len{len}, shape{s.begin(), s.end()} {}
+    mlir::Value addr;
+    mlir::Value len;
+    std::vector<mlir::Value> shape;
+  };
+
+  // CHARACTER array variable using triple notation
+  struct CharFullDim {
+    explicit CharFullDim(mlir::Value addr, mlir::Value len,
+                         llvm::ArrayRef<Triple> s)
+        : addr{addr}, len{len}, shape{s.begin(), s.end()} {}
+    mlir::Value addr;
+    mlir::Value len;
+    std::vector<Triple> shape;
+  };
+
+  // Generalized derived type variable
+  struct Derived {
+    explicit Derived(mlir::Value addr, mlir::Value size,
+                     llvm::ArrayRef<Triple> s,
+                     llvm::ArrayRef<mlir::Value> parameters)
+        : addr{addr}, size{size}, shape{s.begin(), s.end()},
+          params{parameters.begin(), parameters.end()} {}
+    mlir::Value addr;
+    mlir::Value size;                // element size or null
+    std::vector<Triple> shape;       // empty for scalar
+    std::vector<mlir::Value> params; // LEN type parameters, if any
+  };
+
+  //===--------------------------------------------------------------------===//
+  // Constructors
+  //===--------------------------------------------------------------------===//
+
+  SymIndex() : v{None{}} {}
+  template <typename A>
+  SymIndex(const A &x) : v{x} {}
+
+  operator bool() const { return !std::holds_alternative<None>(v); }
+  operator mlir::Value() const { return getAddr(); }
+
+  //===--------------------------------------------------------------------===//
+  // Accessors
+  //===--------------------------------------------------------------------===//
+
+  mlir::Value getAddr() const {
+    return std::visit(common::visitors{
+                          [](const None &) { return mlir::Value{}; },
+                          [](const auto &x) { return x.addr; },
+                      },
+                      v);
+  }
+
+  llvm::Optional<mlir::Value> getCharLen() const {
+    using T = llvm::Optional<mlir::Value>;
+    return std::visit(common::visitors{
+                          [](const Char &x) { return T{x.len}; },
+                          [](const CharShaped &x) { return T{x.len}; },
+                          [](const CharFullDim &x) { return T{x.len}; },
+                          [](const auto &) { return T{}; },
+                      },
+                      v);
+  }
+
+  bool hasRank() const {
+    return std::visit(common::visitors{
+                          [](const Intrinsic &) { return false; },
+                          [](const Char &) { return false; },
+                          [](const None &) { return false; },
+                          [](const auto &x) { return x.shape.size() > 0; },
+                      },
+                      v);
+  }
+
+  bool hasSimpleShape() const {
+    return std::holds_alternative<Shaped>(v) ||
+           std::holds_alternative<CharShaped>(v);
+  }
+
+  std::variant<Intrinsic, Shaped, FullDim, Char, CharShaped, CharFullDim,
+               Derived, None>
+      v;
+};
+
+/// Helper class to map front-end symbols to their MLIR representation. This
+/// provides a way to lookup the ssa-values that comprise a Fortran symbol's
+/// runtime attributes. These attributes include its address, its dynamic size,
+/// dynamic bounds information for non-scalar entities, dynamic type parameters,
+/// etc.
+class SymMap {
+public:
+  /// Add `symbol` to the current map and bind an `index`.
+  void addSymbol(semantics::SymbolRef sym, const SymIndex &index,
+                 bool force = false) {
+    if (force)
+      erase(sym);
+    assert(index && "cannot add an undefined symbol index");
+    symbolMap.try_emplace(&*sym, index);
+  }
+
+  /// Add a trivial symbol mapping to an address.
+  void addSymbol(semantics::SymbolRef sym, mlir::Value value,
+                 bool force = false) {
+    addSymbol(sym, SymIndex::Intrinsic(value), force);
+  }
+
+  /// Add a scalar CHARACTER mapping to an (address, len).
+  void addCharSymbol(semantics::SymbolRef sym, mlir::Value value,
+                     mlir::Value len, bool force = false) {
+    addSymbol(sym, SymIndex::Char(value, len), force);
+  }
+
+  /// Add an array mapping with (address, shape).
+  void addSymbolWithShape(semantics::SymbolRef sym, mlir::Value value,
+                          llvm::ArrayRef<mlir::Value> shape,
+                          bool force = false) {
+    addSymbol(sym, SymIndex::Shaped(value, shape), force);
+  }
+
+  /// Add an array of CHARACTER mapping.
+  void addCharSymbolWithShape(semantics::SymbolRef sym, mlir::Value value,
+                              mlir::Value len,
+                              llvm::ArrayRef<mlir::Value> shape,
+                              bool force = false) {
+    addSymbol(sym, SymIndex::CharShaped(value, len, shape), force);
+  }
+
+  /// Add an array mapping with triple notation.
+  void addSymbolWithTriples(semantics::SymbolRef sym, mlir::Value value,
+                            llvm::ArrayRef<SymIndex::Triple> shape,
+                            bool force = false) {
+    addSymbol(sym, SymIndex::FullDim(value, shape), force);
+  }
+
+  /// Add an array of CHARACTER with triple notation.
+  void addCharSymbolWithTriples(semantics::SymbolRef sym, mlir::Value value,
+                                mlir::Value len,
+                                llvm::ArrayRef<SymIndex::Triple> shape,
+                                bool force = false) {
+    addSymbol(sym, SymIndex::CharFullDim(value, len, shape), force);
+  }
+
+  /// Generalized derived type mapping.
+  void addDerivedSymbol(semantics::SymbolRef sym, mlir::Value value,
+                        mlir::Value size,
+                        llvm::ArrayRef<SymIndex::Triple> shape,
+                        llvm::ArrayRef<mlir::Value> params,
+                        bool force = false) {
+    addSymbol(sym, SymIndex::Derived(value, size, shape, params), force);
+  }
+
+  /// Find `symbol` and return its value if it appears in the current mappings.
+  SymIndex lookupSymbol(semantics::SymbolRef sym) {
+    auto iter = symbolMap.find(&*sym);
+    return (iter == symbolMap.end()) ? SymIndex() : iter->second;
+  }
+
+  void erase(semantics::SymbolRef sym) { symbolMap.erase(&*sym); }
+  void clear() { symbolMap.clear(); }
+
+private:
+  llvm::DenseMap<const semantics::Symbol *, SymIndex> symbolMap;
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_FIRBUILDER_H


### PR DESCRIPTION
The internal symbol map had served its purpose and needs to be replaced with a
mapping structure that is more appropriate for Fortran variables, which can be
composed of a number of runtime values.  This new map will allow us to lower
more complicated entities correctly by tracking their component values.