### PR TITLE
converting affine memory loads back to fir operations

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -31,6 +31,9 @@ std::unique_ptr<mlir::Pass> createCSEPass();
 /// Convert FIR loop constructs to the Affine dialect
 std::unique_ptr<mlir::Pass> createPromoteToAffinePass();
 
+/// Convert Affine operations back to FIR
+std::unique_ptr<mlir::Pass> createAffineDemotionPass();
+
 /// Convert `fir.do_loop` and `fir.if` to a CFG.  This
 /// conversion enables the `createLowerToCFGPass` to transform these to CFG
 /// form.

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -24,6 +24,14 @@ def AffineDialectPromotion : FunctionPass<"promote-to-affine"> {
   let constructor = "fir::createPromoteToAffinePass()";
 }
 
+def AffineDialectDemotion : FunctionPass<"demote-to-affine"> {
+  let summary = "Converts affine.load and affine.store back to fir operations";
+  let description = [{
+    TODO
+  }];
+  let constructor = "fir::createAffineDemotionPass()";
+}
+
 def BasicCSE : FunctionPass<"basic-cse"> {
   let summary = "Basic common sub-expression elimination";
   let description = [{

--- a/flang/lib/Optimizer/CMakeLists.txt
+++ b/flang/lib/Optimizer/CMakeLists.txt
@@ -20,6 +20,7 @@ add_flang_library(FIROptimizer
   Transforms/Inliner.cpp
   Transforms/MemToReg.cpp
   Transforms/AffinePromotion.cpp
+  Transforms/AffineDemotion.cpp
   Transforms/RewriteLoop.cpp
 
   DEPENDS

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -458,7 +458,7 @@ class AffineIfConversion : public mlir::OpRewritePattern<fir::WhereOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
   AffineIfConversion(mlir::MLIRContext *context, AffineFunctionAnalysis &afa)
-      : OpRewritePattern(context), functionAnalysis(afa) {}
+      : OpRewritePattern(context) {}
   mlir::LogicalResult
   matchAndRewrite(fir::WhereOp op,
                   mlir::PatternRewriter &rewriter) const override {
@@ -493,9 +493,6 @@ public:
     rewriter.replaceOp(op, affineIf.getOperation()->getResults());
     return success();
   }
-
-private:
-  AffineFunctionAnalysis &functionAnalysis;
 };
 
 /// Promote fir.loop and fir.where to affine.for and affine.if, in the cases


### PR DESCRIPTION
Removes fir.convert of memrefs and rewrites affine load and store to fir load and store, keeps the indexing calculation using affine apply and affine maps.
