### PR TITLE
Remove the dependence on string literal operator template extensions …

### DIFF
--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -15,8 +15,6 @@
 #include "flang/Semantics/tools.h"
 #include "llvm/ADT/SmallVector.h"
 
-using Fortran::lower::operator""_rt_ident;
-
 #define MakeRuntimeEntry(X) mkKey(RTNAME(X))
 
 template <typename RuntimeEntry>


### PR DESCRIPTION
…to support more build compilers (e.g., MSVC).