### PR TITLE
Lower NINT/FLOOR intrinsic and update STOP/ERROR STOP lowering

### DIFF
--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -11,9 +11,8 @@ ______________
   . error: 'llvm.mlir.global' op initializer region type '!llvm.i1' does not match global type '!llvm.i32'
 
 [Jean]
-
-  . have lowering call the runtime STOP function (instead of the dummy standin)
-  . Intrinsics.cpp:613! - nint
+  . ConvertExpr.cpp:266 - character comparison
+  . ConvertExpr.cpp:458! - concat CHARs
 
 [Val]
 
@@ -23,8 +22,6 @@ ______________
 
 [unassigned]
 
-  . lapack/SRC/sgbcon.f - ConvertExpr.cpp:266 - character comparison
-  . lapack/SRC/sgesvd.f - ConvertExpr.cpp:458! - concat CHARs
   . lapack/SRC/sbdsvdx.f - ConvertExpr.cpp:711! - Ev::Triplet
   . lapack/INSTALL/second_INT_ETIME.f - 'etime' is not a known intrinsic procedure
   . lapack/SRC/chla_transtype.f - type of return operand 0 ('!fir.array<1x!fir.char<1>>') doesn't match function result type ('!fir.char<1>')
@@ -34,7 +31,9 @@ ______________
 FIXED
 _____
 
-bbc: Missing LEN_TRIM lowering
+  . Missing LEN_TRIM lowering
+  . Missing NINT lowering
+  . STOP runtime mismatch
 
   . ConvertExpr.cpp:193 - function type mismatch
   . 'std.call' op incorrect number of operands for callee

--- a/flang/include/flang/Lower/Runtime.h
+++ b/flang/include/flang/Lower/Runtime.h
@@ -202,7 +202,8 @@ private:
 enum class RuntimeEntryCode {
   StopStatement,
   StopStatementText,
-  FailImageStatement
+  FailImageStatement,
+  ProgramEndStatement
 };
 
 mlir::FuncOp genRuntimeFunction(RuntimeEntryCode code,

--- a/flang/include/flang/Lower/Runtime.h
+++ b/flang/include/flang/Lower/Runtime.h
@@ -197,17 +197,12 @@ private:
   Range range{nullptr, nullptr};
 };
 
-// Define Fortran related language (other than IO and maths)
-// TODO: complete this list while working on the runtime.
-enum class RuntimeEntryCode {
-  StopStatement,
-  StopStatementText,
-  FailImageStatement,
-  ProgramEndStatement
-};
+// Define Fortran statement related runtime (other than IO and maths)
 
