### PR TITLE
Fix issue with intrinsics passed as dummy procedure when name different than generic name

### DIFF
--- a/flang/include/flang/Evaluate/intrinsics.h
+++ b/flang/include/flang/Evaluate/intrinsics.h
@@ -76,6 +76,11 @@ public:
   // Inquiry intrinsics are defined in section 16.7, table 16.1
   IntrinsicClass GetIntrinsicClass(const std::string &) const;
 
+  // Return the generic name of a specific intrinsic name.
+  // The name provided is returned if it is a generic intrinsic name or is
+  // not known to be an intrinsic.
+  std::string GetGenericIntrinsicName(const std::string &) const;
+
   // Probe the intrinsics for a match against a specific call.
   // On success, the actual arguments are transferred to the result
   // in dummy argument order; on failure, the actual arguments remain

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1568,6 +1568,7 @@ public:
   bool IsIntrinsic(const std::string &) const;
 
   IntrinsicClass GetIntrinsicClass(const std::string &) const;
+  std::string GetGenericIntrinsicName(const std::string &) const;
 
   std::optional<SpecificCall> Probe(const CallCharacteristics &,
       ActualArguments &, FoldingContext &, const IntrinsicProcTable &) const;
@@ -1623,6 +1624,17 @@ IntrinsicClass IntrinsicProcTable::Implementation::GetIntrinsicClass(
     return subrIntrinsic->second->intrinsicClass;
   }
   return IntrinsicClass::noClass;
+}
+
+std::string IntrinsicProcTable::Implementation::GetGenericIntrinsicName(
+    const std::string &name) const {
+  auto specificIntrinsic{specificFuncs_.find(name)};
+  if (specificIntrinsic != specificFuncs_.end()) {
+    if (const char *genericName{specificIntrinsic->second->generic}) {
+      return {genericName};
+    }
+  }
+  return name;
 }
 
 bool CheckAndRearrangeArguments(ActualArguments &arguments,
@@ -2073,6 +2085,11 @@ bool IntrinsicProcTable::IsIntrinsic(const std::string &name) const {
 IntrinsicClass IntrinsicProcTable::GetIntrinsicClass(
     const std::string &name) const {
   return DEREF(impl_).GetIntrinsicClass(name);
+}
+
+std::string IntrinsicProcTable::GetGenericIntrinsicName(
+    const std::string &name) const {
+  return DEREF(impl_).GetGenericIntrinsicName(name);
 }
 
 std::optional<SpecificCall> IntrinsicProcTable::Probe(

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -343,9 +343,15 @@ private:
   genval(const Fortran::evaluate::ProcedureDesignator &proc) {
     if (const auto *intrinsic = proc.GetSpecificIntrinsic()) {
       auto signature = Fortran::lower::translateSignature(proc, converter);
+      // Intrinsic lowering is based on the generic name, so retrieve it here in
+      // case it is different from the specific name. The type of the specific
+      // intrinsic is retained in the signature.
+      auto genericName =
+          converter.getFoldingContext().intrinsics().GetGenericIntrinsicName(
+              intrinsic->name);
       auto symbolRefAttr =
           Fortran::lower::getUnrestrictedIntrinsicSymbolRefAttr(
-              builder, getLoc(), intrinsic->name, signature);
+              builder, getLoc(), genericName, signature);
       mlir::Value funcPtr =
           builder.create<mlir::ConstantOp>(getLoc(), signature, symbolRefAttr);
       return funcPtr;

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -799,8 +799,10 @@ IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
       getFunctionType(resultType, mlirArgs, builder);
 
   auto runtimeCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
+  // FIXME: set outline back to true and use linkOnce for the wrapper
+  // instead.
   return genElementalCall(runtimeCallGenerator, name, resultType, args,
-                          /* outline */ true);
+                          /* outline */ false);
 }
 
 mlir::Value

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -124,6 +124,16 @@ end subroutine
   !CHECK: %[[len:.*]] = fir.convert %[[unboxed]]#1 : (index) -> i32
   !CHECK: return %[[len]] : i32
 
+! Intrinsic implemented inlined with specific name different from generic
+! CHECK-LABEL: func @_QPtest_iabs
+subroutine test_iabs()
+  intrinsic :: iabs
+  ! CHECK: %[[f:.*]] = constant @fir.abs.i32.ref_i32 : (!fir.ref<i32>) -> i32
+  ! CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<i32>) -> i32) -> (() -> ())
+  ! CHECK: fir.call @_QPfoo_iabs(%[[fcast]]) : (() -> ()) -> ()
+  call foo_iabs(iabs)
+end subroutine
+
 
 ! TODO: exhaustive test of unrestricted intrinsic table 16.2 
 

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -147,6 +147,28 @@ subroutine floor_test2(i, a)
   ! CHECK: fir.convert %[[f]] : (f32) -> i64
 end subroutine
 
