### PR TITLE
Lower dummy procedures

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2653,7 +2653,8 @@ def fir_ConvertOp : fir_OneResultOp<"convert", [NoSideEffect]> {
         (isIntegerCompatible(inType) && isPointerCompatible(outType)) ||
         (isPointerCompatible(inType) && isIntegerCompatible(outType)) ||
         (inType.isa<fir::BoxType>() && outType.isa<fir::BoxType>()) ||
-        (fir::isa_complex(inType) && fir::isa_complex(outType)))
+        (fir::isa_complex(inType) && fir::isa_complex(outType)) ||
+        (inType.isa<mlir::FunctionType>() && outType.isa<mlir::FunctionType>()))
       return mlir::success();
     return emitOpError("invalid type conversion");
   }];

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -204,12 +204,9 @@ static mlir::ParseResult parseCallOp(mlir::OpAsmParser &parser,
   } else {
     auto funcArgs =
         llvm::ArrayRef<mlir::OpAsmParser::OperandType>(operands).drop_front();
-    llvm::SmallVector<mlir::Value, 8> resultArgs(
-        result.operands.begin() + (result.operands.empty() ? 0 : 1),
-        result.operands.end());
     if (parser.resolveOperand(operands[0], funcType, result.operands) ||
         parser.resolveOperands(funcArgs, funcType.getInputs(),
-                               parser.getNameLoc(), resultArgs))
+                               parser.getNameLoc(), result.operands))
       return mlir::failure();
   }
   result.addTypes(funcType.getResults());

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -832,6 +832,9 @@ bool isa_std_type(mlir::Type t) {
 }
 
 bool isa_fir_or_std_type(mlir::Type t) {
+  if (auto funcType = t.dyn_cast<mlir::FunctionType>())
+    return llvm::all_of(funcType.getInputs(), isa_fir_or_std_type) &&  
+      llvm::all_of(funcType.getResults(), isa_fir_or_std_type);
   return isa_fir_type(t) || isa_std_type(t);
 }
 

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -1,0 +1,96 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test dummy procedures
+
+! Test of dummy procedure call
+! CHECK-LABEL: func @_QPfoo(%arg0: () -> ()) -> f32
+real function foo(bar)
+  real :: bar, x
+  ! CHECK: %[[x:.*]] = fir.alloca f32 {name = "x"}
+  x = 42.
+  ! CHECK: %[[funccast:.*]] = fir.convert %arg0 : (() -> ()) -> ((!fir.ref<f32>) -> f32)
+  ! CHECK: fir.call %[[funccast]](%[[x]]) : (!fir.ref<f32>) -> f32
+  foo = bar(x)
+end function
+
+! Test case where dummy procedure is only transiting.
+! CHECK-LABEL: func @_QPprefoo(%arg0: () -> ()) -> f32
+real function prefoo(bar)
+  external :: bar
+  ! CHECK: fir.call @_QPfoo(%arg0) : (() -> ()) -> f32
+  prefoo = foo(bar)
+end function
+
+! Function that will be passed as dummy argument
+!CHECK-LABEL: func @_QPfunc(%arg0: !fir.ref<f32>) -> f32
+real function func(x)
+  real :: x
+  func = x + 0.5
+end function
+
+! Test passing functions as dummy procedure arguments
+! CHECK-LABEL: func @_QPtest_func
+real function test_func()
+  real :: func, prefoo
+  external :: func
+  !CHECK: %[[f:.*]] = constant @_QPfunc : (!fir.ref<f32>) -> f32
+  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<f32>) -> f32) -> (() -> ())
+  !CHECK: fir.call @_QPprefoo(%[[fcast]]) : (() -> ()) -> f32
+  test_func = prefoo(func)
+end function
+
+! Repeat test with dummy subroutine
+
+! CHECK-LABEL: func @_QPfoo_sub(%arg0: () -> ())
+subroutine foo_sub(bar_sub)
+  ! CHECK: %[[x:.*]] = fir.alloca f32 {name = "x"}
+  x = 42.
+  ! CHECK: %[[funccast:.*]] = fir.convert %arg0 : (() -> ()) -> ((!fir.ref<f32>) -> ())
+  ! CHECK: fir.call %[[funccast]](%[[x]]) : (!fir.ref<f32>)
+  call bar_sub(x)
+end subroutine
+
+! Test case where dummy procedure is only transiting.
+! CHECK-LABEL: func @_QPprefoo_sub(%arg0: () -> ())
+subroutine prefoo_sub(bar_sub)
+  external :: bar_sub
+  ! CHECK: fir.call @_QPfoo_sub(%arg0) : (() -> ()) -> ()
+  call foo_sub(bar_sub)
+end subroutine
+
+! Subroutine that will be passed as dummy argument
+!CHECK-LABEL: func @_QPsub(%arg0: !fir.ref<f32>)
+subroutine sub(x)
+  real :: x
+  print *, x
+end subroutine
+
+! Test passing functions as dummy procedure arguments
+! CHECK-LABEL: func @_QPtest_sub
+subroutine test_sub()
+  external :: sub
+  !CHECK: %[[f:.*]] = constant @_QPsub : (!fir.ref<f32>) -> ()
+  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<f32>) -> ()) -> (() -> ())
+  !CHECK: fir.call @_QPprefoo_sub(%[[fcast]]) : (() -> ()) -> ()
+  call prefoo_sub(sub)
+end subroutine
+
+! FIXME: create funcOp if not defined in file
+!subroutine todo1()
+!  external proc_not_defined_in_file
+!  call prefoo_sub(proc_not_defined_in_file)
+!end subroutine
+
+! FIXME: pass intrinsics
+!subroutine todo2()
+!  intrinsic :: acos
+!  print *, prefoo(acos)
+!end subroutine
+
+! TODO: improve dummy procedure types when interface is given.
+! CHECK: func @_QPtodo3(%arg0: () -> ())
+! SHOULD-CHECK: func @_QPtodo3(%arg0: (!fir.ref<f32>) -> f32)
+subroutine todo3(dummy_proc)
+  intrinsic :: acos
+  procedure(acos) :: dummy_proc
+end subroutine


### PR DESCRIPTION
This patch implements dummy procedure lowering with the exception following
TODOs:
- If an external function passed as a dummy argument does not yet have
  an mlir::funcOp, compilation will abort.
- Passing specific intrinsic is not yet supported.
- The type of dummy procedure is () -> (). This could be improved when
  more type knowledge is available. This has currently no functional
  impact.

What's done in this patch:

- Extend CallInterface to handle dummy procedure
- Handle calls to dummy procedure accordingly in ConvertExpr.cpp
- Lower ProcedureDesignator references (with the limitations raised
  above).
- Allow fir.convert to cast between function types, this notably required
  updating fir::isa_fir_or_std_type.
- Fix fir.call parsing in case of indirect calls (the arguments were parsed
  in a temporary vector, and therefore lost).