### PR TITLE
Share call interface logic between callee/caller and handle functions returning character

### DIFF
--- a/flang/include/flang/Lower/Bridge.h
+++ b/flang/include/flang/Lower/Bridge.h
@@ -91,6 +91,10 @@ public:
     return genExprValue(*someExpr, &loc);
   }
 
+  /// Get FoldingContext that is required for some expression
+  /// analysis.
+  virtual Fortran::evaluate::FoldingContext &getFoldingContext() = 0;
+
   //
   // Types
 
@@ -124,6 +128,8 @@ public:
   virtual Fortran::lower::FirOpBuilder &getFirOpBuilder() = 0;
   /// Get the ModuleOp
   virtual mlir::ModuleOp &getModuleOp() = 0;
+  /// Get the MLIRContext
+  virtual mlir::MLIRContext &getMLIRContext() = 0;
   /// Unique a symbol
   virtual std::string mangleName(const semantics::Symbol &) = 0;
   /// Unique a compiler generated identifier. A short prefix should be provided

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -1,0 +1,270 @@
+//===-- Lower/CallInterface.h -- Procedure call interface ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utility that defines fir call interface for procedure both on caller and
+// and callee side and get the related FuncOp.
+// It does not emit any FIR code but for the created mlir::FuncOp, instead it
+// provides back a container of Symbol (callee side)/ActualArgument (caller
+// side) with additional information for each element describing how it must be
+// plugged with the mlir::FuncOp.
+// It handles the fact that hidden arguments may be inserted for the result.
+// while lowering.
+//
+// This utility uses the characteristic of Fortran procedures to operate, which
+// is a term and concept used in Fortran to refer to the signature of a function
+// or subroutine.
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_CALLINTERFACE_H
+#define FORTRAN_LOWER_CALLINTERFACE_H
+
+#include "flang/Common/reference.h"
+#include "mlir/IR/Function.h"
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace Fortran::semantics {
+class Symbol;
+}
+
+namespace Fortran::evaluate {
+class ProcedureRef;
+class ActualArgument;
+namespace characteristics {
+struct Procedure;
+}
+} // namespace Fortran::evaluate
+
+namespace Fortran::lower {
+class AbstractConverter;
+class SymMap;
+namespace pft {
+struct FunctionLikeUnit;
+}
+
+/// PassedEntityTypes helps abstract whether CallInterface is mapping a
+/// Symbol to mlir::Value (callee side) or an ActualArgument to a position
+/// inside the input vector for the CallOp (caller side. It will be up to the
+/// CallInterface user to produce the mlir::Value that will go in this input
+/// vector).
+class CallerInterface;
+class CalleeInterface;
+template <typename T>
+struct PassedEntityTypes {};
+template <>
+struct PassedEntityTypes<CallerInterface> {
+  using FortranEntity = const Fortran::evaluate::ActualArgument *;
+  using FirValue = int;
+};
+template <>
+struct PassedEntityTypes<CalleeInterface> {
+  using FortranEntity = common::Reference<const semantics::Symbol>;
+  using FirValue = mlir::Value;
+};
+
+/// Implementation helper
+template <typename T>
+class CallInterfaceImpl;
+
+/// CallInterface defines all the logic to determine FIR function interfaces
+/// from a characteristic, build the mlir::FuncOp and describe back the argument
+/// mapping to its user.
+/// The logic is shared between the callee and caller sides that it accepts as
+/// a curiously recursive template to handle the few things that cannot be
+/// shared between both side (getting characteristics, mangled name, location).
+/// It maps FIR arguments to front-end Symbol (callee side) or ActualArgument
+/// (caller side) with the same code using the abstract FortranEntity type that
+/// can be either a Symbol or an ActualArgument.
+/// It works in two passes: a first pass over the characteristics that decides
+/// how the interface must be. Then, the funcOp is created for it. Then a simple
+/// pass over fir arguments finalize the interface information that must be
+/// passed back to the user (and may require having the funcOp). All this
+/// passes are driven from the CallInterface constructor.
+template <typename T>
+class CallInterface {
+  friend CallInterfaceImpl<T>;
+
+public:
+  /// Enum the different ways an entity can be passed-by
+  enum class PassEntityBy {
+    BaseAddress,
+    BoxChar,
+    Box,
+    AddressAndLength,
+    /// Value means passed by value at the mlir level, it is not necessarily
+    /// implied by Fortran Value attribute.
+    Value
+  };
+  /// Different properties of an entity that can be passed/returned.
+  /// One-to-One mapping with PassEntityBy but for
+  /// PassEntityBy::AddressAndLength that has two properties.
+  enum class Property {
+    BaseAddress,
+    BoxChar,
+    CharAddress,
+    CharLength,
+    Box,
+    Value
+  };
+
+  using FortranEntity = typename PassedEntityTypes<T>::FortranEntity;
+  using FirValue = typename PassedEntityTypes<T>::FirValue;
+  /// FirPlaceHolder are place holders for the mlir inputs and outputs that are
+  /// created during the first pass before the mlir::FuncOp is created.
+  struct FirPlaceHolder {
+    /// Type for this input/output
+    mlir::Type type;
+    /// Position of related passedEntity in passedArguments.
+    /// (passedEntity is the passedResult this value is resultEntityPosition.
+    int passedEntityPosition;
+    static constexpr int resultEntityPosition = -1;
+    /// Indicate property of the entity passedEntityPosition that must be passed
+    /// through this argument.
+    Property property;
+  };
+
+  /// PassedEntity is what is provided back to the CallInterface user.
+  /// It describe how the entity is plugged in the interface
+  struct PassedEntity {
+    /// How entity is passed by.
+    PassEntityBy passBy;
+    /// What is the entity (SymbolRef for callee/ActualArgument* for caller)
+    /// What is the related mlir::FuncOp argument(s) (mlir::Value for callee /
+    /// index for the caller).
+    FortranEntity entity;
+    FirValue firArgument;
+    FirValue firLength; /* only for AddressAndLength */
+  };
+
+  /// Return the mlir::FuncOp. Note that front block is added by this
+  /// utility if callee side.
+  mlir::FuncOp getFuncOp() const { return func; }
+  /// Number of MLIR inputs/outputs of the created FuncOp.
+  std::size_t getNumFIRArguments() const { return inputs.size(); }
+  std::size_t getNumFIRResults() const { return outputs.size(); }
+  /// Return the MLIR output types.
+  llvm::SmallVector<mlir::Type, 1> getResultType() const;
+
+  /// Return a container of Symbol/ActualArgument* and how they must
+  /// be plugged with the mlir::FuncOp.
+  llvm::ArrayRef<PassedEntity> getPassedArguments() const {
+    return passedArguments;
+  }
+  /// In case the result must be passed by the caller, indicate how.
+  /// nullopt if the result is not passed by the caller.
+  std::optional<PassedEntity> getPassedResult() const { return passedResult; }
+
+private:
+  /// CRTP handle.
+  T &side() { return *static_cast<T *>(this); }
+  /// buildImplicitInterface and buildExplicitInterface are the entry point
+  /// of the first pass that define the interface and is required to get
+  /// the mlir::FuncOp.
+  void
+  buildImplicitInterface(const Fortran::evaluate::characteristics::Procedure &);
+  void
+  buildExplicitInterface(const Fortran::evaluate::characteristics::Procedure &);
+  /// Helper to get type after the first pass.
+  mlir::FunctionType genFunctionType() const;
+  /// Second pass entry point, once the mlir::FuncOp is created
+  void mapBackInputToPassedEntity(const FirPlaceHolder &, FirValue);
+
+  llvm::SmallVector<FirPlaceHolder, 1> outputs;
+  llvm::SmallVector<FirPlaceHolder, 4> inputs;
+  mlir::FuncOp func;
+  llvm::SmallVector<PassedEntity, 4> passedArguments;
+  std::optional<PassedEntity> passedResult;
+
+protected:
+  CallInterface(Fortran::lower::AbstractConverter &c) : converter{c} {}
+  /// Entry point to be called by child ctor (childs need to be initialized
+  /// first).
+  void init();
+  Fortran::lower::AbstractConverter &converter;
+  /// Store characteristic once created, it is required for further information
+  /// (e.g. getting the length of character result)
+  std::unique_ptr<Fortran::evaluate::characteristics::Procedure> characteristic;
+};
+
+//===----------------------------------------------------------------------===//
+// Caller side interface
+//===----------------------------------------------------------------------===//
+
+/// The CallerInterface provides the helpers needed by CallInterface
+/// (getting the characteristic...) and a safe way for the user to
+/// place the mlir::Value arguments into the input vector
+/// once they are lowered.
+class CallerInterface : public CallInterface<CallerInterface> {
+public:
+  CallerInterface(const Fortran::evaluate::ProcedureRef &p,
+                  Fortran::lower::AbstractConverter &c)
+      : CallInterface{c}, procRef{p} {
+    init();
+    actualInputs = llvm::SmallVector<mlir::Value, 3>(getNumFIRArguments());
+  }
+  /// CRTP callbacks
+  bool hasAlternateReturns() const;
+  std::string getMangledName() const;
+  mlir::Location getCalleeLocation() const;
+  Fortran::evaluate::characteristics::Procedure characterize() const;
+  const Fortran::evaluate::ProcedureRef &getCallDescription() const {
+    return procRef;
+  };
+  bool isMainProgram() const { return false; }
+
+  /// Helpers to place the lowered arguments at the right place once they
+  /// have been lowered.
+  void placeInput(const PassedEntity &passedEntity, mlir::Value arg);
+  void placeAddressAndLengthInput(const PassedEntity &passedEntity,
+                                  mlir::Value addr, mlir::Value len);
+  /// Get the input vector once it is complete.
+  const llvm::SmallVector<mlir::Value, 3> &getInputs() const {
+    assert(verifyActualInputs() && "lowered arguments are incomplete");
+    return actualInputs;
+  }
+  /// Return result length when the function return non
+  /// allocatable/pointer character.
+  mlir::Value getResultLength();
+
+private:
+  /// Check that the input vector is complete.
+  bool verifyActualInputs() const;
+  const Fortran::evaluate::ProcedureRef &procRef;
+  llvm::SmallVector<mlir::Value, 3> actualInputs;
+};
+
+//===----------------------------------------------------------------------===//
+// Callee side interface
+//===----------------------------------------------------------------------===//
+
+/// CalleeInterface only provides the helpers needed by CallInterface
+/// to abstract the specificities of the callee side.
+class CalleeInterface : public CallInterface<CalleeInterface> {
+public:
+  CalleeInterface(Fortran::lower::pft::FunctionLikeUnit &f,
+                  Fortran::lower::AbstractConverter &c)
+      : CallInterface{c}, funit{f} {
+    init();
+  }
+  bool hasAlternateReturns() const;
+  std::string getMangledName() const;
+  mlir::Location getCalleeLocation() const;
+  Fortran::evaluate::characteristics::Procedure characterize() const;
+  bool isMainProgram() const;
+  Fortran::lower::pft::FunctionLikeUnit &getCallDescription() const {
+    return funit;
+  };
+
+private:
+  Fortran::lower::pft::FunctionLikeUnit &funit;
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_FIRBUILDER_H

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -105,10 +105,6 @@ translateVariableToFIRType(mlir::MLIRContext *ctxt,
                            common::IntrinsicTypeDefaultKinds const &defaults,
                            const pft::Variable &variable);
 
-mlir::FunctionType translateSymbolToFIRFunctionType(
-    mlir::MLIRContext *ctxt, common::IntrinsicTypeDefaultKinds const &defaults,
-    const SymbolRef symbol);
-
 mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
 
 // Given a ReferenceType of a base type, returns the ReferenceType to

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -224,11 +224,6 @@ public:
     }
   }
 
