### PR TITLE
Added proper error messaging

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -249,6 +249,11 @@ genOutputItemList(Fortran::lower::AbstractConverter &converter,
           itemValue);
       outputFuncArgs.push_back(parts.first);
       outputFuncArgs.push_back(parts.second);
+    } else if (fir::isa_ref_type(itemType)) {
+      // TODO: implement array lowering for non-character types
+      mlir::emitError(loc,
+            "Printing array types other than character arrays is not supported");
+      exit(1);
     } else {
       itemValue = builder.createConvert(loc, argType, itemValue);
       outputFuncArgs.push_back(itemValue);


### PR DESCRIPTION
Adds error messaging for the `print` and `write` examples in #204 