### PR TITLE
Add name mangling support for constants in procedures.

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -40,9 +40,9 @@
       llvm_unreachable("not yet implemented");                                 \
   }
 
-static llvm::cl::opt<bool>
-    dumpBeforeFir("fdebug-dump-pre-fir", llvm::cl::init(false),
-                  llvm::cl::desc("dump the IR tree prior to FIR"));
+static llvm::cl::opt<bool> dumpBeforeFir(
+    "fdebug-dump-pre-fir", llvm::cl::init(false),
+    llvm::cl::desc("dump the Pre-FIR tree prior to FIR generation"));
 
 static llvm::cl::opt<bool>
     disableToDoAssertions("disable-burnside-todo",

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -95,6 +95,9 @@ Fortran::lower::mangle::mangleName(fir::NameUniquer &uniquer,
           },
           [&](const Fortran::semantics::ObjectEntityDetails &) {
             auto modNames = moduleNames(ultimateSymbol);
+            if (Fortran::semantics::IsNamedConstant(ultimateSymbol)) {
+              return uniquer.doConstant(modNames, toStringRef(symbolName));
+            }
             return uniquer.doVariable(modNames, hostName(ultimateSymbol),
                                       toStringRef(symbolName));
           },

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -16,6 +16,13 @@ function foo()
 ! CHECK: }
 end function
 
+! CHECK-LABEL: func @_QPfunctn() -> f32 {
+function functn
+! CHECK-LABEL: fir.global @_QECpi
+  real, parameter :: pi = 3.14
+! CHECK: }
+end function
+
 module testMod
 contains
   ! CHECK-LABEL: func @_QMtestmodPsub() {


### PR DESCRIPTION
A small typo in '--fdebug-dump-pre-fir'.