### PR TITLE
various bug fixes

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -15,6 +15,7 @@
 #define FIR_DIALECT_FIR_OPS
 
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -157,7 +158,8 @@ def fir_NamedAllocateOpBuilder : OpBuilder<
   [{
     result.addTypes(getRefTy(inType));
     result.addAttribute("in_type", TypeAttr::get(inType));
-    result.addAttribute("name", builder.getStringAttr(name));
+    if (!name.empty())
+      result.addAttribute("name", builder.getStringAttr(name));
     result.addOperands(sizes);
     result.addAttributes(attributes);
   }]>;
@@ -196,9 +198,10 @@ class fir_AllocatableBaseOp<string mnemonic, list<OpTrait> traits = []> :
   );
 }
 
-class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
+class fir_AllocatableOp<string mnemonic, Resource resource,
+      list<OpTrait> traits = []> :
     fir_AllocatableBaseOp<mnemonic,
-	!listconcat(traits, [MemoryEffects<[MemAlloc]>])>,
+	!listconcat(traits, [MemoryEffects<[MemAlloc<resource>]>])>,
     fir_TwoBuilders<fir_AllocateOpBuilder, fir_NamedAllocateOpBuilder>,
     Arguments<(ins TypeAttr:$in_type, Variadic<AnyIntegerType>:$args)> {
 
@@ -308,7 +311,8 @@ class fir_AllocatableOp<string mnemonic, list<OpTrait> traits = []> :
 // Memory SSA operations
 //===----------------------------------------------------------------------===//
 
-def fir_AllocaOp : fir_AllocatableOp<"alloca"> {
+def fir_AllocaOp :
+      fir_AllocatableOp<"alloca", AutomaticAllocationScopeResource> {
   let summary = "allocate storage for a temporary on the stack given a type";
   let description = [{
     This primitive operation is used to allocate an object on the stack.  A
@@ -351,7 +355,7 @@ def fir_AllocaOp : fir_AllocatableOp<"alloca"> {
   }];
 }
 
-def fir_LoadOp : fir_OneResultOp<"load", [MemoryEffects<[MemRead]>]> {
+def fir_LoadOp : fir_OneResultOp<"load"> {
   let summary = "load a value from a memory reference";
   let description = [{
     Load a value from a memory reference into an ssa-value (virtual register).
@@ -367,7 +371,7 @@ def fir_LoadOp : fir_OneResultOp<"load", [MemoryEffects<[MemRead]>]> {
     or null.
   }];
 
-  let arguments = (ins AnyReferenceLike:$memref);
+  let arguments = (ins Arg<AnyReferenceLike, "", [MemRead]>:$memref);
 
   let builders = [OpBuilder<
     "OpBuilder &builder, OperationState &result, Value refVal",
@@ -376,9 +380,13 @@ def fir_LoadOp : fir_OneResultOp<"load", [MemoryEffects<[MemRead]>]> {
         mlir::emitError(result.location, "LoadOp has null argument");
         return;
       }
-      auto refTy = refVal.getType().cast<fir::ReferenceType>();
+      auto eleTy = fir::dyn_cast_ptrEleTy(refVal.getType());
+      if (!eleTy) {
+        mlir::emitError(result.location, "not a memory reference type");
+        return;
+      }
       result.addOperands(refVal);
-      result.addTypes(refTy.getEleTy());
+      result.addTypes(eleTy);
     }]
   >];
 
@@ -409,7 +417,7 @@ def fir_LoadOp : fir_OneResultOp<"load", [MemoryEffects<[MemRead]>]> {
   }];
 }
 
-def fir_StoreOp : fir_Op<"store", [MemoryEffects<[MemWrite]>]> {
+def fir_StoreOp : fir_Op<"store", []> {
   let summary = "store an SSA-value to a memory location";
 
   let description = [{
@@ -428,7 +436,8 @@ def fir_StoreOp : fir_Op<"store", [MemoryEffects<[MemWrite]>]> {
     `%p`, is undefined or null.
   }];
 
-  let arguments = (ins AnyType:$value, AnyReferenceLike:$memref);
+  let arguments = (ins AnyType:$value,
+                   Arg<AnyReferenceLike, "", [MemWrite]>:$memref);
 
   let parser = [{
     mlir::Type type;
@@ -491,7 +500,7 @@ def fir_UndefOp : fir_OneResultOp<"undefined", [NoSideEffect]> {
   }];
 }
 
-def fir_AllocMemOp : fir_AllocatableOp<"allocmem"> {
+def fir_AllocMemOp : fir_AllocatableOp<"allocmem", DefaultResource> {
   let summary = "allocate storage on the heap for an object of a given type";
 
   let description = [{
@@ -537,7 +546,7 @@ def fir_FreeMemOp : fir_Op<"freemem", [MemoryEffects<[MemFree]>]> {
     ```
   }];
 
-  let arguments = (ins fir_HeapType:$heapref);
+  let arguments = (ins Arg<fir_HeapType, "", [MemFree]>:$heapref);
 
   let assemblyFormat = "$heapref attr-dict `:` type($heapref)";
 }
@@ -2090,8 +2099,7 @@ def fir_IterWhileOp : region_Op<"iterate_while",
 // Procedure call operations
 //===----------------------------------------------------------------------===//
 
-def fir_CallOp : fir_Op<"call",
-    [MemoryEffects<[MemAlloc, MemFree, MemRead, MemWrite]>]> {
+def fir_CallOp : fir_Op<"call", [CallOpInterface]> {
   let summary = "call a procedure";
 
   let description = [{
@@ -2118,11 +2126,27 @@ def fir_CallOp : fir_Op<"call",
 
   let extraClassDeclaration = [{
     static constexpr StringRef calleeAttrName() { return "callee"; }
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      if (auto calling = getAttrOfType<SymbolRefAttr>(calleeAttrName()))
+        return {arg_operand_begin(), arg_operand_end()};
+      return {arg_operand_begin() + 1, arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      if (auto calling = getAttrOfType<SymbolRefAttr>(calleeAttrName()))
+        return calling;
+      return getOperand(0);
+    }
   }];
 }
 
-def fir_DispatchOp : fir_Op<"dispatch",
-    [MemoryEffects<[MemAlloc, MemFree, MemRead, MemWrite]>]> {
+def fir_DispatchOp : fir_Op<"dispatch", []> {
   let summary = "call a type-bound procedure";
 
   let description = [{

--- a/flang/test/Fir/loop.fir
+++ b/flang/test/Fir/loop.fir
@@ -4,18 +4,20 @@
 
 // CHECK-LABEL: @x
 func @x(%lb : index, %ub : index, %step : index, %b : i1, %addr : !fir.ref<index>) {
+  // CHECK: [[LOOP:[0-9]+]]:
   // CHECK: %[[COND:.*]] = icmp slt i64
   // CHECK: br i1 %[[COND]]
   fir.do_loop %iv = %lb to %ub step %step unordered {
-    // CHECK: br i1 %
+    // expect following conditional blocks to get fused
+    // CHECK: select i1 %
     fir.if %b {
       // CHECK: store i64
       fir.store %iv to %addr : !fir.ref<index>
     } else {
       %zero = constant 0 : index
-      // CHECK: store i64
       fir.store %zero to %addr : !fir.ref<index>
     }
+    // CHECK: br label %[[LOOP]]
   }
   // CHECK: ret void
   return

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -1,5 +1,4 @@
 ! RUN: bbc -o - %s | FileCheck %s
-! XFAIL: *
 
 subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   integer i, j, k, ii, jj, kk
@@ -18,19 +17,22 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   ! CHECK-LABEL: BeginExternalListOutput
   ! CHECK-DAG: fir.load %arg3 :
   ! CHECK-DAG: %[[i1:.*]] = subi %{{.*}}, %[[one:c1.*]] :
-  ! CHECK-DAG: fir.load %arg4 :
-  ! CHECK-DAG: %[[j1:.*]] = subi %{{.*}}, %[[one]] :
+  ! CHECK: fir.load %arg4 :
+  ! CHECK: %[[j1:.*]] = subi %{{.*}}, %[[one]] :
   ! CHECK: fir.coordinate_of %arg6, %[[i1]], %[[j1]] :
   ! CHECK-LABEL: EndIoStatement
   print *, a1(ii,jj)
   ! CHECK-LABEL: BeginExternalListOutput
+  ! CHECK: fir.coordinate_of %{{[0-9]+}}, %{{[0-9]+}} : {{.*}} -> !fir.ref<i32>
   ! CHECK-LABEL: EndIoStatement
   print *, a2(ii,jj)
   ! CHECK-LABEL: BeginExternalListOutput
   ! CHECK-DAG: fir.load %arg3 :
-  ! CHECK-DAG: %[[i2:.*]] = subi %{{.*}}, %c2{{.*}} :
+  ! CHECK-DAG: %[[cc2:.*]] = fir.convert %c2{{.*}} :
+  ! CHECK: %[[i2:.*]] = subi %{{.*}}, %[[cc2]] :
   ! CHECK-DAG: fir.load %arg4 :
-  ! CHECK-DAG: %[[j2:.*]] = subi %{{.*}}, %c3{{.*}} :
+  ! CHECK-DAG: %[[cc3:.*]] = fir.convert %c3{{.*}} :
+  ! CHECK: %[[j2:.*]] = subi %{{.*}}, %[[cc3]] :
   ! CHECK: fir.coordinate_of %arg8, %[[i2]], %[[j2]] :
   ! CHECK-LABEL: EndIoStatement
   print *, a3(ii,jj)

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -226,7 +226,7 @@ static void convertFortranSourceToMLIR(
   pm.addPass(mlir::createLowerToCFGPass());
   // pm.addPass(fir::createMemToRegPass());
   pm.addPass(fir::createCSEPass());
-  //pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCanonicalizerPass());
 
   if (emitLLVM) {
     // Continue to lower from MLIR down to LLVM IR. Emit LLVM and MLIR.

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -91,7 +91,6 @@ static int compileFIR() {
   } else {
     // add all the passes
     // the user can disable them individually
-    //pm.addPass(mlir::createCanonicalizerPass());
     // convert fir dialect to affine
     pm.addPass(fir::createPromoteToAffinePass());
     // convert fir dialect to loop
@@ -100,6 +99,7 @@ static int compileFIR() {
     // convert loop dialect to standard
     pm.addPass(mlir::createLowerToCFGPass());
     // pm.addPass(fir::createMemToRegPass());
+    pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(fir::createCSEPass());
     pm.addPass(fir::createFIRToLLVMPass(uniquer));
     pm.addPass(fir::createLLVMDialectToLLVMPass(out.os()));

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -624,8 +624,11 @@ bool OperationEquivalence::isEquivalentTo(Operation *lhs, Operation *rhs,
   }
   // Compare operands.
   bool ignoreOperands = flags & Flags::IgnoreOperands;
-  if (ignoreOperands)
-    return true;
+  if (ignoreOperands) {
+    // Ignore the operand values, but cannot ignore their types.
+    return std::equal(lhs->operand_type_begin(), lhs->operand_type_end(),
+                      rhs->operand_type_begin());
+  }
   // TODO: Allow commutative operations to have different ordering.
   return std::equal(lhs->operand_begin(), lhs->operand_end(),
                     rhs->operand_begin());


### PR DESCRIPTION
This started out as fixing the canonicalization pass for sgbsvx.f.

It turned into a roll up of a number of fixes for various problems discovered along the way.

More on the original problem, which turned out to be an code spelunking adventure in its own right.

The canonicalizer is getting smarter and including more and more small optimizations. Just one of these is empty block removal. Another is straight-line control merging. Another is fusion with block argument (PHI-node) binding. When the first two of these are applied in the right ways, the CFG for sgbsvx.f was being rewritten. The new CFG happened to reduce the block clusters such that they triggered a match. Blocks were then fused and duplicates removed. Unfortunately, there is a bug in the MLIR algorithm for determining if blocks are truly semantically equivalent. Throw in a bit more graph rewriting and the onion gets bigger and more fun to deal with.