-  mlir::FunctionType genFunctionType(Fortran::lower::SymbolRef sym) {
-    return Fortran::lower::translateSymbolToFIRFunctionType(&mlirContext,
-                                                            defaults, sym);
-  }
-
   //===--------------------------------------------------------------------===//
   // AbstractConverter overrides
   //===--------------------------------------------------------------------===//

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error -Wno-unused-parameter")
 add_flang_library(FortranLower
   Bridge.cpp
   CharRT.cpp
+  CallInterface.cpp
   ComplexExpr.cpp
   ConvertExpr.cpp
   ConvertType.cpp

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -1,0 +1,455 @@
+//===-- CallInterface.cpp -- Procedure call interface ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/CallInterface.h"
+#include "flang/Evaluate/characteristics.h"
+#include "flang/Evaluate/fold.h"
+#include "flang/Lower/Bridge.h"
+#include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/PFTBuilder.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Support/InternalNames.h"
+#include "flang/Semantics/symbol.h"
+#include "flang/Semantics/tools.h"
+
+//===----------------------------------------------------------------------===//
+// Caller side interface implementation
+//===----------------------------------------------------------------------===//
+
+bool Fortran::lower::CallerInterface::hasAlternateReturns() const {
+  return procRef.HasAlternateReturns();
+}
+
+std::string Fortran::lower::CallerInterface::getMangledName() const {
+  const auto &proc = procRef.proc();
+  if (const auto *symbol = proc.GetSymbol())
+    return converter.mangleName(*symbol);
+  assert(proc.GetSpecificIntrinsic() &&
+         "expected intrinsic procedure in designator");
+  return proc.GetName();
+}
+
+mlir::Location Fortran::lower::CallerInterface::getCalleeLocation() const {
+  const auto &proc = procRef.proc();
+  if (const auto *symbol = proc.GetSymbol()) {
+    // FIXME: If the callee is defined in the same file but after the current
+    // unit we do cannot get its location here and the funcOp is created at the
+    // wrong location (i.e, the caller location).
+    if (const auto *details =
+            symbol->detailsIf<Fortran::semantics::ProcEntityDetails>())
+      if (const auto *interfaceSymbol = details->interface().symbol())
+        symbol = interfaceSymbol;
+    return converter.genLocation(symbol->name());
+  }
+  // Unknown location for intrinsics.
+  return converter.genLocation();
+}
+
+Fortran::evaluate::characteristics::Procedure
+Fortran::lower::CallerInterface::characterize() const {
+  auto &foldingContext = converter.getFoldingContext();
+  auto characteristic =
+      Fortran::evaluate::characteristics::Procedure::Characterize(
+          procRef.proc(), foldingContext.intrinsics());
+  assert(characteristic && "Failed to get characteristic from procRef");
+  // The characteristic may not contain the argument characteristic if no
+  // the ProcedureDesignator has no interface.
+  if (!characteristic->HasExplicitInterface()) {
+    for (const auto &arg : procRef.arguments()) {
+      // Argument cannot be optional with implicit interface
+      const auto *expr = arg.value().UnwrapExpr();
+      assert(expr &&
+             "argument in call with implicit interface cannot be assumed type");
+      auto argCharacteristic =
+          Fortran::evaluate::characteristics::DummyArgument::FromActual(
+              "actual", *expr, foldingContext);
+      assert(argCharacteristic &&
+             "failed to characterize argument in implicit call");
+      characteristic->dummyArguments.emplace_back(
+          std::move(*argCharacteristic));
+    }
+  }
+  return *characteristic;
+}
+
+void Fortran::lower::CallerInterface::placeInput(
+    const PassedEntity &passedEntity, mlir::Value arg) {
+  assert(static_cast<int>(actualInputs.size()) > passedEntity.firArgument &&
+         passedEntity.firArgument >= 0 &&
+         passedEntity.passBy != CallInterface::PassEntityBy::AddressAndLength &&
+         "bad arg position");
+  actualInputs[passedEntity.firArgument] = arg;
+}
+
+void Fortran::lower::CallerInterface::placeAddressAndLengthInput(
+    const PassedEntity &passedEntity, mlir::Value addr, mlir::Value len) {
+  assert(static_cast<int>(actualInputs.size()) > passedEntity.firArgument &&
+         static_cast<int>(actualInputs.size()) > passedEntity.firLength &&
+         passedEntity.firArgument >= 0 && passedEntity.firLength >= 0 &&
+         passedEntity.passBy == CallInterface::PassEntityBy::AddressAndLength &&
+         "bad arg position");
+  actualInputs[passedEntity.firArgument] = addr;
+  actualInputs[passedEntity.firLength] = len;
+}
+
+bool Fortran::lower::CallerInterface::verifyActualInputs() const {
+  if (getNumFIRArguments() != actualInputs.size())
+    return false;
+  for (auto arg : actualInputs) {
+    if (!arg)
+      return false;
+  }
+  return true;
+}
+
+template <typename T>
+static inline auto AsGenericExpr(T e) {
+  return Fortran::evaluate::AsGenericExpr(Fortran::common::Clone(e));
+}
+
+mlir::Value Fortran::lower::CallerInterface::getResultLength() {
+  // FIXME: technically, this is a specification expression,
+  // so it should be evaluated on entry of the region we are
+  // in, it can go wrong if the specification expression
+  // uses a symbol that may have change.
+  //
+  // The characteristic has to be explicit for such
+  // cases, so the allocation could also be handled on callee side, in such
+  // case. For now, protect with an unreachable.
+  assert(characteristic && "characteristic was not computed");
+  const auto *typeAndShape =
+      characteristic->functionResult.value().GetTypeAndShape();
+  assert(typeAndShape && "no result type");
+  auto expr = AsGenericExpr(typeAndShape->LEN().value());
+  if (Fortran::evaluate::IsConstantExpr(expr))
+    return converter.genExprValue(expr);
+  llvm_unreachable(
+      "non constant result length on caller side not yet safely handled");
+}
+
+//===----------------------------------------------------------------------===//
+// Callee side interface implementation
+//===----------------------------------------------------------------------===//
+
+bool Fortran::lower::CalleeInterface::hasAlternateReturns() const {
+  return !funit.isMainProgram() &&
+         Fortran::semantics::HasAlternateReturns(funit.getSubprogramSymbol());
+}
+
+std::string Fortran::lower::CalleeInterface::getMangledName() const {
+  return funit.isMainProgram()
+             ? fir::NameUniquer::doProgramEntry().str()
+             : converter.mangleName(funit.getSubprogramSymbol());
+}
+
+mlir::Location Fortran::lower::CalleeInterface::getCalleeLocation() const {
+  // FIXME: do NOT use unknown for the anonymous PROGRAM case. We probably
+  // should just stash the location in the funit regardless.
+  return converter.genLocation(funit.getStartingSourceLoc());
+}
+
+Fortran::evaluate::characteristics::Procedure
+Fortran::lower::CalleeInterface::characterize() const {
+  auto &foldingContext = converter.getFoldingContext();
+  auto characteristic =
+      Fortran::evaluate::characteristics::Procedure::Characterize(
+          funit.getSubprogramSymbol(), foldingContext.intrinsics());
+  assert(characteristic && "Fail to get characteristic from symbol");
+  return *characteristic;
+}
+
+bool Fortran::lower::CalleeInterface::isMainProgram() const {
+  return funit.isMainProgram();
+}
+
+//===----------------------------------------------------------------------===//
+// CallInterface implementation: this part is common to both caller and caller
+// sides.
+//===----------------------------------------------------------------------===//
+
+/// Init drives the different actions to be performed while building a
+/// CallInterface, it does not decide anything about the interface.
+template <typename T>
+void Fortran::lower::CallInterface<T>::init() {
+  if (!side().isMainProgram()) {
+    characteristic =
+        std::make_unique<Fortran::evaluate::characteristics::Procedure>(
+            side().characterize());
+    if (characteristic->CanBeCalledViaImplicitInterface())
+      buildImplicitInterface(*characteristic);
+    else
+      buildExplicitInterface(*characteristic);
+  }
+  // No input/output for main program
+
+  auto name = side().getMangledName();
+  auto module = converter.getModuleOp();
+  func = Fortran::lower::FirOpBuilder::getNamedFunction(module, name);
+  if (!func) {
+    mlir::Location loc = side().getCalleeLocation();
+    mlir::FunctionType ty = genFunctionType();
+    func = Fortran::lower::FirOpBuilder::createFunction(loc, module, name, ty);
+  }
+
+  // map back fir inputs to passed entities
+  if constexpr (std::is_same_v<T, Fortran::lower::CalleeInterface>) {
+    // On the callee side, directly map the mlir::value argument of
+    // the function block to the Fortran symbols.
+    func.addEntryBlock();
+    assert(inputs.size() == func.front().getArguments().size() &&
+           "function previously created with different number of arguments");
+    for (const auto &pair : llvm::zip(inputs, func.front().getArguments()))
+      mapBackInputToPassedEntity(std::get<0>(pair), std::get<1>(pair));
+  } else {
+    // On the caller side, map the index of the mlir argument position
+    // to Fortran ActualArguments.
+    auto firPosition = 0;
+    for (const auto &placeHolder : inputs)
+      mapBackInputToPassedEntity(placeHolder, firPosition++);
+  }
+}
+
+template <typename T>
+void Fortran::lower::CallInterface<T>::mapBackInputToPassedEntity(
+    const FirPlaceHolder &placeHolder, FirValue firValue) {
+  auto &passedEntity =
+      placeHolder.passedEntityPosition == FirPlaceHolder::resultEntityPosition
+          ? passedResult.value()
+          : passedArguments[placeHolder.passedEntityPosition];
+  if (placeHolder.property == Property::CharLength)
+    passedEntity.firLength = firValue;
+  else
+    passedEntity.firArgument = firValue;
+}
+
+/// Helpers to access ActualArgument/Symbols
+static const Fortran::evaluate::ActualArguments &
+getEntityContainer(const Fortran::evaluate::ProcedureRef &proc) {
+  return proc.arguments();
+}
+
+static const std::vector<Fortran::semantics::Symbol *> &
+getEntityContainer(Fortran::lower::pft::FunctionLikeUnit &funit) {
+  return funit.getSubprogramSymbol()
+      .get<Fortran::semantics::SubprogramDetails>()
+      .dummyArgs();
+}
+
+static const Fortran::evaluate::ActualArgument *getDataObjectEntity(
+    const std::optional<Fortran::evaluate::ActualArgument> &arg) {
+  if (arg)
+    return &*arg;
+  return nullptr;
+}
+
+static const Fortran::semantics::Symbol &
+getDataObjectEntity(const Fortran::semantics::Symbol *arg) {
+  assert(arg && "expect symbol for data object entity");
+  return *arg;
+}
+
+static const Fortran::evaluate::ActualArgument *
+getResultEntity(const Fortran::evaluate::ProcedureRef &) {
+  return nullptr;
+}
+
+static const Fortran::semantics::Symbol &
+getResultEntity(Fortran::lower::pft::FunctionLikeUnit &funit) {
+  const auto &details =
+      funit.getSubprogramSymbol().get<Fortran::semantics::SubprogramDetails>();
+  return details.result();
+}
+
+/// This is the actual part that defines the FIR interface based on the
+/// charcteristic. It directly mutates the CallInterface members.
+template <typename T>
+class Fortran::lower::CallInterfaceImpl {
+  using CallInterface = Fortran::lower::CallInterface<T>;
+  using PassEntityBy = typename CallInterface::PassEntityBy;
+  using PassedEntity = typename CallInterface::PassedEntity;
+  using FirValue = typename CallInterface::FirValue;
+  using FortranEntity = typename CallInterface::FortranEntity;
+  using FirPlaceHolder = typename CallInterface::FirPlaceHolder;
+  using Property = typename CallInterface::Property;
+  using TypeAndShape = Fortran::evaluate::characteristics::TypeAndShape;
+
+public:
+  CallInterfaceImpl(CallInterface &i)
+      : interface{i}, mlirContext{i.converter.getMLIRContext()} {}
+
+  void buildImplicitInterface(
+      const Fortran::evaluate::characteristics::Procedure &procedure) {
+    // Handle result
+    auto resultPosition = FirPlaceHolder::resultEntityPosition;
+    if (const auto &result = procedure.functionResult) {
+      if (result->IsProcedurePointer()) // TODO
+        llvm_unreachable("procedure pointer result not yet handled");
+      const auto *typeAndShape = result->GetTypeAndShape();
+      assert(typeAndShape && "expect type for non proc pointer result");
+      auto dynamicType = typeAndShape->type();
+      // Character result allocated by caller and passed has hidden arguments
+      if (dynamicType.category() == Fortran::common::TypeCategory::Character) {
+        handleImplicitCharacterResult(dynamicType);
+      } else {
+        // All result other than characters are simply returned by value in
+        // implicit interfaces
+        auto mlirType =
+            getConverter().genType(dynamicType.category(), dynamicType.kind());
+        addFirOutput(mlirType, resultPosition, Property::Value);
+      }
+    } else if (interface.side().hasAlternateReturns()) {
+      addFirOutput(mlir::IndexType::get(&mlirContext), resultPosition,
+                   Property::Value);
+    }
+    // Handle arguments
+    const auto &argumentEntities =
+        getEntityContainer(interface.side().getCallDescription());
+    for (const auto &pair :
+         llvm::zip(procedure.dummyArguments, argumentEntities)) {
+      const auto &dummy = std::get<0>(pair);
+      std::visit(
+          Fortran::common::visitors{
+              [&](const Fortran::evaluate::characteristics::DummyDataObject
+                      &obj) {
+                handleImplicitDataDummy(obj,
+                                        getDataObjectEntity(std::get<1>(pair)));
+              },
+              [&](const Fortran::evaluate::characteristics::DummyProcedure &) {
+                // TODO
+                llvm_unreachable("dummy procedure pointer not yet handled");
+              },
+              [&](const Fortran::evaluate::characteristics::AlternateReturn &) {
+                // nothing to do
+              },
+          },
+          dummy.u);
+    }
+  }
+  void buildExplicitInterface(
+      const Fortran::evaluate::characteristics::Procedure &procedure) {
+    // TODO
+    llvm_unreachable("Explicit interface lowering TODO");
+  }
+
+private:
+  void
+  handleImplicitCharacterResult(const Fortran::evaluate::DynamicType &type) {
+    auto resultPosition = FirPlaceHolder::resultEntityPosition;
+    setPassedResult(PassEntityBy::AddressAndLength,
+                    getResultEntity(interface.side().getCallDescription()));
+    auto lenTy = mlir::IndexType::get(&mlirContext);
+    auto charRefTy = fir::ReferenceType::get(
+        fir::CharacterType::get(&mlirContext, type.kind()));
+    auto boxCharTy = fir::BoxCharType::get(&mlirContext, type.kind());
+    addFirInput(charRefTy, resultPosition, Property::CharAddress);
+    addFirInput(lenTy, resultPosition, Property::CharLength);
+    /// For now, still also return it by boxchar
+    addFirOutput(boxCharTy, resultPosition, Property::BoxChar);
+  }
+
+  void handleImplicitDataDummy(
+      const Fortran::evaluate::characteristics::DummyDataObject &obj,
+      const FortranEntity &entity) {
+    auto dynamicType = obj.type.type();
+    if (dynamicType.category() == Fortran::common::TypeCategory::Character) {
+      auto boxCharTy = fir::BoxCharType::get(&mlirContext, dynamicType.kind());
+      addFirInput(boxCharTy, nextPassedArgPosition(), Property::BoxChar);
+      addPassedArg(PassEntityBy::BoxChar, entity);
+    } else {
+      mlir::Type type =
+          getConverter().genType(dynamicType.category(), dynamicType.kind());
+      fir::SequenceType::Shape bounds = getBounds(obj.type.shape());
+      if (!bounds.empty())
+        type = fir::SequenceType::get(bounds, type);
+      auto refType = fir::ReferenceType::get(type);
+
+      addFirInput(refType, nextPassedArgPosition(), Property::BaseAddress);
+      addPassedArg(PassEntityBy::BaseAddress, entity);
+    }
+  }
+
+  fir::SequenceType::Shape getBounds(const Fortran::evaluate::Shape &shape) {
+    fir::SequenceType::Shape bounds;
+    for (const auto &extent : shape) {
+      auto bound = fir::SequenceType::getUnknownExtent();
+      if (extent)
+        if (auto i = Fortran::evaluate::ToInt64(Fortran::evaluate::Fold(
+                getConverter().getFoldingContext(), AsGenericExpr(*extent))))
+          bound = *i;
+      bounds.emplace_back(bound);
+    }
+    return bounds;
+  }
+  void addFirInput(mlir::Type type, int entityPosition, Property p) {
+    interface.inputs.emplace_back(FirPlaceHolder{type, entityPosition, p});
+  }
+  void addFirOutput(mlir::Type type, int entityPosition, Property p) {
+    interface.outputs.emplace_back(FirPlaceHolder{type, entityPosition, p});
+  }
+  void addPassedArg(PassEntityBy p, FortranEntity entity) {
+    interface.passedArguments.emplace_back(
+        PassedEntity{p, entity, emptyValue(), emptyValue()});
+  }
+  void setPassedResult(PassEntityBy p, FortranEntity entity) {
+    interface.passedResult =
+        PassedEntity{p, entity, emptyValue(), emptyValue()};
+  }
+  int nextPassedArgPosition() { return interface.passedArguments.size(); }
+
+  static FirValue emptyValue() {
+    if constexpr (std::is_same_v<Fortran::lower::CalleeInterface, T>) {
+      return {};
+    } else {
+      return -1;
+    }
+  }
+
+  Fortran::lower::AbstractConverter &getConverter() {
+    return interface.converter;
+  }
+  CallInterface &interface;
+  mlir::MLIRContext &mlirContext;
+};
+
+template <typename T>
+void Fortran::lower::CallInterface<T>::buildImplicitInterface(
+    const Fortran::evaluate::characteristics::Procedure &procedure) {
+  CallInterfaceImpl<T> impl(*this);
+  impl.buildImplicitInterface(procedure);
+}
+
+template <typename T>
+void Fortran::lower::CallInterface<T>::buildExplicitInterface(
+    const Fortran::evaluate::characteristics::Procedure &procedure) {
+  CallInterfaceImpl<T> impl(*this);
+  impl.buildExplicitInterface(procedure);
+}
+
+template <typename T>
+mlir::FunctionType Fortran::lower::CallInterface<T>::genFunctionType() const {
+  llvm::SmallVector<mlir::Type, 1> returnTys;
+  llvm::SmallVector<mlir::Type, 4> inputTys;
+  for (const auto &placeHolder : outputs)
+    returnTys.emplace_back(placeHolder.type);
+  for (const auto &placeHolder : inputs)
+    inputTys.emplace_back(placeHolder.type);
+  return mlir::FunctionType::get(inputTys, returnTys,
+                                 &converter.getMLIRContext());
+}
+
+template <typename T>
+llvm::SmallVector<mlir::Type, 1>
+Fortran::lower::CallInterface<T>::getResultType() const {
+  llvm::SmallVector<mlir::Type, 1> types;
+  for (const auto &out : outputs)
+    types.emplace_back(out.type);
+  return types;
+}
+
+template class Fortran::lower::CallInterface<Fortran::lower::CalleeInterface>;
+template class Fortran::lower::CallInterface<Fortran::lower::CallerInterface>;

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -323,52 +323,8 @@ public:
     return seqShapeHelper(symbol, bounds);
   }
 
