### PR TITLE
Add hard TODO in lowering for equivalences/stmt functions/common blocks

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1121,10 +1121,29 @@ private:
     return false;
   }
 
+  /// helper to detect statement functions
+  static bool
+  isStatementFunctionCall(const Fortran::evaluate::ProcedureRef &procRef) {
+    if (const auto *symbol = procRef.proc().GetSymbol())
+      if (const auto *details =
+              symbol->detailsIf<Fortran::semantics::SubprogramDetails>())
+        return details->stmtFunction().has_value();
+    return false;
+  }
+
   mlir::Value genProcedureRef(const Fortran::evaluate::ProcedureRef &procRef,
                               mlir::ArrayRef<mlir::Type> resultType) {
     if (const auto *intrinsic = procRef.proc().GetSpecificIntrinsic())
       return genIntrinsicRef(procRef, *intrinsic, resultType[0]);
+
+    // TODO: Statement function: either directly inlined here,
+    // or as a normal call (the function would have to be generated,
+    // it may capture local variables in the expression).
+    if (isStatementFunctionCall(procRef)) {
+      mlir::emitError(getLoc(),
+                      "Statement function calls not yet handled in lowering");
+      exit(1);
+    }
 
     // Implicit interface implementation only
     // TODO: Explicit interface, we need to use Characterize here,

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1041,6 +1041,16 @@ private:
 
 void Fortran::lower::pft::FunctionLikeUnit::processSymbolTable(
     const semantics::Scope &scope) {
+  // TODO: handle equivalence and common blocks
+  if (!scope.equivalenceSets().empty()) {
+    llvm::errs() << "TODO: equivalence not yet handled in lowering.\n"
+                 << "note: equivalence used in "
+                 << (scope.GetName() && !scope.GetName()->empty()
+                         ? scope.GetName()->ToString()
+                         : "unnamed program"s)
+                 << "\n";
+    exit(1);
+  }
   SymbolDependenceDepth sdd{varList};
   for (const auto &iter : scope)
     sdd.analyze(iter.second.get());


### PR DESCRIPTION
Common blocks,equivalences, and statement functions are known TODOs, but the previous behavior was to ignore and compile (leading to link/runtime errors). This patch catch these unhandled situations
in lowering and crashes at compile time with error messages.

These TODOs now fire in #135, #136, #137.