### PR TITLE
Fix two control flow bugs in lapack files.

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1577,10 +1577,17 @@ private:
                           : eval.block);
     }
     eval.visit([&](const auto &stmt) { genFIR(eval, stmt); });
-    if (unstructuredContext && eval.isActionStmt() && eval.controlSuccessor &&
-        eval.controlSuccessor->block && blockIsUnterminated()) {
+    if (unstructuredContext && blockIsUnterminated()) {
       // Exit from an unstructured IF or SELECT construct block.
-      genBranch(eval.controlSuccessor->block);
+      Fortran::lower::pft::Evaluation *successor{};
+      if (eval.isActionStmt())
+        successor = eval.controlSuccessor;
+      else if (eval.isConstruct() &&
+               eval.evaluationList->back()
+                   .lexicalSuccessor->isIntermediateConstructStmt())
+        successor = eval.constructExit;
+      if (successor && successor->block)
+        genBranch(successor->block);
     }
   }
 


### PR DESCRIPTION
File sgtsv.f has a problem transitioning from a structured DO construct
to its containing IF construct.  This problem is fixed in Bridge.cpp.

File dsyevd_2stage.f contains dead code following a RETURN statement
that results in an illegal basic block with multiple terminators.  The
illegal basic block is fixed in PFTBuilder.cpp.  Compilation will still
fail with this fix until a dead code elimination pass is implemented.
Most of the PFTBuilder.cpp changes are cleanup changes.