### PR TITLE
Scalar character concatenation

### DIFF
--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -14,8 +14,10 @@ ______________
   . lapack/INSTALL/second_INT_ETIME.f - 'etime' is not a known intrinsic procedure
   . lapack/INSTALL/dsecnd_INT_ETIME.f - Failed in semantics
   . lapack/INSTALL/second_INT_ETIME.f - Failed in semantics
-
   . lapack/SRC/chla_transtype.f - type of return operand 0 ('!fir.array<1x!fir.char<1>>') doesn't match function result type ('!fir.char<1>')
+
+[unassigned]
+
 
 FIXED
 _____

--- a/flang/LAPACK-bugs.txt
+++ b/flang/LAPACK-bugs.txt
@@ -11,12 +11,9 @@ ______________
     loc("lapack/BLAS/SRC/srotmg.f":116:7): error: DATA statement is not handled.
 
 [Jean]
-  . ConvertExpr.cpp:379! - concat CHARs
   . lapack/INSTALL/second_INT_ETIME.f - 'etime' is not a known intrinsic procedure
   . lapack/INSTALL/dsecnd_INT_ETIME.f - Failed in semantics
   . lapack/INSTALL/second_INT_ETIME.f - Failed in semantics
-
-[unassigned]
 
   . lapack/SRC/chla_transtype.f - type of return operand 0 ('!fir.array<1x!fir.char<1>>') doesn't match function result type ('!fir.char<1>')
 
@@ -34,3 +31,6 @@ _____
 
   . ConvertExpr.cpp:193 - function type mismatch
   . 'std.call' op incorrect number of operands for callee
+
+  . ConvertExpr.cpp:266 - character comparison
+  . ConvertExpr.cpp:379! - concat CHARs

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -78,6 +78,9 @@ public:
   void createAssign(mlir::Value lptr, mlir::Value llen, mlir::Value rptr,
                     mlir::Value rlen);
 
+  /// Create lhs // rhs in temp obtained with fir.alloca
+  mlir::Value createConcatenate(mlir::Value lhs, mlir::Value rhs);
+
   mlir::Value createLenTrim(mlir::Value str);
 
   /// Embox \p addr and \p len and return fir.boxchar.
@@ -176,7 +179,7 @@ protected:
 
   template <Part partId>
   mlir::Value createPartId() {
-    return impl().createIntegerConstant(impl().getIntegerType(32),
+    return impl().createIntegerConstant(impl().getIndexType(),
                                         static_cast<int>(partId));
   }
 };

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -376,7 +376,7 @@ private:
 
   template <int KIND>
   mlir::Value genval(const Fortran::evaluate::Concat<KIND> &op) {
-    TODO();
+    return builder.createConcatenate(genval(op.left()), genval(op.right()));
   }
 
   /// MIN and MAX operations

--- a/flang/test/Lower/concat.f90
+++ b/flang/test/Lower/concat.f90
@@ -1,0 +1,45 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test character scalar concatenation lowering
+
+! CHECK-LABEL: concat_1
+subroutine concat_1(a, b)
+  character(*) :: a, b
+  ! CHECK: call @{{.*}}BeginExternalListOutput
+  ! CHECK-DAG: %[[a:.*]]:2 = fir.unboxchar %arg0
+  ! CHECK-DAG: %[[b:.*]]:2 = fir.unboxchar %arg1
+
+  print *, a // b
+  ! Concatenation
+
+  ! CHECK: %[[len:.*]] = addi %[[a]]#1, %[[b]]#1
+  ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1>, %[[len]]
+
+  ! CHECK-DAG: %[[c0:.*]] = constant 0
+  ! CHECK-DAG: %[[c1:.*]] = constant 1
+  ! CHECK-DAG: %[[count:.*]] = subi %[[a]]#1, %[[c1]]
+  ! CHECK: fir.do_loop %[[index:.*]] = %[[c0]] to %[[count]] step %[[c1]] {
+    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a]]#0, %[[index]]
+    ! CHECK: %[[a_elt:.*]] = fir.load %[[a_addr]]
+    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp]], %[[index]]
+    ! CHECK: fir.store %[[a_elt]] to %[[temp_addr]]
+  ! CHECK: }
+
+  ! CHECK: %[[c1_0:.*]] = constant 1
+  ! CHECK: %[[count2:.*]] = subi %[[len]], %[[c1_0]]
+  ! CHECK: fir.do_loop %[[index2:.*]] = %[[a]]#1 to %[[count2]] step %[[c1_0]] {
+    ! CHECK: %[[b_index:.*]] = subi %[[index]], %[[a]]#1
+    ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b]]#0, %[[b_index]]
+    ! CHECK: %[[b_elt:.*]] = fir.load %[[b_addr]]
+    ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp]], %[[index2]]
+    ! CHECK: fir.store %[[b_elt]] to %[[temp_addr2]]
+  ! CHECK: }
+
+  ! CHECK: %[[embox_temp:.*]] = fir.emboxchar %[[temp]], %[[len]]
+
+  ! IO runtime call
+  ! CHECK: %[[result:.*]]:2 = fir.unboxchar %[[embox_temp]]
+  ! CHECK-DAG: %[[raddr:.*]] = fir.convert %[[result]]#0
+  ! CHECK-DAG: %[[rlen:.*]] = fir.convert %[[result]]#1
+  ! CHECK: call @{{.*}}OutputAscii(%{{.*}}, %[[raddr]], %[[rlen]])
+end subroutine

