### PR TITLE
Add a static flag on the link line to avoid the linker failing when

### DIFF
--- a/flang/test/Examples/hello.f90
+++ b/flang/test/Examples/hello.f90
@@ -6,7 +6,7 @@
 
 ! RUN: bbc %s -o - | tco | llc --filetype=obj -o %t.o
 ! RUN: %CC -I%S/../.. %S/main.c -c -o %t.main.o
-! RUN: %CC %t.o %t.main.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm
+! RUN: %CC %t.o %t.main.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm -static
 ! RUN: ./a.out | FileCheck %s
 
 ! CHECK: Hello, World!


### PR DESCRIPTION
using the local tools setup.

Can you see if this improves the situation? Thanks.
