### PR TITLE
This is some initial work on getting Burnside to use the new symbol m…

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -67,9 +67,15 @@ public:
 
   /// Return blank character of given \p type !fir.char<kind>
   mlir::Value createBlankConstant(fir::CharacterType type);
+  
   /// Lower \p lhs = \p rhs where \p lhs and \p rhs are scalar characters.
   /// It handles cases where \p lhs and \p rhs may overlap.
   void createAssign(mlir::Value lhs, mlir::Value rhs);
+
+  /// Lower an assignment where the buffer and LEN parameter are known and do
+  /// not need to be unboxed.
+  void createAssign(mlir::Value lptr, mlir::Value llen, mlir::Value rptr,
+                    mlir::Value rlen);
 
   /// Embox \p addr and \p len and return fir.boxchar.
   /// Take care of type conversions before emboxing.

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -262,18 +262,27 @@ class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
     static constexpr llvm::StringRef inType() { return "in_type"; }
     static constexpr llvm::StringRef lenpName() { return "len_param_count"; }
     mlir::Type getAllocatedType();
+    
     bool hasLenParams() { return bool{getAttr(lenpName())}; }
+    
     unsigned numLenParams() {
       if (auto val = getAttrOfType<mlir::IntegerAttr>(lenpName()))
         return val.getInt();
       return 0;
     }
+    
     operand_range getLenParams() {
       return {operand_begin(), operand_begin() + numLenParams()};
     }
+    
+    unsigned numShapeOperands() {
+      return operand_end() - operand_begin() + numLenParams();
+    }
+    
     operand_range getShapeOperands() {
       return {operand_begin() + numLenParams(), operand_end()};
     }
+    
     static mlir::Type getRefTy(mlir::Type ty);
 
     /// Get the input type of the allocation