-mlir::FuncOp genRuntimeFunction(RuntimeEntryCode code,
-                                Fortran::lower::FirOpBuilder &builder);
+mlir::FuncOp genStopStatementRuntime(FirOpBuilder &);
+mlir::FuncOp genStopStatementTextRuntime(FirOpBuilder &);
+mlir::FuncOp genFailImageStatementRuntime(FirOpBuilder &);
+mlir::FuncOp genProgramEndStatementRuntime(FirOpBuilder &);
 
 } // namespace Fortran::lower
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1519,7 +1519,46 @@ private:
               const Fortran::parser::StopStmt &stmt) {
     auto callee = genRuntimeFunction(
         Fortran::lower::RuntimeEntryCode::StopStatement, *builder);
+    auto calleeType = callee.getType();
     llvm::SmallVector<mlir::Value, 8> operands;
+    assert(calleeType.getNumInputs() == 3 &&
+           "expected 3 arguments in STOP runtime");
+    // First operand is stop code (zero if absent)
+    if (const auto &code =
+            std::get<std::optional<Fortran::parser::StopCode>>(stmt.t)) {
+      auto expr = Fortran::semantics::GetExpr(*code);
+      assert(expr && "failed getting typed expression");
+      operands.push_back(genExprValue(*expr));
+    } else {
+      operands.push_back(
+          builder->createIntegerConstant(calleeType.getInput(0), 0));
+    }
+    // Second operand indicates ERROR STOP
+    bool isError = std::get<Fortran::parser::StopStmt::Kind>(stmt.t) ==
+                   Fortran::parser::StopStmt::Kind::ErrorStop;
+    operands.push_back(
+        builder->createIntegerConstant(calleeType.getInput(1), isError));
+
+    // Third operand indicates QUIET (default to false).
+    if (const auto &quiet =
+            std::get<std::optional<Fortran::parser::ScalarLogicalExpr>>(
+                stmt.t)) {
+      auto expr = Fortran::semantics::GetExpr(*quiet);
+      assert(expr && "failed getting typed expression");
+      operands.push_back(genExprValue(*expr));
+    } else {
+      operands.push_back(
+          builder->createIntegerConstant(calleeType.getInput(2), 0));
+    }
+
+    // Cast operands in case they have different integer/logical types
+    // compare to runtime.
+    auto i = 0;
+    for (auto &op : operands) {
+      auto type = calleeType.getInput(i++);
+      if (op.getType() != type)
+        op = builder->create<fir::ConvertOp>(toLocation(), type, op);
+    }
     builder->create<mlir::CallOp>(toLocation(), callee, operands);
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1508,8 +1508,7 @@ private:
   // call FAIL IMAGE in runtime
   void genFIR(Fortran::lower::pft::Evaluation &eval,
               const Fortran::parser::FailImageStmt &stmt) {
-    auto callee = genRuntimeFunction(
-        Fortran::lower::RuntimeEntryCode::FailImageStatement, *builder);
+    auto callee = genFailImageStatementRuntime(*builder);
     llvm::SmallVector<mlir::Value, 1> operands; // FAIL IMAGE has no args
     builder->create<mlir::CallOp>(toLocation(), callee, operands);
   }
@@ -1517,8 +1516,7 @@ private:
   // call STOP, ERROR STOP in runtime
   void genFIR(Fortran::lower::pft::Evaluation &eval,
               const Fortran::parser::StopStmt &stmt) {
-    auto callee = genRuntimeFunction(
-        Fortran::lower::RuntimeEntryCode::StopStatement, *builder);
+    auto callee = genStopStatementRuntime(*builder);
     auto calleeType = callee.getType();
     llvm::SmallVector<mlir::Value, 8> operands;
     assert(calleeType.getNumInputs() == 3 &&
@@ -1556,8 +1554,7 @@ private:
     auto i = 0;
     for (auto &op : operands) {
       auto type = calleeType.getInput(i++);
-      if (op.getType() != type)
-        op = builder->create<fir::ConvertOp>(toLocation(), type, op);
+      op = builder->createConvert(toLocation(), type, op);
     }
     builder->create<mlir::CallOp>(toLocation(), callee, operands);
   }

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -7,102 +7,45 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Runtime.h"
+#include "RTBuilder.h"
 #include "flang/Lower/FIRBuilder.h"
-#include "mlir/IR/StandardTypes.h"
-#include "mlir/IR/Types.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/ErrorHandling.h"
 
-namespace Fortran::lower {
+#include "../runtime/stop.h"
 
-mlir::Type RuntimeStaticDescription::getMLIRType(TypeCode t,
-                                                 mlir::MLIRContext *context) {
-  switch (t) {
-  case TypeCode::i32:
-    return mlir::IntegerType::get(32, context);
-  case TypeCode::i64:
-    return mlir::IntegerType::get(64, context);
-  case TypeCode::f32:
-    return mlir::FloatType::getF32(context);
-  case TypeCode::f64:
-    return mlir::FloatType::getF64(context);
-  // TODO need to access mapping between fe/target
-  case TypeCode::c32:
-    return fir::CplxType::get(context, 4);
-  case TypeCode::c64:
-    return fir::CplxType::get(context, 8);
-  case TypeCode::boolean:
-    return mlir::IntegerType::get(8, context);
-  case TypeCode::charPtr:
-    return fir::ReferenceType::get(fir::CharacterType::get(context, 1));
-  // ! IOCookie is experimental only so far
-  case TypeCode::IOCookie:
-    return fir::ReferenceType::get(mlir::IntegerType::get(64, context));
-  }
-  llvm_unreachable("bug");
-  return {};
-}
-
-mlir::FunctionType RuntimeStaticDescription::getMLIRFunctionType(
-    mlir::MLIRContext *context) const {
-  llvm::SmallVector<mlir::Type, 2> argMLIRTypes;
-  for (const TypeCode &t : argumentTypeCodes) {
-    argMLIRTypes.push_back(getMLIRType(t, context));
-  }
-  if (resultTypeCode.has_value()) {
-    mlir::Type resMLIRType{getMLIRType(*resultTypeCode, context)};
-    return mlir::FunctionType::get(argMLIRTypes, resMLIRType, context);
-  }
-  return mlir::FunctionType::get(argMLIRTypes, {}, context);
-}
-
-mlir::FuncOp RuntimeStaticDescription::getFuncOp(
-    Fortran::lower::FirOpBuilder &builder) const {
-  auto module = builder.getModule();
-  auto funTy = getMLIRFunctionType(module.getContext());
-  auto function = builder.addNamedFunction(symbol, funTy);
-  function.setAttr("fir.runtime", builder.getUnitAttr());
-  if (funTy != function.getType())
-    llvm_unreachable("runtime function type mismatch");
-  return function;
-}
-
-class RuntimeEntryDescription : public RuntimeStaticDescription {
-public:
-  using Key = RuntimeEntryCode;
-  constexpr RuntimeEntryDescription(Key k, const char *s, MaybeTypeCode r,
-                                    TypeCodeVector a)
-      : RuntimeStaticDescription{s, r, a}, key{k} {}
+struct RuntimeEntry {
+  using Key = Fortran::lower::RuntimeEntryCode;
   Key key;
+  llvm::StringRef symbol;
+  Fortran::lower::FuncTypeBuilderFunc typeBuilder;
 };
 
-static constexpr RuntimeEntryDescription runtimeTable[]{
-    {RuntimeEntryCode::StopStatement, "StopStatement",
-     RuntimeStaticDescription::voidTy,
-     RuntimeStaticDescription::TypeCodeVector::create<
-         RuntimeStaticDescription::TypeCode::i32,
-         RuntimeStaticDescription::TypeCode::boolean,
-         RuntimeStaticDescription::TypeCode::boolean>()},
-    {RuntimeEntryCode::StopStatementText, "StopStatementText",
-     RuntimeStaticDescription::voidTy,
-     RuntimeStaticDescription::TypeCodeVector::create<
-         RuntimeStaticDescription::TypeCode::charPtr,
-         RuntimeStaticDescription::TypeCode::i32,
-         RuntimeStaticDescription::TypeCode::boolean,
-         RuntimeStaticDescription::TypeCode::boolean>()},
-    {RuntimeEntryCode::FailImageStatement, "StopStatementText",
-     RuntimeStaticDescription::voidTy,
-     RuntimeStaticDescription::TypeCodeVector::create<>()},
-};
+#define QUOTE_HELPER(X) #X
+#define QUOTE(X) QUOTE_HELPER(X)
+#define QUOTE_RTNAME(X) QUOTE(RTNAME(X))
 
-static constexpr StaticMultimapView<RuntimeEntryDescription> runtimeMap{
-    runtimeTable};
+#define MakeEntry(X)                                                           \
+  {                                                                            \
+    Fortran::lower::RuntimeEntryCode::X, QUOTE_RTNAME(X),                      \
+        Fortran::lower::RuntimeTableKey<decltype(RTNAME(X))>::getTypeModel()   \
+  }
 
-mlir::FuncOp genRuntimeFunction(RuntimeEntryCode code,
-                                Fortran::lower::FirOpBuilder &builder) {
-  auto description = runtimeMap.find(code);
-  assert(description != runtimeMap.end());
-  return description->getFuncOp(builder);
+static constexpr RuntimeEntry runtimeTable[]{
+    MakeEntry(StopStatement), MakeEntry(StopStatementText),
+    MakeEntry(FailImageStatement), MakeEntry(ProgramEndStatement)};
+
+static constexpr Fortran::lower::StaticMultimapView runtimeMap(runtimeTable);
+
+mlir::FuncOp
+Fortran::lower::genRuntimeFunction(RuntimeEntryCode code,
+                                   Fortran::lower::FirOpBuilder &builder) {
+  auto entry = runtimeMap.find(code);
+  assert(entry != runtimeMap.end());
+  auto func = builder.getNamedFunction(entry->symbol);
+  if (func)
+    return func;
+  auto funTy = entry->typeBuilder(builder.getContext());
+  func = builder.createFunction(entry->symbol, funTy);
+  func.setAttr("fir.runtime", builder.getUnitAttr());
+  return func;
 }
-
-} // namespace Fortran::lower

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -44,6 +44,25 @@ subroutine dble_test(a)
   print *, dble(a)
 end subroutine
 
+! CEILING
+! CHECK-LABEL: ceiling_test1
+subroutine ceiling_test1(i, a)
+  integer :: i
+  real :: a
+  i = ceiling(a)
+  ! CHECK: %[[f:.*]] = call @llvm.ceil.f32
+  ! CHECK: fir.convert %[[f]] : (f32) -> i32
+end subroutine
+! CHECK-LABEL: ceiling_test2
+subroutine ceiling_test2(i, a)
+  integer(8) :: i
+  real :: a
+  i = ceiling(a, 8)
+  ! CHECK: %[[f:.*]] = call @llvm.ceil.f32
+  ! CHECK: fir.convert %[[f]] : (f32) -> i64
+end subroutine
+
+
 ! CONJG
 ! CHECK-LABEL: conjg_test
 subroutine conjg_test(z1, z2)
@@ -52,6 +71,24 @@ subroutine conjg_test(z1, z2)
   ! CHECK: fir.negf
   ! CHECK: fir.insert_value
   z2 = conjg(z1)
+end subroutine
+
+! FLOOR
+! CHECK-LABEL: floor_test1
+subroutine floor_test1(i, a)
+  integer :: i
+  real :: a
+  i = floor(a)
+  ! CHECK: %[[f:.*]] = call @llvm.floor.f32
+  ! CHECK: fir.convert %[[f]] : (f32) -> i32
+end subroutine
+! CHECK-LABEL: floor_test2
+subroutine floor_test2(i, a)
+  integer(8) :: i
+  real :: a
+  i = floor(a, 8)
+  ! CHECK: %[[f:.*]] = call @llvm.floor.f32
+  ! CHECK: fir.convert %[[f]] : (f32) -> i64
 end subroutine
 
 ! ICHAR
@@ -72,7 +109,7 @@ subroutine len_test(i, c)
 end subroutine
 
 ! LEN_TRIM
-!CHECK-LABEL: len_trim_test
+! CHECK-LABEL: len_trim_test
 integer function len_trim_test(c)
   character(*) :: c
   ltrim = len_trim(c)
@@ -90,6 +127,22 @@ integer function len_trim_test(c)
   ! CHECK-DAG: %[[len:.*]] = addi %[[lastIndex]], %[[c1]]
   ! CHECK: select %[[iterateResult]], %[[c0]], %[[len]]
 end function
+
+! NINT
+! CHECK-LABEL: nint_test1
+subroutine nint_test1(i, a)
+  integer :: i
+  real :: a
+  i = nint(a)
+  ! CHECK: call @llvm.lround.i32.f32
+end subroutine
+! CHECK-LABEL: nint_test2
+subroutine nint_test2(i, a)
+  integer(8) :: i
+  real(8) :: a
+  i = nint(a, 8)
+  ! CHECK: call @llvm.lround.i64.f64
+end subroutine
 
 
 

--- a/flang/test/Lower/stop.f90
+++ b/flang/test/Lower/stop.f90
@@ -1,0 +1,51 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL stop_test
+subroutine stop_test(b)
+ ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
+ ! CHECK-DAG: %[[false:.*]] = constant 0 : i1
+ ! CHECK-DAG: %[[false_0:.*]] = constant 0 : i1
+ ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[false_0]])
+ stop
+end subroutine
+! CHECK: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none
+
+! CHECK-LABEL stop_code
+subroutine stop_code()
+  stop 42
+ ! CHECK-DAG: %[[c42:.*]] = constant 42 : i32
+ ! CHECK-DAG: %[[false:.*]] = constant 0 : i1
+ ! CHECK-DAG: %[[false_0:.*]] = constant 0 : i1
+ ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c42]], %[[false]], %[[false_0]])
+end subroutine
+
+! CHECK-LABEL stop_error
+subroutine stop_error()
+  error stop
+ ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
+ ! CHECK-DAG: %[[true:.*]] = constant 1 : i1
+ ! CHECK-DAG: %[[false:.*]] = constant 0 : i1
+ ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[true]], %[[false]])
+end subroutine
+
+! CHECK-LABEL stop_quiet
+subroutine stop_quiet(b)
+  logical :: b
+  stop, quiet = b
+ ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
+ ! CHECK-DAG: %[[false:.*]] = constant 0 : i1
+ ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
+ ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
+ ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[bi1]])
+end subroutine
+
+! CHECK-LABEL stop_error_code_quiet
+subroutine stop_error_code_quiet(b)
+  logical :: b
+  error stop 66, quiet = b
+ ! CHECK-DAG: %[[c66:.*]] = constant 66 : i32
+ ! CHECK-DAG: %[[true:.*]] = constant 1 : i1
+ ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
+ ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
+ ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c66]], %[[true]], %[[bi1]])
+end subroutine


### PR DESCRIPTION
- Lower NINT/FLOOR using LLVM lround/floor intrinsics
- Use RTBuilder.h to get stop runtime interface and update STOP statement lowering to use it.
