### PR TITLE
Fix call site mangling of external procedures

### DIFF
--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -36,16 +36,11 @@ std::string Fortran::lower::CallerInterface::getMangledName() const {
 
 mlir::Location Fortran::lower::CallerInterface::getCalleeLocation() const {
   const auto &proc = procRef.proc();
-  if (const auto *symbol = proc.GetSymbol()) {
-    // FIXME: If the callee is defined in the same file but after the current
-    // unit we do cannot get its location here and the funcOp is created at the
-    // wrong location (i.e, the caller location).
-    if (const auto *details =
-            symbol->detailsIf<Fortran::semantics::ProcEntityDetails>())
-      if (const auto *interfaceSymbol = details->interface().symbol())
-        symbol = interfaceSymbol;
+  // FIXME: If the callee is defined in the same file but after the current
+  // unit we do cannot get its location here and the funcOp is created at the
+  // wrong location (i.e, the caller location).
+  if (const auto *symbol = proc.GetSymbol())
     return converter.genLocation(symbol->name());
-  }
   // Unknown location for intrinsics.
   return converter.genLocation();
 }

--- a/flang/test/Lower/call-site-mangling.f90
+++ b/flang/test/Lower/call-site-mangling.f90
@@ -2,9 +2,9 @@
 
 subroutine sub()
   real :: x
-  ! CHECK-LABEL: fir.call @_QPasubroutine()
+  ! CHECK: fir.call @_QPasubroutine()
   call AsUbRoUtInE();
-  ! CHECK-LABEL: fir.call @_QPfoo()
+  ! CHECK: fir.call @_QPfoo()
   x = foo()
 end subroutine
 
@@ -20,18 +20,18 @@ end module
 subroutine sub1()
   use testMod
   real :: x
-  ! CHECK-LABEL: fir.call @_QMtestmodPsub()
+  ! CHECK: fir.call @_QMtestmodPsub()
   call Sub();
-  ! CHECK-LABEL: fir.call @_QMtestmodPfoo()
+  ! CHECK: fir.call @_QMtestmodPfoo()
   x = foo()
 end subroutine
 
 subroutine sub2()
   use testMod, localfoo => foo, localsub => sub
   real :: x
-  ! CHECK-LABEL: fir.call @_QMtestmodPsub()
+  ! CHECK: fir.call @_QMtestmodPsub()
   call localsub();
-  ! CHECK-LABEL: fir.call @_QMtestmodPfoo()
+  ! CHECK: fir.call @_QMtestmodPfoo()
   x = localfoo()
 end subroutine
 
@@ -39,9 +39,9 @@ end subroutine
 
 subroutine sub3()
   real :: x
-  ! CHECK-LABEL: fir.call @_QFsub3Psub()
+  ! CHECK: fir.call @_QFsub3Psub()
   call sub();
-  ! CHECK-LABEL: fir.call @_QFsub3Pfoo()
+  ! CHECK: fir.call @_QFsub3Pfoo()
   x = foo()
 contains
   subroutine sub()
@@ -50,3 +50,30 @@ contains
   function foo()
   end function
 end subroutine
+
+function foo1()
+  real :: bar1
+  ! CHECK: fir.call @_QPbar1()
+  foo1 = bar1()
+end function
+
+function foo2()
+  ! CHECK: fir.call @_QPbar2()
+  foo2 = bar2()
+end function
+
+function foo3()
+  interface
+  real function bar3()
+  end function
+  end interface
+  ! CHECK: fir.call @_QPbar3()
+  foo3 = bar3()
+end function
+
+function foo4()
+  external :: bar4
+  ! CHECK: fir.call @_QPbar4()
+  foo4 = bar4()
+end function
+

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -6,8 +6,7 @@ function char_return_callee(i)
   integer :: i
 end function
 
-! FIXME: the mangling is incorrect.
-! CHECK-LABEL: func @_QFtest_char_return_callerPchar_return_caller(!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPchar_return_caller(!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
 subroutine test_char_return_caller
   character(10) :: char_return_caller
   print *, char_return_caller(5)


### PR DESCRIPTION
This addresses issue #138:
- Symbol with ProcEntityDetails are always external procedures unless they are
  procedure pointers/dummy arguments. Add a check for pointers/dummies and remove
  the IsExternal check that is only answering true if the procedure appeared in
  an explicit EXTERNAL statement. In case of dummies/pointers, mangle as a variable not a procedure (this can be revisited when actually lowering those).

On top of issue 138:

- Another issue was that when an external program is defined
inside an interface, then the related Symbol has SubprogramDetails, so
isExternal must be checked in this case. See bar3 in added tests for an
example of what was failing.

- Looking at ProcEntityDetails more closely, I understand that the
related interface symbol has nothing to do with the actual definition,
so just remove this from the logic looking for the callee definition
source location.