### PR TITLE
Thread ExtendedValue in intrinsic lowering helper.

### DIFF
--- a/flang/include/flang/Lower/IntrinsicCall.h
+++ b/flang/include/flang/Lower/IntrinsicCall.h
@@ -11,6 +11,10 @@
 
 #include "flang/Lower/FIRBuilder.h"
 
+namespace fir {
+class ExtendedValue;
+}
+
 namespace Fortran::lower {
 
 // TODO: Expose interface to get specific intrinsic function address.
@@ -32,8 +36,9 @@ public:
   /// Generate the FIR+MLIR operations for the generic intrinsic \p name
   /// with arguments \p args and expected result type \p resultType.
   /// Returned mlir::Value is the returned Fortran intrinsic value.
-  mlir::Value genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
-                               llvm::ArrayRef<mlir::Value> args);
+  fir::ExtendedValue genIntrinsicCall(llvm::StringRef name,
+                                      mlir::Type resultType,
+                                      llvm::ArrayRef<fir::ExtendedValue> args);
 
   //===--------------------------------------------------------------------===//
   // Direct access to intrinsics that may be used by lowering outside

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -516,15 +516,14 @@ private:
   fir::ExtendedValue
   genval(const Fortran::evaluate::Extremum<Fortran::evaluate::Type<TC, KIND>>
              &op) {
-    std::string name =
-        op.ordering == Fortran::evaluate::Ordering::Greater ? "max"s : "min"s;
-    auto type = converter.genType(TC, KIND);
+    bool isMax = op.ordering == Fortran::evaluate::Ordering::Greater;
     auto lhs = genunbox(op.left());
     auto rhs = genunbox(op.right());
     assert(lhs && rhs && "boxed value not handled");
     llvm::SmallVector<mlir::Value, 2> operands{lhs, rhs};
-    return Fortran::lower::IntrinsicCallOpsHelper{builder, getLoc()}
-        .genIntrinsicCall(name, type, operands);
+    Fortran::lower::IntrinsicCallOpsHelper helper(builder, getLoc());
+
+    return isMax ? helper.genMax(operands) : helper.genMin(operands);
   }
 
   template <int KIND>
@@ -1097,14 +1096,14 @@ private:
     TODO(); // Derived type functions (user + intrinsics)
   }
 
-  mlir::Value
+  fir::ExtendedValue
   genIntrinsicRef(const Fortran::evaluate::ProcedureRef &procRef,
                   const Fortran::evaluate::SpecificIntrinsic &intrinsic,
                   mlir::ArrayRef<mlir::Type> resultType) {
     if (resultType.size() != 1)
       TODO(); // Intrinsic subroutine
 
-    llvm::SmallVector<mlir::Value, 2> operands;
+    llvm::SmallVector<fir::ExtendedValue, 2> operands;
     // Lower arguments
     // For now, logical arguments for intrinsic are lowered to `fir.logical`
     // so that TRANSFER can work. For some arguments, it could lead to useless
@@ -1114,11 +1113,9 @@ private:
     for (const auto &arg : procRef.arguments()) {
       if (auto *expr = Fortran::evaluate::UnwrapExpr<
               Fortran::evaluate::Expr<Fortran::evaluate::SomeType>>(arg)) {
-        auto x = genval(*expr);
-        auto arg = fir::getBase(x);
-        operands.push_back(arg);
+        operands.emplace_back(genval(*expr));
       } else {
-        operands.push_back(nullptr); // optional
+        operands.emplace_back(mlir::Value{}); // optional
       }
     }
     // Let the intrinsic library lower the intrinsic procedure call
@@ -1144,8 +1141,9 @@ private:
     return false;
   }
 
-  mlir::Value genProcedureRef(const Fortran::evaluate::ProcedureRef &procRef,
-                              mlir::ArrayRef<mlir::Type> resultType) {
+  fir::ExtendedValue
+  genProcedureRef(const Fortran::evaluate::ProcedureRef &procRef,
+                  mlir::ArrayRef<mlir::Type> resultType) {
     if (const auto *intrinsic = procRef.proc().GetSpecificIntrinsic())
       return genIntrinsicRef(procRef, *intrinsic, resultType[0]);
 
@@ -1275,7 +1273,7 @@ private:
     if (caller.getPassedResult())
       return resRef;
     if (resultType.size() == 0)
-      return {}; // subroutine call
+      return mlir::Value{}; // subroutine call
     // For now, Fortran returned values are implemented with a single MLIR
     // function return value.
     assert(call.getNumResults() == 1 &&


### PR DESCRIPTION
This change paves the way for handling arrays in intrinsic lowering:
- Start threading `fir::ExtendedValue` at the interface of the intrinsic helper.
- Add scalar/extended generator to prepare for elemental lowering.