--- a/flang/test/Lower/end-to-end-character-assignment-driver.cpp
+++ b/flang/test/Lower/end-to-end-character-assignment-driver.cpp
@@ -26,15 +26,15 @@ struct Fchar {
   LenT len;
 };
 
-template<typename... T> using SubF18 = void (*)(Fchar, Fchar, T...);
-template<typename... T>
+template <typename... T> using SubF18 = void (*)(Fchar, Fchar, T...);
+template <typename... T>
 using SubF77 = void (*)(char *, char *, T..., LenT, LenT);
-template<typename... T>
+template <typename... T>
 void CallSubroutine(SubF18<T...> f, Fchar s1, Fchar s2, T... args) {
   f(s1, s2, args...);
 }
 
-template<typename... T>
+template <typename... T>
 void CallSubroutine(SubF77<T...> f, Fchar s1, Fchar s2, T... args) {
   f(s1.data, s2.data, args..., s1.len, s2.len);
 }
@@ -42,31 +42,31 @@ void CallSubroutine(SubF77<T...> f, Fchar s1, Fchar s2, T... args) {
 // Define structures to create and manipulate Fortran Character
 // A canary is always added at the end of character storage so that
 // invalid overwrites can be detected.
-template<int K> struct CharStorage {};
-template<> struct CharStorage<1> {
+template <int K> struct CharStorage {};
+template <> struct CharStorage<1> {
   using Type = std::string;
   static const Type canary;
 };
 const CharStorage<1>::Type CharStorage<1>::canary{"_CaNaRy"};
 
-template<> struct CharStorage<2> {
+template <> struct CharStorage<2> {
   using Type = std::u16string;
   static const Type canary;
 };
 const CharStorage<2>::Type CharStorage<2>::canary{u"_CaNaRy"};
 
-template<> struct CharStorage<4> {
+template <> struct CharStorage<4> {
   using Type = std::u32string;
   static const Type canary;
 };
 const CharStorage<4>::Type CharStorage<4>::canary{U"_CaNaRy"};
 
-template<int Kind> struct FcharData {
+template <int Kind> struct FcharData {
   using String = typename CharStorage<Kind>::Type;
   using CharT = typename String::value_type;
   FcharData(String str)
-    : data{str + CharStorage<Kind>::canary}, len{static_cast<LenT>(
-                                                 str.length())} {}
+      : data{str + CharStorage<Kind>::canary}, len{static_cast<LenT>(
+                                                   str.length())} {}
   Fchar getFchar() {
     const char *addr{reinterpret_cast<const char *>(data.data())};
     return Fchar{const_cast<char *>(addr), len};
@@ -98,10 +98,10 @@ template<int Kind> struct FcharData {
   }
 
   String data;
-  LenT len;  // may differ from string length for test purposes
+  LenT len; // may differ from string length for test purposes
 };
 
-template<int Kind>
+template <int Kind>
 bool Check(const FcharData<Kind> &test, const FcharData<Kind> &ref,
     const std::string &desc) {
   if (test.data != ref.data) {
@@ -115,7 +115,7 @@ bool Check(const FcharData<Kind> &test, const FcharData<Kind> &ref,
 
 // Call compiled test subroutine and compare variable afterwards with a
 // reference. Compare against result from reference subroutine.
-template<int Kind, typename... T>
+template <int Kind, typename... T>
 bool TestSubroutine(const std::string &testName, SubF18<T...> fooTest,
     SubF18<T...> fooRef, const FcharData<Kind> &s1, const FcharData<Kind> &s2,
     T... otherArgs) {
@@ -134,7 +134,7 @@ bool TestSubroutine(const std::string &testName, SubF18<T...> fooTest,
 }
 
 // Compare against precomputed results.
-template<int Kind, typename... T>
+template <int Kind, typename... T>
 bool TestSubroutine(const std::string &testName, SubF18<T...> fooTest,
     const FcharData<Kind> &s1, const FcharData<Kind> &refS1,
     const FcharData<Kind> &s2, const FcharData<Kind> &refS2, T... otherArgs) {
@@ -150,21 +150,21 @@ bool TestSubroutine(const std::string &testName, SubF18<T...> fooTest,
 // Test driver code (could maybe generated somehow)
 
 // String data to be used as inputs during the tests.
-template<int Kind> struct Inputs { static FcharData<Kind> s1, s2, s3; };
+template <int Kind> struct Inputs { static FcharData<Kind> s1, s2, s3; };
 
-template<> FcharData<1> Inputs<1>::s1{"aw*lSe4frliaw"};
-template<> FcharData<1> Inputs<1>::s2{"8\n e7t4$%&52Z"};
-template<> FcharData<1> Inputs<1>::s3{"quAli64^&$*#$8gl6"};
+template <> FcharData<1> Inputs<1>::s1{"aw*lSe4frliaw"};
+template <> FcharData<1> Inputs<1>::s2{"8\n e7t4$%&52Z"};
+template <> FcharData<1> Inputs<1>::s3{"quAli64^&$*#$8gl6"};
 
-template<> FcharData<2> Inputs<2>::s1{u"\u4e4dhy7&3o8%\u4e24"};
-template<> FcharData<2> Inputs<2>::s2{u"\u4f60\u4e0d\u662f F18 !\uff1f"};
-template<>
+template <> FcharData<2> Inputs<2>::s1{u"\u4e4dhy7&3o8%\u4e24"};
+template <> FcharData<2> Inputs<2>::s2{u"\u4f60\u4e0d\u662f F18 !\uff1f"};
+template <>
 FcharData<2> Inputs<2>::s3{
     u"\u4f60\u597d\uff0c\u6211\u66df F18 ! \u4f60\u5462\uff1f"};
 
-template<> FcharData<4> Inputs<4>::s1{U"\u4e4dhy7&3o8%\u4e24"};
-template<> FcharData<4> Inputs<4>::s2{U"\u4f60\u4e0d\u662f F18 !\uff1f"};
-template<>
+template <> FcharData<4> Inputs<4>::s1{U"\u4e4dhy7&3o8%\u4e24"};
+template <> FcharData<4> Inputs<4>::s2{U"\u4f60\u4e0d\u662f F18 !\uff1f"};
+template <>
 FcharData<4> Inputs<4>::s3{
     U"\u4f60\u597d\uff0c\u6211\u66df F18 ! \u4f60\u5462\uff1f"};
 
@@ -181,7 +181,7 @@ void _QPassign2(Fchar, Fchar);
 void _QPassign4(Fchar, Fchar);
 }
 
-template<int Kind, typename Func>
+template <int Kind, typename Func>
 void TestNormalAssignement(Func testedSub, int &tests, int &passed) {
   auto &s1{Inputs<Kind>::s1};
   auto &s2{Inputs<Kind>::s2};
@@ -226,7 +226,7 @@ void _QPassign_substring2(Fchar, Fchar, int *, int *);
 void _QPassign_substring4(Fchar, Fchar, int *, int *);
 }
 
-template<int Kind, typename Func>
+template <int Kind, typename Func>
 void TestSubstringAssignement(Func testedSub, int &tests, int &passed) {
   auto &s1{Inputs<Kind>::s3};
   auto &s2{Inputs<Kind>::s1};
@@ -262,7 +262,7 @@ void _QPassign_overlap2(Fchar, Fchar, int *);
 void _QPassign_overlap4(Fchar, Fchar, int *);
 }
 
-template<int Kind, typename Func>
+template <int Kind, typename Func>
 void TestOverlappingAssignement(Func testedSub, int &tests, int &passed) {
   auto &s1{Inputs<Kind>::s1};
   auto &s2{Inputs<Kind>::s2};
@@ -295,7 +295,7 @@ void _QPassign_spec_expr_len2(Fchar s1, Fchar s2, int *l1, int *l2);
 void _QPassign_spec_expr_len4(Fchar s1, Fchar s2, int *l1, int *l2);
 }
 
-template<int Kind, typename Func>
+template <int Kind, typename Func>
 void TestSpecExprLenAssignement(Func testedSub, int &tests, int &passed) {
   auto &s1{Inputs<Kind>::s1};
   auto &s2{Inputs<Kind>::s2};
@@ -333,6 +333,30 @@ void TestSpecExprLenAssignement(Func testedSub, int &tests, int &passed) {
   }
 }
 
+// Test concatenation
+extern "C" {
+// SUBROUTINE concat1(s1, s2)
+//  CHARACTER(*) :: s1, s2
+//  s2 = s1 // " another piece of string"
+// END SUBROUTINE
+void _QPconcat1(Fchar s1, Fchar s2);
+}
+
+template <int Kind, typename Func>
+void TestConcat(Func testedSub, int &tests, int &passed) {
+  auto &s1{Inputs<Kind>::s1};
+  using ST = typename CharStorage<Kind>::Type;
+  ST appended = " another piece of string";
+  FcharData<Kind> output{ST(s1.len + appended.length(), ' ')};
+
+  const std::string &desc{"concatenation"};
+  FcharData<Kind> expected{s1.data.substr(0, s1.len) + appended};
+  tests++;
+  if (TestSubroutine(desc, testedSub, s1, s1, output, /* expect*/ expected)) {
+    passed++;
+  }
+}
+
 int main(int, char **) {
   int tests{0}, passed{0};
 
@@ -351,6 +375,8 @@ int main(int, char **) {
   TestSpecExprLenAssignement<1>(_QPassign_spec_expr_len1, tests, passed);
   TestSpecExprLenAssignement<2>(_QPassign_spec_expr_len2, tests, passed);
   TestSpecExprLenAssignement<4>(_QPassign_spec_expr_len4, tests, passed);
+
+  TestConcat<1>(_QPconcat1, tests, passed);
 
   std::cout << passed << " tests passed out of " << tests << std::endl;
   return tests == passed ? 0 : -1;

--- a/flang/test/Lower/end-to-end-character-assignment.f90
+++ b/flang/test/Lower/end-to-end-character-assignment.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-llvm -o - %s | tco | llc | as -o %t
+! RUN: bbc -emit-llvm -o - %s | tco | llc --relocation-model=pic | as -o %t
 ! RUN: %CXX -std=c++17 %t %S/end-to-end-character-assignment-driver.cpp
 ! RUN: ./a.out
 
@@ -74,3 +74,13 @@ subroutine assign_spec_expr_len4(s1, s2, l1, l2)
   character(l2, 4) :: s2
   s1 = s2
 end subroutine
+
+! Test string concatenation
+subroutine concat1(s1, s2)
+  character(*) :: s1, s2
+  s2 = s1 // " another piece of string"
+end subroutine
+! FIXME: concat test for other kind not written because there constant
+! character with kind !=1 have issues (most likely due to the presence null
+! bytes in the middle of the string. This has nothing to do with concat it
+! just prevent running the tests.


### PR DESCRIPTION
In-lined character concatenation implementation using fir.loop and fir.alloca to allocate the result.
Note: I first tried implementing this using the runtime `
`CharacterConcatenateScalar1`, but it requires a descriptor and this pulls in new issue, so I think an inlined implementation is easier for F77.