### PR TITLE
lower passing unrestricted intrnsics as arguments

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -35,6 +35,7 @@ class Symbol;
 
 namespace Fortran::evaluate {
 class ProcedureRef;
+struct ProcedureDesignator;
 class ActualArgument;
 namespace characteristics {
 struct Procedure;
@@ -161,10 +162,6 @@ public:
   std::optional<PassedEntity> getPassedResult() const { return passedResult; }
   /// Returns the mlir function type
   mlir::FunctionType genFunctionType() const;
-
-private:
-  /// CRTP handle.
-  T &side() { return *static_cast<T *>(this); }
   /// buildImplicitInterface and buildExplicitInterface are the entry point
   /// of the first pass that define the interface and is required to get
   /// the mlir::FuncOp.
@@ -172,6 +169,10 @@ private:
   buildImplicitInterface(const Fortran::evaluate::characteristics::Procedure &);
   void
   buildExplicitInterface(const Fortran::evaluate::characteristics::Procedure &);
+
+private:
+  /// CRTP handle.
+  T &side() { return *static_cast<T *>(this); }
   /// Second pass entry point, once the mlir::FuncOp is created
   void mapBackInputToPassedEntity(const FirPlaceHolder &, FirValue);
 
@@ -273,6 +274,11 @@ public:
 private:
   Fortran::lower::pft::FunctionLikeUnit &funit;
 };
+
+/// Translate a procedure characteristics to an mlir::FunctionType signature.
+mlir::FunctionType
+translateSignature(const Fortran::evaluate::ProcedureDesignator &,
+                   Fortran::lower::AbstractConverter &);
 
 } // namespace Fortran::lower
 

--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -106,6 +106,19 @@ public:
   /// Character lengths. TODO: move this to FirOpBuilder?
   mlir::Type getLengthType() { return builder.getIndexType(); }
 
+  /// Create an extended value from:
+  /// - fir.boxchar<kind>
+  /// - fir.ref<fir.array<len x fir.char<kind>>>
+  /// - fir.array<len x fir.char<kind>>
+  /// - fir.char<kind>
+  /// - fir.ref<char<kind>>
+  /// If the no length is passed, it is attempted to be extracted from \p
+  /// character (or its type). This will crash if this is not possible.
+  /// The returned value is a CharBoxValue if \p character is a scalar,
+  /// otherwise it is a CharArrayBoxValue.
+  fir::ExtendedValue toExtendedValue(mlir::Value character,
+                                     mlir::Value len = {});
+
 private:
   fir::CharBoxValue materializeValue(const fir::CharBoxValue &str);
   fir::CharBoxValue toDataLengthPair(mlir::Value character);

--- a/flang/include/flang/Lower/IntrinsicCall.h
+++ b/flang/include/flang/Lower/IntrinsicCall.h
@@ -27,39 +27,40 @@ namespace Fortran::lower {
 
 /// Helper for building calls to intrinsic functions in the runtime support
 /// libraries.
-class IntrinsicCallOpsHelper {
-public:
-  explicit IntrinsicCallOpsHelper(FirOpBuilder &builder, mlir::Location loc)
-      : builder(builder), loc(loc) {}
-  IntrinsicCallOpsHelper(const IntrinsicCallOpsHelper &) = delete;
 
-  /// Generate the FIR+MLIR operations for the generic intrinsic \p name
-  /// with arguments \p args and expected result type \p resultType.
-  /// Returned mlir::Value is the returned Fortran intrinsic value.
-  fir::ExtendedValue genIntrinsicCall(llvm::StringRef name,
-                                      mlir::Type resultType,
-                                      llvm::ArrayRef<fir::ExtendedValue> args);
+/// Generate the FIR+MLIR operations for the generic intrinsic \p name
+/// with arguments \p args and expected result type \p resultType.
+/// Returned mlir::Value is the returned Fortran intrinsic value.
+fir::ExtendedValue genIntrinsicCall(FirOpBuilder &, mlir::Location,
+                                    llvm::StringRef name, mlir::Type resultType,
+                                    llvm::ArrayRef<fir::ExtendedValue> args);
 
-  //===--------------------------------------------------------------------===//
-  // Direct access to intrinsics that may be used by lowering outside
-  // of intrinsic call lowering.
-  //===--------------------------------------------------------------------===//
+/// Get SymbolRefAttr of runtime (or wrapper function containing inlined
+// implementation) of an unrestricted intrinsic (defined by its signature
+// and generic name)
+mlir::SymbolRefAttr
+getUnrestrictedIntrinsicSymbolRefAttr(FirOpBuilder &, mlir::Location,
+                                      llvm::StringRef name,
+                                      mlir::FunctionType signature);
 
-  /// Generate maximum. There must be at least one argument and all arguments
-  /// must have the same type.
-  mlir::Value genMax(llvm::ArrayRef<mlir::Value> args);
+//===--------------------------------------------------------------------===//
+// Direct access to intrinsics that may be used by lowering outside
+// of intrinsic call lowering.
+//===--------------------------------------------------------------------===//
 
-  /// Generate minimum. Same constraints as genMax.
-  mlir::Value genMin(llvm::ArrayRef<mlir::Value> args);
+/// Generate maximum. There must be at least one argument and all arguments
+/// must have the same type.
+mlir::Value genMax(FirOpBuilder &, mlir::Location,
+                   llvm::ArrayRef<mlir::Value> args);
 
-  /// Generate power function x**y with given the expected
-  /// result type.
-  mlir::Value genPow(mlir::Type resultType, mlir::Value x, mlir::Value y);
+/// Generate minimum. Same constraints as genMax.
+mlir::Value genMin(FirOpBuilder &, mlir::Location,
+                   llvm::ArrayRef<mlir::Value> args);
 
-private:
-  FirOpBuilder &builder;
-  mlir::Location loc;
-};
+/// Generate power function x**y with given the expected
+/// result type.
+mlir::Value genPow(FirOpBuilder &, mlir::Location, mlir::Type resultType,
+                   mlir::Value x, mlir::Value y);
 
 } // namespace Fortran::lower
 

