### PR TITLE
LEN_TRIM inline implementation + make character length index type

### DIFF
--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -12,8 +12,6 @@ ______________
 
 [Jean]
 
-  Intrinsics lowering problems
-  . bbc: Lower/Intrinsics.cpp:763: Assertion `false && "LEN_TRIM TODO"' failed.
 
 [unassigned]
 
@@ -23,4 +21,6 @@ ______________
   . Intrinsics.cpp:613! - nint
   . error: unreachable blocks were not converted
   . error: 'llvm.mlir.global' op initializer region type '!llvm.i1' does not match global type '!llvm.i32'
+
+bbc: Missing LEN_TRIM lowering
 

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -78,6 +78,8 @@ public:
   void createAssign(mlir::Value lptr, mlir::Value llen, mlir::Value rptr,
                     mlir::Value rlen);
 
+  mlir::Value createLenTrim(mlir::Value str);
+
   /// Embox \p addr and \p len and return fir.boxchar.
   /// Take care of type conversions before emboxing.
   /// \p len is converted to the integer type for character lengths if needed.

--- a/flang/lib/Lower/Intrinsics.cpp
+++ b/flang/lib/Lower/Intrinsics.cpp
@@ -703,14 +703,12 @@ mlir::Value IntrinsicLibrary::genIchar(mlir::Type resultType,
 }
 
 // LEN_TRIM
-mlir::Value IntrinsicLibrary::genLenTrim(mlir::Type,
+mlir::Value IntrinsicLibrary::genLenTrim(mlir::Type resultType,
                                          llvm::ArrayRef<mlir::Value> args) {
   // Optional KIND argument reflected in result type.
   assert(args.size() >= 1);
-  // FIXME: LEN_TRIM needs actual runtime and to be define in CharRT.h
-  llvm_unreachable("LEN_TRIM TODO");
-  // Fake implementation for debugging:
-  // return builder.createIntegerConstant(resultType, 0);
+  auto len = builder.createLenTrim(args[0]);
+  return builder.createHere<fir::ConvertOp>(resultType, len);
 }
 
 // MERGE
@@ -800,7 +798,7 @@ static mlir::Value createExtremumCompare(Fortran::lower::FirOpBuilder &builder,
       static_assert(behavior == ExtremumBehavior::IeeeMinMaxNum,
                     "ieeeMinNum/ieeeMaxNum behavior not implemented");
     }
-  } else if (type.isa<mlir::IntegerType>()) {
+  } else if (type.isa<mlir::IntegerType>() || type.isa<mlir::IndexType>()) {
     result = builder.createHere<mlir::CmpIOp>(integerPredicate, left, right);
   } else if (type.isa<fir::CharacterType>()) {
     // TODO: ! character min and max is tricky because the result

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -15,10 +15,9 @@ subroutine assign1(lhs, rhs)
 
   ! CHECK: %[[cmp_len:[0-9]+]] = cmpi "slt", %[[lhs:.*]]#1, %[[rhs:.*]]#1
   ! CHECK-NEXT: %[[min_len:[0-9]+]] = select %[[cmp_len]], %[[lhs]]#1, %[[rhs]]#1
-  ! CHECK-NEXT: %[[minIdxLen:.*]] = fir.convert %[[min_len]]
 
   ! Allocate temp in case rhs and lhs may overlap
-  ! CHECK: %[[tmp:.*]] = fir.alloca !fir.char<1>, %[[minIdxLen]]
+  ! CHECK: %[[tmp:.*]] = fir.alloca !fir.char<1>, %[[min_len]]
 
   ! Copy of rhs into temp
   ! CHECK: fir.do_loop %[[i:.*]] =
@@ -63,13 +62,13 @@ subroutine assign_substring1(str, rhs, lb, ub)
 
 
   ! Compute substring length
-  ! CHECK-DAG: %[[diff:.*]] = subi %[[ub]], %[[lb]]
-  ! CHECK-DAG: %[[c1:.*]] = constant 1
+  ! CHECK-DAG: %[[ubi:.*]] = fir.convert %[[ub]] : (i64) -> index
+  ! CHECK-DAG: %[[diff:.*]] = subi %[[ubi]], %[[lbi]]
   ! CHECK-DAG: %[[pre_lhs_len:.*]] = addi %[[diff]], %[[c1]]
   ! CHECK-DAG: %[[c0:.*]] = constant 0
   ! CHECK-DAG: %[[cmp_len:.*]] = cmpi "slt", %[[pre_lhs_len]], %[[c0]]
-  ! CHECK-DAG: %[[lhs_len:.*]] = select %[[cmp_len]], %[[c0]], %[[pre_lhs_len]]
 
+  ! CHECK-DAG: %[[lhs_len:.*]] = select %[[cmp_len]], %[[c0]], %[[pre_lhs_len]]
   ! CHECK: %[[lhs_box:.*]] = fir.emboxchar %[[lhs_addr]], %[[lhs_len]]
 
   ! The rest of the assignment is just as the one above, only test that the


### PR DESCRIPTION
- LEN_TRIM inline implementation as a runtime alternative (until it is there) using fir::iterate_while.
- Also change character length type from i64 to mlir::IndexType (and fix the few places that were expecting i64).