### PR TITLE
Fix a bug in argument passing. When the expression is already a refer…

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -857,6 +857,7 @@ class ExprLowering {
         if (fir::isa_ref_type(val.getType())) {
           // expression is already a reference, so just pass it
           // FIXME: check box types here as well
+          // FIXME: pointer/heap may actually need to be passed by reference
           addr = val;
         } else {
           // expression is a value, so store it in a temporary so we can

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -853,8 +853,17 @@ class ExprLowering {
       } else {
         // create a temp to store the expression value
         auto val = genval(*expr);
-        auto addr = builder.createTemporary(getLoc(), val.getType());
-        builder.create<fir::StoreOp>(getLoc(), val, addr);
+        mlir::Value addr;
+        if (fir::isa_ref_type(val.getType())) {
+          // expression is already a reference, so just pass it
+          // FIXME: check box types here as well
+          addr = val;
+        } else {
+          // expression is a value, so store it in a temporary so we can
+          // pass-by-reference
+          addr = builder.createTemporary(getLoc(), val.getType());
+          builder.create<fir::StoreOp>(getLoc(), val, addr);
+        }
         argTypes.push_back(addr.getType());
         operands.push_back(addr);
       }


### PR DESCRIPTION
…ence,

we don't need or want to create a reference to the reference to pass the original reference. Instead just pass the reference itself.