### PR TITLE
[flang] Lower NULL() intrinsic.

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -70,6 +70,10 @@ public:
   /// Safely create a reference type to the type `eleTy`.
   mlir::Type getRefType(mlir::Type eleTy);
 
+  /// Create a null constant of type RefType and value 0. Need to pass in the
+  /// Location information.
+  mlir::Value createNullConstant(mlir::Location loc);
+
   /// Create an integer constant of type \p type and value \p i.
   mlir::Value createIntegerConstant(mlir::Location loc, mlir::Type integerType,
                                     std::int64_t i);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -339,7 +339,9 @@ private:
         getLoc(), func.getType(), builder.getSymbolRefAttr(name));
     return funcPtr;
   }
-  fir::ExtendedValue genval(const Fortran::evaluate::NullPointer &) { TODO(); }
+  fir::ExtendedValue genval(const Fortran::evaluate::NullPointer &) {
+    return builder.createNullConstant(location);
+  }
   fir::ExtendedValue genval(const Fortran::evaluate::StructureConstructor &) {
     TODO();
   }

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -38,6 +38,14 @@ mlir::Type Fortran::lower::FirOpBuilder::getRefType(mlir::Type eleTy) {
   return fir::ReferenceType::get(eleTy);
 }
 
+mlir::Value
+Fortran::lower::FirOpBuilder::createNullConstant(mlir::Location loc) {
+  auto indexType{this->getIndexType()};
+  auto zero{this->createIntegerConstant(loc, indexType, 0)};
+  auto noneRefType{this->getRefType(this->getNoneType())};
+  return this->createConvert(loc, noneRefType, zero);
+}
+
 mlir::Value Fortran::lower::FirOpBuilder::createIntegerConstant(
     mlir::Location loc, mlir::Type ty, std::int64_t cst) {
   return create<mlir::ConstantOp>(loc, ty, getIntegerAttr(ty, cst));

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -40,10 +40,10 @@ mlir::Type Fortran::lower::FirOpBuilder::getRefType(mlir::Type eleTy) {
 
 mlir::Value
 Fortran::lower::FirOpBuilder::createNullConstant(mlir::Location loc) {
-  auto indexType{this->getIndexType()};
-  auto zero{this->createIntegerConstant(loc, indexType, 0)};
-  auto noneRefType{this->getRefType(this->getNoneType())};
-  return this->createConvert(loc, noneRefType, zero);
+  auto indexType = getIndexType();
+  auto zero = createIntegerConstant(loc, indexType, 0);
+  auto noneRefType = getRefType(getNoneType());
+  return createConvert(loc, noneRefType, zero);
 }
 
 mlir::Value Fortran::lower::FirOpBuilder::createIntegerConstant(

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -4,13 +4,38 @@
 subroutine pointerTests
   ! CHECK: fir.global @_QFpointertestsEptr1 : !fir.ptr<i32>
   integer, pointer :: ptr1 => NULL()
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<i32>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<i32>
+
   ! CHECK: fir.global @_QFpointertestsEptr2 : !fir.ptr<f32>
   real, pointer :: ptr2 => NULL()
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<f32>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<f32>
+
   ! CHECK: fir.global @_QFpointertestsEptr3 : !fir.ptr<!fir.complex<4>>
   complex, pointer :: ptr3 => NULL()
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.complex<4>>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.complex<4>>
+
   ! CHECK: fir.global @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>
   character, pointer :: ptr4 => NULL()
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1>
+
   ! CHECK: fir.global @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
   logical, pointer :: ptr5 => NULL()
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.logical<4>>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.logical<4>>
+
 end subroutine pointerTests
 

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -23,12 +23,12 @@ subroutine pointerTests
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.complex<4>>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.complex<4>>
 
-  ! CHECK: fir.global @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>
+  ! CHECK: fir.global @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>>
   character, pointer :: ptr4 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
-  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1>
-  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1>>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1>>
 
   ! CHECK: fir.global @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
   logical, pointer :: ptr5 => NULL()

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -1,0 +1,16 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPpointertests
+subroutine pointerTests
+  ! CHECK: fir.global @_QFpointertestsEptr1 : !fir.ptr<i32>
+  integer, pointer :: ptr1 => NULL()
+  ! CHECK: fir.global @_QFpointertestsEptr2 : !fir.ptr<f32>
+  real, pointer :: ptr2 => NULL()
+  ! CHECK: fir.global @_QFpointertestsEptr3 : !fir.ptr<!fir.complex<4>>
+  complex, pointer :: ptr3 => NULL()
+  ! CHECK: fir.global @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>
+  character, pointer :: ptr4 => NULL()
+  ! CHECK: fir.global @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
+  logical, pointer :: ptr5 => NULL()
+end subroutine pointerTests
+


### PR DESCRIPTION
I did try to add more test considering `MOLD` but there is a `TODO`.
 ```
program usemold
   integer, pointer :: ptr7
   ptr7 => NULL(MOLD=ptr1)
end program
```
is a [TODO](https://github.com/flang-compiler/f18-llvm-project/blob/17fa1ca1604cdc315154bf8ef367e9edce051874/flang/lib/Lower/Bridge.cpp#L1360)


Null pointers with derived types assert [here](https://github.com/flang-compiler/f18-llvm-project/blob/538e1b1494864982f84c1591906e0ee9850c2506/flang/lib/Lower/PFTBuilder.cpp#L990)
on below test
```
 type listNode
        integer :: nodeData
        TYPE(listNode), POINTER :: nextNode => NULL()
  end type
```