### PR TITLE
FIR changes:

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -10,6 +10,8 @@
 #define OPTIMIZER_DIALECT_FIROPS_H
 
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Interfaces/SideEffects.h"
 
 using namespace mlir;
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2001,10 +2001,12 @@ def fir_IterWhileOp : region_Op<"iterate_while",
     [DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
   let summary = "DO loop with early exit condition";
   let description = [{
-    This construct is useful for lowering implied-DO loops with "exceptions"
-    that are threaded as a saturating bool value.  A `true` disposition means
-    the next loop iteration should proceed. A `false` indicates that the
-    "iterate_while" operation should terminate and return.
+    This construct is useful for lowering implied-DO loops. It is very similar
+    to `fir::LoopOp` with the addition that it requires a single loop-carried
+    bool value that signals an early exit condition to the operation. A `true`
+    disposition means the next loop iteration should proceed. A `false`
+    indicates that the `fir.iterate_while` operation should terminate and
+    return its iteration arguments.
   }];
 
   let arguments = (ins

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -15,6 +15,7 @@
 #define FIR_DIALECT_FIR_OPS
 
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffects.td"
 
 def fir_Dialect : Dialect {
@@ -195,7 +196,8 @@ class fir_AllocatableBaseOp<string mnemonic, list<OpTrait> traits = []> :
 }
 
 class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
-    fir_AllocatableBaseOp<mnemonic, traits>,
+    fir_AllocatableBaseOp<mnemonic,
+	!listconcat(traits, [MemoryEffects<[MemAlloc]>])>,
     fir_TwoBuilders<fir_AllocateOpBuilder, fir_NamedAllocateOpBuilder>,
     Arguments<(ins TypeAttr:$in_type, Variadic<AnyIntegerType>:$args)> {
 
@@ -292,9 +294,11 @@ class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 }
 
+//===----------------------------------------------------------------------===//
 // Memory SSA operations
+//===----------------------------------------------------------------------===//
 
-def fir_AllocaOp : fir_AllocatableOp<"alloca", [MemoryEffects<[MemAlloc]>]> {
+def fir_AllocaOp : fir_AllocatableOp<"alloca"> {
   let summary = "allocate storage for a temporary on the stack given a type";
   let description = [{
     This primitive operation is used to allocate an object on the stack.  A
@@ -477,8 +481,7 @@ def fir_UndefOp : fir_OneResultOp<"undefined", [NoSideEffect]> {
   }];
 }
 
-def fir_AllocMemOp :
-    fir_AllocatableOp<"allocmem", [MemoryEffects<[MemAlloc]>]> {
+def fir_AllocMemOp : fir_AllocatableOp<"allocmem"> {
   let summary = "allocate storage on the heap for an object of a given type";
 
   let description = [{
@@ -529,7 +532,8 @@ def fir_FreeMemOp : fir_Op<"freemem", [MemoryEffects<[MemFree]>]> {
   let assemblyFormat = "$heapref attr-dict `:` type($heapref)";
 }
 
-//===----------------------------------------------------------------------===//// Terminator operations
+//===----------------------------------------------------------------------===//
+// Terminator operations
 //===----------------------------------------------------------------------===//
 
 class fir_SwitchTerminatorOp<string mnemonic, list<OpTrait> traits = []> :
@@ -1824,20 +1828,51 @@ def fir_LenParamIndexOp : fir_OneResultOp<"len_param_index", [NoSideEffect]> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
 // Fortran loops
+//===----------------------------------------------------------------------===//
 
-def ImplicitFirTerminator : SingleBlockImplicitTerminator<"FirEndOp">;
+def fir_ResultOp : fir_Op<"result", [Terminator]> {
+  let summary = "special terminator for use in fir region operations";
 
-def fir_LoopOp : fir_Op<"loop", [ImplicitFirTerminator, RecursiveSideEffects]> {
+  let description = [{
+    Result takes a list of ssa-values produced in the block and forwards them
+    as a result to the operation that owns the region of the block. The
+    operation can retain the values or return them to its parent block
+    depending upon its semantics.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$results);
+  let builders = [
+    OpBuilder<"Builder *builder, OperationState &result", "/* do nothing */">
+  ];
+  let printer = [{ return ::print(p, *this); }];
+  let verifier = [{ return ::verify(*this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+}
+
+def FirRegionTerminator : SingleBlockImplicitTerminator<"ResultOp">;
+
+class region_Op<string mnemonic, list<OpTrait> traits = []> :
+    fir_Op<mnemonic,
+    !listconcat(traits, [FirRegionTerminator, RecursiveSideEffects])> {
+  let printer = [{ return ::print(p, *this); }];
+  let verifier = [{ return ::verify(*this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+}
+
+def fir_LoopOp : region_Op<"do_loop",
+    [DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
   let summary = "generalized loop operation";
   let description = [{
     Generalized high-level looping construct. This operation is similar to
-    MLIR's `loop.for`. An ordered loop will return the final value of `%i`.
+    MLIR's `loop.for`.
 
     ```mlir
       %l = constant 0 : index
       %u = constant 9 : index
-      fir.loop %i = %l to %u unordered {
+      %s = constant 1 : index
+      fir.do_loop %i = %l to %u step %s unordered {
         %x = fir.convert %i : (index) -> i32
         %v = fir.call @compute(%x) : (i32) -> f32
         %p = fir.coordinate_of %A, %i : (!fir.ref<f32>, index) -> !fir.ref<f32>
@@ -1850,121 +1885,61 @@ def fir_LoopOp : fir_Op<"loop", [ImplicitFirTerminator, RecursiveSideEffects]> {
   }];
 
   let arguments = (ins
-    Variadic<Index>:$indexArgs,
-    OptionalAttr<I64Attr>:$constantStep,
-    OptionalAttr<I64Attr>:$constantLowerBound,
-    OptionalAttr<I64Attr>:$constantUpperBound,
+    Index:$lowerBound,
+    Index:$upperBound,
+    Index:$step,
+    Variadic<AnyType>:$initArgs,
     OptionalAttr<UnitAttr>:$unordered
   );
-
-  let results = (outs);
-
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
   let regions = (region SizedRegion<1>:$region);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<"mlir::Builder *builder, OperationState &result,"
-              "int64_t lowerBound, int64_t upperBound, int64_t step = 1,"
-              "bool unordered = false,"
-              "ArrayRef<NamedAttribute> attributes = {}">,
-    OpBuilder<"mlir::Builder *builder, OperationState &result,"
               "mlir::Value lowerBound, mlir::Value upperBound,"
               "mlir::Value step, bool unordered = false,"
-              "ArrayRef<NamedAttribute> attributes = {}">,
-    OpBuilder<"mlir::Builder *builder, OperationState &result,"
-              "mlir::Value lowerBound, mlir::Value upperBound,"
-              "bool unordered = false,"
-              "ArrayRef<NamedAttribute> attributes = {}">,
-    OpBuilder<"mlir::Builder *builder, OperationState &result,"
-              "mlir::Value lowerBound, mlir::Value upperBound,"
-              "int64_t step, bool unordered = false,"
+              "ValueRange iterArgs = llvm::None,"
               "ArrayRef<NamedAttribute> attributes = {}">
   ];
 
-  let parser = "return parseLoopOp(parser, result);";
-
-  let printer = [{
-    p << getOperationName() << ' ' << getInductionVar() << " = ";
-    if (constantLowerBound())
-      p << "(" << *constantLowerBound() << ")";
-    else
-      p.printOperand(getLowerBoundOperand());
-    p << " to ";
-    if (constantUpperBound())
-      p << "(" << *constantUpperBound() << ")";
-    else
-      p.printOperand(getUpperBoundOperand());
-    if (constantStep()) {
-      p << " step (" << *constantStep() << ")";
-    } else {
-      if (indexArgs().size() > 2) {
-        p << " step ";
-        p.printOperand(getStepOperand());
-      }
-    }
-    if (unordered())
-      p << " unordered";
-    p.printRegion(region(), /*printEntryBlockArgs=*/false,
-                            /*printBlockTerminators=*/false);
-    p.printOptionalAttrDict(getAttrs(), {unorderedAttrName(), stepAttrName(),
-                            lowerAttrName(), upperAttrName()});
-  }];
-
-  let verifier = [{
-    const auto argSize = indexArgs().size();
-    if (!((argSize == 0) || (argSize == 2) || (argSize == 3)))
-      return emitOpError("wrong number of ssa arguments");
-    if (argSize > 2) {
-      // FIXME: size of step must be 1
-      auto *s = (*(indexArgs().begin() + 2)).getDefiningOp();
-      if (auto cst = dyn_cast_or_null<mlir::ConstantIndexOp>(s))
-        if (cst.getValue() == 0)
-          return emitOpError("constant step operand must be nonzero");
-    }
-
-    // Check that the body defines as single block argument for the induction
-    // variable.
-    auto *body = getBody();
-    if (body->getNumArguments() != 1 ||
-        !body->getArgument(0).getType().isIndex())
-      return emitOpError("expected body to have a single index argument for "
-                         "the induction variable");
-    return mlir::success();
-  }];
-
   let extraClassDeclaration = [{
     static constexpr llvm::StringRef unorderedAttrName() { return "unordered"; }
-    static constexpr llvm::StringRef stepAttrName() { return "constantStep"; }
-    static constexpr llvm::StringRef upperAttrName() {
-      return "constantUpperBound";
+
+    mlir::Value getInductionVar() { return getBody()->getArgument(0); }
+    mlir::OpBuilder getBodyBuilder() {
+      return OpBuilder(getBody(), std::prev(getBody()->end()));
     }
-    static constexpr llvm::StringRef lowerAttrName() {
-      return "constantLowerBound";
+    mlir::Block::BlockArgListType getRegionIterArgs() {
+      return getBody()->getArguments().drop_front();
+    }
+    mlir::Operation::operand_range getIterOperands() {
+      return getOperands().drop_front(getNumControlOperands());
+    }
+
+    void setLowerBound(Value bound) { getOperation()->setOperand(0, bound); }
+    void setUpperBound(Value bound) { getOperation()->setOperand(1, bound); }
+    void setStep(Value step) { getOperation()->setOperand(2, step); }
+
+    /// Number of region arguments for loop-carried values
+    unsigned getNumRegionIterArgs() {
+      return getBody()->getNumArguments() - 1;
+    }
+    /// Number of operands controlling the loop: lb, ub, step
+    unsigned getNumControlOperands() { return 3; }
+    /// Does the operation hold operands for loop-carried values
+    bool hasIterOperands() {
+      return getOperation()->getNumOperands() > getNumControlOperands();
+    }
+    /// Get Number of loop-carried values
+    unsigned getNumIterOperands() {
+      return getOperation()->getNumOperands() - getNumControlOperands();
     }
 
     /// Get the body of the loop
     mlir::Block *getBody() { return &region().front(); }
-
-    /// Get the block argument corresponding to the loop control value (PHI)
-    mlir::Value getInductionVar() { return getBody()->getArgument(0); }
-
-    mlir::Value getLowerBoundOperand() {
-      if (indexArgs().size() != 0)
-        return *indexArgs().begin();
-      return {};
-    }
-    
-    mlir::Value getUpperBoundOperand() {
-      if (indexArgs().size() != 0)
-        return *(indexArgs().begin() + 1);
-      return {};
-    }
-
-    mlir::Value getStepOperand() {
-      if (indexArgs().size() == 3)
-        return *(indexArgs().begin() + 2);
-      return {};
-    }
 
     void setUnordered() {
       getOperation()->setAttr(unorderedAttrName(),
@@ -1973,62 +1948,38 @@ def fir_LoopOp : fir_Op<"loop", [ImplicitFirTerminator, RecursiveSideEffects]> {
   }];
 }
 
-def fir_WhereOp :
-    fir_Op<"where", [ImplicitFirTerminator, RecursiveSideEffects]> {
-  let summary = "generalized conditional operation";
+def fir_WhereOp : region_Op<"if"> {
+  let summary = "if-then-else conditional operation";
   let description = [{
-    To conditionally execute operations (typically) within the body of a
-    `fir.loop` operation. This operation is similar to `loop.if`.
+    Used to conditionally execute operations. This operation is the FIR
+    dialect's version of `loop.if`.
 
     ```mlir
       %56 = ... : i1
       %78 = ... : !fir.ref<!T>
-      fir.where %56 {
+      fir.if %56 {
         fir.store %76 to %78 : !fir.ref<!T>
-      } otherwise {
+      } else {
         fir.store %77 to %78 : !fir.ref<!T>
       }
     ```
   }];
 
   let arguments = (ins I1:$condition);
+  let results = (outs Variadic<AnyType>:$results);
 
-  let regions = (region SizedRegion<1>:$whereRegion, AnyRegion:$otherRegion);
+  let regions = (region
+    SizedRegion<1>:$whereRegion,
+    AnyRegion:$otherRegion
+  );
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<"Builder *builder, OperationState &result, "
-              "Value cond, bool withOtherRegion">
+              "Value cond, bool withOtherRegion">,
+    OpBuilder<"Builder *builder, OperationState &result, "
+              "TypeRange resultTypes, Value cond, bool withOtherRegion">
   ];
-
-  let parser = [{ return parseWhereOp(parser, result); }];
-
-  let printer = [{
-    p << getOperationName() << ' ' << condition();
-    p.printRegion(whereRegion(), /*printEntryBlockArgs=*/false,
-        /*printBlockTerminators=*/false);
-
-    // Print the 'else' regions if it exists and has a block.
-    auto &otherReg = otherRegion();
-    if (!otherReg.empty() && !otherReg.front().empty() &&
-        otherReg.front().front().isKnownNonTerminator()) {
-      p << " otherwise";
-      p.printRegion(otherReg, /*printEntryBlockArgs=*/false,
-          /*printBlockTerminators=*/false);
-    }
-    p.printOptionalAttrDict(getAttrs());
-  }];
-
-  let verifier = [{
-    for (auto &region : getOperation()->getRegions()) {
-      if (region.empty())
-        continue;
-      for (auto &b : region)
-        if (b.getNumArguments() != 0)
-          return emitOpError("requires that child entry blocks have no args");
-    }
-    return mlir::success();
-  }];
 
   let extraClassDeclaration = [{
     mlir::OpBuilder getWhereBodyBuilder() {
@@ -2046,7 +1997,74 @@ def fir_WhereOp :
   let hasFolder = 1;
 }
 
+def fir_IterWhileOp : region_Op<"iterate_while",
+    [DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
+  let summary = "DO loop with early exit condition";
+  let description = [{
+    This construct is useful for lowering implied-DO loops with "exceptions"
+    that are threaded as a saturating bool value.  A `true` disposition means
+    the next loop iteration should proceed. A `false` indicates that the
+    "iterate_while" operation should terminate and return.
+  }];
+
+  let arguments = (ins
+    Index:$lowerBound,
+    Index:$upperBound,
+    Index:$step,
+    Variadic<AnyType>:$initArgs
+  );
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+  let regions = (region SizedRegion<1>:$region);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<"mlir::Builder *builder, OperationState &result,"
+              "mlir::Value iterate, mlir::Value lowerBound,"
+	      "mlir::Value upperBound, mlir::Value step,"
+              "ValueRange iterArgs = llvm::None,"
+              "ArrayRef<NamedAttribute> attributes = {}">
+  ];
+  
+  let extraClassDeclaration = [{
+    mlir::Block *getBody() { return &region().front(); }
+    mlir::Value getIterateVar() { return getBody()->getArgument(1); }
+    mlir::Value getInductionVar() { return getBody()->getArgument(0); }
+    mlir::OpBuilder getBodyBuilder() {
+      return mlir::OpBuilder(getBody(), std::prev(getBody()->end()));
+    }
+    mlir::Block::BlockArgListType getRegionIterArgs() {
+      return getBody()->getArguments().drop_front();
+    }
+    mlir::Operation::operand_range getIterOperands() {
+      return getOperands().drop_front(getNumControlOperands());
+    }
+
+    void setLowerBound(Value bound) { getOperation()->setOperand(0, bound); }
+    void setUpperBound(Value bound) { getOperation()->setOperand(1, bound); }
+    void setStep(mlir::Value step) { getOperation()->setOperand(2, step); }
+
+    /// Number of region arguments for loop-carried values
+    unsigned getNumRegionIterArgs() {
+      return getBody()->getNumArguments() - 1;
+    }
+    /// Number of operands controlling the loop
+    unsigned getNumControlOperands() { return 3; }
+    /// Does the operation hold operands for loop-carried values
+    bool hasIterOperands() {
+      return getOperation()->getNumOperands() > getNumControlOperands();
+    }
+    /// Get Number of loop-carried values
+    unsigned getNumIterOperands() {
+      return getOperation()->getNumOperands() - getNumControlOperands();
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Procedure call operations
+//===----------------------------------------------------------------------===//
 
 def fir_CallOp : fir_Op<"call",
     [MemoryEffects<[MemAlloc, MemFree, MemRead, MemWrite]>]> {
@@ -2782,6 +2800,8 @@ def fir_GlobalLenOp : fir_Op<"global_len", []> {
     static constexpr llvm::StringRef intAttrName() { return "intval"; }
   }];
 }
+
+def ImplicitFirTerminator : SingleBlockImplicitTerminator<"FirEndOp">;
 
 def fir_DispatchTableOp : fir_Op<"dispatch_table",
     [IsolatedFromAbove, Symbol, ImplicitFirTerminator]> {

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2011,9 +2011,11 @@ def fir_IterWhileOp : region_Op<"iterate_while",
     Index:$lowerBound,
     Index:$upperBound,
     Index:$step,
+    I1:$iterateIn,
     Variadic<AnyType>:$initArgs
   );
   let results = (outs
+    I1:$iterateResult,
     Variadic<AnyType>:$results
   );
   let regions = (region SizedRegion<1>:$region);
@@ -2021,8 +2023,8 @@ def fir_IterWhileOp : region_Op<"iterate_while",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<"mlir::Builder *builder, OperationState &result,"
-              "mlir::Value iterate, mlir::Value lowerBound,"
-	      "mlir::Value upperBound, mlir::Value step,"
+              "mlir::Value lowerBound, mlir::Value upperBound,"
+	      "mlir::Value step, mlir::Value iterate,"
               "ValueRange iterArgs = llvm::None,"
               "ArrayRef<NamedAttribute> attributes = {}">
   ];

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -590,6 +590,160 @@ mlir::ParseResult fir::GlobalOp::verifyValidLinkage(StringRef linkage) {
 }
 
 //===----------------------------------------------------------------------===//
+// IterWhileOp
+//===----------------------------------------------------------------------===//
+
+void fir::IterWhileOp::build(mlir::Builder *builder,
+                             mlir::OperationState &result, mlir::Value iterate,
+                             mlir::Value lb, mlir::Value ub, mlir::Value step,
+                             mlir::ValueRange iterArgs,
+                             llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  result.addOperands({lb, ub, step, iterate});
+  result.addTypes(iterate.getType());
+  result.addOperands(iterArgs);
+  for (auto v : iterArgs)
+    result.addTypes(v.getType());
+  mlir::Region *bodyRegion = result.addRegion();
+  bodyRegion->push_back(new Block{});
+  bodyRegion->front().addArgument(builder->getIndexType());
+  bodyRegion->front().addArgument(iterate.getType());
+  for (auto v : iterArgs)
+    bodyRegion->front().addArgument(v.getType());
+  result.addAttributes(attributes);
+}
+
+static mlir::ParseResult parseIterWhileOp(mlir::OpAsmParser &parser,
+                                          mlir::OperationState &result) {
+  auto &builder = parser.getBuilder();
+  mlir::OpAsmParser::OperandType inductionVariable, lb, ub, step;
+  if (parser.parseRegionArgument(inductionVariable) || parser.parseEqual())
+    return mlir::failure();
+
+  // Parse loop bounds.
+  auto indexType = builder.getIndexType();
+  if (parser.parseOperand(lb) ||
+      parser.resolveOperand(lb, indexType, result.operands) ||
+      parser.parseKeyword("to") || parser.parseOperand(ub) ||
+      parser.resolveOperand(ub, indexType, result.operands) ||
+      parser.parseKeyword("step") || parser.parseOperand(step) ||
+      parser.resolveOperand(step, indexType, result.operands))
+    return failure();
+
+  // Parse the initial iteration arguments.
+  llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> regionArgs, operands;
+  llvm::SmallVector<mlir::Type, 4> argTypes;
+  // Induction variable.
+  regionArgs.push_back(inductionVariable);
+
+  if (parser.parseKeyword("iter_args"))
+    return mlir::failure();
+  // Parse assignment list and results type list.
+  if (parser.parseAssignmentList(regionArgs, operands) ||
+      parser.parseArrowTypeList(result.types))
+    return failure();
+  // Resolve input operands.
+  for (auto operand_type : llvm::zip(operands, result.types))
+    if (parser.resolveOperand(std::get<0>(operand_type),
+                              std::get<1>(operand_type), result.operands))
+      return failure();
+
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
+    return mlir::failure();
+
+  argTypes.push_back(indexType);
+  // Loop carried variables
+  argTypes.append(result.types.begin(), result.types.end());
+  // Parse the body region.
+  auto *body = result.addRegion();
+  if (regionArgs.size() != argTypes.size())
+    return parser.emitError(
+        parser.getNameLoc(),
+        "mismatch in number of loop-carried values and defined values");
+
+  if (parser.parseRegion(*body, regionArgs, argTypes))
+    return failure();
+
+  fir::IterWhileOp::ensureTerminator(*body, builder, result.location);
+
+  return mlir::success();
+}
+
+static mlir::LogicalResult verify(fir::IterWhileOp op) {
+  if (auto cst = dyn_cast_or_null<ConstantIndexOp>(op.step().getDefiningOp()))
+    if (cst.getValue() <= 0)
+      return op.emitOpError("constant step operand must be positive");
+
+  // Check that the body defines as single block argument for the induction
+  // variable.
+  auto *body = op.getBody();
+  if (!body->getArgument(1).getType().isInteger(1))
+    return op.emitOpError(
+        "expected body second argument to be an index argument for "
+        "the induction variable");
+  if (!body->getArgument(0).getType().isIndex())
+    return op.emitOpError(
+        "expected body first argument to be an index argument for "
+        "the induction variable");
+
+  auto opNumResults = op.getNumResults();
+  if (opNumResults == 0)
+    return mlir::failure();
+  if (op.getNumIterOperands() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of loop-carried values and defined values");
+  if (op.getNumRegionIterArgs() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of basic block args and defined values");
+  auto iterOperands = op.getIterOperands();
+  auto iterArgs = op.getRegionIterArgs();
+  auto opResults = op.getResults();
+  unsigned i = 0;
+  for (auto e : llvm::zip(iterOperands, iterArgs, opResults)) {
+    if (std::get<0>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter operand and defined value";
+    if (std::get<1>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter region arg and defined value";
+
+    i++;
+  }
+  return mlir::success();
+}
+
+static void print(mlir::OpAsmPrinter &p, fir::IterWhileOp op) {
+  bool printBlockTerminators = false;
+  p << fir::IterWhileOp::getOperationName() << ' ' << op.getInductionVar()
+    << " = " << op.lowerBound() << " to " << op.upperBound() << " step "
+    << op.step();
+  assert(op.hasIterOperands());
+  p << " iter_args(";
+  auto regionArgs = op.getRegionIterArgs();
+  auto operands = op.getIterOperands();
+  llvm::interleaveComma(llvm::zip(regionArgs, operands), p, [&](auto it) {
+    p << std::get<0>(it) << " = " << std::get<1>(it);
+  });
+  p << ") -> (" << op.getResultTypes() << ')';
+  printBlockTerminators = true;
+  p.printOptionalAttrDictWithKeyword(op.getAttrs(), {});
+  p.printRegion(op.region(), /*printEntryBlockArgs=*/false,
+                printBlockTerminators);
+}
+
+mlir::Region &fir::IterWhileOp::getLoopBody() { return region(); }
+
+bool fir::IterWhileOp::isDefinedOutsideOfLoop(mlir::Value value) {
+  return !region().isAncestor(value.getParentRegion());
+}
+
+mlir::LogicalResult
+fir::IterWhileOp::moveOutOfLoop(llvm::ArrayRef<mlir::Operation *> ops) {
+  for (auto op : ops)
+    op->moveBefore(*this);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LoadOp
 //===----------------------------------------------------------------------===//
 
@@ -612,124 +766,83 @@ mlir::ParseResult fir::LoadOp::getElementOf(mlir::Type &ele, mlir::Type ref) {
 //===----------------------------------------------------------------------===//
 
 void fir::LoopOp::build(mlir::Builder *builder, mlir::OperationState &result,
-                        int64_t lowerBound, int64_t upperBound, int64_t step,
-                        bool unordered,
-                        llvm::ArrayRef<mlir::NamedAttribute> attributes) {
-  mlir::Region *bodyRegion = result.addRegion();
-  LoopOp::ensureTerminator(*bodyRegion, *builder, result.location);
-  bodyRegion->front().addArgument(builder->getIndexType());
-  result.addAttribute(lowerAttrName(), builder->getI64IntegerAttr(lowerBound));
-  result.addAttribute(upperAttrName(), builder->getI64IntegerAttr(upperBound));
-  result.addAttribute(stepAttrName(), builder->getI64IntegerAttr(step));
-  if (unordered)
-    result.addAttribute(unorderedAttrName(), builder->getUnitAttr());
-  result.addAttributes(attributes);
-}
-
-void fir::LoopOp::build(mlir::Builder *builder, OperationState &result,
-                        mlir::Value lb, mlir::Value ub, int64_t step,
-                        bool unordered, ArrayRef<NamedAttribute> attributes) {
-  result.addOperands({lb, ub});
-  mlir::Region *bodyRegion = result.addRegion();
-  LoopOp::ensureTerminator(*bodyRegion, *builder, result.location);
-  bodyRegion->front().addArgument(builder->getIndexType());
-  result.addAttribute(stepAttrName(), builder->getI64IntegerAttr(step));
-  if (unordered)
-    result.addAttribute(unorderedAttrName(), builder->getUnitAttr());
-  result.addAttributes(attributes);
-}
-
-void fir::LoopOp::build(mlir::Builder *builder, OperationState &result,
-                        mlir::Value lb, mlir::Value ub, bool unordered,
-                        ArrayRef<NamedAttribute> attributes) {
-  result.addOperands({lb, ub});
-  mlir::Region *bodyRegion = result.addRegion();
-  LoopOp::ensureTerminator(*bodyRegion, *builder, result.location);
-  bodyRegion->front().addArgument(builder->getIndexType());
-  if (unordered)
-    result.addAttribute(unorderedAttrName(), builder->getUnitAttr());
-  result.addAttributes(attributes);
-}
-
-void fir::LoopOp::build(mlir::Builder *builder, OperationState &result,
                         mlir::Value lb, mlir::Value ub, mlir::Value step,
-                        bool unordered, ArrayRef<NamedAttribute> attributes) {
+                        bool unordered, mlir::ValueRange iterArgs,
+                        llvm::ArrayRef<mlir::NamedAttribute> attributes) {
   result.addOperands({lb, ub, step});
+  result.addOperands(iterArgs);
+  for (auto v : iterArgs)
+    result.addTypes(v.getType());
   mlir::Region *bodyRegion = result.addRegion();
-  LoopOp::ensureTerminator(*bodyRegion, *builder, result.location);
+  bodyRegion->push_back(new Block{});
+  if (iterArgs.empty())
+    LoopOp::ensureTerminator(*bodyRegion, *builder, result.location);
   bodyRegion->front().addArgument(builder->getIndexType());
+  for (auto v : iterArgs)
+    bodyRegion->front().addArgument(v.getType());
   if (unordered)
     result.addAttribute(unorderedAttrName(), builder->getUnitAttr());
   result.addAttributes(attributes);
 }
 
-/// Parse a `fir.loop` operation.
 static mlir::ParseResult parseLoopOp(mlir::OpAsmParser &parser,
                                      mlir::OperationState &result) {
   auto &builder = parser.getBuilder();
-  OpAsmParser::OperandType inductionVariable, lb, ub, step;
+  mlir::OpAsmParser::OperandType inductionVariable, lb, ub, step;
   // Parse the induction variable followed by '='.
   if (parser.parseRegionArgument(inductionVariable) || parser.parseEqual())
     return mlir::failure();
 
   // Parse loop bounds.
-  // There is a constant form and an operand form.
-  mlir::Type indexType = builder.getIndexType();
-  if (mlir::succeeded(parser.parseOptionalLParen())) {
-    // constant iteration space form (with optional constant step):
-    // `(` int `)` `to` `(` int `)` [`step` `(` int `)`]
-    mlir::IntegerAttr lvalue;
-    mlir::IntegerAttr uvalue;
-    if (parser.parseAttribute(lvalue, fir::LoopOp::lowerAttrName(),
-                              result.attributes) ||
-        parser.parseRParen() || parser.parseKeyword("to") ||
-        parser.parseLParen() ||
-        parser.parseAttribute(uvalue, fir::LoopOp::upperAttrName(),
-                              result.attributes) ||
-        parser.parseRParen())
-      return mlir::failure();
-    if (mlir::succeeded(parser.parseOptionalKeyword("step"))) {
-      mlir::IntegerAttr value;
-      if (parser.parseLParen() ||
-          parser.parseAttribute(value, fir::LoopOp::stepAttrName(),
-                                result.attributes) ||
-          parser.parseRParen())
-        return mlir::failure();
-    }
-  } else {
-    // value iteration space form (with optional value or constant step):
-    // %lb `to` %ub [`step` (%sv | `(` int `)`)]
-    if (parser.parseOperand(lb) || parser.parseKeyword("to") ||
-        parser.parseOperand(ub) ||
-        parser.resolveOperands({lb, ub}, indexType, result.operands))
-      return mlir::failure();
-    if (mlir::succeeded(parser.parseOptionalKeyword("step"))) {
-      if (mlir::succeeded(parser.parseOptionalLParen())) {
-        mlir::IntegerAttr value;
-        if (parser.parseAttribute(value, fir::LoopOp::stepAttrName(),
-                                  result.attributes) ||
-            parser.parseRParen())
-          return mlir::failure();
-      } else if (parser.parseOperand(step) ||
-                 parser.resolveOperand(step, indexType, result.operands)) {
-        return mlir::failure();
-      }
-    }
-  }
-  // Parse the optional `unordered` keyword
-  if (mlir::succeeded(parser.parseOptionalKeyword(LoopOp::unorderedAttrName())))
-    result.addAttribute(LoopOp::unorderedAttrName(), builder.getUnitAttr());
+  auto indexType = builder.getIndexType();
+  if (parser.parseOperand(lb) ||
+      parser.resolveOperand(lb, indexType, result.operands) ||
+      parser.parseKeyword("to") || parser.parseOperand(ub) ||
+      parser.resolveOperand(ub, indexType, result.operands) ||
+      parser.parseKeyword("step") || parser.parseOperand(step) ||
+      parser.resolveOperand(step, indexType, result.operands))
+    return failure();
 
-  // Parse the body region.
-  mlir::Region *body = result.addRegion();
-  if (parser.parseRegion(*body, inductionVariable, indexType))
+  if (mlir::succeeded(parser.parseOptionalKeyword("unordered")))
+    result.addAttribute(fir::LoopOp::unorderedAttrName(),
+                        builder.getUnitAttr());
+
+  // Parse the optional initial iteration arguments.
+  llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> regionArgs, operands;
+  llvm::SmallVector<mlir::Type, 4> argTypes;
+  regionArgs.push_back(inductionVariable);
+
+  if (succeeded(parser.parseOptionalKeyword("iter_args"))) {
+    // Parse assignment list and results type list.
+    if (parser.parseAssignmentList(regionArgs, operands) ||
+        parser.parseArrowTypeList(result.types))
+      return failure();
+    // Resolve input operands.
+    for (auto operand_type : llvm::zip(operands, result.types))
+      if (parser.resolveOperand(std::get<0>(operand_type),
+                                std::get<1>(operand_type), result.operands))
+        return failure();
+  }
+
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
     return mlir::failure();
+
+  // Induction variable.
+  argTypes.push_back(indexType);
+  // Loop carried variables
+  argTypes.append(result.types.begin(), result.types.end());
+  // Parse the body region.
+  auto *body = result.addRegion();
+  if (regionArgs.size() != argTypes.size())
+    return parser.emitError(
+        parser.getNameLoc(),
+        "mismatch in number of loop-carried values and defined values");
+
+  if (parser.parseRegion(*body, regionArgs, argTypes))
+    return failure();
 
   fir::LoopOp::ensureTerminator(*body, builder, result.location);
 
-  // Parse the optional attribute list.
-  if (parser.parseOptionalAttrDict(result.attributes))
-    return mlir::failure();
   return mlir::success();
 }
 
@@ -742,6 +855,81 @@ fir::LoopOp fir::getForInductionVarOwner(mlir::Value val) {
   return dyn_cast_or_null<fir::LoopOp>(containingInst);
 }
 
+// Lifted from loop.loop
+static mlir::LogicalResult verify(fir::LoopOp op) {
+  if (auto cst = dyn_cast_or_null<ConstantIndexOp>(op.step().getDefiningOp()))
+    if (cst.getValue() <= 0)
+      return op.emitOpError("constant step operand must be positive");
+
+  // Check that the body defines as single block argument for the induction
+  // variable.
+  auto *body = op.getBody();
+  if (!body->getArgument(0).getType().isIndex())
+    return op.emitOpError(
+        "expected body first argument to be an index argument for "
+        "the induction variable");
+
+  auto opNumResults = op.getNumResults();
+  if (opNumResults == 0)
+    return success();
+  if (op.getNumIterOperands() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of loop-carried values and defined values");
+  if (op.getNumRegionIterArgs() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of basic block args and defined values");
+  auto iterOperands = op.getIterOperands();
+  auto iterArgs = op.getRegionIterArgs();
+  auto opResults = op.getResults();
+  unsigned i = 0;
+  for (auto e : llvm::zip(iterOperands, iterArgs, opResults)) {
+    if (std::get<0>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter operand and defined value";
+    if (std::get<1>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter region arg and defined value";
+
+    i++;
+  }
+  return success();
+}
+
+static void print(mlir::OpAsmPrinter &p, fir::LoopOp op) {
+  bool printBlockTerminators = false;
+  p << fir::LoopOp::getOperationName() << ' ' << op.getInductionVar() << " = "
+    << op.lowerBound() << " to " << op.upperBound() << " step " << op.step();
+  if (op.unordered())
+    p << " unordered";
+  if (op.hasIterOperands()) {
+    p << " iter_args(";
+    auto regionArgs = op.getRegionIterArgs();
+    auto operands = op.getIterOperands();
+    llvm::interleaveComma(llvm::zip(regionArgs, operands), p, [&](auto it) {
+      p << std::get<0>(it) << " = " << std::get<1>(it);
+    });
+    p << ") -> (" << op.getResultTypes() << ')';
+    printBlockTerminators = true;
+  }
+  p.printOptionalAttrDictWithKeyword(op.getAttrs(),
+                                     {fir::LoopOp::unorderedAttrName()});
+  p.printRegion(op.region(), /*printEntryBlockArgs=*/false,
+                printBlockTerminators);
+}
+
+mlir::Region &fir::LoopOp::getLoopBody() { return region(); }
+
+bool fir::LoopOp::isDefinedOutsideOfLoop(mlir::Value value) {
+  return !region().isAncestor(value.getParentRegion());
+}
+
+mlir::LogicalResult
+fir::LoopOp::moveOutOfLoop(llvm::ArrayRef<mlir::Operation *> ops) {
+  for (auto op : ops)
+    op->moveBefore(*this);
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // MulfOp
 //===----------------------------------------------------------------------===//
@@ -749,6 +937,49 @@ fir::LoopOp fir::getForInductionVarOwner(mlir::Value val) {
 mlir::OpFoldResult fir::MulfOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
   return mlir::constFoldBinaryOp<FloatAttr>(
       opnds, [](APFloat a, APFloat b) { return a * b; });
+}
+
+//===----------------------------------------------------------------------===//
+// ResultOp
+//===----------------------------------------------------------------------===//
+
+static mlir::LogicalResult verify(fir::ResultOp op) {
+  auto parentOp = op.getParentOp();
+  auto results = parentOp->getResults();
+  auto operands = op.getOperands();
+
+  if (isa<fir::WhereOp>(parentOp) || isa<fir::LoopOp>(parentOp) ||
+      isa<fir::IterWhileOp>(parentOp)) {
+    if (parentOp->getNumResults() != op.getNumOperands())
+      return op.emitOpError() << "parent of result must have same arity";
+    for (auto e : llvm::zip(results, operands)) {
+      if (std::get<0>(e).getType() != std::get<1>(e).getType())
+        return op.emitOpError()
+               << "types mismatch between result op and its parent";
+    }
+  } else {
+    return op.emitOpError()
+           << "result only terminates if, do_loop, or iterate_while regions";
+  }
+  return success();
+}
+
+static mlir::ParseResult parseResultOp(mlir::OpAsmParser &parser,
+                                       mlir::OperationState &result) {
+  llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> operands;
+  llvm::SmallVector<mlir::Type, 4> types;
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  if (parser.parseOperandList(operands) ||
+      parser.parseOptionalColonTypeList(types) ||
+      parser.resolveOperands(operands, types, loc, result.operands))
+    return failure();
+  return success();
+}
+
+static void print(mlir::OpAsmPrinter &p, fir::ResultOp op) {
+  p << op.getOperationName();
+  if (op.getNumOperands() != 0)
+    p << ' ' << op.getOperands() << " : " << op.getOperandTypes();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1191,7 +1422,7 @@ static mlir::ParseResult parseWhereOp(OpAsmParser &parser,
 
   WhereOp::ensureTerminator(*thenRegion, parser.getBuilder(), result.location);
 
-  if (!parser.parseOptionalKeyword("otherwise")) {
+  if (!parser.parseOptionalKeyword("else")) {
     if (parser.parseRegion(*elseRegion, {}, {}))
       return mlir::failure();
     WhereOp::ensureTerminator(*elseRegion, parser.getBuilder(),
@@ -1217,6 +1448,43 @@ fir::WhereOp::fold(llvm::ArrayRef<mlir::Attribute> opnds,
     return mlir::success();
   }
   return mlir::failure();
+}
+
+static LogicalResult verify(fir::WhereOp op) {
+  // Verify that the entry of each child region does not have arguments.
+  for (auto &region : op.getOperation()->getRegions()) {
+    if (region.empty())
+      continue;
+
+    for (auto &b : region)
+      if (b.getNumArguments() != 0)
+        return op.emitOpError(
+            "requires that child entry blocks have no arguments");
+  }
+  if (op.getNumResults() != 0 && op.otherRegion().empty())
+    return op.emitOpError("must have an else block if defining values");
+
+  return mlir::success();
+}
+
+static void print(mlir::OpAsmPrinter &p, fir::WhereOp op) {
+  bool printBlockTerminators = false;
+  p << fir::WhereOp::getOperationName() << ' ' << op.condition();
+  if (!op.results().empty()) {
+    p << " -> (" << op.getResultTypes() << ')';
+    printBlockTerminators = true;
+  }
+  p.printRegion(op.whereRegion(), /*printEntryBlockArgs=*/false,
+                printBlockTerminators);
+
+  // Print the 'else' regions if it exists and has a block.
+  auto &otherReg = op.otherRegion();
+  if (!otherReg.empty()) {
+    p << " else";
+    p.printRegion(otherReg, /*printEntryBlockArgs=*/false,
+                  printBlockTerminators);
+  }
+  p.printOptionalAttrDict(op.getAttrs());
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
+++ b/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
@@ -93,27 +93,9 @@ public:
   mlir::LogicalResult
   matchAndRewrite(LoopOp loop, mlir::PatternRewriter &rewriter) const override {
     auto loc = loop.getLoc();
-    auto low = loop.getLowerBoundOperand();
-    if (!low) {
-      assert(loop.constantLowerBound().hasValue());
-      auto lb = *loop.constantLowerBound();
-      low = rewriter.create<mlir::ConstantIndexOp>(loc, lb.getSExtValue());
-    }
-    auto high = loop.getUpperBoundOperand();
-    if (!high) {
-      assert(loop.constantUpperBound().hasValue());
-      auto ub = *loop.constantUpperBound();
-      high = rewriter.create<mlir::ConstantIndexOp>(loc, ub.getSExtValue());
-    }
-    auto step = loop.getStepOperand();
-    if (!step) {
-      if (loop.constantStep().hasValue()) {
-        auto st = *loop.constantStep();
-        step = rewriter.create<mlir::ConstantIndexOp>(loc, st.getSExtValue());
-      } else {
-        step = rewriter.create<mlir::ConstantIndexOp>(loc, 1);
-      }
-    }
+    auto low = loop.lowerBound();
+    auto high = loop.upperBound();
+    auto step = loop.step();
     assert(low && high && step);
     // ForOp has different bounds semantics. Adjust upper bound.
     auto adjustUp = rewriter.create<mlir::AddIOp>(loc, high, step);
@@ -150,13 +132,89 @@ public:
 };
 
 /// Replace FirEndOp with TerminatorOp
-class LoopFirEndConv : public mlir::OpRewritePattern<FirEndOp> {
+class LoopResultConv : public mlir::OpRewritePattern<ResultOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
   mlir::LogicalResult
-  matchAndRewrite(FirEndOp op, mlir::PatternRewriter &rewriter) const override {
+  matchAndRewrite(ResultOp op, mlir::PatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<mlir::loop::YieldOp>(op);
+    return success();
+  }
+};
+
+class LoopIterWhileConv : public mlir::OpRewritePattern<IterWhileOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(IterWhileOp whileOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Location loc = whileOp.getLoc();
+
+    // Start by splitting the block containing the 'fir.do_loop' into two parts.
+    // The part before will get the init code, the part after will be the end
+    // point.
+    auto *initBlock = rewriter.getInsertionBlock();
+    auto initPosition = rewriter.getInsertionPoint();
+    auto *endBlock = rewriter.splitBlock(initBlock, initPosition);
+
+    // Use the first block of the loop body as the condition block since it is
+    // the block that has the induction variable and loop-carried values as
+    // arguments. Split out all operations from the first block into a new
+    // block. Move all body blocks from the loop body region to the region
+    // containing the loop.
+    auto *conditionBlock = &whileOp.region().front();
+    auto *firstBodyBlock =
+        rewriter.splitBlock(conditionBlock, conditionBlock->begin());
+    auto *lastBodyBlock = &whileOp.region().back();
+    rewriter.inlineRegionBefore(whileOp.region(), endBlock);
+    auto iv = conditionBlock->getArgument(0);
+
+    // Append the induction variable stepping logic to the last body block and
+    // branch back to the condition block. Loop-carried values are taken from
+    // operands of the loop terminator.
+    mlir::Operation *terminator = lastBodyBlock->getTerminator();
+    rewriter.setInsertionPointToEnd(lastBodyBlock);
+    auto step = whileOp.step();
+    auto stepped = rewriter.create<AddIOp>(loc, iv, step).getResult();
+    if (!stepped)
+      return failure();
+
+    llvm::SmallVector<mlir::Value, 8> loopCarried;
+    loopCarried.push_back(stepped);
+    loopCarried.append(terminator->operand_begin(), terminator->operand_end());
+    rewriter.create<BranchOp>(loc, conditionBlock, loopCarried);
+    rewriter.eraseOp(terminator);
+
+    // Compute loop bounds before branching to the condition.
+    rewriter.setInsertionPointToEnd(initBlock);
+    mlir::Value lowerBound = whileOp.lowerBound();
+    mlir::Value upperBound = whileOp.upperBound();
+    if (!lowerBound || !upperBound)
+      return failure();
+
+    // The initial values of loop-carried values is obtained from the operands
+    // of the loop operation.
+    llvm::SmallVector<mlir::Value, 8> destOperands;
+    destOperands.push_back(lowerBound);
+    auto iterOperands = whileOp.getIterOperands();
+    destOperands.append(iterOperands.begin(), iterOperands.end());
+    rewriter.create<BranchOp>(loc, conditionBlock, destOperands);
+
+    // With the body block done, we can fill in the condition block.
+    rewriter.setInsertionPointToEnd(conditionBlock);
+    auto comp1 =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::slt, iv, upperBound);
+    // Remember to AND in the early-exit bool.
+    auto comparison =
+        rewriter.create<AndOp>(loc, comp1, whileOp.getIterateVar());
+    rewriter.create<CondBranchOp>(loc, comparison, firstBodyBlock,
+                                  ArrayRef<Value>(), endBlock,
+                                  ArrayRef<Value>());
+    // The result of the loop operation is the values of the condition block
+    // arguments except the induction variable on the last iteration.
+    rewriter.replaceOp(whileOp, conditionBlock->getArguments().drop_front());
     return success();
   }
 };
@@ -171,12 +229,14 @@ public:
 
     auto *context = &getContext();
     mlir::OwningRewritePatternList patterns;
-    patterns.insert<LoopLoopConv, LoopWhereConv, LoopFirEndConv>(context);
+    patterns
+        .insert<LoopLoopConv, LoopWhereConv, LoopResultConv, LoopIterWhileConv>(
+            context);
     mlir::ConversionTarget target = *context;
     target.addLegalDialect<mlir::AffineDialect, FIROpsDialect,
                            mlir::loop::LoopOpsDialect,
                            mlir::StandardOpsDialect>();
-    target.addIllegalOp<FirEndOp, LoopOp, WhereOp>();
+    target.addIllegalOp<ResultOp, LoopOp, WhereOp>();
 
     // apply the patterns
     if (mlir::failed(mlir::applyPartialConversion(getFunction(), target,

--- a/flang/test/Fir/embox-write.fir
+++ b/flang/test/Fir/embox-write.fir
@@ -9,7 +9,7 @@ func @set_all_n(%n : index, %x : i32) {
   %a = fir.embox %aMem, %aDim : (!fir.ref<!fir.array<?xi32>>, !fir.dims<1>) -> !fir.box<!fir.array<?xi32>>
   // CHECK: phi i64
   // CHECK-NEXT: icmp
-  fir.loop %i = %c1 to %n unordered {
+  fir.do_loop %i = %c1 to %n step %c1 unordered {
     %1 = fir.coordinate_of %a, %i : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
     // CHECK: store i32 %{{.*}}, i32* %{{.*}}
     fir.store %x to %1 : !fir.ref<i32>

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -402,14 +402,16 @@ func @character_literal() -> !fir.array<13 x !fir.char<1>> {
   return %0 : !fir.array<13 x !fir.char<1>>
 }
 
+func @earlyexit2(%a : i32) -> i1
+
 // CHECK-LABEL: @early_exit
-func @early_exit(%ok : i1) -> i1 {
+func @early_exit(%ok : i1, %k : i32) -> i1 {
   %c1 = constant 1 : index
   %c100 = constant 100 : index
-  // CHECK: %{{.*}} = fir.iterate_while %{{.*}} = %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (i1) {
-  %newOk = fir.iterate_while %i = %c1 to %c100 step %c1 iter_args(%ok_ = %ok) -> (i1) {
-    %stop = constant 0 : i1
-    fir.result %stop : i1
+  // CHECK: %{{.*}} = fir.iterate_while (%{{.*}} = %{{.*}} step %{{.*}}) and (%{{.*}} = %{{.*}}) iter_args(%{{.*}} = %{{.*}}) -> (i32) {
+  %newOk:2 = fir.iterate_while (%i = %c1 to %c100 step %c1) and (%ok_ = %ok) iter_args(%v = %k) -> (i32) {
+    %stop = call @earlyexit2(%v) : (i32) -> i1
+    fir.result %stop, %v : i1, i32
   }
-  return %newOk : i1
+  return %newOk#0 : i1
 }

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -153,13 +153,13 @@ func @loop() {
   %c1 = constant 1 : index
   %c10 = constant 10 : index
   %ct = constant true
-  // CHECK: fir.loop %{{.*}} = %{{.*}} to %{{.*}} {
-  fir.loop %i = %c1 to %c10 {
-    // CHECK: fir.where %{{.*}} {
-    fir.where %ct {
+  // CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+  fir.do_loop %i = %c1 to %c10 step %c1 {
+    // CHECK: fir.if %{{.*}} {
+    fir.if %ct {
       fir.call @nop() : () -> ()
-    // CHECK: } otherwise {
-    } otherwise {
+    // CHECK: } else {
+    } else {
       fir.call @nop() : () -> ()
     }
   }
@@ -400,4 +400,16 @@ func @character_literal() -> !fir.array<13 x !fir.char<1>> {
   // CHECK: fir.string_lit "Hello, World!"(13) : !fir.char<1>
   %0 = fir.string_lit "Hello, World!"(13) : !fir.char<1>
   return %0 : !fir.array<13 x !fir.char<1>>
+}
+
+// CHECK-LABEL: @early_exit
+func @early_exit(%ok : i1) -> i1 {
+  %c1 = constant 1 : index
+  %c100 = constant 100 : index
+  // CHECK: %{{.*}} = fir.iterate_while %{{.*}} = %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (i1) {
+  %newOk = fir.iterate_while %i = %c1 to %c100 step %c1 iter_args(%ok_ = %ok) -> (i1) {
+    %stop = constant 0 : i1
+    fir.result %stop : i1
+  }
+  return %newOk : i1
 }

--- a/flang/test/Fir/loop.fir
+++ b/flang/test/Fir/loop.fir
@@ -6,12 +6,12 @@
 func @x(%lb : index, %ub : index, %step : index, %b : i1, %addr : !fir.ref<index>) {
   // CHECK: %[[COND:.*]] = icmp slt i64
   // CHECK: br i1 %[[COND]]
-  fir.loop %iv = %lb to %ub step %step unordered {
+  fir.do_loop %iv = %lb to %ub step %step unordered {
     // CHECK: br i1 %
-    fir.where %b {
+    fir.if %b {
       // CHECK: store i64
       fir.store %iv to %addr : !fir.ref<index>
-    } otherwise {
+    } else {
       %zero = constant 0 : index
       // CHECK: store i64
       fir.store %zero to %addr : !fir.ref<index>

--- a/flang/test/Fir/loop10.fir
+++ b/flang/test/Fir/loop10.fir
@@ -6,12 +6,13 @@
 func @x(%addr : !fir.ref<!fir.array<10x10xi32>>) -> index {
   %c0 = constant 0 : index
   %c10 = constant 10 : index
+  %c1 = constant 1 : index
   // CHECK: %[[ROW:.*]] = phi i64
   // CHECK: icmp slt i64 %[[ROW]], 11
-  fir.loop %iv = %c0 to %c10 {
+  fir.do_loop %iv = %c0 to %c10 step %c1 {
     // CHECK: %[[COL:.*]] = phi i64
     // CHECK: icmp slt i64 %[[COL]], 11
-    fir.loop %jv = (0) to (10) {
+    fir.do_loop %jv = %c0 to %c10 step %c1 {
       // CHECK: getelementptr {{.*}} %[[ADDR]], i64 0, i64 %[[ROW]], i64 %[[COL]]
       %ptr = fir.coordinate_of %addr, %jv, %iv : (!fir.ref<!fir.array<10x10xi32>>, index, index) -> !fir.ref<i32>
       %c22 = constant 22 : i32

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -17,7 +17,7 @@ subroutine assign1(lhs, rhs)
   ! CHECK: [[tmp:%[0-9]+]] = fir.alloca !fir.char<1>, [[min_len]]
 
   ! Copy of rhs into temp
-  ! CHECK: fir.loop [[i:%[[:alnum:]_]+]]
+  ! CHECK: fir.do_loop [[i:%[[:alnum:]_]+]]
     ! CHECK-DAG: [[rhs_addr:%[0-9]+]] = fir.coordinate_of [[rhs]]#0, [[i]]
     ! CHECK-DAG: [[tmp_addr:%[0-9]+]] = fir.coordinate_of [[tmp]], [[i]]
     ! CHECK-DAG: [[rhs_elt:%[0-9]+]] = fir.load [[rhs_addr]]
@@ -25,7 +25,7 @@ subroutine assign1(lhs, rhs)
   ! CHECK: }
 
   ! Copy of temp into lhs
-  ! CHECK: fir.loop [[i:%[[:alnum:]]+]]
+  ! CHECK: fir.do_loop [[i:%[[:alnum:]]+]]
     ! CHECK-DAG: [[tmp_addr:%[0-9]+]] = fir.coordinate_of [[tmp]], [[i]]
     ! CHECK-DAG: [[lhs_addr:%[0-9]+]] = fir.coordinate_of [[lhs]]#0, [[i]]
     ! CHECK-DAG: [[tmp_elt:%[0-9]+]] = fir.load [[tmp_addr]]
@@ -35,7 +35,7 @@ subroutine assign1(lhs, rhs)
   ! Padding
   ! CHECK: [[c32:%[[:alnum:]_]+]] = constant 32 : i8
   ! CHECK: [[blank:%[0-9]+]] = fir.convert [[c32]] : (i8) -> !fir.char<1>
-  ! CHECK: fir.loop [[i:%[[:alnum:]_]+]]
+  ! CHECK: fir.do_loop [[i:%[[:alnum:]_]+]]
     ! CHECK-DAG: [[lhs_addr:%[0-9]+]] = fir.coordinate_of [[lhs]]#0, [[i]]
     ! CHECK: fir.store [[blank]] to [[lhs_addr]]
   ! CHECK: }
@@ -84,7 +84,7 @@ subroutine assign_constant(lhs)
   ! CHECK-DAG: %[[lhs:.*]]:2 = fir.unboxchar %[[ARG]] :
   ! CHECK-DAG: %[[tmp:.*]] = fir.address_of(@{{.*}}) :
   lhs = "Hello World"
-  ! CHECK: fir.loop %[[i:.*]] = %{{.*}} to %{{.*}} {
+  ! CHECK: fir.do_loop %[[i:.*]] = %{{.*}} to %{{.*}} {
     ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[i]]
     ! CHECK-DAG: %[[tmp_elt:.*]] = fir.load %[[tmp_addr]]
     ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[i]]
@@ -94,7 +94,7 @@ subroutine assign_constant(lhs)
   ! Padding
   ! CHECK-DAG: %[[c32:.*]] = constant 32 : i8
   ! CHECK-DAG: %[[blank:.*]] = fir.convert %[[c32]] : (i8) -> !fir.char<1>
-  ! CHECK: fir.loop %[[j:.*]] = %{{.*}} to %{{.*}} {
+  ! CHECK: fir.do_loop %[[j:.*]] = %{{.*}} to %{{.*}} {
     ! CHECK: %[[jhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[j]]
     ! CHECK: fir.store %[[blank]] to %[[jhs_addr]]
   ! CHECK: }


### PR DESCRIPTION
This patch changes the FIR region operations to be more like those found in
the loop dialect.  The changes are driven by the desire to be able to convert
FIR into a register ssa form.  The changes are specifically:

  - fir.loop has been replaced by fir.do_loop. The new form has the same
    semantics (inclusive bounds, unordered), but can now carry ssa-values
    around the loop and return them as results to the parent.
  - fir.where has been replaced by fir.if. This new form is identical to
    the current loop.if operation.
  - fir.iterate_while has been added. This operation is very similar to
    fir.loop with the addition that it requires a single loop-carried bool
    value that signals an early-exit condition to the operation.  While that
    value is true, iterate_while will continue to iterate. When it becomes
    false, the loop is exited.
  - fir.result is the new terminator for the above ops to facilitate the
    carrying of ssa-values through block arguments (phi nodes).