### PR TITLE
adding other flang passes to cli parser, accepting cl options in tco

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -24,4 +24,28 @@ def AffineDialectPromotion : FunctionPass<"promote-to-affine"> {
   let constructor = "fir::createPromoteToAffinePass()";
 }
 
+def BasicCSE : FunctionPass<"basic-cse"> {
+  let summary = "Basic common sub-expression elimination";
+  let description = [{
+      TODO
+  }];
+  let constructor = "fir::createCSEPass()";
+}
+
+def ControlFlowLowering : FunctionPass<"lower-control-flow"> {
+  let summary = "Convert affine dialect, fir.select_type to standard dialect";
+  let description = [{
+      TODO
+  }];
+  let constructor = "fir::createControlFlowLoweringPass()";
+}
+
+def CFGConversion : FunctionPass<"cfg-conversion"> {
+  let summary = "Convert FIR structured control flow ops to CFG ops.";
+  let description = [{
+      TODO
+  }];
+  let constructor = "fir::createFirToCfgPass()";
+}
+
 #endif // FLANG_OPTIMIZER_TRANSFORMS_PASSES

--- a/flang/lib/Optimizer/Transforms/CSE.cpp
+++ b/flang/lib/Optimizer/Transforms/CSE.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "PassDetail.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/Attributes.h"
@@ -90,11 +91,11 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
       return false;
     // Compare operands.
     if (lhs->isCommutative()) {
-      SmallVector<void*, 8> lops;
+      SmallVector<void *, 8> lops;
       for (const auto &lod : lhs->getOperands())
         lops.push_back(lod.getAsOpaquePointer());
       llvm::sort(lops.begin(), lops.end());
-      SmallVector<void*, 8> rops;
+      SmallVector<void *, 8> rops;
       for (const auto &rod : rhs->getOperands())
         rops.push_back(rod.getAsOpaquePointer());
       llvm::sort(rops.begin(), rops.end());
@@ -112,7 +113,7 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
 };
 
 /// Basic common sub-expression elimination.
-struct BasicCSE : public mlir::PassWrapper<BasicCSE, mlir::FunctionPass> {
+struct BasicCSE : public fir::BasicCSEBase<BasicCSE> {
   BasicCSE() {}
   BasicCSE(const BasicCSE &) {}
 

--- a/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
+++ b/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PassDetail.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
@@ -136,7 +137,7 @@ struct SelectTypeOpConversion : public FIROpConversion<SelectTypeOp> {
 
 /// Convert affine dialect, fir.select_type to standard dialect
 class ControlFlowLoweringPass
-    : public mlir::PassWrapper<ControlFlowLoweringPass, mlir::FunctionPass> {
+    : public ControlFlowLoweringBase<ControlFlowLoweringPass> {
 public:
   explicit ControlFlowLoweringPass() {}
 

--- a/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
+++ b/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PassDetail.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Transforms/Passes.h"
@@ -259,8 +260,7 @@ public:
 };
 
 /// Convert FIR structured control flow ops to CFG ops.
-class CfgConversion
-    : public mlir::PassWrapper<CfgConversion, mlir::FunctionPass> {
+class CfgConversion : public CFGConversionBase<CfgConversion> {
 public:
   void runOnFunction() override {
     if (disableCfgConversion)

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -85,11 +85,11 @@ static int compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
   fir::KindMapping kindMap{context.get()};
   mlir::PassManager pm{context.get()};
   mlir::applyPassManagerCLOptions(pm);
-  if (passPipeline.hasAnyOccurrences()) {
-    passPipeline.addToPipeline(pm);
-  } else if (emitFir) {
+  if (emitFir) {
     // parse the input and pretty-print it back out
     // -emit-fir intentionally disables all the passes
+  } else if (passPipeline.hasAnyOccurrences()) {
+    passPipeline.addToPipeline(pm);
   } else {
     // add all the passes
     // the user can disable them individually


### PR DESCRIPTION
Adding other flang passes to command line through mlir tablegen. Allows using `--basic-cse --cfg-conversion --lower-control-flow` through both bbc and tco. Also updated tco to accept cl arguments for pass pipeline.