### PR TITLE
Harden access to Evaluation::evaluationList

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -247,6 +247,27 @@ struct Evaluation : EvaluationVariant {
     }});
   }
 
+  /// Return nested evaluation list that may be empty.
+  EvaluationList &getNestedEvaluations() {
+    assert(evaluationList && "no nested evaluations");
+    return *evaluationList;
+  }
+
+  /// Return true if this Evaluation has at least one nested evaluation.
+  bool hasNestedEvaluations() const {
+    return evaluationList && !evaluationList->empty();
+  }
+
+  Evaluation &getFirstNestedEvaluation() {
+    assert(hasNestedEvaluations() && "no nested evaluations");
+    return evaluationList->front();
+  }
+
+  Evaluation &getLastNestedEvaluation() {
+    assert(hasNestedEvaluations() && "no nested evaluations");
+    return evaluationList->back();
+  }
+
   /// Return FunctionLikeUnit to which this evaluation
   /// belongs. Nullptr if it does not belong to such unit.
   FunctionLikeUnit *getOwningProcedure() const;
@@ -333,13 +354,13 @@ struct Variable {
       : sym{&sym}, depth{depth}, global{global} {}
 
   const Fortran::semantics::Symbol &getSymbol() const { return *sym; }
-  
+
   bool isGlobal() const { return global; }
   bool isHeapAlloc() const { return heapAlloc; }
   bool isPointer() const { return pointer; }
   bool isTarget() const { return target; }
   int getDepth() const { return depth; }
-  
+
   void setHeapAlloc(bool to = true) { heapAlloc = to; }
   void setPointer(bool to = true) { pointer = to; }
   void setTarget(bool to = true) { target = to; }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -682,7 +682,8 @@ private:
   void genFIR(const Fortran::parser::DoConstruct &) {
     auto &eval = getEval();
     bool unstructuredContext = eval.lowerAsUnstructured();
-    Fortran::lower::pft::Evaluation &doStmtEval = eval.evaluationList->front();
+    Fortran::lower::pft::Evaluation &doStmtEval =
+        eval.getFirstNestedEvaluation();
     auto *doStmt = doStmtEval.getIf<Fortran::parser::NonLabelDoStmt>();
     assert(doStmt && "missing DO statement");
     const auto &loopControl =
@@ -727,7 +728,7 @@ private:
       genFIRIncrementLoopBegin(incrementLoopInfo[i]);
 
     // Generate loop body code.
-    for (auto &e : *eval.evaluationList)
+    for (auto &e : eval.getNestedEvaluations())
       genFIR(e, unstructuredContext);
     setCurrentEval(eval);
 
@@ -825,7 +826,7 @@ private:
       // Structured fir.where nest.
       fir::WhereOp underWhere;
       mlir::OpBuilder::InsertPoint insPt;
-      for (auto &e : *eval.evaluationList) {
+      for (auto &e : eval.getNestedEvaluations()) {
         if (auto *s = e.getIf<Fortran::parser::IfThenStmt>()) {
           // fir.where op
           std::tie(insPt, underWhere) = genWhereCondition(s);
@@ -847,7 +848,7 @@ private:
     }
 
     // Unstructured branch sequence.
-    for (auto &e : *eval.evaluationList) {
+    for (auto &e : eval.getNestedEvaluations()) {
       const Fortran::parser::ScalarLogicalExpr *cond = nullptr;
       if (auto *s = e.getIf<Fortran::parser::IfThenStmt>()) {
         maybeStartBlock(e.block);
@@ -871,7 +872,7 @@ private:
   }
 
   void genFIR(const Fortran::parser::CaseConstruct &) {
-    for (auto &e : *getEval().evaluationList)
+    for (auto &e : getEval().getNestedEvaluations())
       genFIR(e);
   }
 
@@ -1469,7 +1470,7 @@ private:
       // When transitioning from unstructured to structured code,
       // the structured code could be a target that starts a new block.
       maybeStartBlock(eval.isConstruct() && eval.lowerAsStructured()
-                          ? eval.evaluationList->front().block
+                          ? eval.getFirstNestedEvaluation().block
                           : eval.block);
     }
 
@@ -1481,11 +1482,10 @@ private:
       Fortran::lower::pft::Evaluation *successor{};
       if (eval.isActionStmt()) {
         successor = eval.controlSuccessor;
-      } else if (eval.isConstruct()) {
-        assert(!eval.evaluationList->empty() && "empty construct eval list");
-        if (eval.evaluationList->back()
-                .lexicalSuccessor->isIntermediateConstructStmt())
-          successor = eval.constructExit;
+      } else if (eval.isConstruct() &&
+                 eval.getLastNestedEvaluation()
+                     .lexicalSuccessor->isIntermediateConstructStmt()) {
+        successor = eval.constructExit;
       }
       if (successor && successor->block)
         genBranch(successor->block);
@@ -1862,11 +1862,10 @@ private:
         eval.localBlocks[i] = builder->createBlock(&builder->getRegion());
       if (eval.isConstruct() || eval.isDirective()) {
         if (eval.lowerAsUnstructured()) {
-          createEmptyBlocks(*eval.evaluationList);
-        } else {
+          createEmptyBlocks(eval.getNestedEvaluations());
+        } else if (eval.hasNestedEvaluations()) {
           // A structured construct that is a target starts a new block.
-          Fortran::lower::pft::Evaluation &constructStmt =
-              eval.evaluationList->front();
+          auto &constructStmt = eval.getFirstNestedEvaluation();
           if (constructStmt.isNewBlock)
             constructStmt.block = builder->createBlock(&builder->getRegion());
         }


### PR DESCRIPTION
This change is motivated by random failures found in LAPACK dlaebz.f, stgevc.f, dstebz.f, sstebz.f, dlaebz.f, slaebz.f with empty list issue  + an `eval.evaluationList->font()` access  that caused undefined behaviour with some directives (segfaults in random places/valgrind complaining).

This PR adds "safe" (with asserts) accessors to this list and its back/front elements. They are named dumbly according to the access they are doing, @vdonaldson if you thing some better names could apply, I'll gladly change them.
Also, I added an `if (eval.hasAtLeastOneNestedEvaluation())` but maybe `if eval.isConstruct()` is more appropriate (its unclear to me if the part of the code it protects could or not apply to directives).