### PR TITLE
quick and dirty

### DIFF
--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -225,7 +225,7 @@ static void convertFortranSourceToMLIR(
   pm.addPass(mlir::createLowerToCFGPass());
   // pm.addPass(fir::createMemToRegPass());
   pm.addPass(fir::createCSEPass());
-  pm.addPass(mlir::createCanonicalizerPass());
+  //pm.addPass(mlir::createCanonicalizerPass());
 
   if (emitLLVM) {
     // Continue to lower from MLIR down to LLVM IR. Emit LLVM and MLIR.


### PR DESCRIPTION
workaround some bug in canonicalize that is causing failure in sgbsvx, etc.

I'm just going to comment the canonicalize pass out for now and until I can spend more time figuring out where it's going cray-cray.