### PR TITLE
Fix real**integer lowering regression from #24

### DIFF
--- a/flang/lib/Lower/Intrinsics.cpp
+++ b/flang/lib/Lower/Intrinsics.cpp
@@ -194,7 +194,7 @@ enum MathRuntimeVersion {
   llvmOnly
 };
 llvm::cl::opt<MathRuntimeVersion> mathRuntimeVersion(
-    "math_runtime", llvm::cl::desc("Select math runtime version:"),
+    "math-runtime", llvm::cl::desc("Select math runtime version:"),
     llvm::cl::values(
         clEnumValN(fastVersion, "fast", "use pgmath fast runtime"),
         clEnumValN(relaxedVersion, "relaxed", "use pgmath relaxed runtime"),
@@ -278,17 +278,20 @@ public:
     if (nResults != to.getNumResults() || nInputs != to.getNumInputs()) {
       infinite = true;
     } else {
-      for (decltype(nInputs) i{0}; i < nInputs; ++i)
+      for (decltype(nInputs) i{0}; i < nInputs && !infinite; ++i)
         addArgumentDistance(from.getInput(i), to.getInput(i));
-      for (decltype(nResults) i{0}; i < nResults; ++i)
+      for (decltype(nResults) i{0}; i < nResults && !infinite; ++i)
         addResultDistance(to.getResult(i), from.getResult(i));
     }
   }
+  /// Beware both d1.isSmallerThan(d2) *and* d2.isSmallerThan(d1) may be
+  /// false if both d1 and d2 are infinite. This implies that
+  ///  d1.isSmallerThan(d2) is not equivalent to !d2.isSmallerThan(d1)
   bool isSmallerThan(const FunctionDistance &d) const {
-    return d.infinite ||
-           (!infinite && std::lexicographical_compare(
-                             conversions.begin(), conversions.end(),
-                             d.conversions.begin(), d.conversions.end()));
+    return !infinite &&
+           (d.infinite || std::lexicographical_compare(
+                              conversions.begin(), conversions.end(),
+                              d.conversions.begin(), d.conversions.end()));
   }
   bool isLosingPrecision() const {
     return conversions[narrowingArg] != 0 || conversions[extendingResult] != 0;
@@ -589,8 +592,7 @@ mlir::Value IntrinsicLibrary::genRuntimeCall(llvm::StringRef name,
     for (mlir::Value arg : args) {
       auto actualType = actualFuncType.getInput(i);
       if (soughtFuncType.getInput(i) != actualType) {
-        auto castedArg =
-            builder.convertOnAssign(builder.getLoc(), actualType, arg);
+        auto castedArg = builder.createHere<fir::ConvertOp>(actualType, arg);
         convertedArguments.push_back(castedArg);
       } else {
         convertedArguments.push_back(arg);
@@ -601,8 +603,7 @@ mlir::Value IntrinsicLibrary::genRuntimeCall(llvm::StringRef name,
     mlir::Type soughtType = soughtFuncType.getResult(0);
     mlir::Value res = call.getResult(0);
     if (actualFuncType.getResult(0) != soughtType) {
-      auto castedRes =
-          builder.convertOnAssign(builder.getLoc(), soughtType, res);
+      auto castedRes = builder.createHere<fir::ConvertOp>(soughtType, res);
       return castedRes;
     } else {
       return res;

--- a/flang/runtime/pgmath.h.inc
+++ b/flang/runtime/pgmath.h.inc
@@ -16,6 +16,8 @@
 // intrinsic alphabetical order.
 // Define PGMATH_FAST/RELAXED/PRECISE to restrict the PGMATH_USE visit
 // to the targeted versions.
+// Define PGMATH_USE_OTHER to visit math functions that are not related to
+// floating points (e.g. int**int pow).
 
 // Control Macros
 #ifdef PGMATH_DECLARE
@@ -33,6 +35,7 @@
 #define PGMATH_USE_D(name, func) PGMATH_USE_ALL_TYPES(name, func)
 #define PGMATH_USE_C(name, func) PGMATH_USE_ALL_TYPES(name, func)
 #define PGMATH_USE_Z(name, func) PGMATH_USE_ALL_TYPES(name, func)
+#define PGMATH_USE_OTHER(name, func) PGMATH_USE_ALL_TYPES(name, func)
 #endif
 
 #ifndef PGMATH_USE_S
@@ -49,6 +52,10 @@
 
 #ifndef PGMATH_USE_Z
 #define PGMATH_USE_Z(name, x)
+#endif
+
+#ifndef PGMATH_USE_OTHER
+#define PGMATH_USE_OTHER(name, x)
 #endif
 
 #define PGMATH_REAL_IMPL(impl, func) \
@@ -232,6 +239,41 @@ PGMATH_USE_S(mod, __fs_mod_1)
 PGMATH_USE_D(mod, __fd_mod_1)
 
 PGMATH_ALL2(pow)
+// Versions of pow with integer exponents
+#define PGMATH_DELCARE_POW(impl) \
+  PGMATH_DECLARE(float __##impl##s_powi_1(float, int)) \
+  PGMATH_DECLARE(double __##impl##d_powi_1(double, int)) \
+  PGMATH_DECLARE(float _Complex __##impl##c_powi_1(float _Complex, int)) \
+  PGMATH_DECLARE(double _Complex __##impl##z_powi_1(double _Complex, int)) \
+  PGMATH_USE_S(pow, __##impl##s_powi_1) \
+  PGMATH_USE_D(pow, __##impl##d_powi_1) \
+  PGMATH_USE_C(pow, __##impl##c_powi_1) \
+  PGMATH_USE_Z(pow, __##impl##z_powi_1) \
+  PGMATH_DECLARE(float __##impl##s_powk_1(float, int64_t)) \
+  PGMATH_DECLARE(double __##impl##d_powk_1(double, int64_t)) \
+  PGMATH_DECLARE(float _Complex __##impl##c_powk_1(float _Complex, int64_t)) \
+  PGMATH_DECLARE(double _Complex __##impl##z_powk_1(double _Complex, int64_t)) \
+  PGMATH_USE_S(pow, __##impl##s_powk_1) \
+  PGMATH_USE_D(pow, __##impl##d_powk_1) \
+  PGMATH_USE_C(pow, __##impl##c_powk_1) \
+  PGMATH_USE_Z(pow, __##impl##z_powk_1)
+
+#ifdef PGMATH_FAST
+PGMATH_DELCARE_POW(f)
+#endif
+#ifdef PGMATH_RELAXED
+PGMATH_DELCARE_POW(r)
+#endif
+#ifdef PGMATH_PRECISE
+PGMATH_DELCARE_POW(p)
+#endif
+
+// integer ** integer versions of pow
+PGMATH_DECLARE(int __mth_i_ipowi(int, int))
+PGMATH_DECLARE(int64_t __mth_i_kpowk(int64_t, int64_t))
+PGMATH_USE_OTHER(pow, __mth_i_ipowi)
+PGMATH_USE_OTHER(pow, __mth_i_kpowk)
+
 PGMATH_ALL(sin)
 PGMATH_ALL(sinh)
 PGMATH_MTH_VERSION_REAL(sqrt)
@@ -247,4 +289,5 @@ PGMATH_ALL(tanh)
 #undef PGMATH_USE_D
 #undef PGMATH_USE_C
 #undef PGMATH_USE_Z
+#undef PGMATH_USE_OTHER
 #undef PGMATH_USE_ALL_TYPES

--- a/flang/test/Lower/pow.f90
+++ b/flang/test/Lower/pow.f90
@@ -1,0 +1,81 @@
+! RUN: bbc -emit-fir %s -o - -math-runtime=fast | FileCheck %s
+
+! Test power operation lowering
+
+! CHECK-LABEL: pow_r4_i4
+subroutine pow_r4_i4(x, y, z)
+  real :: x, z
+  integer :: y
+  z = x ** y
+  ! CHECK: call @__fs_powi_1
+end subroutine
+
+! CHECK-LABEL: pow_r4_i8
+subroutine pow_r4_i8(x, y, z)
+  real :: x, z
+  integer(8) :: y
+  z = x ** y
+  ! CHECK: call @__fs_powk_1
+end subroutine
+
+! CHECK-LABEL: pow_r8_i4
+subroutine pow_r8_i4(x, y, z)
+  real(8) :: x, z
+  integer :: y
+  z = x ** y
+  ! CHECK: call @__fd_powi_1
+end subroutine
+
+! CHECK-LABEL: pow_r8_i8
+subroutine pow_r8_i8(x, y, z)
+  real(8) :: x, z
+  integer(8) :: y
+  z = x ** y
+  ! CHECK: call @__fd_powk_1
+end subroutine
+
+! CHECK-LABEL: pow_i4_i4
+subroutine pow_i4_i4(x, y, z)
+  integer(4) :: x, y, z
+  z = x ** y
+  ! CHECK: call @__mth_i_ipowi
+end subroutine
+
+! CHECK-LABEL: pow_i8_i8
+subroutine pow_i8_i8(x, y, z)
+  integer(8) :: x, y, z
+  z = x ** y
+  ! CHECK: call @__mth_i_kpowk
+end subroutine
+
+! CHECK-LABEL: pow_c4_i4
+subroutine pow_c4_i4(x, y, z)
+  complex :: x, z
+  integer :: y
+  z = x ** y
+  ! CHECK: call @__fc_powi_1
+end subroutine
+
+! CHECK-LABEL: pow_c4_i8
+subroutine pow_c4_i8(x, y, z)
+  complex :: x, z
+  integer(8) :: y
+  z = x ** y
+  ! CHECK: call @__fc_powk_1
+end subroutine
+
+! CHECK-LABEL: pow_c8_i4
+subroutine pow_c8_i4(x, y, z)
+  complex(8) :: x, z
+  integer :: y
+  z = x ** y
+  ! CHECK: call @__fz_powi_1
+end subroutine
+
+! CHECK-LABEL: pow_c8_i8
+subroutine pow_c8_i8(x, y, z)
+  complex(8) :: x, z
+  integer(8) :: y
+  z = x ** y
+  ! CHECK: call @__fz_powk_1
+end subroutine


### PR DESCRIPTION
As discussed in [here](https://github.com/flang-compiler/f18-llvm-project/pull/31#discussion_r417429744) in #31, there was a regression in runtime mapping to intrinsics after #34 refactoring.
It turns out all `thing**integer` runtime were now missing from the mapping and the code was trying to use the complex**complex runtime to lower them.
1. Add the missing runtime (It is not used in folding that has implementation on the abstract types for it, so it was not missing there).
2. Fix the runtime mapping code to fail has it should have instead of trying to generate bad code. Remove the `convertOnAssign` that should not be used here (only harmless conversions should be generated by this utility).
3. Add tests for all flavors of pow.