### PR TITLE
add verification to lowering

### DIFF
--- a/flang/include/flang/Lower/Support/Verifier.h
+++ b/flang/include/flang/Lower/Support/Verifier.h
@@ -1,0 +1,30 @@
+//===-- Lower/Support/Verifier.h -- verify pass for lowering ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LOWER_SUPPORT_VERIFIER_H
+#define LOWER_SUPPORT_VERIFIER_H
+
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+
+namespace Fortran::lower {
+
+/// A verification pass to verify the output from the bridge. This provides a
+/// little bit of glue to run a verifier pass directly.
+class VerifierPass
+    : public mlir::PassWrapper<VerifierPass, mlir::OperationPass<>> {
+  void runOnOperation() override final {
+    if (mlir::failed(mlir::verify(getOperation())))
+      signalPassFailure();
+    markAllAnalysesPreserved();
+  }
+};
+
+} // namespace Fortran::lower
+
+#endif // LOWER_SUPPORT_VERIFIER_H


### PR DESCRIPTION
Adds a verifier to always be run immediately after lowering. This is to verify that lowering is producing legal output.