### PR TITLE
[flang][OpenMP] Added support for lowering OpenMP barrier construct

### DIFF
--- a/flang/include/flang/Lower/OpenMP.h
+++ b/flang/include/flang/Lower/OpenMP.h
@@ -12,6 +12,8 @@
 namespace Fortran {
 namespace parser {
 struct OpenMPConstruct;
+struct OpenMPStandaloneConstruct;
+struct OpenMPSimpleStandaloneConstruct;
 struct OmpEndLoopDirective;
 } // namespace parser
 
@@ -25,6 +27,12 @@ struct Evaluation;
 
 void genOpenMPConstruct(AbstractConverter &, pft::Evaluation &,
                         const parser::OpenMPConstruct &);
+
+void genOMP(AbstractConverter &, pft::Evaluation &,
+            const parser::OpenMPStandaloneConstruct &);
+
+void genOMP(AbstractConverter &, pft::Evaluation &,
+            const parser::OpenMPSimpleStandaloneConstruct &);
 
 void genOpenMPEndLoop(AbstractConverter &, pft::Evaluation &,
                       const parser::OmpEndLoopDirective &);

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -46,6 +46,7 @@ inline void registerFIR() {
     mlir::registerDialect<mlir::StandardOpsDialect>();
     mlir::registerDialect<mlir::vector::VectorDialect>();
     mlir::registerDialect<FIROpsDialect>();
+    mlir::registerDialect<mlir::omp::OpenMPDialect>();
     return true;
   }();
 }

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -16,12 +16,12 @@
 #define TODO() llvm_unreachable("not yet implemented")
 
 void Fortran::lower::genOpenMPConstruct(
-    Fortran::lower::AbstractConverter &ABSConv,
-    Fortran::lower::pft::Evaluation &Eval,
-    const Fortran::parser::OpenMPConstruct &OMPConstruct) {
+    Fortran::lower::AbstractConverter &absConv,
+    Fortran::lower::pft::Evaluation &eval,
+    const Fortran::parser::OpenMPConstruct &ompConstruct) {
   if (auto StandaloneConstruct{
           std::get_if<Fortran::parser::OpenMPStandaloneConstruct>(
-              &OMPConstruct.u)}) {
+              &ompConstruct.u)}) {
 
     if (auto SimpleStandaloneConstruct{
             std::get_if<Fortran::parser::OpenMPSimpleStandaloneConstruct>(
@@ -33,8 +33,8 @@ void Fortran::lower::genOpenMPConstruct(
       default:
         TODO();
       case parser::OmpSimpleStandaloneDirective::Directive::Barrier: {
-        ABSConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
-            ABSConv.getCurrentLocation());
+        absConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
+            absConv.getCurrentLocation());
         break;
       }
       }

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -8,15 +8,43 @@
 
 #include "flang/Lower/OpenMP.h"
 #include "flang/Lower/Bridge.h"
+#include "flang/Lower/FIRBuilder.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Parser/parse-tree.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MD5.h"
 
 #define TODO() llvm_unreachable("not yet implemented")
 
 void Fortran::lower::genOpenMPConstruct(
-    Fortran::lower::AbstractConverter &, Fortran::lower::pft::Evaluation &,
-    const Fortran::parser::OpenMPConstruct &) {
-  TODO();
+    Fortran::lower::AbstractConverter &ABSConv,
+    Fortran::lower::pft::Evaluation &Eval,
+    const Fortran::parser::OpenMPConstruct &OMPConstruct) {
+  if (auto StandaloneConstruct =
+          std::get_if<Fortran::parser::OpenMPStandaloneConstruct>(
+              &OMPConstruct.u)) {
+
+    if (auto SimpleStandaloneConstruct =
+            std::get_if<Fortran::parser::OpenMPSimpleStandaloneConstruct>(
+                &StandaloneConstruct->u)) {
+      const auto &Directive{
+          std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
+              SimpleStandaloneConstruct->t)};
+      switch (Directive.v) {
+      default:
+        TODO();
+      case parser::OmpSimpleStandaloneDirective::Directive::Barrier: {
+        ABSConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
+            ABSConv.getCurrentLocation());
+        break;
+      }
+      }
+    }
+  }
 }
 
 void Fortran::lower::genOpenMPEndLoop(

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -12,11 +12,6 @@
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Parser/parse-tree.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Module.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/MD5.h"
 
 #define TODO() llvm_unreachable("not yet implemented")
 
@@ -24,13 +19,13 @@ void Fortran::lower::genOpenMPConstruct(
     Fortran::lower::AbstractConverter &ABSConv,
     Fortran::lower::pft::Evaluation &Eval,
     const Fortran::parser::OpenMPConstruct &OMPConstruct) {
-  if (auto StandaloneConstruct =
+  if (auto StandaloneConstruct{
           std::get_if<Fortran::parser::OpenMPStandaloneConstruct>(
-              &OMPConstruct.u)) {
+              &OMPConstruct.u)}) {
 
-    if (auto SimpleStandaloneConstruct =
+    if (auto SimpleStandaloneConstruct{
             std::get_if<Fortran::parser::OpenMPSimpleStandaloneConstruct>(
-                &StandaloneConstruct->u)) {
+                &StandaloneConstruct->u)}) {
       const auto &Directive{
           std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
               SimpleStandaloneConstruct->t)};

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -24,13 +24,23 @@ void Fortran::lower::genOMP(
       std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
           simpleStandaloneConstruct.t);
   switch (directive.v) {
-  default:
-    TODO();
-  case parser::OmpSimpleStandaloneDirective::Directive::Barrier: {
+
+  case parser::OmpSimpleStandaloneDirective::Directive::Barrier:
     absConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
         absConv.getCurrentLocation());
     break;
-  }
+  case parser::OmpSimpleStandaloneDirective::Directive::Taskwait:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::Taskyield:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::TargetEnterData:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::TargetExitData:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::TargetUpdate:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::Ordered:
+    TODO();
   }
 }
 

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -15,31 +15,73 @@
 
 #define TODO() llvm_unreachable("not yet implemented")
 
+void Fortran::lower::genOMP(
+    Fortran::lower::AbstractConverter &absConv,
+    Fortran::lower::pft::Evaluation &eval,
+    const Fortran::parser::OpenMPSimpleStandaloneConstruct
+        &simpleStandaloneConstruct) {
+  const auto &directive =
+      std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
+          simpleStandaloneConstruct.t);
+  switch (directive.v) {
+  default:
+    TODO();
+  case parser::OmpSimpleStandaloneDirective::Directive::Barrier: {
+    absConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
+        absConv.getCurrentLocation());
+    break;
+  }
+  }
+}
+
+void Fortran::lower::genOMP(
+    Fortran::lower::AbstractConverter &absConv,
+    Fortran::lower::pft::Evaluation &eval,
+    const Fortran::parser::OpenMPStandaloneConstruct &standaloneConstruct) {
+  std::visit(
+      common::visitors{
+          [&](const Fortran::parser::OpenMPSimpleStandaloneConstruct
+                  &simpleStandaloneConstruct) {
+            genOMP(absConv, eval, simpleStandaloneConstruct);
+          },
+          [&](const Fortran::parser::OpenMPFlushConstruct &flushConstruct) {
+            TODO();
+          },
+          [&](const Fortran::parser::OpenMPCancelConstruct &cancelConstruct) {
+            TODO();
+          },
+          [&](const Fortran::parser::OpenMPCancellationPointConstruct
+                  &cancellationPointConstruct) { TODO(); },
+      },
+      standaloneConstruct.u);
+}
+
 void Fortran::lower::genOpenMPConstruct(
     Fortran::lower::AbstractConverter &absConv,
     Fortran::lower::pft::Evaluation &eval,
     const Fortran::parser::OpenMPConstruct &ompConstruct) {
-  if (auto StandaloneConstruct{
-          std::get_if<Fortran::parser::OpenMPStandaloneConstruct>(
-              &ompConstruct.u)}) {
 
-    if (auto SimpleStandaloneConstruct{
-            std::get_if<Fortran::parser::OpenMPSimpleStandaloneConstruct>(
-                &StandaloneConstruct->u)}) {
-      const auto &Directive{
-          std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
-              SimpleStandaloneConstruct->t)};
-      switch (Directive.v) {
-      default:
-        TODO();
-      case parser::OmpSimpleStandaloneDirective::Directive::Barrier: {
-        absConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
-            absConv.getCurrentLocation());
-        break;
-      }
-      }
-    }
-  }
+  std::visit(
+      common::visitors{
+          [&](const Fortran::parser::OpenMPStandaloneConstruct
+                  &standaloneConstruct) {
+            genOMP(absConv, eval, standaloneConstruct);
+          },
+          [&](const Fortran::parser::OpenMPSectionsConstruct
+                  &sectionsConstruct) { TODO(); },
+          [&](const Fortran::parser::OpenMPLoopConstruct &loopConstruct) {
+            TODO();
+          },
+          [&](const Fortran::parser::OpenMPBlockConstruct &blockConstruct) {
+            TODO();
+          },
+          [&](const Fortran::parser::OpenMPAtomicConstruct &atomicConstruct) {
+            TODO();
+          },
+          [&](const Fortran::parser::OpenMPCriticalConstruct
+                  &criticalConstruct) { TODO(); },
+      },
+      ompConstruct.u);
 }
 
 void Fortran::lower::genOpenMPEndLoop(

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2697,6 +2697,7 @@ struct FIRToLLVMLoweringPass
     mlir::populateStdToLLVMConversionPatterns(typeConverter, pattern);
     mlir::ConversionTarget target{*context};
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+    target.addLegalDialect<mlir::omp::OpenMPDialect>();
 
     // required NOPs for applying a full conversion
     target.addLegalOp<mlir::ModuleOp, mlir::ModuleTerminatorOp>();

--- a/flang/test/Lower/omp-barrier.f90
+++ b/flang/test/Lower/omp-barrier.f90
@@ -4,8 +4,8 @@
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 ! RUN: bbc -fopenmp -emit-llvm %s -o - | \
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
-! RUN: bbc -fopenmp -emit-llvm %s -o - | \
-! RUN:   mlir-translate -mlir-to-llvmir - | FileCheck %s --check-prefix=LLVMIR
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco | FileCheck %s --check-prefix=LLVMIR
 
 program barrier
 

--- a/flang/test/Lower/omp-barrier.f90
+++ b/flang/test/Lower/omp-barrier.f90
@@ -1,0 +1,24 @@
+! This test checks lowering of OpenMP Barrier Directive.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp -emit-llvm %s -o - | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-llvm %s -o - | \
+! RUN:   mlir-translate -mlir-to-llvmir - | FileCheck %s --check-prefix=LLVMIR
+
+program barrier
+
+        integer :: a,b,c
+
+!$OMP BARRIER
+!FIRDialect: omp.barrier
+!LLVMIRDialect: omp.barrier
+!LLVMIR: call void @__kmpc_barrier(%struct.ident_t* @1, i32 %omp_global_thread_num)
+        c = a + b
+!$OMP BARRIER
+!FIRDialect: omp.barrier
+!LLVMIRDialect: omp.barrier
+!LLVMIR: call void @__kmpc_barrier(%struct.ident_t* @1, i32 %omp_global_thread_num1)
+
+end program


### PR DESCRIPTION
This patch adds lowering support for OpenMP barrier construct to OpenMP Dialect operations.

Since this is the very first patch in this direction, so in order to support lowering, this patch do following infra setup:
- registers OpenMPDialect for lowering.
- registers OpenMPDialect as a legal Dialect to the legalizer.
- Also setup some basic infrastructure to lower other OpenMP constructs. This is in spirit to convey the overall design of lowering to OpenMP Dialect.

- Patch is mergeable/upstream, but since upstream flang doesn't have **bbc** so this can't be validated in upstream. However if community wants we can have review here and merge it in upstream(leaving the test case down stream in this branch).