--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -14,6 +14,10 @@
 #include "llvm/ADT/StringRef.h"
 #include <cstdint>
 
+namespace mlir {
+class FunctionType;
+}
+
 namespace fir {
 
 /// Internal name mangling of identifiers
@@ -122,6 +126,17 @@ private:
   std::string doKinds(llvm::ArrayRef<std::int64_t> kinds);
   std::string toLower(llvm::StringRef name);
 };
+
+/// Returns a name suitable to define mlir functions for Fortran intrinsic
+/// Procedure. These names are guaranteed to not conflict with user defined
+/// procedures. This is needed to implement Fortran generic intrinsics as
+/// several mlir functions specialized for the argument types.
+/// The result is guaranteed to be distinct for different mlir::FunctionType
+/// arguments. The mangling pattern is:
+///    fir.<generic name>.<result type>.<arg type>...
+/// e.g ACOS(COMPLEX(4)) is mangled as fir.acos.z4.z4
+std::string mangleIntrinsicProcedure(llvm::StringRef genericName,
+                                     mlir::FunctionType);
 
 } // namespace fir
 

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -211,8 +211,8 @@ void Fortran::lower::CharacterExprHelper::createAssign(
   // if needed.
   mlir::Value copyCount = lhs.getLen();
   if (!compileTimeSameLength)
-    copyCount = Fortran::lower::IntrinsicCallOpsHelper{builder, loc}.genMin(
-        {lhs.getLen(), rhs.getLen()});
+    copyCount =
+        Fortran::lower::genMin(builder, loc, {lhs.getLen(), rhs.getLen()});
 
   fir::CharBoxValue safeRhs = rhs;
   if (needToMaterialize(rhs)) {

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -65,38 +65,61 @@ fir::CharBoxValue Fortran::lower::CharacterExprHelper::materializeValue(
 
 fir::CharBoxValue
 Fortran::lower::CharacterExprHelper::toDataLengthPair(mlir::Value character) {
+  // TODO: get rid of toDataLengthPair when adding support for arrays
+  auto charBox = toExtendedValue(character).getCharBox();
+  assert(charBox && "Array unsupported in character lowering helper");
+  return *charBox;
+}
+
+fir::ExtendedValue
+Fortran::lower::CharacterExprHelper::toExtendedValue(mlir::Value character,
+                                                     mlir::Value len) {
   auto lenType = getLengthType();
   auto type = character.getType();
-  if (auto boxCharType = type.dyn_cast<fir::BoxCharType>()) {
+  auto base = character;
+  mlir::Value resultLen = len;
+  llvm::SmallVector<mlir::Value, 2> extents;
+
+  if (auto refType = type.dyn_cast<fir::ReferenceType>())
+    type = refType.getEleTy();
+
+  if (auto arrayType = type.dyn_cast<fir::SequenceType>()) {
+    type = arrayType.getEleTy();
+    auto shape = arrayType.getShape();
+    auto cstLen = shape[0];
+    if (!resultLen && cstLen != fir::SequenceType::getUnknownExtent())
+      resultLen = builder.createIntegerConstant(loc, lenType, cstLen);
+    // FIXME: only allow `?` in last dimension ?
+    auto typeExtents =
+        llvm::ArrayRef<fir::SequenceType::Extent>{shape}.drop_front();
+    for (auto extent : typeExtents) {
+      if (extent == fir::SequenceType::getUnknownExtent())
+        extents.emplace_back(mlir::Value{});
+      else
+        extents.emplace_back(
+            builder.createIntegerConstant(loc, builder.getIndexType(), extent));
+    }
+  } else if (type.isa<fir::CharacterType>()) {
+    if (!resultLen)
+      resultLen = builder.createIntegerConstant(loc, lenType, 1);
+  } else if (auto boxCharType = type.dyn_cast<fir::BoxCharType>()) {
     auto refType = builder.getRefType(boxCharType.getEleTy());
     auto unboxed =
         builder.create<fir::UnboxCharOp>(loc, refType, lenType, character);
-    return {unboxed.getResult(0), unboxed.getResult(1)};
+    base = unboxed.getResult(0);
+    if (!resultLen)
+      resultLen = unboxed.getResult(1);
+  } else if (type.isa<fir::BoxType>()) {
+    mlir::emitError(loc, "descriptor or derived type not yet handled");
+  } else {
+    llvm_unreachable("Cannot translate mlir::Value to character ExtendedValue");
   }
-  if (auto seqType = type.dyn_cast<fir::CharacterType>()) {
-    // Materialize length for usage into character manipulations.
-    auto len = builder.createIntegerConstant(loc, lenType, 1);
-    return {character, len};
-  }
-  if (auto refType = type.dyn_cast<fir::ReferenceType>())
-    type = refType.getEleTy();
-  if (auto seqType = type.dyn_cast<fir::SequenceType>()) {
-    assert(seqType.hasConstantShape() &&
-           "ssa array value must have constant length");
-    auto shape = seqType.getShape();
-    assert(shape.size() == 1 && "only scalar character supported");
-    // Materialize length for usage into character manipulations.
-    auto len = builder.createIntegerConstant(loc, lenType, shape[0]);
-    // FIXME: this seems to work for tests, but don't think it is correct
-    if (auto load = dyn_cast<fir::LoadOp>(character.getDefiningOp()))
-      return {load.memref(), len};
-    return {character, len};
-  }
-  if (auto charTy = type.dyn_cast<fir::CharacterType>()) {
-    auto len = builder.createIntegerConstant(loc, lenType, 1);
-    return {character, len};
-  }
-  llvm::report_fatal_error("unexpected character type");
+
+  if (!resultLen)
+    mlir::emitError(loc, "no dynamic length found for character");
+  if (!extents.empty())
+    return fir::CharArrayBoxValue{base, resultLen, extents};
+  return fir::CharBoxValue{base, resultLen};
 }
 
 /// Get fir.ref<fir.char<kind>> type.

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -20,6 +20,7 @@
 #include "flang/Lower/ConvertType.h"
 #include "flang/Lower/FIRBuilder.h"
 #include "flang/Lower/Runtime.h"
+#include "flang/Optimizer/Support/InternalNames.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
@@ -167,10 +168,6 @@ private:
 };
 } // namespace
 
-// FIXME: consider merging IntrinsicLibrary class and the
-// InstrinsicCallOpsHelper class. They serve the same purpose and the methods
-// here can just be private to the helper.
-
 // TODO error handling -> return a code or directly emit messages ?
 struct IntrinsicLibrary {
 
@@ -197,6 +194,13 @@ struct IntrinsicLibrary {
   mlir::Value genRuntimeCall(llvm::StringRef name, mlir::Type,
                              llvm::ArrayRef<mlir::Value>);
 
+  using RuntimeCallGenerator =
+      std::function<mlir::Value(Fortran::lower::FirOpBuilder &, mlir::Location,
+                                llvm::ArrayRef<mlir::Value>)>;
+  RuntimeCallGenerator
+  getRuntimeCallGenerator(llvm::StringRef name,
+                          mlir::FunctionType soughtFuncType);
+
   mlir::Value genAbs(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genAimag(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genAint(mlir::Type, llvm::ArrayRef<mlir::Value>);
@@ -211,8 +215,8 @@ struct IntrinsicLibrary {
   mlir::Value genIchar(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genIEOr(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genIOr(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  fir::ExtendedValue genLen(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genLenTrim(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
-  // mlir::Value genLenTrim(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genMerge(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genMod(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genNint(mlir::Type, llvm::ArrayRef<mlir::Value>);
@@ -234,15 +238,40 @@ struct IntrinsicLibrary {
   /// This can be used to keep the FIR more readable. Only one function will
   /// be generated for all the similar calls in a program.
   /// If the Generator is nullptr, the wrapper uses genRuntimeCall.
-  mlir::Value outlineInWrapper(ElementalGenerator g, llvm::StringRef name,
+  template <typename GeneratorType>
+  mlir::Value outlineInWrapper(GeneratorType, llvm::StringRef name,
                                mlir::Type resultType,
                                llvm::ArrayRef<mlir::Value> args);
+  fir::ExtendedValue outlineInWrapper(ExtendedGenerator, llvm::StringRef name,
+                                      mlir::Type resultType,
+                                      llvm::ArrayRef<fir::ExtendedValue> args);
+
+  template <typename GeneratorType>
+  mlir::FuncOp getWrapper(GeneratorType, llvm::StringRef name,
+                          mlir::FunctionType, bool loadRefArguments = false);
 
   /// Generate calls to ElementalGenerator, handling the elemental aspects
-  fir::ExtendedValue genElementalCall(ElementalGenerator, llvm::StringRef name,
-                                      mlir::Type resultType,
-                                      llvm::ArrayRef<fir::ExtendedValue> args,
-                                      bool outline);
+  template <typename GeneratorType>
+  fir::ExtendedValue
+  genElementalCall(GeneratorType, llvm::StringRef name, mlir::Type resultType,
+                   llvm::ArrayRef<fir::ExtendedValue> args, bool outline);
+
+  /// Helper to invoke code generator for the intrinsics given arguments.
+  mlir::Value invokeGenerator(ElementalGenerator generator,
+                              mlir::Type resultType,
+                              llvm::ArrayRef<mlir::Value> args);
+  mlir::Value invokeGenerator(RuntimeCallGenerator generator,
+                              mlir::Type resultType,
+                              llvm::ArrayRef<mlir::Value> args);
+  mlir::Value invokeGenerator(ExtendedGenerator generator,
+                              mlir::Type resultType,
+                              llvm::ArrayRef<mlir::Value> args);
+
+  /// Get pointer to unrestricted intrinsic. Generate the related unrestricted
+  /// intrinsic if it is not defined yet.
+  mlir::SymbolRefAttr
+  getUnrestrictedIntrinsicSymbolRefAttr(llvm::StringRef name,
+                                        mlir::FunctionType signature);
 
   Fortran::lower::FirOpBuilder &builder;
   mlir::Location loc;
@@ -277,6 +306,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"ichar", &I::genIchar},
     {"ieor", &I::genIEOr},
     {"ior", &I::genIOr},
+    {"len", &I::genLen},
     {"len_trim", &I::genLenTrim},
     {"max", &I::genExtremum<Extremum::Max, ExtremumBehavior::MinMaxss>},
     {"min", &I::genExtremum<Extremum::Min, ExtremumBehavior::MinMaxss>},
@@ -536,6 +566,8 @@ private:
   bool infinite{false}; // When forbidden conversion or wrong argument number
 };
 
+/// Build mlir::FuncOp from runtime symbol description and add
+/// fir.runtime attribute.
 static mlir::FuncOp getFuncOp(mlir::Location loc,
                               Fortran::lower::FirOpBuilder &builder,
                               const RuntimeFunction &runtime) {
@@ -548,12 +580,15 @@ static mlir::FuncOp getFuncOp(mlir::Location loc,
 /// Select runtime function that has the smallest distance to the intrinsic
 /// function type and that will not imply narrowing arguments or extending the
 /// result.
+/// If nothing is found, the mlir::FuncOp will contain a nullptr.
 template <std::size_t N>
-llvm::Optional<mlir::FuncOp> searchFunctionInLibrary(
-    mlir::Location loc, Fortran::lower::FirOpBuilder &builder,
-    const RuntimeFunction (&lib)[N], llvm::StringRef name,
-    mlir::FunctionType funcType, const RuntimeFunction **bestNearMatch,
-    FunctionDistance &bestMatchDistance) {
+mlir::FuncOp searchFunctionInLibrary(mlir::Location loc,
+                                     Fortran::lower::FirOpBuilder &builder,
+                                     const RuntimeFunction (&lib)[N],
+                                     llvm::StringRef name,
+                                     mlir::FunctionType funcType,
+                                     const RuntimeFunction **bestNearMatch,
+                                     FunctionDistance &bestMatchDistance) {
   auto map = StaticMultimapView(lib);
   auto range = map.equal_range(name);
   for (auto iter{range.first}; iter != range.second && iter; ++iter) {
@@ -575,12 +610,14 @@ llvm::Optional<mlir::FuncOp> searchFunctionInLibrary(
 /// Search runtime for the best runtime function given an intrinsic name
 /// and interface. The interface may not be a perfect match in which case
 /// the caller is responsible to insert argument and return value conversions.
-static llvm::Optional<mlir::FuncOp>
-getRuntimeFunction(mlir::Location loc, Fortran::lower::FirOpBuilder &builder,
-                   llvm::StringRef name, mlir::FunctionType funcType) {
+/// If nothing is found, the mlir::FuncOp will contain a nullptr.
+static mlir::FuncOp getRuntimeFunction(mlir::Location loc,
+                                       Fortran::lower::FirOpBuilder &builder,
+                                       llvm::StringRef name,
+                                       mlir::FunctionType funcType) {
   const RuntimeFunction *bestNearMatch = nullptr;
   FunctionDistance bestMatchDistance{};
-  llvm::Optional<mlir::FuncOp> match;
+  mlir::FuncOp match;
   if (mathRuntimeVersion == fastVersion) {
     match = searchFunctionInLibrary(loc, builder, pgmathFast, name, funcType,
                                     &bestNearMatch, bestMatchDistance);
@@ -616,60 +653,102 @@ static mlir::FunctionType
 getFunctionType(mlir::Type resultType, llvm::ArrayRef<mlir::Value> arguments,
                 Fortran::lower::FirOpBuilder &builder) {
   llvm::SmallVector<mlir::Type, 2> argumentTypes;
-  for (auto &arg : arguments) {
-    if (arg)
-      argumentTypes.push_back(arg.getType());
-  }
+  for (auto &arg : arguments)
+    argumentTypes.push_back(arg.getType());
   return mlir::FunctionType::get(argumentTypes, resultType,
                                  builder.getModule().getContext());
 }
 
-/// Helper to encode type into string for intrinsic wrapper name.
-// TODO find nicer type to string infra or move this in a mangling utility
-// mlir as Type::dump(ostream) methods but it may adds !
-static std::string typeToString(mlir::Type t) {
-  if (auto i{t.dyn_cast<mlir::IntegerType>()}) {
-    return "i" + std::to_string(i.getWidth());
+/// fir::ExtendedValue to mlir::Value translation layer
+
+fir::ExtendedValue toExtendedValue(mlir::Value val,
+                                   Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc) {
+  assert(val && "optional unhandled here");
+  auto type = val.getType();
+  auto base = val;
+  mlir::Value len;
+  auto indexType = builder.getIndexType();
+  llvm::SmallVector<mlir::Value, 2> extents;
+
+  if (auto refType = type.dyn_cast<fir::ReferenceType>())
+    type = refType.getEleTy();
+
+  if (auto arrayType = type.dyn_cast<fir::SequenceType>()) {
+    type = arrayType.getEleTy();
+    llvm::ArrayRef<fir::SequenceType::Extent> shape = arrayType.getShape();
+    if (auto charType = type.dyn_cast<fir::CharacterType>()) {
+      auto cstLen = arrayType.getShape()[0];
+      shape = shape.drop_front();
+      if (cstLen == fir::SequenceType::getUnknownExtent())
+        mlir::emitError(loc, "No runtime length for given mlir::Value");
+      len = builder.createIntegerConstant(loc, indexType, cstLen);
+    }
+    for (auto extent : shape) {
+      if (extent == fir::SequenceType::getUnknownExtent())
+        extents.emplace_back(mlir::Value{});
+      else
+        extents.emplace_back(
+            builder.createIntegerConstant(loc, indexType, extent));
+    }
+  } else if (type.isa<fir::BoxCharType>()) {
+    std::tie(base, len) =
+        Fortran::lower::CharacterExprHelper{builder, loc}.createUnboxChar(val);
+  } else if (type.isa<fir::CharacterType>()) {
+    len = builder.createIntegerConstant(loc, indexType, 1);
+  } else if (type.isa<fir::BoxType>() || type.isa<fir::RecordType>()) {
+    mlir::emitError(loc, "descriptor or derived type not yet handled");
   }
-  if (auto cplx{t.dyn_cast<fir::CplxType>()}) {
-    return "z" + std::to_string(cplx.getFKind());
-  }
-  if (auto real{t.dyn_cast<fir::RealType>()}) {
-    return "r" + std::to_string(real.getFKind());
-  }
-  if (auto f{t.dyn_cast<mlir::FloatType>()}) {
-    return "f" + std::to_string(f.getWidth());
-  }
-  if (auto logical{t.dyn_cast<fir::LogicalType>()}) {
-    return "l" + std::to_string(logical.getFKind());
-  }
-  if (auto character{t.dyn_cast<fir::CharacterType>()}) {
-    return "c" + std::to_string(character.getFKind());
-  }
-  llvm_unreachable("no mangling for type");
+
+  if (len && !extents.empty())
+    return fir::CharArrayBoxValue{base, len, extents};
+  if (len)
+    return fir::CharBoxValue{base, len};
+  if (!extents.empty())
+    return fir::ArrayBoxValue{base, extents};
+  return base;
 }
 
-/// Generate a function name for function where intrinsic implementation
-/// are outlined. It is not a legal Fortran name and could therefore
-/// safely be matched later if needed.
-static std::string getIntrinsicWrapperName(const llvm::StringRef &intrinsic,
-                                           mlir::FunctionType funTy) {
-  std::string name{"fir." + intrinsic.str() + "."};
-  assert(funTy.getNumResults() == 1 && "only function mangling supported");
-  name += typeToString(funTy.getResult(0));
-  auto e = funTy.getNumInputs();
-  for (decltype(e) i = 0; i < e; ++i) {
-    name += "." + typeToString(funTy.getInput(i));
+llvm::SmallVector<fir::ExtendedValue, 2>
+toExtendedValue(llvm::ArrayRef<mlir::Value> values,
+                Fortran::lower::FirOpBuilder &builder, mlir::Location loc) {
+  llvm::SmallVector<fir::ExtendedValue, 2> extendedValues;
+  for (auto val : values)
+    extendedValues.emplace_back(toExtendedValue(val, builder, loc));
+  return extendedValues;
+}
+
+mlir::Value toValue(const fir::ExtendedValue &val,
+                    Fortran::lower::FirOpBuilder &builder, mlir::Location loc) {
+  if (auto charBox = val.getCharBox()) {
+    auto buffer = charBox->getBuffer();
+    if (buffer.getType().isa<fir::BoxCharType>())
+      return buffer;
+    return Fortran::lower::CharacterExprHelper{builder, loc}.createEmboxChar(
+        buffer, charBox->getLen());
   }
-  return name;
+
+  // FIXME: need to access other ExtendedValue variants and handle them
+  // properly.
+  return fir::getBase(val);
+}
+
+llvm::SmallVector<mlir::Value, 2>
+toValue(llvm::ArrayRef<fir::ExtendedValue> extendedValues,
+        Fortran::lower::FirOpBuilder &builder, mlir::Location loc) {
+  llvm::SmallVector<mlir::Value, 2> values;
+  for (const auto &extendedVal : extendedValues)
+    values.emplace_back(toValue(extendedVal, builder, loc));
+  return values;
 }
 
 //===----------------------------------------------------------------------===//
 // IntrinsicLibrary
 //===----------------------------------------------------------------------===//
 
+template <typename GeneratorType>
 fir::ExtendedValue IntrinsicLibrary::genElementalCall(
-    ElementalGenerator generator, llvm::StringRef name, mlir::Type resultType,
+    GeneratorType generator, llvm::StringRef name, mlir::Type resultType,
     llvm::ArrayRef<fir::ExtendedValue> args, bool outline) {
   llvm::SmallVector<mlir::Value, 2> scalarArgs;
   for (const auto &arg : args) {
@@ -682,9 +761,28 @@ fir::ExtendedValue IntrinsicLibrary::genElementalCall(
       exit(1);
     }
   }
-  return outline || !generator
-             ? outlineInWrapper(generator, name, resultType, scalarArgs)
-             : std::invoke(generator, *this, resultType, scalarArgs);
+  if (outline)
+    return outlineInWrapper(generator, name, resultType, scalarArgs);
+  return invokeGenerator(generator, resultType, scalarArgs);
+}
+
+/// Some ExtendedGenerator operating on characters are also elemental
+/// (e.g LEN_TRIM).
+template <>
+fir::ExtendedValue
+IntrinsicLibrary::genElementalCall<IntrinsicLibrary::ExtendedGenerator>(
+    ExtendedGenerator generator, llvm::StringRef name, mlir::Type resultType,
+    llvm::ArrayRef<fir::ExtendedValue> args, bool outline) {
+  for (const auto &arg : args)
+    if (!arg.getUnboxed() && !arg.getCharBox()) {
+      // TODO: get the result shape and create the loop...
+      mlir::emitError(loc, "array or descriptor not yet handled in elemental "
+                           "intrinsic lowering");
+      exit(1);
+    }
+  if (outline)
+    return outlineInWrapper(generator, name, resultType, args);
+  return std::invoke(generator, *this, resultType, args);
 }
 
 fir::ExtendedValue
@@ -697,23 +795,55 @@ IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
               std::get_if<ElementalGenerator>(&handler.generator))
         return genElementalCall(*elementalGenerator, name, resultType, args,
                                 outline);
-      // Some extended generator are also elemental
       const auto &generator = std::get<ExtendedGenerator>(handler.generator);
-      // TODO: Handle wrappers for calls with ExtendedValue
+      if (handler.isElemental)
+        return genElementalCall(generator, name, resultType, args, outline);
+      if (outline)
+        return outlineInWrapper(generator, name, resultType, args);
       return std::invoke(generator, *this, resultType, args);
     }
 
   // Try the runtime if no special handler was defined for the
   // intrinsic being called. Maths runtime only has numerical elemental.
-  return genElementalCall(nullptr, name, resultType, args, true);
+  mlir::FunctionType soughtFuncType =
+      getFunctionType(resultType, toValue(args, builder, loc), builder);
+  auto runtimeCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
+  return genElementalCall(runtimeCallGenerator, name, resultType, args,
+                          /* outline */ true);
 }
 
 mlir::Value
-IntrinsicLibrary::outlineInWrapper(ElementalGenerator generator,
-                                   llvm::StringRef name, mlir::Type resultType,
-                                   llvm::ArrayRef<mlir::Value> args) {
-  auto funcType = getFunctionType(resultType, args, builder);
-  std::string wrapperName = getIntrinsicWrapperName(name, funcType);
+IntrinsicLibrary::invokeGenerator(ElementalGenerator generator,
+                                  mlir::Type resultType,
+                                  llvm::ArrayRef<mlir::Value> args) {
+  return std::invoke(generator, *this, resultType, args);
+}
+
+mlir::Value
+IntrinsicLibrary::invokeGenerator(RuntimeCallGenerator generator,
+                                  mlir::Type resultType,
+                                  llvm::ArrayRef<mlir::Value> args) {
+  return generator(builder, loc, args);
+}
+
+mlir::Value
+IntrinsicLibrary::invokeGenerator(ExtendedGenerator generator,
+                                  mlir::Type resultType,
+                                  llvm::ArrayRef<mlir::Value> args) {
+  auto extendedArgs = toExtendedValue(args, builder, loc);
+  auto extendedResult = std::invoke(generator, *this, resultType, extendedArgs);
+  return toValue(extendedResult, builder, loc);
+}
+
+template <typename GeneratorType>
+mlir::FuncOp IntrinsicLibrary::getWrapper(GeneratorType generator,
+                                          llvm::StringRef name,
+                                          mlir::FunctionType funcType,
+                                          bool loadRefArguments) {
+  assert(funcType.getNumResults() == 1 &&
+         "expect one result for intrinsic functions");
+  auto resultType = funcType.getResult(0);
+  std::string wrapperName = fir::mangleIntrinsicProcedure(name, funcType);
   auto function = builder.getNamedFunction(wrapperName);
   if (!function) {
     // First time this wrapper is needed, build it.
@@ -727,67 +857,154 @@ IntrinsicLibrary::outlineInWrapper(ElementalGenerator generator,
     auto localBuilder = std::make_unique<Fortran::lower::FirOpBuilder>(
         function, builder.getKindMap());
     localBuilder->setInsertionPointToStart(&function.front());
-    llvm::SmallVector<mlir::Value, 2> localArguments;
-    for (mlir::BlockArgument bArg : function.front().getArguments())
-      localArguments.push_back(bArg);
-
     // Location of code inside wrapper of the wrapper is independent from
     // the location of the intrinsic call.
     auto localLoc = localBuilder->getUnknownLoc();
+    llvm::SmallVector<mlir::Value, 2> localArguments;
+    for (mlir::BlockArgument bArg : function.front().getArguments()) {
+      auto refType = bArg.getType().dyn_cast<fir::ReferenceType>();
+      if (loadRefArguments && refType) {
+        auto loaded = localBuilder->create<fir::LoadOp>(localLoc, bArg);
+        localArguments.push_back(loaded);
+      } else {
+        localArguments.push_back(bArg);
+      }
+    }
+
     IntrinsicLibrary localLib{*localBuilder, localLoc};
-    mlir::Value result =
-        generator ? std::invoke(generator, localLib, resultType, localArguments)
-                  : std::invoke(&IntrinsicLibrary::genRuntimeCall, localLib,
-                                name, resultType, localArguments);
+    auto result =
+        localLib.invokeGenerator(generator, resultType, localArguments);
     localBuilder->create<mlir::ReturnOp>(localLoc, result);
   } else {
     // Wrapper was already built, ensure it has the sought type
-    assert(function.getType() == funcType);
+    assert(function.getType() == funcType &&
+           "conflict between intrinsic wrapper types");
   }
-  auto call = builder.create<mlir::CallOp>(loc, function, args);
-  return call.getResult(0);
+  return function;
 }
+
+/// Helpers to detect absent optional (not yet supported in outlining).
+bool static hasAbsentOptional(llvm::ArrayRef<mlir::Value> args) {
+  for (const auto &arg : args)
+    if (!arg)
+      return true;
+  return false;
+}
+bool static hasAbsentOptional(llvm::ArrayRef<fir::ExtendedValue> args) {
+  for (const auto &arg : args)
+    if (!fir::getBase(arg))
+      return true;
+  return false;
+}
+
+template <typename GeneratorType>
+mlir::Value
+IntrinsicLibrary::outlineInWrapper(GeneratorType generator,
+                                   llvm::StringRef name, mlir::Type resultType,
+                                   llvm::ArrayRef<mlir::Value> args) {
+  if (hasAbsentOptional(args)) {
+    // TODO: absent optional in outlining is an issue: we cannot just ignore
+    // them. Needs a better interface here. The issue is that we cannot easily
+    // tell that a value is optional or not here if it is presents. And if it is
+    // absent, we cannot tell what it type should be.
+    mlir::emitError(loc, "todo: cannot outline call to intrinsic " +
+                             llvm::Twine(name) +
+                             " with absent optional argument");
+    exit(1);
+  }
+
+  auto funcType = getFunctionType(resultType, args, builder);
+  auto wrapper = getWrapper(generator, name, funcType);
+  return builder.create<mlir::CallOp>(loc, wrapper, args).getResult(0);
+}
+
+fir::ExtendedValue
+IntrinsicLibrary::outlineInWrapper(ExtendedGenerator generator,
+                                   llvm::StringRef name, mlir::Type resultType,
+                                   llvm::ArrayRef<fir::ExtendedValue> args) {
+  if (hasAbsentOptional(args)) {
+    // TODO
+    mlir::emitError(loc, "todo: cannot outline call to intrinsic " +
+                             llvm::Twine(name) +
+                             " with absent optional argument");
+    exit(1);
+  }
+  auto mlirArgs = toValue(args, builder, loc);
+  auto funcType = getFunctionType(resultType, mlirArgs, builder);
+  auto wrapper = getWrapper(generator, name, funcType);
+  auto mlirResult =
+      builder.create<mlir::CallOp>(loc, wrapper, mlirArgs).getResult(0);
+  return toExtendedValue(mlirResult, builder, loc);
+}
+
+IntrinsicLibrary::RuntimeCallGenerator
+IntrinsicLibrary::getRuntimeCallGenerator(llvm::StringRef name,
+                                          mlir::FunctionType soughtFuncType) {
+  auto funcOp = getRuntimeFunction(loc, builder, name, soughtFuncType);
+  if (!funcOp)
+    llvm::report_fatal_error("missing intrinsic: " + llvm::Twine(name) + "\n");
+
+  mlir::FunctionType actualFuncType = funcOp.getType();
+  assert(actualFuncType.getNumResults() == soughtFuncType.getNumResults() &&
+         actualFuncType.getNumInputs() == soughtFuncType.getNumInputs() &&
+         actualFuncType.getNumResults() == 1 && "Bad intrinsic match");
+
+  return [funcOp, actualFuncType, soughtFuncType](
+             Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+             llvm::ArrayRef<mlir::Value> args) {
+    llvm::SmallVector<mlir::Value, 2> convertedArguments;
+    for (const auto &pair : llvm::zip(actualFuncType.getInputs(), args))
+      convertedArguments.push_back(
+          builder.createConvert(loc, std::get<0>(pair), std::get<1>(pair)));
+    auto call = builder.create<mlir::CallOp>(loc, funcOp, convertedArguments);
+    mlir::Type soughtType = soughtFuncType.getResult(0);
+    return builder.createConvert(loc, soughtType, call.getResult(0));
+  };
+}
+
+mlir::SymbolRefAttr IntrinsicLibrary::getUnrestrictedIntrinsicSymbolRefAttr(
+    llvm::StringRef name, mlir::FunctionType signature) {
+  // Unrestricted intrinsics signature follows implicit rules: argument
+  // are passed by references. But the runtime versions expect values.
+  // So instead of duplicating the runtime, just have the wrappers loading
+  // this before calling the code generators.
+  bool loadRefArguments = true;
+  mlir::FuncOp funcOp;
+  for (auto &handler : handlers)
+    if (name == handler.name)
+      funcOp = std::visit(
+          [&](auto generator) {
+            return getWrapper(generator, name, signature, loadRefArguments);
+          },
+          handler.generator);
+
+  if (!funcOp) {
+    llvm::SmallVector<mlir::Type, 2> argTypes;
+    for (auto type : signature.getInputs()) {
+      if (auto refType = type.dyn_cast<fir::ReferenceType>())
+        argTypes.push_back(refType.getEleTy());
+      else
+        argTypes.push_back(type);
+    }
+    auto soughtFuncType =
+        builder.getFunctionType(signature.getResults(), argTypes);
+    auto rtCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
+    funcOp = getWrapper(rtCallGenerator, name, signature, loadRefArguments);
+  }
+
+  return builder.getSymbolRefAttr(funcOp.getName());
+}
+
+//===----------------------------------------------------------------------===//
+// Code generators for the intrinsic
+//===----------------------------------------------------------------------===//
 
 mlir::Value IntrinsicLibrary::genRuntimeCall(llvm::StringRef name,
                                              mlir::Type resultType,
                                              llvm::ArrayRef<mlir::Value> args) {
-  // Look up runtime
   mlir::FunctionType soughtFuncType =
       getFunctionType(resultType, args, builder);
-  if (auto funcOp = getRuntimeFunction(loc, builder, name, soughtFuncType)) {
-    mlir::FunctionType actualFuncType = funcOp->getType();
-    if (actualFuncType.getNumResults() != soughtFuncType.getNumResults() ||
-        actualFuncType.getNumInputs() != soughtFuncType.getNumInputs() ||
-        actualFuncType.getNumInputs() != args.size() ||
-        actualFuncType.getNumResults() != 1) {
-      llvm_unreachable("Bad intrinsic match");
-    }
-    llvm::SmallVector<mlir::Value, 2> convertedArguments;
-    int i = 0;
-    for (mlir::Value arg : args) {
-      auto actualType = actualFuncType.getInput(i);
-      if (soughtFuncType.getInput(i) != actualType) {
-        auto castedArg = builder.createConvert(loc, actualType, arg);
-        convertedArguments.push_back(castedArg);
-      } else {
-        convertedArguments.push_back(arg);
-      }
-      ++i;
-    }
-    auto call = builder.create<mlir::CallOp>(loc, *funcOp, convertedArguments);
-    mlir::Type soughtType = soughtFuncType.getResult(0);
-    mlir::Value res = call.getResult(0);
-    if (actualFuncType.getResult(0) != soughtType) {
-      auto castedRes = builder.createConvert(loc, soughtType, res);
-      return castedRes;
-    } else {
-      return res;
-    }
-  } else {
-    // could not find runtime function
-    llvm::report_fatal_error("missing intrinsic: " + llvm::Twine(name) + "\n");
-  }
-  return {}; // gets rid of warnings
+  return getRuntimeCallGenerator(name, soughtFuncType)(builder, loc, args);
 }
 
 mlir::Value IntrinsicLibrary::genConversion(mlir::Type resultType,
@@ -951,6 +1168,28 @@ mlir::Value IntrinsicLibrary::genIOr(mlir::Type resultType,
   return builder.create<mlir::OrOp>(loc, args[0], args[1]);
 }
 
+// LEN
+// Note that this is only used for unrestricted intrinsic.
+// Usage of LEN are otherwise rewritten as descriptor inquiries by the
+// front-end.
+fir::ExtendedValue
+IntrinsicLibrary::genLen(mlir::Type resultType,
+                         llvm::ArrayRef<fir::ExtendedValue> args) {
+  // Optional KIND argument reflected in result type.
+  assert(args.size() >= 1);
+  mlir::Value len;
+  if (const auto *charBox = args[0].getCharBox()) {
+    len = charBox->getLen();
+  } else if (const auto *charBoxArray = args[0].getCharBox()) {
+    len = charBoxArray->getLen();
+  } else {
+    Fortran::lower::CharacterExprHelper helper{builder, loc};
+    len = helper.createUnboxChar(fir::getBase(args[0])).second;
+  }
+
+  return builder.createConvert(loc, resultType, len);
+}
+
 // LEN_TRIM
 fir::ExtendedValue
 IntrinsicLibrary::genLenTrim(mlir::Type resultType,
@@ -1087,34 +1326,45 @@ mlir::Value IntrinsicLibrary::genExtremum(mlir::Type,
 }
 
 //===----------------------------------------------------------------------===//
-// IntrinsicCallOpsHelper
+// Public intrinsic call helpers
 //===----------------------------------------------------------------------===//
 
-fir::ExtendedValue Fortran::lower::IntrinsicCallOpsHelper::genIntrinsicCall(
-    llvm::StringRef name, mlir::Type resultType,
-    llvm::ArrayRef<fir::ExtendedValue> args) {
+fir::ExtendedValue
+Fortran::lower::genIntrinsicCall(Fortran::lower::FirOpBuilder &builder,
+                                 mlir::Location loc, llvm::StringRef name,
+                                 mlir::Type resultType,
+                                 llvm::ArrayRef<fir::ExtendedValue> args) {
   return IntrinsicLibrary{builder, loc}.genIntrinsicCall(name, resultType,
                                                          args);
 }
 
-mlir::Value Fortran::lower::IntrinsicCallOpsHelper::genMax(
-    llvm::ArrayRef<mlir::Value> args) {
+mlir::Value Fortran::lower::genMax(Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc,
+                                   llvm::ArrayRef<mlir::Value> args) {
   assert(args.size() > 0 && "max requires at least one argument");
   return IntrinsicLibrary{builder, loc}
       .genExtremum<Extremum::Max, ExtremumBehavior::MinMaxss>(args[0].getType(),
                                                               args);
 }
 
-mlir::Value Fortran::lower::IntrinsicCallOpsHelper::genMin(
-    llvm::ArrayRef<mlir::Value> args) {
+mlir::Value Fortran::lower::genMin(Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc,
+                                   llvm::ArrayRef<mlir::Value> args) {
   assert(args.size() > 0 && "min requires at least one argument");
   return IntrinsicLibrary{builder, loc}
       .genExtremum<Extremum::Min, ExtremumBehavior::MinMaxss>(args[0].getType(),
                                                               args);
 }
 
-mlir::Value Fortran::lower::IntrinsicCallOpsHelper::genPow(mlir::Type type,
-                                                           mlir::Value x,
-                                                           mlir::Value y) {
+mlir::Value Fortran::lower::genPow(Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc, mlir::Type type,
+                                   mlir::Value x, mlir::Value y) {
   return IntrinsicLibrary{builder, loc}.genRuntimeCall("pow", type, {x, y});
+}
+
+mlir::SymbolRefAttr Fortran::lower::getUnrestrictedIntrinsicSymbolRefAttr(
+    Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+    llvm::StringRef name, mlir::FunctionType signature) {
+  return IntrinsicLibrary{builder, loc}.getUnrestrictedIntrinsicSymbolRefAttr(
+      name, signature);
 }


### PR DESCRIPTION
Unrestricted intrinsic are created on the fly with intrinsic lowering
using the wrappers. The only trick is that unrestricted intrinsic takes
references, so the wrapper must be modified to load the values in such
cases.

- Refactor intrinsic library for better wrapper creation handling and to return
  symbolRefAttr of created wrappers.
- Add a layer to translate mlir::Value to fir::ExtendedValue (this is required around outlining of intrinsic code that is generated with fir::ExtendedValue).
- Extend the CallInterface to produce function type outside of call sites/function
  definition (This is needed for function pointers/dummy arguments not yet defined
  and intrinsics)