### PR TITLE
Internal boxing

### DIFF
--- a/flang/include/flang/Lower/Bridge.h
+++ b/flang/include/flang/Lower/Bridge.h
@@ -18,8 +18,10 @@
 #define FORTRAN_LOWER_BRIDGE_H_
 
 #include "flang/Common/Fortran.h"
+#include "flang/Lower/Support/BoxValue.h"
 #include "flang/Optimizer/Support/KindMapping.h"
 #include "mlir/IR/Module.h"
+#include <variant>
 
 namespace Fortran {
 namespace common {
@@ -60,6 +62,10 @@ namespace Fortran::lower {
 using SomeExpr = evaluate::Expr<evaluate::SomeType>;
 using SymbolRef = common::Reference<const semantics::Symbol>;
 class FirOpBuilder;
+
+using ExValue =
+    std::variant<fir::UnboxedValue, fir::CharBoxValue, fir::ArrayBoxValue,
+                 fir::CharArrayBoxValue, fir::BoxValue, fir::ProcBoxValue>;
 
 //===----------------------------------------------------------------------===//
 

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -1,0 +1,122 @@
+//===-- Lower/Support/BoxValue.h -- FIR box values --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LOWER_SUPPORT_BOXVALUE_H
+#define LOWER_SUPPORT_BOXVALUE_H
+
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace fir {
+
+//===----------------------------------------------------------------------===//
+//
+// Boxed values
+//
+// Define a set of containers to use internally to keep track of extended values
+// associated with a Fortran subexpression. These associations are maintained
+// during the construction of FIR.
+//
+//===----------------------------------------------------------------------===//
+
+/// Most expressions of intrinsic type can be passed unboxed. Their properties are known statically.
+using UnboxedValue = mlir::Value;
+
+/// Abstract base class.
+struct AbstractBox {
+  AbstractBox() = delete;
+  AbstractBox(mlir::Value addr) : baseAddr{addr} {}
+  mlir::Value getAddr() const { return baseAddr; }
+  
+  mlir::Value baseAddr;
+};
+
+/// Expressions of CHARACTER type have an associated, possibly dynamic LEN value.
+struct CharBoxValue : public AbstractBox {
+  CharBoxValue(mlir::Value addr, mlir::Value len)
+      : AbstractBox{addr}, len{len} {}
+
+  mlir::Value getLen() const { return len; }
+  
+  mlir::Value len;
+};
+
+/// Abstract base class.
+/// Expressions of type array have at minimum a shape. These expressions may have lbound attributes (dynamic values) that affect the interpretation of indexing expressions.
+struct AbstractArrayBox {
+  AbstractArrayBox() = default;
+  AbstractArrayBox(llvm::ArrayRef<mlir::Value> extents,
+                   llvm::ArrayRef<mlir::Value> lbounds)
+      : extents{extents.begin(), extents.end()}, lbounds{lbounds.begin(),
+                                                         lbounds.end()} {}
+
+  // Every array has extents that describe its shape.
+  const llvm::SmallVectorImpl<mlir::Value> &getExtends() const {
+    return extents;
+  }
+
+  // An array expression may have user-defined lower bound values.
+  // If this vector is empty, the default in all dimensions in `1`.
+  const llvm::SmallVectorImpl<mlir::Value> &getLBounds() const {
+    return lbounds;
+  }
+
+  bool lboundsAllOne() const { return lbounds.empty(); }
+
+  llvm::SmallVector<mlir::Value, 4> extents;
+  llvm::SmallVector<mlir::Value, 4> lbounds;
+};
+
+/// Expressions with rank > 0 have extents. They may also have lbounds that are
+/// not 1.
+struct ArrayBoxValue : public AbstractBox, public AbstractArrayBox {
+  ArrayBoxValue(mlir::Value addr, llvm::ArrayRef<mlir::Value> extents,
+                llvm::ArrayRef<mlir::Value> lbounds = {})
+      : AbstractBox{addr}, AbstractArrayBox{extents, lbounds} {}
+};
+
+/// Expressions of type CHARACTER and with rank > 0.
+struct CharArrayBoxValue : public CharBoxValue, public AbstractArrayBox {
+  CharArrayBoxValue(mlir::Value addr, mlir::Value len,
+                    llvm::ArrayRef<mlir::Value> extents,
+                    llvm::ArrayRef<mlir::Value> lbounds = {})
+      : CharBoxValue{addr, len}, AbstractArrayBox{extents, lbounds} {}
+};
+
+/// Expressions that are procedure POINTERs may need a set of references to
+/// variables in the host scope.
+struct ProcBoxValue : public AbstractBox {
+  ProcBoxValue(mlir::Value addr, mlir::Value context)
+      : AbstractBox{addr}, hostContext{context} {}
+
+  mlir::Value hostContext;
+};
+
+/// In the generalized form, a boxed value can have a dynamic size, be an array
+/// with dynamic extents and lbounds, and take dynamic type parameters.
+struct BoxValue : public AbstractBox, public AbstractArrayBox {
+  BoxValue(mlir::Value addr) : AbstractBox{addr}, AbstractArrayBox{} {}
+  BoxValue(mlir::Value addr, mlir::Value len)
+      : AbstractBox{addr}, AbstractArrayBox{}, len{len} {}
+  BoxValue(mlir::Value addr, llvm::ArrayRef<mlir::Value> extents,
+           llvm::ArrayRef<mlir::Value> lbounds = {})
+      : AbstractBox{addr}, AbstractArrayBox{extents, lbounds} {}
+  BoxValue(mlir::Value addr, mlir::Value len,
+           llvm::ArrayRef<mlir::Value> params,
+           llvm::ArrayRef<mlir::Value> extents,
+           llvm::ArrayRef<mlir::Value> lbounds = {})
+      : AbstractBox{addr}, AbstractArrayBox{extents, lbounds}, len{len},
+        params{params.begin(), params.end()} {}
+
+  mlir::Value len;
+  llvm::SmallVector<mlir::Value, 2> params;
+};
+
+} // namespace fir
+
+#endif // LOWER_SUPPORT_BOXVALUE_H

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1764,7 +1764,7 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]> {
   let summary = "insert a new sub-value into a copy of an existing aggregate";
 
   let description = [{
-    Insert a value from an entity with a type composed of tuples, arrays,
+    Insert a value into an entity with a type composed of tuples, arrays,
     and/or derived types. Returns a new ssa value with the same type as the
     original entity. Cannot be used on values of `!fir.box` type.
 
@@ -1783,6 +1783,24 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]> {
   let arguments = (ins AnyCompositeLike:$adt, AnyType:$val,
                        Variadic<AnyComponentType>:$coor);
   let results = (outs AnyCompositeLike);
+
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoSideEffect]> {
+  let summary = "insert sub-value into a range on an existing sequence";
+
+  let description = [{
+    Insert a constant value into an entity with an array type. Returns a
+    new ssa value where the range of offsets from the original array have been
+    replaced with the constant. The result is an array type entity.
+  }];
+
+  let arguments = (ins fir_SequenceType:$seq, AnyType:$val,
+                       Index:$start, Index:$end);
+  let results = (outs fir_SequenceType);
 
   let assemblyFormat = [{
     operands attr-dict `:` functional-type(operands, results)

--- a/flang/lib/Lower/CharRT.cpp
+++ b/flang/lib/Lower/CharRT.cpp
@@ -107,10 +107,10 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
     llvm_unreachable("runtime does not support CHARACTER KIND");
   }
   auto fTy = beginFunc.getType();
-  auto lptr = builder.create<fir::ConvertOp>(loc, fTy.getInput(0), lhsBuff);
-  auto llen = builder.create<fir::ConvertOp>(loc, fTy.getInput(2), lhsLen);
-  auto rptr = builder.create<fir::ConvertOp>(loc, fTy.getInput(1), rhsBuff);
-  auto rlen = builder.create<fir::ConvertOp>(loc, fTy.getInput(3), rhsLen);
+  auto lptr = builder.createConvert(loc, fTy.getInput(0), lhsBuff);
+  auto llen = builder.createConvert(loc, fTy.getInput(2), lhsLen);
+  auto rptr = builder.createConvert(loc, fTy.getInput(1), rhsBuff);
+  auto rlen = builder.createConvert(loc, fTy.getInput(3), rhsLen);
   llvm::SmallVector<mlir::Value, 4> args = {lptr, rptr, llen, rlen};
   auto tri = builder.create<mlir::CallOp>(loc, beginFunc, args).getResult(0);
   auto zero = builder.createIntegerConstant(tri.getType(), 0);

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -34,9 +34,7 @@ int64_t toConstant(const Fortran::evaluate::Expr<A> &e) {
 }
 
 #undef TODO
-#define TODO()                                                                 \
-  assert(false && "not yet implemented");                                      \
-  return {}
+#define TODO() llvm_unreachable("not yet implemented")
 
 // one argument template, must be specialized
 template <Fortran::common::TypeCategory TC>

--- a/flang/lib/Lower/Intrinsics.cpp
+++ b/flang/lib/Lower/Intrinsics.cpp
@@ -610,10 +610,7 @@ mlir::Value IntrinsicLibrary::genRuntimeCall(llvm::StringRef name,
     }
   } else {
     // could not find runtime function
-    llvm::errs() << "missing intrinsic: " << name << "\n";
-    llvm_unreachable("no runtime found for this intrinsics");
-    // TODO: better error handling ?
-    //  - Try to have compile time check of runtime completeness ?
+    llvm::report_fatal_error("missing intrinsic: " + llvm::Twine(name) + "\n");
   }
   return {}; // gets rid of warnings
 }
@@ -622,7 +619,7 @@ mlir::Value IntrinsicLibrary::genConversion(mlir::Type resultType,
                                             llvm::ArrayRef<mlir::Value> args) {
   // There can be an optional kind in second argument.
   assert(args.size() >= 1);
-  return builder.convertOnAssign(builder.getLoc(), resultType, args[0]);
+  return builder.convertWithSemantics(builder.getLoc(), resultType, args[0]);
 }
 
 // ABS

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -86,6 +86,10 @@ Fortran::lower::mangle::mangleName(fir::NameUniquer &uniquer,
           },
           [&](const Fortran::semantics::ProcEntityDetails &) {
             auto modNames = moduleNames(ultimateSymbol);
+            // Does an subprogram declared external ever require a scope prefix?
+            if (Fortran::semantics::IsExternal(ultimateSymbol))
+              return uniquer.doProcedure(llvm::None, llvm::None,
+                                         toStringRef(symbolName));
             return uniquer.doProcedure(modNames, hostName(ultimateSymbol),
                                        toStringRef(symbolName));
           },

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -99,7 +99,7 @@ struct SymIndex {
     mlir::Value addr;
     mlir::Value size;                         // element size or null
     llvm::SmallVector<Bounds, 4> shape;       // empty for scalar
-    llvm::SmallVector<mlir::Value, 4> params; // LEN type parameters, if any
+    llvm::SmallVector<mlir::Value, 2> params; // LEN type parameters, if any
   };
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
This is some very initial work in threading box values into the bridge.  It is nowhere close to done, but it is meant to signal what is coming.

Specifically, Fortran "values" are aggregate in the sense that they are supported by other runtime values (attributes). In order for Burnside to begin lowering these more complicated objects, it needs to model these extended values and (probably) the evaluation context. This patch is to start moving the bridge in that direction and break the scalar/value correspondence we've leaned on to date.
