### PR TITLE
LAPACK: fix for implicit subprogram argument types

### DIFF
--- a/flang/lib/Lower/CharRT.cpp
+++ b/flang/lib/Lower/CharRT.cpp
@@ -107,10 +107,10 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
     llvm_unreachable("runtime does not support CHARACTER KIND");
   }
   auto fTy = beginFunc.getType();
-  auto lptr = builder.create<fir::ConvertOp>(loc, fTy.getInput(0), lhsBuff);
-  auto llen = builder.create<fir::ConvertOp>(loc, fTy.getInput(2), lhsLen);
-  auto rptr = builder.create<fir::ConvertOp>(loc, fTy.getInput(1), rhsBuff);
-  auto rlen = builder.create<fir::ConvertOp>(loc, fTy.getInput(3), rhsLen);
+  auto lptr = builder.createConvert(loc, fTy.getInput(0), lhsBuff);
+  auto llen = builder.createConvert(loc, fTy.getInput(2), lhsLen);
+  auto rptr = builder.createConvert(loc, fTy.getInput(1), rhsBuff);
+  auto rlen = builder.createConvert(loc, fTy.getInput(3), rhsLen);
   llvm::SmallVector<mlir::Value, 4> args = {lptr, rptr, llen, rlen};
   auto tri = builder.create<mlir::CallOp>(loc, beginFunc, args).getResult(0);
   auto zero = builder.createIntegerConstant(tri.getType(), 0);

--- a/flang/lib/Lower/Intrinsics.cpp
+++ b/flang/lib/Lower/Intrinsics.cpp
@@ -610,10 +610,7 @@ mlir::Value IntrinsicLibrary::genRuntimeCall(llvm::StringRef name,
     }
   } else {
     // could not find runtime function
-    llvm::errs() << "missing intrinsic: " << name << "\n";
-    llvm_unreachable("no runtime found for this intrinsics");
-    // TODO: better error handling ?
-    //  - Try to have compile time check of runtime completeness ?
+    llvm::report_fatal_error("missing intrinsic: " + llvm::Twine(name) + "\n");
   }
   return {}; // gets rid of warnings
 }
@@ -622,7 +619,7 @@ mlir::Value IntrinsicLibrary::genConversion(mlir::Type resultType,
                                             llvm::ArrayRef<mlir::Value> args) {
   // There can be an optional kind in second argument.
   assert(args.size() >= 1);
-  return builder.convertOnAssign(builder.getLoc(), resultType, args[0]);
+  return builder.convertWithSemantics(builder.getLoc(), resultType, args[0]);
 }
 
 // ABS


### PR DESCRIPTION
Generally, move towards making conversions more formal in the bridge.