### PR TITLE
To improve build times, lop off the f18 tool's dependence on Lowering. Mov…

### DIFF
--- a/flang/test/Lower/pre-fir-tree01.f90
+++ b/flang/test/Lower/pre-fir-tree01.f90
@@ -1,4 +1,4 @@
-! RUN: %f18 -fdebug-pre-fir-tree -fparse-only %s | FileCheck %s
+! RUN: bbc -pft-test -o %t %s | FileCheck %s
 
 ! Test structure of the Pre-FIR tree
 

--- a/flang/test/Lower/pre-fir-tree02.f90
+++ b/flang/test/Lower/pre-fir-tree02.f90
@@ -1,4 +1,4 @@
-! RUN: %f18 -fdebug-pre-fir-tree -fparse-only %s | FileCheck %s
+! RUN: bbc -pft-test -o %t %s | FileCheck %s
 
 ! Test Pre-FIR Tree captures all the intended nodes from the parse-tree
 ! Coarray and OpenMP related nodes are tested in other files.

--- a/flang/test/Lower/pre-fir-tree03.f90
+++ b/flang/test/Lower/pre-fir-tree03.f90
@@ -1,4 +1,4 @@
-! RUN: %f18 -fdebug-pre-fir-tree -fparse-only -fopenmp %s | FileCheck %s
+! RUN: bbc -pft-test -fopenmp -o %t %s | FileCheck %s
 
 ! Test Pre-FIR Tree captures OpenMP related constructs
 

--- a/flang/test/Lower/pre-fir-tree04.f90
+++ b/flang/test/Lower/pre-fir-tree04.f90
@@ -1,4 +1,5 @@
-! RUN: %f18_with_includes -fdebug-pre-fir-tree -fparse-only %s | FileCheck %s
+! RUN: bbc -pft-test -o %t %s | FileCheck %s
+! XFAIL: *
 
 ! Test Pre-FIR Tree captures all the coarray related statements
 

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(f18
   FortranParser
   FortranEvaluate
   FortranSemantics
-  FortranLower
   LLVMSupport
 )
 

--- a/flang/tools/f18/f18.cpp
+++ b/flang/tools/f18/f18.cpp
@@ -11,7 +11,6 @@
 #include "flang/Common/Fortran-features.h"
 #include "flang/Common/default-kinds.h"
 #include "flang/Evaluate/expression.h"
-#include "flang/Lower/PFTBuilder.h"
 #include "flang/Parser/characters.h"
 #include "flang/Parser/dump-parse-tree.h"
 #include "flang/Parser/message.h"
@@ -95,7 +94,6 @@ struct DriverOptions {
   bool dumpUnparse{false};
   bool dumpUnparseWithSymbols{false};
   bool dumpParseTree{false};
-  bool dumpPreFirTree{false};
   bool dumpSymbols{false};
   bool debugResolveNames{false};
   bool debugNoSemantics{false};
@@ -314,14 +312,6 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
         nullptr /* action before each statement */, &asFortran);
     return {};
   }
-  if (driver.dumpPreFirTree) {
-    if (auto ast{Fortran::lower::createPFT(parseTree, semanticsContext)}) {
-      Fortran::lower::dumpPFT(llvm::outs(), *ast);
-    } else {
-      llvm::errs() << "Pre FIR Tree is NULL.\n";
-      exitStatus = EXIT_FAILURE;
-    }
-  }
   if (driver.parseOnly) {
     return {};
   }
@@ -491,8 +481,6 @@ int main(int argc, char *const argv[]) {
       options.needProvenanceRangeToCharBlockMappings = true;
     } else if (arg == "-fdebug-dump-parse-tree") {
       driver.dumpParseTree = true;
-    } else if (arg == "-fdebug-pre-fir-tree") {
-      driver.dumpPreFirTree = true;
     } else if (arg == "-fdebug-dump-symbols") {
       driver.dumpSymbols = true;
     } else if (arg == "-fdebug-resolve-names") {


### PR DESCRIPTION
…ed the functionality to bbc, added some option support, and am able to run 3 of the 4 tests. Marked the last as expected fail.

This cuts my REPL time in about half, since only `bbc` has to link rather than both `bbc` and `f18`. Some extra include paths have to be slapped in to get the 4th test to run right, looks like.