### PR TITLE
converting fir loads to affine loads for affine promotion

### DIFF
--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -149,7 +149,6 @@ bool AffineLoopAnalysis::analyzeArrayReference(mlir::Value arrayRef) {
     canPromote = false;
   }
   return canPromote;
-
 }
 
 bool AffineLoopAnalysis::analyzeBody(fir::LoopOp loopOperation,
@@ -249,8 +248,7 @@ private:
         "AffineLoopConversion: array type in coordinate operation not valid\n");
   }
   std::pair<mlir::AffineApplyOp, fir::ConvertOp>
-  createAffineOps(mlir::Value arrayRef,
-                  mlir::PatternRewriter &rewriter) const {
+  createAffineOps(mlir::Value arrayRef, mlir::PatternRewriter &rewriter) const {
     auto acoOp = arrayRef.getDefiningOp<ArrayCoorOp>();
     auto genDim = acoOp.dims().getDefiningOp<GenDimsOp>();
     auto affineMap =


### PR DESCRIPTION
Currently converts memory loads depending on array coordinate and gendim to affine map and affine loads.
from:
```
%a1 : !fir.ref<!fir.array<?x?xf32>>
  %dim = fir.gendims %j1, %k2, %c1, %j2, %k2, %c1 : (index, index, index, index, index, index) -> !fir.dims<2>
... for.do_loop ...
      %a1_idx = fir.array_coor %a1(%dim) %r,%s : (!arr_d2, !fir.dims<2>, index, index) -> !fir.ref<f32>
      %a1_v = fir.load %a1_idx : !fir.ref<f32>
```
to:
```
... affine.for ...
      %a1_idx = affine.apply affine_map<(d0, d1)[s0, s1, s2, s3, s4, s5] -> ((d1 - s3) * ((s1 - s0 + 1) * s2) + d0 - s0)>(%r, %s)[%j1, %k1, %c1, %j2, %k2, %c1]
      %a1_aff = fir.convert %a1 : (!fir.ref<!fir.array<?x?xf32>>) -> memref<?xf32>
      %a1_v = affine.load %a1_aff[%a1_idx] : memref<?xf32>

```