### PR TITLE
Another crash apparently related to issue #74. Add check for empty list.

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -367,7 +367,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   parser::CharBlock getStartingSourceLoc() {
     if (beginStmt)
       return stmtSourceLoc(*beginStmt);
-    if (evaluationList.size())
+    if (!evaluationList.empty())
       return evaluationList.front().position;
     return stmtSourceLoc(endStmt);
   }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1585,7 +1585,8 @@ private:
     if (unstructuredContext) {
       // When transitioning from unstructured to structured code,
       // the structured code might be a target that starts a new block.
-      maybeStartBlock(eval.isConstruct() && eval.lowerAsStructured()
+      maybeStartBlock(eval.isConstruct() && eval.lowerAsStructured() &&
+                              !eval.evaluationList->empty()
                           ? eval.evaluationList->front().block
                           : eval.block);
     }


### PR DESCRIPTION
See issue #74.

This was a crash with dstebz.f.