### PR TITLE
[flang][OpenMP] Added support for lowering OpenMP taskyield construct

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -39,7 +39,9 @@ static void genOMP(Fortran::lower::AbstractConverter &absConv,
         absConv.getCurrentLocation());
     break;
   case llvm::omp::Directive::OMPD_taskyield:
-    TODO();
+    absConv.getFirOpBuilder().create<mlir::omp::TaskyieldOp>(
+        absConv.getCurrentLocation());
+    break;
   case llvm::omp::Directive::OMPD_target_enter_data:
     TODO();
   case llvm::omp::Directive::OMPD_target_exit_data:

--- a/flang/test/Lower/omp-taskyield.f90
+++ b/flang/test/Lower/omp-taskyield.f90
@@ -1,0 +1,24 @@
+! This test checks lowering of OpenMP taskyield Directive.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp -emit-llvm %s -o - | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco | FileCheck %s --check-prefix=LLVMIR
+
+program taskyield
+
+        integer :: a,b,c
+
+!$OMP TASKYIELD
+!FIRDialect: omp.taskyield
+!LLVMIRDialect: omp.taskyield
+!LLVMIR: %{{.*}} = call i32 @__kmpc_omp_taskyield(%struct.ident_t* @{{.*}}, i32 %{{.*}})
+        c = a + b
+!$OMP TASKYIELD
+!FIRDialect: omp.taskyield
+!LLVMIRDialect: omp.taskyield
+!LLVMIR: %{{.*}} = call i32 @__kmpc_omp_taskyield(%struct.ident_t* @{{.*}}, i32 %{{.*}})
+
+end program

--- a/flang/unittests/Lower/OpenMPLoweringTest.cpp
+++ b/flang/unittests/Lower/OpenMPLoweringTest.cpp
@@ -56,4 +56,19 @@ TEST_F(OpenMPLoweringTest, TaskWait) {
   EXPECT_EQ(succeeded(taskWaitOp.verify()), true);
 }
 
+TEST_F(OpenMPLoweringTest, TaskYield) {
+  // Construct a dummy parse tree node for `!OMP taskyield`.
+  struct Fortran::parser::OmpSimpleStandaloneDirective taskYieldDirective(
+      llvm::omp::Directive::OMPD_taskyield);
+
+  // Check and lower the `!OMP taskyield` node to `TaskYieldOp` operation of
+  // OpenMPDialect.
+  EXPECT_EQ(taskYieldDirective.v, llvm::omp::Directive::OMPD_taskyield);
+  auto taskYieldOp = mlirOpBuilder->create<mlir::omp::TaskyieldOp>(
+      mlirOpBuilder->getUnknownLoc());
+
+  EXPECT_EQ(taskYieldOp.getOperationName(), "omp.taskyield");
+  EXPECT_EQ(succeeded(taskYieldOp.verify()), true);
+}
+
 // main() from gtest_main


### PR DESCRIPTION
This patch adds lowering support for OpenMP-5.0 taskyield construct to OpenMP Dialect operations.