### PR TITLE
[flang] Implement genBuffer.

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -964,15 +964,30 @@ getFormat<Fortran::parser::PrintStmt>(
                    strTy, lenTy, labelMap, assignMap);
 }
 
-static std::tuple<mlir::Value, mlir::Value, mlir::Value>
+/// Generate a reference to a buffer and the length of buffer.There are 3 cases
+/// An IoUnit can be variable, a ScalarIntExpr (i.e FileUnitNumber) or a *.
+/// The first is handled here, rest 2 are somewhere else.
+static std::tuple<mlir::Value, mlir::Value>
 genBuffer(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
           const Fortran::parser::IoUnit &iounit, mlir::Type strTy,
           mlir::Type lenTy) {
-  [[maybe_unused]] auto &var = std::get<Fortran::parser::Variable>(iounit.u);
-  TODO();
+  // Variable
+  auto *var = std::get_if<Fortran::parser::Variable>(&iounit.u);
+  assert(var && "Has to be a variable");
+  auto e = Fortran::semantics::GetExpr(*var);
+  auto &builder = converter.getFirOpBuilder();
+  if (Fortran::semantics::ExprHasTypeCategory(
+          *e, Fortran::common::TypeCategory::Character)) {
+    // Helper to query [BUFFER, LEN].
+    Fortran::lower::CharacterExprHelper helper(builder, loc);
+    auto dataLen = helper.materializeCharacter(converter.genExprValue(*e));
+    auto buff = builder.createConvert(loc, strTy, dataLen.first);
+    auto len = builder.createConvert(loc, lenTy, dataLen.second);
+    return {buff, len};
+  }
 }
 template <typename A>
-std::tuple<mlir::Value, mlir::Value, mlir::Value>
+std::tuple<mlir::Value, mlir::Value>
 getBuffer(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
           const A &stmt, mlir::Type strTy, mlir::Type lenTy) {
   if (stmt.iounit)

--- a/flang/test/Lower/read-write-buffer.f90
+++ b/flang/test/Lower/read-write-buffer.f90
@@ -1,0 +1,16 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! A test to check the buffer and it's length.
+
+! CHECK-LABEL: @_QPsome
+subroutine some()
+  character(LEN=255):: buffer
+  character(LEN=255):: greeting
+10 format (A255)
+  ! CHECK:  fir.address_of(@{{.*}}) :
+  write (buffer, 10) "compiler"
+  read (buffer, 10) greeting
+end
+! CHECK-LABEL: fir.global @_QQcl.636F6D70696C6572
+! CHECK: %[[lit:.*]] = fir.string_lit "compiler"(8) : !fir.char<1>
+! CHECK: fir.has_value %[[lit]] : !fir.array<8x!fir.char<1>>
+! CHECK: }


### PR DESCRIPTION
fix for #222

This is somewhat incomplete patch, I have some basic queries also wanted to know is using `lowerStringLit` is the right approach here.
Queries:
1. How would I test this? 
2. What would be the representation for a `star` node?
3. Whether it's a `Variable` or a `FileUnitNumber` should there be an error when `Fortran::common::TypeCategory` is not `Character`?