### PR TITLE
Lower fir.ref<fir.array< ? x cst... x type >> to llvm<type>*

### DIFF
--- a/flang/test/Fir/array-to-llvm.fir
+++ b/flang/test/Fir/array-to-llvm.fir
@@ -1,0 +1,12 @@
+// RUN: tco %s |  FileCheck %s
+
+// CHECK-LABEL: declare void @foo0([20 x [10 x [5 x i32]]]*)
+func @foo0(%arg0: !fir.ref<!fir.array<5x10x20xi32>>)
+// CHECK-LABEL: declare void @foo1(i32*)
+func @foo1(%arg0: !fir.ref<!fir.array<?x10x20xi32>>)
+// CHECK-LABEL: declare void @foo2(i32*)
+func @foo2(%arg0: !fir.ref<!fir.array<5x?x20xi32>>)
+// CHECK-LABEL: declare void @foo3([10 x [5 x i32]]*)
+func @foo3(%arg0: !fir.ref<!fir.array<5x10x?xi32>>)
+// CHECK-LABEL: declare void @foo4(i32*)
+func @foo4(%arg0: !fir.ref<!fir.array<?x?x?xi32>>)


### PR DESCRIPTION
This PR allows lowering array types that have non constant inner bounds to LLVM, the handling of accesses to such fir sequence type was already done using a base pointer + add and multiplication.