+! IABS
+! CHECK-LABEL: iabs_test
+subroutine iabs_test(a, b)
+  integer :: a, b
+  ! CHECK: shift_right_signed
+  ! CHECK: xor
+  ! CHECK: subi
+  b = iabs(a)
+end subroutine
+
+! IABS - Check if the return type (RT) has default kind.
+! CHECK-LABEL: iabs_test
+subroutine iabs_testRT(a, b)
+  integer(KIND=4) :: a
+  integer(KIND=16) :: b
+  ! CHECK: shift_right_signed
+  ! CHECK: xor
+  ! CHECK: %[[RT:.*]] =  subi
+  ! CHECK: fir.convert %[[RT]] : (i32)
+  b = iabs(a)
+end subroutine
+
 ! IAND
 ! CHECK-LABEL: iand_test
 subroutine iand_test(a, b)

--- a/flang/unittests/Evaluate/intrinsics.cpp
+++ b/flang/unittests/Evaluate/intrinsics.cpp
@@ -292,6 +292,43 @@ void TestIntrinsics() {
       .DoCall(); // bad type
 
   // TODO: test other intrinsics
+
+  // Test unrestricted specific to generic name mapping (table 16.2).
+  TEST(table.GetGenericIntrinsicName("alog") == "log");
+  TEST(table.GetGenericIntrinsicName("alog10") == "log10");
+  TEST(table.GetGenericIntrinsicName("amod") == "mod");
+  TEST(table.GetGenericIntrinsicName("cabs") == "abs");
+  TEST(table.GetGenericIntrinsicName("ccos") == "cos");
+  TEST(table.GetGenericIntrinsicName("cexp") == "exp");
+  TEST(table.GetGenericIntrinsicName("clog") == "log");
+  TEST(table.GetGenericIntrinsicName("csin") == "sin");
+  TEST(table.GetGenericIntrinsicName("csqrt") == "sqrt");
+  TEST(table.GetGenericIntrinsicName("dabs") == "abs");
+  TEST(table.GetGenericIntrinsicName("dacos") == "acos");
+  TEST(table.GetGenericIntrinsicName("dasin") == "asin");
+  TEST(table.GetGenericIntrinsicName("datan") == "atan");
+  TEST(table.GetGenericIntrinsicName("datan2") == "atan2");
+  TEST(table.GetGenericIntrinsicName("dcos") == "cos");
+  TEST(table.GetGenericIntrinsicName("dcosh") == "cosh");
+  TEST(table.GetGenericIntrinsicName("ddim") == "dim");
+  TEST(table.GetGenericIntrinsicName("dexp") == "exp");
+  TEST(table.GetGenericIntrinsicName("dint") == "aint");
+  TEST(table.GetGenericIntrinsicName("dlog") == "log");
+  TEST(table.GetGenericIntrinsicName("dlog10") == "log10");
+  TEST(table.GetGenericIntrinsicName("dmod") == "mod");
+  TEST(table.GetGenericIntrinsicName("dnint") == "anint");
+  TEST(table.GetGenericIntrinsicName("dsign") == "sign");
+  TEST(table.GetGenericIntrinsicName("dsin") == "sin");
+  TEST(table.GetGenericIntrinsicName("dsinh") == "sinh");
+  TEST(table.GetGenericIntrinsicName("dsqrt") == "sqrt");
+  TEST(table.GetGenericIntrinsicName("dtan") == "tan");
+  TEST(table.GetGenericIntrinsicName("dtanh") == "tanh");
+  TEST(table.GetGenericIntrinsicName("iabs") == "abs");
+  TEST(table.GetGenericIntrinsicName("idim") == "dim");
+  TEST(table.GetGenericIntrinsicName("idnint") == "nint");
+  TEST(table.GetGenericIntrinsicName("isign") == "sign");
+  // Test a case where specific and generic name are the same.
+  TEST(table.GetGenericIntrinsicName("acos") == "acos");
 }
 } // namespace Fortran::evaluate
 


### PR DESCRIPTION
Solve issue #257 
The intrinsic lowering facility is based on the generic intrinsics to avoid
duplicating implementations. Specific intrinsic calls are re-written to calls to
the generic versions by the front-end but this cannot be done when specific intrinsic
are passed as arguments (the rewrite would yield illegal/ambiguous unparsed Fortran).
Solve the issue by making the specific to generic name mapping accessible in lowering
and so that it can be used to generate the unrestricted intrinsic functions.

Workaround issue #289: intrinsic wrappers should have internal linkage since they may be generated in more than one compilation unit, however, I could not find a way to specify that an mlir::FuncOp has internal linkage. As a workaround, do not outline any intrinsic calls by default. This workaround will not work in case the intrinsics are used as dummy arguments in several compilation unit (in which case, we still need to build wrappers in each compilation unit so that we can pass a pointer to something).