@@ -285,7 +294,7 @@ class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
   // Verify checks common to all allocation operations
   string allocVerify = [{
     llvm::SmallVector<llvm::StringRef, 8> visited;
-    if (verifyInType(getInType(), visited))
+    if (verifyInType(getInType(), visited, numShapeOperands()))
       return emitOpError("invalid type for allocation");
     if (verifyRecordLenParams(getInType(), numLenParams()))
       return emitOpError("LEN params do not correspond to type");

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1612,6 +1612,7 @@ private:
   void instantiateLocal(const Fortran::lower::pft::Variable &var) {
     const auto &sym = var.getSymbol();
     const auto loc = toLocation();
+    builder->setLocation(loc);
     auto idxTy = builder->getIndexType();
     const auto isDummy = Fortran::semantics::IsDummy(sym);
     SymbolIndexAnalyzer sia(sym);
@@ -1623,6 +1624,9 @@ private:
         assert(lookupSymbol(sym) && "must already be in map");
         return;
       }
+      // TODO: What about lower host-associated variables? (They probably need
+      // to be handled as dummy parameters.)
+      
       // Otherwise, it's a local variable.
       auto local = createNewLocal(loc, sym);
       addSymbol(sym, local);
@@ -1643,7 +1647,6 @@ private:
     if (sia.isChar) {
       // if element type is a CHARACTER, determine the LEN value
       if (isDummy) {
-        builder->setLocation(loc);
         auto unboxchar = builder->createUnboxChar(addr);
         auto boxAddr = unboxchar.first;
         if (auto c = sia.getCharLenConst()) {

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -95,6 +95,131 @@ struct IncrementLoopInfo {
 };
 } // namespace
 
+static bool symIsChar(const Fortran::semantics::Symbol &sym) {
+  return sym.GetType()->category() ==
+         Fortran::semantics::DeclTypeSpec::Character;
+}
+
+static bool symIsArray(const Fortran::semantics::Symbol &sym) {
+  const auto *det = sym.detailsIf<Fortran::semantics::ObjectEntityDetails>();
+  return det ? det->IsArray() : false;
+}
+
+static bool isExplicitShape(const Fortran::semantics::Symbol &sym) {
+  const auto *det = sym.detailsIf<Fortran::semantics::ObjectEntityDetails>();
+  if (det && det->IsArray())
+    return det->shape().IsExplicitShape();
+  return false;
+}
+
+/// Temporary helper to detect shapes that do not require evaluating
+/// bound expressions at runtime or to get the shape from a descriptor.
+static bool isConstantShape(const Fortran::semantics::ArraySpec &shape) {
+  auto isConstant = [](const auto &bound) {
+    const auto &expr = bound.GetExplicit();
+    return expr.has_value() && Fortran::evaluate::IsConstantExpr(*expr);
+  };
+  for (const auto &susbcript : shape) {
+    const auto &lb = susbcript.lbound();
+    const auto &ub = susbcript.ubound();
+    if (isConstant(lb) && (isConstant(ub) || ub.isAssumed()))
+      continue;
+    return false;
+  }
+  return true;
+}
+
+namespace {
+struct SymbolIndexAnalyzer {
+  using FromBox = std::monostate;
+
+  explicit SymbolIndexAnalyzer(const Fortran::semantics::Symbol &sym)
+      : sym{sym} {}
+  SymbolIndexAnalyzer() = delete;
+  SymbolIndexAnalyzer(const SymbolIndexAnalyzer &) = delete;
+
+  void analyze() {
+    isChar = symIsChar(sym);
+    if (isChar) {
+      const auto &lenParam = sym.GetType()->characterTypeSpec().length();
+      if (auto expr = lenParam.GetExplicit()) {
+        auto len = Fortran::evaluate::AsGenericExpr(std::move(*expr));
+        auto asInt = Fortran::evaluate::ToInt64(len);
+        if (asInt) {
+          charLen = *asInt;
+        } else {
+          charLen = len;
+          staticSize = false;
+        }
+      } else {
+        charLen = FromBox{};
+        staticSize = false;
+      }
+    }
+    isArray = symIsArray(sym);
+    for (const auto &subs : getSymShape()) {
+      auto low = subs.lbound().GetExplicit();
+      auto high = subs.ubound().GetExplicit();
+      if (staticSize && low && high) {
+        auto lb = Fortran::evaluate::ToInt64(*low);
+        auto ub = Fortran::evaluate::ToInt64(*high);
+        if (lb && ub) {
+          staticLBound.push_back(*lb);
+          staticShape.push_back(*ub - *lb + 1);
+          continue;
+        }
+      }
+      staticSize = false;
+      dynamicBound.push_back(&subs);
+    }
+  }
+
+  const Fortran::semantics::ArraySpec &getSymShape() {
+    return sym.get<Fortran::semantics::ObjectEntityDetails>().shape();
+  }
+
+  /// Get the CHARACTER's LEN value, if there is one.
+  llvm::Optional<int64_t> getCharLenConst() {
+    if (isChar)
+      if (auto *res = std::get_if<int64_t>(&charLen))
+        return {*res};
+    return {};
+  }
+
+  /// Get the CHARACTER's LEN expression, if there is one.
+  llvm::Optional<Fortran::semantics::SomeExpr> getCharLenExpr() {
+    if (isChar)
+      if (auto *res = std::get_if<Fortran::semantics::SomeExpr>(&charLen))
+        return {*res};
+    return {};
+  }
+
+  /// Is it a CHARACTER with a constant LEN?
+  bool charConstSize() const {
+    return isChar && std::holds_alternative<int64_t>(charLen);
+  }
+
+  bool isTrivial() const { return !(isChar || isArray); }
+
+  bool lboundIsAllOnes() const {
+    return staticSize &&
+           llvm::all_of(staticLBound, [](int64_t v) { return v == 1; });
+  }
+
+  llvm::SmallVector<int64_t, 8> staticLBound;
+  llvm::SmallVector<int64_t, 8> staticShape;
+  llvm::SmallVector<const Fortran::semantics::ShapeSpec *, 8> dynamicBound;
+  bool staticSize{true};
+  bool isChar{false};
+  bool isArray{false};
+
+private:
+  std::variant<FromBox, int64_t, Fortran::semantics::SomeExpr> charLen{
+      FromBox{}};
+  const Fortran::semantics::Symbol &sym;
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // FirConverter
 //===----------------------------------------------------------------------===//
@@ -1373,23 +1498,6 @@ private:
     return Fortran::lower::FirOpBuilder::createFunction(loc, module, name, ty);
   }
 
-  /// Temporary helper to detect shapes that do not require evaluating
-  /// bound expressions at runtime or to get the shape from a descriptor.
-  static bool isConstantShape(const Fortran::semantics::ArraySpec &shape) {
-    auto isConstant{[](const auto &bound) {
-      const auto &expr = bound.GetExplicit();
-      return expr.has_value() && Fortran::evaluate::IsConstantExpr(*expr);
-    }};
-    for (const auto &susbcript : shape) {
-      const auto &lb = susbcript.lbound();
-      const auto &ub = susbcript.ubound();
-      if (isConstant(lb) && (isConstant(ub) || ub.isAssumed()))
-        break;
-      return false;
-    }
-    return true;
-  }
-
   /// Evaluate specification expressions of local symbol and add
   /// the resulting `mlir::Value` to localSymbols.
   /// Before evaluating a specification expression, the symbols
@@ -1476,43 +1584,26 @@ private:
     llvm_unreachable("Varun: put your code here");
   }
 
-  // FIXME: This is not quite right. The constant rows should *NOT* be entered
-  // into the shape. (This will allocate too much space.)
-  bool collectVariableDynamicShape(llvm::SmallVectorImpl<mlir::Value> &shape,
-                                   const Fortran::semantics::Symbol &sym) {
-    if (const auto *det =
-            sym.detailsIf<Fortran::semantics::ObjectEntityDetails>()) {
-      const auto &shapeSpec = det->shape();
-      if (isConstantShape(shapeSpec))
-        return false;
-      for (const auto &subs : shapeSpec) {
-        if (subs.lbound().isExplicit() && subs.ubound().isExplicit()) {
-          auto lo = builder->convertToIndexType(genExprValue(
-              Fortran::semantics::SomeExpr(*subs.lbound().GetExplicit())));
-          auto hi = builder->convertToIndexType(genExprValue(
-              Fortran::semantics::SomeExpr(*subs.ubound().GetExplicit())));
-          auto one = builder->createIntegerConstant(builder->getIndexType(), 1);
-          auto loc = toLocation();
-          auto diff = builder->create<mlir::SubIOp>(loc, hi, lo);
-          auto sizeDim = builder->create<mlir::AddIOp>(loc, one, diff);
-          shape.push_back(sizeDim);
-        } else {
-          TODO();
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
   /// Create a stack slot for a local variable. Precondition: the insertion
   /// point of the builder must be in the entry block, which is currently being
   /// constructed.
   mlir::Value createNewLocal(mlir::Location loc,
                              const Fortran::semantics::Symbol &sym,
                              llvm::ArrayRef<mlir::Value> shape = {}) {
-    return builder->create<fir::AllocaOp>(
-        loc, genType(sym), sym.name().ToString(), llvm::None, shape);
+    auto ty = genType(sym);
+    auto nm = sym.name().ToString();
+    if (shape.size())
+      if (auto arrTy = ty.dyn_cast<fir::SequenceType>()) {
+        // elide the constant dimensions before construction
+        assert(shape.size() == arrTy.getDimension());
+        llvm::SmallVector<mlir::Value, 8> args;
+        auto typeShape = arrTy.getShape();
+        for (unsigned i = 0, end = arrTy.getDimension(); i < end; ++i)
+          if (typeShape[i] == fir::SequenceType::getUnknownExtent())
+            args.push_back(shape[i]);
+        return builder->create<fir::AllocaOp>(loc, ty, nm, llvm::None, args);
+      }
+    return builder->create<fir::AllocaOp>(loc, ty, nm, llvm::None, shape);
   }
 
   /// Instantiate a local variable. Precondition: Each variable will be visited
@@ -1520,67 +1611,188 @@ private:
   /// depends will already have been visited.
   void instantiateLocal(const Fortran::lower::pft::Variable &var) {
     const auto &sym = var.getSymbol();
+    const auto loc = toLocation();
+    auto idxTy = builder->getIndexType();
+    const auto isDummy = Fortran::semantics::IsDummy(sym);
+    SymbolIndexAnalyzer sia(sym);
+    sia.analyze();
 
-    // If this is an array, collect it's dynamic shape. If it's size is constant
-    // `shape` will have no size.
-    llvm::SmallVector<mlir::Value, 8> shape;
-    auto hasDynamicShape = collectVariableDynamicShape(shape, sym);
-
-    const auto *type = sym.GetType();
-    auto loc = toLocation();
-    if (type->category() == Fortran::semantics::DeclTypeSpec::Character) {
-      const auto &lengthParam = type->characterTypeSpec().length();
-      if (auto expr = lengthParam.GetExplicit()) {
-        auto len =
-            genExprValue(Fortran::evaluate::AsGenericExpr(std::move(*expr)));
-        if (Fortran::semantics::IsDummy(sym)) {
-          if (hasDynamicShape) {
-            // case: `CHARACTER(LEN=i_arg) :: c_var(dims)`
-            TODO();
-          }
-          // case: `CHARACTER(LEN=i_arg) :: c_arg`
-          // Rebox the argument with the user-specified length. An alternative
-          // lowering would be to unbox the buffer reference and keep track of
-          // it and the length in the lookup table.
-
-          // NOTE: we could have a debug mode to generate diagnostic code to
-          // verify that the reboxing is simpatico.
-          auto original = lookupSymbol(sym);
-          auto unboxed = builder->createUnboxChar(original);
-          auto addr = builder->createEmboxChar(unboxed.first, len);
-          addCharSymbol(sym, addr, len, /*forced=*/true);
-        } else {
-          auto charTy = genType(sym);
-          if (hasDynamicShape) {
-            // case: `CHARACTER(LEN=i_arg) :: c_var(dims)`
-            TODO();
-          }
-          auto addr = builder->createCharacterTemp(charTy, len);
-          addCharSymbol(sym, addr, len);
-        }
+    if (sia.isTrivial()) {
+      if (isDummy) {
+        // This is an argument.
+        assert(lookupSymbol(sym) && "must already be in map");
         return;
       }
-      // If it is deferred or assumed, then argument must be a boxchar.
-      assert(lookupSymbol(sym) && "CHARACTER argument must be added");
+      // Otherwise, it's a local variable.
+      auto local = createNewLocal(loc, sym);
+      addSymbol(sym, local);
       return;
     }
 
-    // If this is an argument, we don't need to add a stack slot.
-    // TODO: consider pass-by-value however.
-    if (Fortran::semantics::IsDummy(sym))
-      return;
+    // The non-trivial cases are when we have an argument or local that has a
+    // repetition value. Arguments might be passed as simple pointers and need
+    // to be cast to a multi-dimensional array with constant bounds (possibly
+    // with a missing column), bounds computed in the callee (here), or with
+    // bounds from the caller (boxed somewhere else). Locals have the same
+    // properties except they are never boxed arguments from the caller and
+    // never having a missing column size.
+    mlir::Value addr = lookupSymbol(sym);
+    mlir::Value len{};
+    bool mustBeDummy = false;
 
-    // FIXME: (1) If this is a POINTER variable, a !fir.ptr should be allocated
-    // and set to null. (2) If this is an ALLOCATABLE variable, a !fir.heap
-    // should be allocated and set to null (deferred, double indirect) or an
-    // allocmem value be allocated (immediate, one-level indirect). (3) If the
-    // variable is neither POINTER nor ALLOCATABLE, we should examine the size
-    // of the variable. If the variable is "very large" (per some heuristic),
-    // then it ought to be promoted to the heap, rather than allocated on the
-    // stack. In all cases, the `pft::Variable` can then be used to track heap
-    // allocations (either immediate or by promotion) and reclaim the heap space
-    // in the exit block.
-    auto local = createNewLocal(loc, sym, shape);
+    if (sia.isChar) {
+      // if element type is a CHARACTER, determine the LEN value
+      if (isDummy) {
+        builder->setLocation(loc);
+        auto unboxchar = builder->createUnboxChar(addr);
+        auto boxAddr = unboxchar.first;
+        if (auto c = sia.getCharLenConst()) {
+          // Set/override LEN with a constant
+          len = builder->createIntegerConstant(idxTy, *c);
+          addr = builder->createEmboxChar(boxAddr, len);
+        } else if (auto e = sia.getCharLenExpr()) {
+          // Set/override LEN with an expression
+          len = genExprValue(*e);
+          addr = builder->createEmboxChar(boxAddr, len);
+        } else {
+          // LEN is from the boxchar
+          len = unboxchar.second;
+          mustBeDummy = true;
+        }
+        // XXX: Subsequent lowering expects a CHARACTER variable to be in a
+        // boxchar. We assert that here. We might want to reconsider this
+        // precondition.
+        assert(addr.getType().isa<fir::BoxCharType>());
+      } else {
+        // local CHARACTER variable
+        if (auto c = sia.getCharLenConst()) {
+          len = builder->createIntegerConstant(idxTy, *c);
+        } else {
+          auto e = sia.getCharLenExpr();
+          assert(e && "CHARACTER variable must have LEN parameter");
+          len = genExprValue(*e);
+        }
+        assert(!addr);
+      }
+    }
+
+    if (sia.isArray) {
+      // if object is an array process the lower bound and extent values
+      llvm::SmallVector<Fortran::lower::SymIndex::Bounds, 8> bounds;
+      mustBeDummy = !isExplicitShape(sym);
+      if (sia.staticSize) {
+        // object shape is constant
+        auto castTy = fir::ReferenceType::get(genType(sym));
+        if (addr)
+          addr = builder->create<fir::ConvertOp>(loc, castTy, addr);
+        if (sia.lboundIsAllOnes()) {
+          // if lower bounds are all ones, build simple shaped object
+          llvm::SmallVector<mlir::Value, 8> shape;
+          for (auto i : sia.staticShape)
+            shape.push_back(builder->createIntegerConstant(idxTy, i));
+          if (sia.isChar) {
+            if (isDummy) {
+              localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
+              return;
+            }
+            // local CHARACTER array with constant size
+            auto local = createNewLocal(loc, sym);
+            localSymbols.addCharSymbolWithShape(sym, local, len, shape);
+            return;
+          }
+          if (isDummy) {
+            localSymbols.addSymbolWithShape(sym, addr, shape, true);
+            return;
+          }
+          // local array with constant size
+          auto local = createNewLocal(loc, sym);
+          localSymbols.addSymbolWithShape(sym, local, shape);
+          return;
+        }
+      } else {
+        // cast to the known constant parts from the declaration
+        auto castTy = fir::ReferenceType::get(genType(sym));
+        if (addr)
+          addr = builder->create<fir::ConvertOp>(loc, castTy, addr);
+      }
+      // construct constants and populate `bounds`
+      for (const auto &i : llvm::zip(sia.staticLBound, sia.staticShape)) {
+        auto fst = builder->createIntegerConstant(idxTy, std::get<0>(i));
+        auto snd = builder->createIntegerConstant(idxTy, std::get<1>(i));
+        bounds.emplace_back(fst, snd);
+      }
+
+      // default array case: populate `bounds` with lower and extent values
+      for (const auto &spec : sia.dynamicBound) {
+        auto low = spec->lbound().GetExplicit();
+        auto high = spec->ubound().GetExplicit();
+        if (low && high) {
+          // let the folder deal with the common `ub - 1 + 1` case
+          auto lb = genExprValue(Fortran::semantics::SomeExpr{*low});
+          auto ub = genExprValue(Fortran::semantics::SomeExpr{*high});
+          auto ty = ub.getType();
+          auto diff = builder->create<mlir::SubIOp>(loc, ty, ub, lb);
+          auto one = builder->createIntegerConstant(ty, 1);
+          auto sz = builder->create<mlir::AddIOp>(loc, ty, diff, one);
+          auto idx = builder->create<fir::ConvertOp>(loc, idxTy, sz);
+          bounds.emplace_back(lb, idx);
+          continue;
+        }
+        break;
+      }
+
+      auto unzip =
+          [&](llvm::SmallVectorImpl<mlir::Value> &shape,
+              llvm::ArrayRef<Fortran::lower::SymIndex::Bounds> bounds) {
+            std::for_each(bounds.begin(), bounds.end(), [&](const auto &pair) {
+              mlir::Value second;
+              std::tie(std::ignore, second) = pair;
+              shape.push_back(second);
+            });
+          };
+      if (sia.isChar) {
+        if (isDummy) {
+          localSymbols.addCharSymbolWithBounds(sym, addr, len, bounds, true);
+          return;
+        }
+        // local CHARACTER array with computed bounds
+        assert(!mustBeDummy);
+        llvm::SmallVector<mlir::Value, 8> shape;
+        shape.push_back(len);
+        unzip(shape, bounds);
+        auto local = createNewLocal(loc, sym, shape);
+        localSymbols.addCharSymbolWithBounds(sym, local, len, bounds);
+        return;
+      }
+      if (isDummy) {
+        localSymbols.addSymbolWithBounds(sym, addr, bounds, true);
+        return;
+      }
+      // local array with computed bounds
+      assert(!mustBeDummy);
+      llvm::SmallVector<mlir::Value, 8> shape;
+      unzip(shape, bounds);
+      auto local = createNewLocal(loc, sym, shape);
+      localSymbols.addSymbolWithBounds(sym, local, bounds);
+      return;
+    }
+
+    // not an array, so process as scalar argument
+    if (sia.isChar) {
+      if (isDummy) {
+        addCharSymbol(sym, addr, len, true);
+        return;
+      }
+      assert(!mustBeDummy);
+      auto local = createNewLocal(loc, sym);
+      addCharSymbol(sym, local, len);
+      return;
+    }
+    if (isDummy) {
+      addSymbol(sym, addr, true);
+      return;
+    }
+    auto local = createNewLocal(loc, sym);
     addSymbol(sym, local);
   }
 

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -210,9 +210,9 @@ class ExprLowering {
   /// Returns a reference to a symbol or its box/boxChar descriptor if it has
   /// one.
   mlir::Value gen(Fortran::semantics::SymbolRef sym) {
-    // FIXME: not all symbols are local
     if (auto val = symMap.lookupSymbol(sym))
       return val;
+    llvm_unreachable("all symbols should be in the map");
     auto addr = builder.createTemporary(getLoc(), converter.genType(sym),
                                         sym->name().ToString());
     symMap.addSymbol(sym, addr);
@@ -229,10 +229,6 @@ class ExprLowering {
   }
 
   mlir::Value genval(const Fortran::evaluate::BOZLiteralConstant &) { TODO(); }
-  mlir::Value genval(const Fortran::evaluate::ProcedureRef &procRef) {
-    llvm::SmallVector<mlir::Type, 1> resTy;
-    return genProcedureRef(procRef, resTy);
-  }
   mlir::Value genval(const Fortran::evaluate::ProcedureDesignator &) { TODO(); }
   mlir::Value genval(const Fortran::evaluate::NullPointer &) { TODO(); }
   mlir::Value genval(const Fortran::evaluate::StructureConstructor &) {
@@ -530,7 +526,6 @@ class ExprLowering {
   genval(const Fortran::evaluate::Constant<Fortran::evaluate::Type<TC, KIND>>
              &con) {
     // TODO:
-    // - character type constant
     // - array constant not handled
     // - derived type constant
     if constexpr (TC == Fortran::lower::IntegerCat) {
@@ -887,6 +882,10 @@ class ExprLowering {
     llvm::SmallVector<mlir::Type, 1> resTy;
     resTy.push_back(converter.genType(TC, KIND));
     return genProcedureRef(funRef, resTy);
+  }
+  mlir::Value genval(const Fortran::evaluate::ProcedureRef &procRef) {
+    llvm::SmallVector<mlir::Type, 1> resTy;
+    return genProcedureRef(procRef, resTy);
   }
 
   template <typename A>

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -432,7 +432,8 @@ public:
         return fir::SequenceType::get(genSeqShape(symbol, charLen), returnTy);
       }
       return fir::SequenceType::get(genSeqShape(symbol), returnTy);
-    } else if (Fortran::semantics::IsPointer(*symbol)) {
+    }
+    if (Fortran::semantics::IsPointer(*symbol)) {
       // FIXME: what about allocatable?
       return fir::ReferenceType::get(returnTy);
     }

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -152,14 +152,11 @@ struct CharacterOpsBuilderImpl {
         return boxType.getEleTy();
       if (auto refType = type.dyn_cast<fir::ReferenceType>())
         type = refType.getEleTy();
-      if (auto seqType = type.dyn_cast<fir::SequenceType>()) {
+      if (auto seqType = type.dyn_cast<fir::SequenceType>())
         type = seqType.getEleTy();
-      }
-      if (auto charType = type.dyn_cast<fir::CharacterType>()) {
+      if (auto charType = type.dyn_cast<fir::CharacterType>())
         return charType;
-      }
       llvm_unreachable("Invalid character value type");
-      return mlir::Type{}.dyn_cast<fir::CharacterType>();
     }
 
     fir::CharacterType getCharacterType() const {
@@ -414,6 +411,19 @@ void Fortran::lower::CharacterOpsBuilder<T>::createAssign(mlir::Value lhs,
 }
 template void Fortran::lower::CharacterOpsBuilder<
     Fortran::lower::FirOpBuilder>::createAssign(mlir::Value, mlir::Value);
+
+template <typename T>
+void Fortran::lower::CharacterOpsBuilder<T>::createAssign(mlir::Value lptr,
+                                                          mlir::Value llen,
+                                                          mlir::Value rptr,
+                                                          mlir::Value rlen) {
+  CharacterOpsBuilderImpl bimpl = impl();
+  bimpl.createAssign(CharacterOpsBuilderImpl::Char{lptr, llen},
+                     CharacterOpsBuilderImpl::Char{rptr, rlen});
+}
+template void
+Fortran::lower::CharacterOpsBuilder<Fortran::lower::FirOpBuilder>::createAssign(
+    mlir::Value lptr, mlir::Value llen, mlir::Value rptr, mlir::Value rlen);
 
 template <typename T>
 mlir::Value

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -36,8 +36,8 @@ struct SymIndex {
   // For lookups that fail, have a monostate
   using None = std::monostate;
 
-  // Capture triple notation ssa-values
-  using Triple = std::tuple<mlir::Value, mlir::Value, mlir::Value>;
+  // Capture bounds notation ssa-values
+  using Bounds = std::tuple<mlir::Value, mlir::Value>;
 
   // Trivial intrinsic type
   struct Intrinsic {
@@ -53,12 +53,12 @@ struct SymIndex {
     llvm::SmallVector<mlir::Value, 4> shape;
   };
 
-  // Array variable that uses triple notation
+  // Array variable that uses bounds notation
   struct FullDim {
-    explicit FullDim(mlir::Value addr, llvm::ArrayRef<Triple> s)
+    explicit FullDim(mlir::Value addr, llvm::ArrayRef<Bounds> s)
         : addr{addr}, shape{s.begin(), s.end()} {}
     mlir::Value addr;
-    llvm::SmallVector<Triple, 4> shape;
+    llvm::SmallVector<Bounds, 4> shape;
   };
 
   // CHARACTER type variable with its dependent type LEN parameter
@@ -78,26 +78,26 @@ struct SymIndex {
     llvm::SmallVector<mlir::Value, 4> shape;
   };
 
-  // CHARACTER array variable using triple notation
+  // CHARACTER array variable using bounds notation
   struct CharFullDim {
     explicit CharFullDim(mlir::Value addr, mlir::Value len,
-                         llvm::ArrayRef<Triple> s)
+                         llvm::ArrayRef<Bounds> s)
         : addr{addr}, len{len}, shape{s.begin(), s.end()} {}
     mlir::Value addr;
     mlir::Value len;
-    llvm::SmallVector<Triple, 4> shape;
+    llvm::SmallVector<Bounds, 4> shape;
   };
 
   // Generalized derived type variable
   struct Derived {
     explicit Derived(mlir::Value addr, mlir::Value size,
-                     llvm::ArrayRef<Triple> s,
+                     llvm::ArrayRef<Bounds> s,
                      llvm::ArrayRef<mlir::Value> parameters)
         : addr{addr}, size{size}, shape{s.begin(), s.end()},
           params{parameters.begin(), parameters.end()} {}
     mlir::Value addr;
     mlir::Value size;                         // element size or null
-    llvm::SmallVector<Triple, 4> shape;       // empty for scalar
+    llvm::SmallVector<Bounds, 4> shape;       // empty for scalar
     llvm::SmallVector<mlir::Value, 4> params; // LEN type parameters, if any
   };
 
@@ -189,17 +189,17 @@ public:
     makeSym(sym, SymIndex::CharShaped(value, len, shape), force);
   }
 
-  /// Add an array mapping with triple notation.
-  void addSymbolWithTriples(semantics::SymbolRef sym, mlir::Value value,
-                            llvm::ArrayRef<SymIndex::Triple> shape,
+  /// Add an array mapping with bounds notation.
+  void addSymbolWithBounds(semantics::SymbolRef sym, mlir::Value value,
+                            llvm::ArrayRef<SymIndex::Bounds> shape,
                             bool force = false) {
     makeSym(sym, SymIndex::FullDim(value, shape), force);
   }
 
-  /// Add an array of CHARACTER with triple notation.
-  void addCharSymbolWithTriples(semantics::SymbolRef sym, mlir::Value value,
+  /// Add an array of CHARACTER with bounds notation.
+  void addCharSymbolWithBounds(semantics::SymbolRef sym, mlir::Value value,
                                 mlir::Value len,
-                                llvm::ArrayRef<SymIndex::Triple> shape,
+                                llvm::ArrayRef<SymIndex::Bounds> shape,
                                 bool force = false) {
     makeSym(sym, SymIndex::CharFullDim(value, len, shape), force);
   }
@@ -207,7 +207,7 @@ public:
   /// Generalized derived type mapping.
   void addDerivedSymbol(semantics::SymbolRef sym, mlir::Value value,
                         mlir::Value size,
-                        llvm::ArrayRef<SymIndex::Triple> shape,
+                        llvm::ArrayRef<SymIndex::Bounds> shape,
                         llvm::ArrayRef<mlir::Value> params,
                         bool force = false) {
     makeSym(sym, SymIndex::Derived(value, size, shape, params), force);

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -1,44 +1,47 @@
-! RUN: bbc %s -o "-" -emit-fir | FileCheck %s
+! RUN: bbc %s -o - -emit-fir | FileCheck %s
+! RUN: bbc %s -o - | FileCheck --check-prefix=UNBOX %s
 
 ! Simple character assignment tests
+! UNBOX-LABEL: assign1
 ! CHECK-LABEL: assign1
 subroutine assign1(lhs, rhs)
   character(*, 1) :: lhs, rhs
   lhs = rhs
-  ! Unboxing
-  ! CHECK-DAG:[[lhs:%[0-9]+]]:2 = fir.unboxchar %arg0
-  ! CHECK-DAG:[[rhs:%[0-9]+]]:2 = fir.unboxchar %arg1
-
   ! Compute minimum length
-  ! CHECK-DAG:%[[cmp_len:[0-9]+]] = cmpi "slt", [[lhs]]#1, [[rhs]]#1
-  ! CHECK-DAG:[[min_len:%[0-9]+]] = select %[[cmp_len]], [[lhs]]#1, [[rhs]]#1
+  ! UNBOX-DAG: %[[lhs:.*]]:2 = fir.unboxchar %arg0
+  ! UNBOX-DAG: %[[rhs:.*]]:2 = fir.unboxchar %arg1
+  ! UNBOX: %[[cmp_len:[0-9]+]] = cmpi "slt", %[[lhs]]#1, %[[rhs]]#1
+  ! UNBOX-NEXT: %[[min_len:[0-9]+]] = select %[[cmp_len]], %[[lhs]]#1, %[[rhs]]#1
+
+  ! CHECK: %[[cmp_len:[0-9]+]] = cmpi "slt", %[[lhs:.*]]#1, %[[rhs:.*]]#1
+  ! CHECK-NEXT: %[[min_len:[0-9]+]] = select %[[cmp_len]], %[[lhs]]#1, %[[rhs]]#1
 
   ! Allocate temp in case rhs and lhs may overlap
-  ! CHECK: [[tmp:%[0-9]+]] = fir.alloca !fir.char<1>, [[min_len]]
+  ! CHECK: %[[tmp:.*]] = fir.alloca !fir.char<1>, %[[min_len]]
 
   ! Copy of rhs into temp
-  ! CHECK: fir.loop [[i:%[[:alnum:]_]+]]
-    ! CHECK-DAG: [[rhs_addr:%[0-9]+]] = fir.coordinate_of [[rhs]]#0, [[i]]
-    ! CHECK-DAG: [[tmp_addr:%[0-9]+]] = fir.coordinate_of [[tmp]], [[i]]
-    ! CHECK-DAG: [[rhs_elt:%[0-9]+]] = fir.load [[rhs_addr]]
-    ! CHECK: fir.store [[rhs_elt]] to [[tmp_addr]]
-  ! CHECK: }
+  ! CHECK: fir.loop %[[i:.*]] =
+    ! CHECK-DAG: %[[rhs_addr:.*]] = fir.coordinate_of %[[rhs]]#0, %[[i]]
+    ! CHECK-DAG: %[[rhs_elt:.*]] = fir.load %[[rhs_addr]]
+    ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[i]]
+    ! CHECK: fir.store %[[rhs_elt]] to %[[tmp_addr]]
+  ! CHECK-NEXT: }
 
   ! Copy of temp into lhs
-  ! CHECK: fir.loop [[i:%[[:alnum:]]+]]
-    ! CHECK-DAG: [[tmp_addr:%[0-9]+]] = fir.coordinate_of [[tmp]], [[i]]
-    ! CHECK-DAG: [[lhs_addr:%[0-9]+]] = fir.coordinate_of [[lhs]]#0, [[i]]
-    ! CHECK-DAG: [[tmp_elt:%[0-9]+]] = fir.load [[tmp_addr]]
-    ! CHECK: fir.store [[tmp_elt]] to [[lhs_addr]]
-  ! CHECK: }
+  ! CHECK: fir.loop %[[ii:.*]] =
+    ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[ii]]
+    ! CHECK-DAG: %[[tmp_elt:.*]] = fir.load %[[tmp_addr]]
+    ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[ii]]
+    ! CHECK: fir.store %[[tmp_elt]] to %[[lhs_addr]]
+  ! CHECK-NEXT: }
 
   ! Padding
-  ! CHECK: [[c32:%[[:alnum:]_]+]] = constant 32 : i8
-  ! CHECK: [[blank:%[0-9]+]] = fir.convert [[c32]] : (i8) -> !fir.char<1>
-  ! CHECK: fir.loop [[i:%[[:alnum:]_]+]]
-    ! CHECK-DAG: [[lhs_addr:%[0-9]+]] = fir.coordinate_of [[lhs]]#0, [[i]]
-    ! CHECK: fir.store [[blank]] to [[lhs_addr]]
-  ! CHECK: }
+  ! CHECK: %[[c32:.*]] = constant 32 : i8
+  ! CHECK: %[[blank:.*]] = fir.convert %[[c32]] : (i8) -> !fir.char<1>
+  ! CHECK: fir.loop %[[ij:.*]] =
+    ! CHECK: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[ij]]
+    ! CHECK: fir.store %[[blank]] to %[[lhs_addr]]
+  ! CHECK-NEXT: }
 end subroutine
 
 ! Test substring assignment
@@ -47,47 +50,49 @@ subroutine assign_substring1(str, rhs, lb, ub)
   character(*, 1) :: rhs, str
   integer(8) :: lb, ub
   str(lb:ub) = rhs
-  ! CHECK-DAG: [[lb:%[0-9]+]] = fir.load %arg2
-  ! CHECK-DAG: [[ub:%[0-9]+]] = fir.load %arg3
-  ! CHECK-DAG: [[str:%[0-9]+]]:2 = fir.unboxchar %arg0
+  ! CHECK-DAG: %[[lb:.*]] = fir.load %arg2
+  ! CHECK-DAG: %[[ub:.*]] = fir.load %arg3
+  ! CHECK: %[[str:.*]]:2 = fir.unboxchar %arg0
 
   ! Compute substring offset
-  ! CHECK-DAG: [[lbi:%[0-9]+]] = fir.convert [[lb]] : (i64) -> index
-  ! CHECK-DAG: [[c1:%[[:alnum:]_]+]] = constant 1
-  ! CHECK-DAG: [[offset:%[0-9]+]] = subi [[lbi]], [[c1]]
-  ! CHECK-DAG: [[lhs_addr:%[0-9]+]] = fir.coordinate_of [[str]]#0, [[offset]]
+  ! CHECK-DAG: %[[lbi:.*]] = fir.convert %[[lb]] : (i64) -> index
+  ! CHECK-DAG: %[[c1:.*]] = constant 1
+  ! CHECK-DAG: %[[offset:.*]] = subi %[[lbi]], %[[c1]]
+  ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[str]]#0, %[[offset]]
 
 
   ! Compute substring length
-  ! CHECK-DAG: [[diff:%[0-9]+]] = subi [[ub]], [[lb]]
-  ! CHECK-DAG: [[c1:%[[:alnum:]_]+]] = constant 1
-  ! CHECK-DAG: [[pre_lhs_len:%[0-9]+]] = addi [[diff]], [[c1]]
-  ! CHECK-DAG: [[c0:%[[:alnum:]_]+]] = constant 0
-  ! CHECK-DAG: [[cmp_len:%[0-9]+]] = cmpi "slt", [[pre_lhs_len]], [[c0]]
-  ! CHECK-DAG: [[lhs_len:%[0-9]+]] = select [[cmp_len]], [[c0]], [[pre_lhs_len]]
+  ! CHECK-DAG: %[[diff:.*]] = subi %[[ub]], %[[lb]]
+  ! CHECK-DAG: %[[c1:.*]] = constant 1
+  ! CHECK-DAG: %[[pre_lhs_len:.*]] = addi %[[diff]], %[[c1]]
+  ! CHECK-DAG: %[[c0:.*]] = constant 0
+  ! CHECK-DAG: %[[cmp_len:.*]] = cmpi "slt", %[[pre_lhs_len]], %[[c0]]
+  ! CHECK-DAG: %[[lhs_len:.*]] = select %[[cmp_len]], %[[c0]], %[[pre_lhs_len]]
 
-  ! CHECK: [[lhs_box:%[0-9]+]] = fir.emboxchar [[lhs_addr]], [[lhs_len]]
+  ! CHECK: %[[lhs_box:.*]] = fir.emboxchar %[[lhs_addr]], %[[lhs_len]]
 
   ! The rest of the assignment is just as the one above, only test that the
   ! substring box is the one used
   ! ...
-  ! CHECK: [[lhs:%[0-9]+]]:2 = fir.unboxchar [[lhs_box]]
+  ! CHECK: %[[lhs:.*]]:2 = fir.unboxchar %[[lhs_box]]
   ! ...
-  ! CHECK: fir.coordinate_of [[lhs]]#0, {{.*}}
+  ! CHECK: fir.coordinate_of %[[lhs]]#0,
   ! ...
 end subroutine
 
+! UNBOX-LABEL: assign_constant
 ! CHECK-LABEL: assign_constant
 ! CHECK: (%[[ARG:.*]]:{{.*}})
 subroutine assign_constant(lhs)
   character(*, 1) :: lhs
-  ! CHECK-DAG: %[[lhs:.*]]:2 = fir.unboxchar %[[ARG]] :
+  ! UNBOX: %[[lhs:.*]]:2 = fir.unboxchar %arg0
   ! CHECK-DAG: %[[tmp:.*]] = fir.address_of(@{{.*}}) :
   lhs = "Hello World"
   ! CHECK: fir.loop %[[i:.*]] = %{{.*}} to %{{.*}} {
     ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[i]]
     ! CHECK-DAG: %[[tmp_elt:.*]] = fir.load %[[tmp_addr]]
-    ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[i]]
+    ! UNBOX: = fir.coordinate_of %[[lhs]]#0, %
+    ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs:.*]]#0, %[[i]]
     ! CHECK: fir.store %[[tmp_elt]] to %[[lhs_addr]]
   ! CHECK: }
 
@@ -95,6 +100,7 @@ subroutine assign_constant(lhs)
   ! CHECK-DAG: %[[c32:.*]] = constant 32 : i8
   ! CHECK-DAG: %[[blank:.*]] = fir.convert %[[c32]] : (i8) -> !fir.char<1>
   ! CHECK: fir.loop %[[j:.*]] = %{{.*}} to %{{.*}} {
+    ! UNBOX: = fir.coordinate_of %[[lhs]]#0, %
     ! CHECK: %[[jhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[j]]
     ! CHECK: fir.store %[[blank]] to %[[jhs_addr]]
   ! CHECK: }


### PR DESCRIPTION
…ap for

lowering.  This piece primarily gets started in the direction of being able
to lower dynamic arrays and character types correctly.

There is still more work in fully leveraging this in the bridge, but all the
existing tests pass with this rewrite.