### PR TITLE
Fix for #250

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -16,6 +16,7 @@
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Parser/parse-tree.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "llvm/Frontend/OpenMP/OMPConstants.h"
 
 #define TODO() llvm_unreachable("not yet implemented")
 
@@ -28,24 +29,24 @@ void Fortran::lower::genOMP(
       std::get<Fortran::parser::OmpSimpleStandaloneDirective>(
           simpleStandaloneConstruct.t);
   switch (directive.v) {
-#if 0 // does not compile
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::Barrier:
+
+  default:
+    break;
+  case llvm::omp::Directive::OMPD_barrier:
     absConv.getFirOpBuilder().create<mlir::omp::BarrierOp>(
         absConv.getCurrentLocation());
     break;
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::Taskwait:
+  case llvm::omp::Directive::OMPD_taskwait:
     TODO();
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::Taskyield:
+  case llvm::omp::Directive::OMPD_taskyield:
     TODO();
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::
-      TargetEnterData:
+  case llvm::omp::Directive::OMPD_target_enter_data:
     TODO();
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::TargetExitData:
+  case llvm::omp::Directive::OMPD_target_exit_data:
     TODO();
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::TargetUpdate:
+  case llvm::omp::Directive::OMPD_target_update:
     TODO();
-  case Fortran::parser::OmpSimpleStandaloneDirective::Directive::Ordered:
-#endif
+  case llvm::omp::Directive::OMPD_ordered:
     TODO();
   }
 }

--- a/flang/test/Lower/omp-barrier.f90
+++ b/flang/test/Lower/omp-barrier.f90
@@ -1,8 +1,5 @@
 ! This test checks lowering of OpenMP Barrier Directive.
 
-! https://github.com/flang-compiler/f18-llvm-project/issues/250
-! XFAIL: *
-
 ! RUN: bbc -fopenmp -emit-fir %s -o - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 ! RUN: bbc -fopenmp -emit-llvm %s -o - | \


### PR DESCRIPTION
This FIX https://github.com/flang-compiler/f18-llvm-project/issues/250 for time being.
Since after https://github.com/flang-compiler/f18-llvm-project/commit/2ddba3082ca79080b14f372ebe4b5bdbc5f694ed, all the OpenMP directives are clubbed into a common namespace **lib::omp**. This makes all the eum visible in switch case at _flang/lib/Lower/OpenMP.cpp:28_.

This patch rolls back the switch case to default based(for not applicable directive in context of **OmpSimpleStandaloneDirective**). 
This is needed otherwise compiler will throw compile time errors for all the unhandled not applicable cases.