### PR TITLE
Fix visibility of globals in regression tests after changes in PR 294

### DIFF
--- a/flang/test/Lower/global-init.f90
+++ b/flang/test/Lower/global-init.f90
@@ -2,7 +2,7 @@
 
 program bar
 ! CHECK: fir.address_of(@[[name1:.*]]my_data)
-! CHECK: fir.global @[[name1]]
+! CHECK: fir.global internal @[[name1]]
   integer, save :: my_data = 1
   print *, my_data
 contains
@@ -10,7 +10,7 @@ contains
 ! CHECK-LABEL: func @_QPfoo
 subroutine foo()
 ! CHECK: fir.address_of(@[[name2:.*foo.*my_data]])
-! CHECK: fir.global @[[name2]]
+! CHECK: fir.global internal @[[name2]]
   integer, save :: my_data = 2
   print *, my_data + 1
 end subroutine
@@ -18,7 +18,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPfoo2
 subroutine foo2()
 ! CHECK: fir.address_of(@[[name3:.*foo2.*my_data]])
-! CHECK: fir.global @[[name3]]
+! CHECK: fir.global internal @[[name3]]
   integer, save :: my_data
   my_data = 4
   print *, my_data
@@ -27,11 +27,11 @@ end subroutine
 ! CHECK-LABEL: func @_QPfoo3
 subroutine foo3()
 ! CHECK-DAG: fir.address_of(@[[name4:.*foo3.*idata]]){{.*}}fir.array<5xi32>
-! CHECK-DAG: fir.global @[[name4]]{{.*}}fir.array<5xi32>
+! CHECK-DAG: fir.global internal @[[name4]]{{.*}}fir.array<5xi32>
 ! CHECK-DAG: fir.address_of(@[[name5:.*foo3.*rdata]]){{.*}}fir.array<3xf16>
-! CHECK-DAG: fir.global @[[name5]]{{.*}}fir.array<3xf16>
+! CHECK-DAG: fir.global internal @[[name5]]{{.*}}fir.array<3xf16>
 ! CHECK-DAG: fir.address_of(@[[name6:.*foo3.*my_data]]){{.*}}fir.array<2x4xi64>
-! CHECK-DAG: fir.global @[[name6]]{{.*}}fir.array<2x4xi64>
+! CHECK-DAG: fir.global internal @[[name6]]{{.*}}fir.array<2x4xi64>
   integer*4, dimension(5), save :: idata = (/ (i*i, i=1,5) /)
   integer*8, dimension(2, 10:13), save :: my_data = reshape((/1,2,3,4,5,6,7,8/), shape(my_data))
   real*2, dimension(7:9), save :: rdata = (/100., 99., 98./)

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -2,35 +2,35 @@
 
 ! CHECK-LABEL: func @_QPpointertests
 subroutine pointerTests
-  ! CHECK: fir.global @_QFpointertestsEptr1 : !fir.ptr<i32>
+  ! CHECK: fir.global internal @_QFpointertestsEptr1 : !fir.ptr<i32>
   integer, pointer :: ptr1 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<i32>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<i32>
 
-  ! CHECK: fir.global @_QFpointertestsEptr2 : !fir.ptr<f32>
+  ! CHECK: fir.global internal @_QFpointertestsEptr2 : !fir.ptr<f32>
   real, pointer :: ptr2 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<f32>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<f32>
 
-  ! CHECK: fir.global @_QFpointertestsEptr3 : !fir.ptr<!fir.complex<4>>
+  ! CHECK: fir.global internal @_QFpointertestsEptr3 : !fir.ptr<!fir.complex<4>>
   complex, pointer :: ptr3 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.complex<4>>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.complex<4>>
 
-  ! CHECK: fir.global @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>>
+  ! CHECK: fir.global internal @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>>
   character, pointer :: ptr4 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1>>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1>>
 
-  ! CHECK: fir.global @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
+  ! CHECK: fir.global internal @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
   logical, pointer :: ptr5 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -17,7 +17,7 @@ function foo()
 ! CHECK: }
 end function
 
-! CHECK-LABEL: fir.global @_QFfooEpi : f32 {
+! CHECK-LABEL: fir.global internal @_QFfooEpi : f32 {
 
 ! CHECK-LABEL: func @_QPfunctn() -> f32 {
 function functn
@@ -25,7 +25,7 @@ function functn
 ! CHECK: }
 end function
 
-! CHECK-LABEL: fir.global @_QFfunctnECpi constant : f32 {
+! CHECK-LABEL: fir.global internal @_QFfunctnECpi constant : f32 {
 
 module testMod
 contains


### PR DESCRIPTION
#294 change globals to have internal visibility. This adds an "internal" keyword to fir dumps that broke some regression tests. Fix the regression tests (the "internal" keyword is now expected).