### PR TITLE
using mlir declarative pass definition

### DIFF
--- a/flang/include/flang/Optimizer/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Dialect)
+add_subdirectory(Transforms)

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -11,7 +11,11 @@
 
 #include "mlir/IR/Dialect.h"
 #include "mlir/InitAllDialects.h"
-#include "mlir/InitAllPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/LocationSnapshot.h"
+#include "mlir/Dialect/Affine/Passes.h"
 
 namespace fir {
 
@@ -49,26 +53,32 @@ inline void registerFIR() {
 /// Register the standard passes we use. This comes from registerAllPasses(),
 /// but is a smaller set since we aren't using many of the passes found there.
 inline void registerGeneralPasses() {
-  mlir::createCanonicalizerPass();
-  mlir::createCSEPass();
-  mlir::createSuperVectorizePass({});
-  mlir::createLoopUnrollPass();
-  mlir::createLoopUnrollAndJamPass();
-  mlir::createSimplifyAffineStructuresPass();
-  mlir::createLoopFusionPass();
-  mlir::createLoopInvariantCodeMotionPass();
-  mlir::createAffineLoopInvariantCodeMotionPass();
-  mlir::createPipelineDataTransferPass();
-  mlir::createLowerAffinePass();
-  mlir::createLoopTilingPass(0);
-  mlir::createLoopCoalescingPass();
-  mlir::createAffineDataCopyGenerationPass(0, 0);
-  mlir::createMemRefDataFlowOptPass();
-  mlir::createStripDebugInfoPass();
-  mlir::createPrintOpStatsPass();
-  mlir::createInlinerPass();
-  mlir::createSymbolDCEPass();
-  mlir::createLocationSnapshotPass({});
+using mlir::Pass;
+#define GEN_PASS_REGISTRATION_Canonicalizer
+#define GEN_PASS_REGISTRATION_CSE
+#define GEN_PASS_REGISTRATION_AffineLoopFusion
+#define GEN_PASS_REGISTRATION_LoopInvariantCodeMotion
+#define GEN_PASS_REGISTRATION_LoopCoalescing
+#define GEN_PASS_REGISTRATION_StripDebugInfo
+#define GEN_PASS_REGISTRATION_PrintOpStats
+#define GEN_PASS_REGISTRATION_Inliner
+#define GEN_PASS_REGISTRATION_MemRefDataFlowOpt
+#define GEN_PASS_REGISTRATION_SymbolDCE
+#define GEN_PASS_REGISTRATION_LocationSnapshot
+#define GEN_PASS_REGISTRATION_PipelineDataTransfer
+#include "mlir/Transforms/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION_AffineVectorize
+#define GEN_PASS_REGISTRATION_AffineLoopUnroll
+#define GEN_PASS_REGISTRATION_AffineLoopUnrollAndJam
+#define GEN_PASS_REGISTRATION_SimplifyAffineStructures
+#define GEN_PASS_REGISTRATION_AffineLoopInvariantCodeMotion
+#define GEN_PASS_REGISTRATION_AffineLoopTiling
+#define GEN_PASS_REGISTRATION_AffineDataCopyGeneration
+#include "mlir/Dialect/Affine/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION_ConvertAffineToStandard
+#include "mlir/Conversion/Passes.h.inc"
 }
 
 inline void registerFIRPasses() { registerGeneralPasses(); }

--- a/flang/include/flang/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Transforms/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(FIROptTransformsPassIncGen)
+
+add_mlir_doc(Passes -gen-pass-doc OptimizerTransformPasses ./)

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -9,6 +9,8 @@
 #ifndef OPTIMIZER_TRANSFORMS_PASSES_H
 #define OPTIMIZER_TRANSFORMS_PASSES_H
 
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
 #include <memory>
 
 namespace mlir {
@@ -48,6 +50,13 @@ std::unique_ptr<mlir::Pass> createInlinerPass();
 bool inlinerIsEnabled();
 bool canLegallyInline(mlir::Operation *op, mlir::Region *reg,
                       mlir::BlockAndValueMapping &map);
+
+inline void registerOptTransformPasses() {
+using mlir::Pass;
+// declarative passes
+#define GEN_PASS_REGISTRATION
+#include "flang/Optimizer/Transforms/Passes.h.inc"
+}
 
 } // namespace fir
 

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -1,0 +1,27 @@
+//===-- Passes.td - Transforms pass definition file --------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for passes within the Optimizer/Transforms/
+//  directory.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FLANG_OPTIMIZER_TRANSFORMS_PASSES
+#define FLANG_OPTIMIZER_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def AffineDialectPromotion : FunctionPass<"promote-to-affine"> {
+  let summary = "Promotes fir.loop and fir.where to affine.for and affine.if where possible";
+  let description = [{
+    TODO
+  }];
+  let constructor = "fir::createPromoteToAffinePass()";
+}
+
+#endif // FLANG_OPTIMIZER_TRANSFORMS_PASSES

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flang_library(FIRTransforms
 
   DEPENDS
   FIROpsIncGen
+  FIROptTransformsPassIncGen
   ${dialect_libs}
 
   LINK_LIBS

--- a/flang/lib/Optimizer/Transforms/PassDetail.h
+++ b/flang/lib/Optimizer/Transforms/PassDetail.h
@@ -1,0 +1,22 @@
+//===- PassDetail.h - Optimizer Transforms Pass class details ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OPTMIZER_TRANSFORMS_PASSDETAIL_H_
+#define OPTMIZER_TRANSFORMS_PASSDETAIL_H_
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+namespace fir {
+
+#define GEN_PASS_CLASSES
+#include "flang/Optimizer/Transforms/Passes.h.inc"
+
+} // end namespace mlir
+
+#endif // OPTMIZER_TRANSFORMS_PASSDETAIL_H_

--- a/flang/lib/Optimizer/Transforms/RaiseToAffine.cpp
+++ b/flang/lib/Optimizer/Transforms/RaiseToAffine.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PassDetail.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Transforms/Passes.h"
@@ -47,7 +48,7 @@ public:
 /// Promote fir.loop and fir.where to affine.for and affine.if, in the cases
 /// where such a promotion is possible.
 class AffineDialectPromotion
-    : public mlir::PassWrapper<AffineDialectPromotion, mlir::FunctionPass> {
+  : public AffineDialectPromotionBase<AffineDialectPromotion> {
 public:
   void runOnFunction() override {
     if (disableAffinePromo)


### PR DESCRIPTION
currently only for promote to affine
fixed registration of mlir passes

new options automatically added to `bbc`:
```
    Passes:
      --affine-data-copy-generate            -   Generate explicit copying for affine memory operations
        --fast-mem-capacity=<ulong>          - Set fast memory space capacity in KiB (default: unlimited)
        --fast-mem-space=<uint>              - Fast memory space identifier for copy generation (default: 1)
        --generate-dma                       - Generate DMA instead of point-wise copy                                                                                                         
        --min-dma-transfer=<int>             - Minimum DMA transfer size supported by the target in bytes
        --skip-non-unit-stride-loops         - Testing purposes: avoid non-unit stride loop choice depths for copy placement
        --slow-mem-space=<uint>              - Slow memory space identifier for copy generation (default: 0)
        --tag-mem-space=<uint>               - Tag memory space identifier for copy generation (default: 0)
      --affine-loop-fusion                   -   Fuse affine loop nests
        --fusion-compute-tolerance=<number>  - Fractional increase in additional computation tolerated while fusing
        --fusion-fast-mem-space=<uint>       - Faster memory space number to promote fusion buffers to
        --fusion-local-buf-threshold=<ulong> - Threshold size (KiB) for promoting local buffers to fast memory space
        --fusion-maximal                     - Enables maximal loop fusion
      --affine-loop-invariant-code-motion    -   Hoist loop invariant instructions outside of affine loops
      --affine-loop-tile                     -   Tile affine loop nests
        --cache-size=<ulong>                 - Set size of cache to tile for in KiB
        --separate                           - Separate full and partial tiles
        --tile-size=<uint>                   - Use this tile size for all loops
        --tile-sizes=<uint>                  - List of tile sizes for each perfect nest (overridden by -tile-size)
      --affine-loop-unroll                   -   Unroll affine loops
        --unroll-factor=<uint>               - Use this unroll factor for all loops being unrolled
        --unroll-full                        - Fully unroll loops
        --unroll-full-threshold=<uint>       - Unroll all loops with trip count less than or equal to this
        --unroll-num-reps=<uint>             - Unroll innermost loops repeatedly this many times
      --affine-loop-unroll-jam               -   Unroll and jam affine loops
        --unroll-jam-factor=<uint>           - Use this unroll jam factor for all loops (default 4)
      --affine-super-vectorize               -   Vectorize to a target independent n-D vector abstraction
        --test-fastest-varying=<long>        - Specify a 1-D, 2-D or 3-D pattern of fastest varying memory dimensions to match. See defaultPatterns in Vectorize.cpp for a description and exam
ples. This is used for testing purposes
        --virtual-vector-size=<long>         - Specify an n-D virtual vector size for vectorization
      --canonicalize                         -   Canonicalize operations
      --cse                                  -   Eliminate common sub-expressions
      --fir-to-llvmir                        -   Conversion of the FIR dialect to the LLVM-IR dialect
      --inline                               -   Inline function calls
        --disable-simplify                   - Disable running simplifications during inlining
        --max-iterations=<uint>              - Maximum number of iterations when inlining within an SCC
      --loop-coalescing                      -   Coalesce nested loops with independent bounds into a single loop
      --loop-invariant-code-motion           -   Hoist loop invariant instructions outside of the loop
      --lower-affine                         -   Lower Affine operations to a combination of Standard and SCF operations
      --memref-dataflow-opt                  -   Perform store/load forwarding for memrefs
      --print-op-stats                       -   Print statistics of operations
      --promote-to-affine                    -   Promotes fir.loop and fir.where to affine.for and affine.if where possible
      --simplify-affine-structures           -   Simplify affine expressions in maps/sets and normalize memrefs
      --snapshot-op-locations                -   Generate new locations from the current IR
        --filename=<string>                  - The filename to print the generated IR
        --tag=<string>                       - A tag to use when fusing the new locations with the original. If unset, the locations are replaced.
```