### PR TITLE
move safe conversion to builder. rework FirOpBuilder for KindMapping.

### DIFF
--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -13,14 +13,14 @@ ______________
   Intrinsics lowering problems
   . bbc: Lower/Intrinsics.cpp:763: Assertion `false && "LEN_TRIM TODO"' failed.
 
-  lapack/BLAS/SRC/zhemm.f:304:27: 'fir.convert' op invalid type conversion
-  . bbc: This looks like the intrinsic lowering is not converting between floats and complex quite right.
-
   
 FIXED
 _____
 
+
 unexpected character type [xerbla]
+
+intrinsics: zhemm.f:304:27: 'fir.convert' op invalid type conversion
 
 error: 'fir.convert' related to assignments
 

--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -17,10 +17,9 @@ ______________
 FIXED
 _____
 
-
 unexpected character type [xerbla]
 
-intrinsics: zhemm.f:304:27: 'fir.convert' op invalid type conversion
+intrinsics: 'fir.convert' op invalid type conversion
 
 error: 'fir.convert' related to assignments
 

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -19,6 +19,7 @@
 #include "flang/Common/reference.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/KindMapping.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
 #include "mlir/IR/Module.h"
@@ -222,7 +223,8 @@ class FirOpBuilder : public mlir::OpBuilder,
                      public ComplexOpsBuilder<FirOpBuilder>,
                      public IntrinsicCallOpsBuilder<FirOpBuilder> {
 public:
-  using OpBuilder::OpBuilder;
+  explicit FirOpBuilder(mlir::Operation *op, const fir::KindMapping &kindMap)
+      : OpBuilder{op}, kindMap{kindMap} {}
 
   /// TODO: remove this as caching the location may have the location
   /// unexpectedly overridden along the way.
@@ -250,6 +252,11 @@ public:
   mlir::FuncOp getFunction() {
     return getRegion().getParentOfType<mlir::FuncOp>();
   }
+
+  const fir::KindMapping &getKindMap() { return kindMap; }
+
+  mlir::Value convertOnAssign(mlir::Location loc, mlir::Type toTy,
+                              mlir::Value val);
 
   /// Get the entry block of the current Function
   mlir::Block *getEntryBlock() { return &getFunction().front(); }
@@ -394,6 +401,7 @@ public:
 
 private:
   llvm::Optional<mlir::Location> currentLoc{};
+  const fir::KindMapping &kindMap;
 };
 
 } // namespace Fortran::lower


### PR DESCRIPTION
fixes all the internal conversion problems when lowering intrinsics as exposed by BLAS.

After this patch and #29 there are two missing features needed to support BLAS. `DATA` statements and the `LEN_TRIM` intrinsic.