### PR TITLE
Fix build failure with Wno-unused-parameter removal.

### DIFF
--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error -Wno-unused-parameter")
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_flang_library(FortranLower


### PR DESCRIPTION
Revert Cmake changes from PR #256.