### PR TITLE
Adjust the C/C++ compiler environment

### DIFF
--- a/flang/test/Lower/end-to-end-character-assignment.f90
+++ b/flang/test/Lower/end-to-end-character-assignment.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-llvm -o - %s | tco | llc --relocation-model=pic | as -o %t
-! RUN: %CXX -std=c++17 %t %S/end-to-end-character-assignment-driver.cpp
+! RUN: %CXX -fPIC -std=c++17 %t %S/end-to-end-character-assignment-driver.cpp
 ! RUN: ./a.out
 
 ! This is an end-to-end test that is driven from a c++ program that builds

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -88,3 +88,10 @@ llvm_config.add_tool_substitutions(tools, [config.flang_llvm_tools_dir])
 result = lit_config.params.get("LIBPGMATH")
 if result:
     config.environment["LIBPGMATH"] = True
+
+# Preserve the GCC environment for
+# Examples/hello.cpp and Lower/end-to-end-character-assignment-driver.cpp
+if 'C_INCLUDE_PATH' in os.environ:
+    config.environment['C_INCLUDE_PATH'] = os.environ.get('C_INCLUDE_PATH')
+if 'CPLUS_INCLUDE_PATH' in os.environ:
+    config.environment['CPLUS_INCLUDE_PATH'] = os.environ.get('CPLUS_INCLUDE_PATH')


### PR DESCRIPTION
The hello world sample and the end-to-end character assignment
test both use the host GCC to build and link their executable.
Some environments use GCC with the env vars C_INCLUDE_PATH and
CPLUS_INCLUDE_PATH set; test must be preserved in the lit env.

Until flang gets a proper driver, the end-to-end "hello world"
example uses a pipeline of bbc, tco, llc, and as to create the
test's PIC relocatable object file. On some systems, GCC needs
the -fPIC to override the default choice of a static link.