-  mlir::Type genDummyArgType(const Fortran::semantics::Symbol &dummy) {
-    if (auto *type{dummy.GetType()}) {
-      auto *tySpec{type->AsIntrinsic()};
-      if (tySpec &&
-          tySpec->category() == Fortran::common::TypeCategory::Character) {
-        auto kind = toConstant(tySpec->kind());
-        return fir::BoxCharType::get(context, kind);
-      }
-    }
-    if (Fortran::semantics::IsDescriptor(dummy)) {
-      // FIXME: This should be the first case, but it seems to
-      // fire at assumed length character on purpose which is
-      // not what I expect.
-      TODO();
-    }
-    return fir::ReferenceType::get(gen(dummy));
-  }
-
-  mlir::FunctionType genFunctionType(Fortran::semantics::SymbolRef symbol) {
-    llvm::SmallVector<mlir::Type, 1> returnTys;
-    llvm::SmallVector<mlir::Type, 4> inputTys;
-    if (auto *proc =
-            symbol->detailsIf<Fortran::semantics::SubprogramDetails>()) {
-      if (proc->isFunction())
-        returnTys.emplace_back(gen(proc->result()));
-      else if (Fortran::semantics::HasAlternateReturns(symbol))
-        returnTys.emplace_back(mlir::IndexType::get(context));
-      for (auto *arg : proc->dummyArgs()) {
-        // A nullptr arg is an alternate return label specifier; skip it.
-        if (arg)
-          inputTys.emplace_back(genDummyArgType(*arg));
-      }
-    } else if (symbol->detailsIf<Fortran::semantics::ProcEntityDetails>()) {
-      // TODO Should probably use Fortran::evaluate::Characteristics for that.
-      TODO();
-    } else if (symbol->detailsIf<Fortran::semantics::MainProgramDetails>()) {
-    } else {
-      assert(false && "unexpected symbol details for function");
-    }
-    return mlir::FunctionType::get(inputTys, returnTys, context);
-  }
-
   mlir::Type genSymbolHelper(const Fortran::semantics::Symbol &symbol,
                              bool isAlloc = false, bool isPtr = false) {
-    if (symbol.detailsIf<Fortran::semantics::SubprogramDetails>())
-      return genFunctionType(symbol);
     mlir::Type ty;
     if (auto *type{symbol.GetType()}) {
       if (auto *tySpec{type->AsIntrinsic()}) {
@@ -539,13 +495,6 @@ mlir::Type Fortran::lower::translateVariableToFIRType(
     const Fortran::common::IntrinsicTypeDefaultKinds &defaults,
     const Fortran::lower::pft::Variable &var) {
   return TypeBuilder{context, defaults}.gen(var);
-}
-
-mlir::FunctionType Fortran::lower::translateSymbolToFIRFunctionType(
-    mlir::MLIRContext *context,
-    const Fortran::common::IntrinsicTypeDefaultKinds &defaults,
-    const SymbolRef symbol) {
-  return TypeBuilder{context, defaults}.genFunctionType(symbol);
 }
 
 mlir::Type Fortran::lower::convertReal(mlir::MLIRContext *context, int kind) {

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -1,0 +1,17 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
+function char_return_callee(i)
+  character(10) :: char_return_callee
+  integer :: i
+end function
+
+! FIXME: the mangling is incorrect.
+! CHECK-LABEL: func @_QFtest_char_return_callerPchar_return_caller(!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+subroutine test_char_return_caller
+  character(10) :: char_return_caller
+  print *, char_return_caller(5)
+end subroutine
+
+! TODO more implicit interface cases with/without explicit interface
+


### PR DESCRIPTION
This patch groups three places that where dealing with function interfaces
into a single place (there was a type utility, the callee and caller side).

It introduces a `CallInterface` class utility that uses `evaluate::characteristics::Procedure` to decide what FIR signature must the related mlir::FuncOp have. The decision logic (inside `CallInterfaceImpl`)
is shared between caller and callee side.

The whole point of all the abstractions in CallInterface/CalleeInterface/CallerInterface is to allow `CallInterfaceImpl` to be the only point of truth regarding function signature, whether on the callee or caller side. It has a "low value" with implicit interface that are not so complex (but for things dealing with characters), but it paves the way for f90 and later interface handling, that is more complex (may require finalization on entry, or to compact non-contiguous arguments...). 

This utility is used in this patch to support implicit functions returning characters (that require a hidden argument). The current implementation keeps boxchar for character implicit argument but splits the data/len of character return that is passed as argument to distinguish it clearly.  


