### PR TITLE
Fix undefined behaviour introduced by rebase with D80285

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2544,7 +2544,12 @@ struct FIRToLLVMLoweringPass
         SubfOpConversion, UnboxCharOpConversion, UnboxOpConversion,
         UnboxProcOpConversion, UndefOpConversion, UnreachableOpConversion,
         XArrayCoorOpConversion, XEmboxOpConversion>(context, typeConverter);
-    mlir::populateStdToLLVMConversionPatterns(typeConverter, pattern);
+    // Workaround D80285: beware, optional LowerToLLVMOptions argument of
+    // populateStdToLLVMConversionPatterns is broken. It ends up creating a
+    // reference over a temp that has the lifetime of the call. Do not use
+    // it.
+    mlir::LowerToLLVMOptions options;
+    mlir::populateStdToLLVMConversionPatterns(typeConverter, pattern, options);
     mlir::ConversionTarget target{*context};
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();
 


### PR DESCRIPTION
https://reviews.llvm.org/D80285 introduced a bug (use after lifetime undefined behaviour), that only showed up with some compilers.
MLIR people are fixing it (I ping their Phabricator review). In the meantime, here is a small workaround.