### PR TITLE
need to flip from column-major to row-major when converting to LLVM.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -144,7 +144,7 @@ public:
   static CplxType get(mlir::MLIRContext *ctxt, KindTy kind);
 
   /// Get the corresponding fir.real<k> type.
-  mlir::Type getElementType() const;
+  mlir::Type getEleTy() const;
 
   KindTy getFKind() const;
 };

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -910,7 +910,7 @@ CplxType fir::CplxType::get(mlir::MLIRContext *ctxt, KindTy kind) {
   return Base::get(ctxt, FIR_COMPLEX, kind);
 }
 
-mlir::Type fir::CplxType::getElementType() const {
+mlir::Type fir::CplxType::getEleTy() const {
   return fir::RealType::get(getContext(), getFKind());
 }
 


### PR DESCRIPTION
Fix a bug that was blocking Varun.