### PR TITLE
[refactoring] This refactors one of the extensions out of FirOpBuilde…

### DIFF
--- a/flang/include/flang/Lower/ComplexExpr.h
+++ b/flang/include/flang/Lower/ComplexExpr.h
@@ -1,0 +1,84 @@
+//===-- Lower/ComplexExpr.h -- lowering of complex values -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_COMPLEXEXPR_H
+#define FORTRAN_LOWER_COMPLEXEXPR_H
+
+#include "flang/Lower/FIRBuilder.h"
+
+namespace Fortran::lower {
+
+class FirOpBuilder;
+
+/// Helper to facilitate lowering of COMPLEX manipulations in FIR.
+class ComplexExprHelper {
+public:
+  explicit ComplexExprHelper(FirOpBuilder &builder, mlir::Location loc)
+      : builder(builder), loc(loc) {}
+
+  // The values of part enum members are meaningful for
+  // InsertValueOp and ExtractValueOp so they are explicit.
+  enum class Part { Real = 0, Imag = 1 };
+
+  /// Type helper. Determine the type. Do not create MLIR operations.
+  mlir::Type getComplexPartType(mlir::Value cplx);
+  mlir::Type getComplexPartType(mlir::Type complexType);
+
+  /// Complex operation creation helper. They create MLIR operations.
+  mlir::Value createComplex(fir::KindTy kind, mlir::Value real,
+                            mlir::Value imag);
+
+  /// Create a complex value.
+  mlir::Value createComplex(mlir::Type complexType, mlir::Value real,
+                            mlir::Value imag);
+
+  mlir::Value extractComplexPart(mlir::Value cplx, bool isImagPart) {
+    return isImagPart ? extract<Part::Imag>(cplx) : extract<Part::Real>(cplx);
+  }
+
+  /// Returns (Real, Imag) pair of \p cplx
+  std::pair<mlir::Value, mlir::Value> extractParts(mlir::Value cplx) {
+    return {extract<Part::Real>(cplx), extract<Part::Imag>(cplx)};
+  }
+
+  mlir::Value insertComplexPart(mlir::Value cplx, mlir::Value part,
+                                bool isImagPart) {
+    return isImagPart ? insert<Part::Imag>(cplx, part)
+                      : insert<Part::Real>(cplx, part);
+  }
+
+  mlir::Value createComplexCompare(mlir::Value cplx1, mlir::Value cplx2,
+                                   bool eq);
+
+protected:
+  template <Part partId>
+  mlir::Value extract(mlir::Value cplx) {
+    return builder.create<fir::ExtractValueOp>(loc, getComplexPartType(cplx),
+                                               cplx, createPartId<partId>());
+  }
+
+  template <Part partId>
+  mlir::Value insert(mlir::Value cplx, mlir::Value part) {
+    return builder.create<fir::InsertValueOp>(loc, cplx.getType(), cplx, part,
+                                              createPartId<partId>());
+  }
+
+  template <Part partId>
+  mlir::Value createPartId() {
+    return builder.createIntegerConstant(loc, builder.getIndexType(),
+                                         static_cast<int>(partId));
+  }
+
+private:
+  FirOpBuilder &builder;
+  mlir::Location loc;
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_COMPLEXEXPR_H

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error -Wno-unused-parameter")
 add_flang_library(FortranLower
   Bridge.cpp
   CharRT.cpp
+  ComplexExpr.cpp
   ConvertExpr.cpp
   ConvertType.cpp
   FIRBuilder.cpp

--- a/flang/lib/Lower/ComplexExpr.cpp
+++ b/flang/lib/Lower/ComplexExpr.cpp
@@ -1,0 +1,58 @@
+//===-- ComplexExpr.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/ComplexExpr.h"
+#include "flang/Lower/ConvertType.h"
+
+//===----------------------------------------------------------------------===//
+// ComplexExprHelper implementation
+//===----------------------------------------------------------------------===//
+
+mlir::Type
+Fortran::lower::ComplexExprHelper::getComplexPartType(mlir::Type complexType) {
+  return Fortran::lower::convertReal(
+      builder.getContext(), complexType.cast<fir::CplxType>().getFKind());
+}
+
+mlir::Type
+Fortran::lower::ComplexExprHelper::getComplexPartType(mlir::Value cplx) {
+  return getComplexPartType(cplx.getType());
+}
+
+mlir::Value Fortran::lower::ComplexExprHelper::createComplex(fir::KindTy kind,
+                                                             mlir::Value real,
+                                                             mlir::Value imag) {
+  auto complexTy = fir::CplxType::get(builder.getContext(), kind);
+  mlir::Value und = builder.create<fir::UndefOp>(loc, complexTy);
+  return insert<Part::Imag>(insert<Part::Real>(und, real), imag);
+}
+
+mlir::Value Fortran::lower::ComplexExprHelper::createComplex(mlir::Type cplxTy,
+                                                             mlir::Value real,
+                                                             mlir::Value imag) {
+  mlir::Value und = builder.create<fir::UndefOp>(loc, cplxTy);
+  return insert<Part::Imag>(insert<Part::Real>(und, real), imag);
+}
+
+mlir::Value Fortran::lower::ComplexExprHelper::createComplexCompare(
+    mlir::Value cplx1, mlir::Value cplx2, bool eq) {
+  auto real1 = extract<Part::Real>(cplx1);
+  auto real2 = extract<Part::Real>(cplx2);
+  auto imag1 = extract<Part::Imag>(cplx1);
+  auto imag2 = extract<Part::Imag>(cplx2);
+
+  mlir::CmpFPredicate predicate =
+      eq ? mlir::CmpFPredicate::UEQ : mlir::CmpFPredicate::UNE;
+  mlir::Value realCmp =
+      builder.create<mlir::CmpFOp>(loc, predicate, real1, real2);
+  mlir::Value imagCmp =
+      builder.create<mlir::CmpFOp>(loc, predicate, imag1, imag2);
+
+  return eq ? builder.create<mlir::AndOp>(loc, realCmp, imagCmp).getResult()
+            : builder.create<mlir::OrOp>(loc, realCmp, imagCmp).getResult();
+}


### PR DESCRIPTION
…r and

turns it into its own standalone class.

Some of the reasons to do this:

  1. Ease upstreaming a bit so that the bridge isn't giant monolithic chunks
     of code that are hard on reviewers, etc. Let's things be upstreamed
     in smaller chunks.
  2. Get rid of the arguably gratuitous use of CRTP here. That eliminates
     a significant percentage of boilerplate fluff that just made the code
     difficult to read and maintain. Since the extension was really only
     used with exactly one class, the template machinery merely logically
     partitioned a monolithic interface, which can be done more directly
     with a simple class, as shown in this patch.
  3. Moves in the direction of making FirOpBuilder a more principled class
     that helps solve one problem: the creation/insertion of Ops into the
     IR of a FuncOp.