### PR TITLE
[Flang] Added lowering for variable label format statements

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -15,6 +15,7 @@
 
 #include "flang/Common/Fortran.h"
 #include "mlir/IR/Module.h"
+#include "Utils.h"
 
 namespace Fortran {
 namespace common {
@@ -60,6 +61,12 @@ public:
 
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
+
+  /// Get the label set associated with a symbol.
+  virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;
+
+  /// Get the code defined by a label
+  virtual Fortran::lower::pft::Evaluation* lookupLabel(pft::Label label) = 0;
 
   //===--------------------------------------------------------------------===//
   // Expressions

--- a/flang/include/flang/Lower/IO.h
+++ b/flang/include/flang/Lower/IO.h
@@ -17,6 +17,8 @@
 #include "flang/Semantics/symbol.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
+#include "SymbolMap.h"
+#include "Utils.h"
 
 namespace mlir {
 class Value;
@@ -43,14 +45,6 @@ namespace lower {
 class AbstractConverter;
 class BridgeImpl;
 
-namespace pft {
-struct Evaluation;
-using LabelEvalMap = llvm::DenseMap<Fortran::parser::Label, Evaluation *>;
-using SymbolRef = Fortran::common::Reference<const Fortran::semantics::Symbol>;
-using LabelSet = llvm::SmallSet<Fortran::parser::Label, 5>;
-using SymbolLabelMap = llvm::DenseMap<SymbolRef, LabelSet>;
-} // namespace pft
-
 /// Generate IO call(s) for BACKSPACE; return the IOSTAT code
 mlir::Value genBackspaceStatement(AbstractConverter &,
                                   const parser::BackspaceStmt &);
@@ -74,15 +68,11 @@ mlir::Value genOpenStatement(AbstractConverter &, const parser::OpenStmt &);
 
 /// Generate IO call(s) for PRINT
 void genPrintStatement(AbstractConverter &converter,
-                       const parser::PrintStmt &stmt,
-                       pft::LabelEvalMap &labelMap,
-                       pft::SymbolLabelMap &assignMap);
+                       const parser::PrintStmt &stmt);
 
 /// Generate IO call(s) for READ; return the IOSTAT code
 mlir::Value genReadStatement(AbstractConverter &converter,
-                             const parser::ReadStmt &stmt,
-                             pft::LabelEvalMap &labelMap,
-                             pft::SymbolLabelMap &assignMap);
+                             const parser::ReadStmt &stmt);
 
 /// Generate IO call(s) for REWIND; return the IOSTAT code
 mlir::Value genRewindStatement(AbstractConverter &, const parser::RewindStmt &);
@@ -92,9 +82,7 @@ mlir::Value genWaitStatement(AbstractConverter &, const parser::WaitStmt &);
 
 /// Generate IO call(s) for WRITE; return the IOSTAT code
 mlir::Value genWriteStatement(AbstractConverter &converter,
-                              const parser::WriteStmt &stmt,
-                              pft::LabelEvalMap &labelMap,
-                              pft::SymbolLabelMap &assignMap);
+                              const parser::WriteStmt &stmt);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -23,6 +23,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/raw_ostream.h"
+#include "Utils.h"
 
 namespace mlir {
 class Block;
@@ -170,10 +171,6 @@ static constexpr bool isFunctionLike{common::HasMember<
     A, std::tuple<parser::MainProgram, parser::FunctionSubprogram,
                   parser::SubroutineSubprogram,
                   parser::SeparateModuleSubprogram>>};
-
-using LabelSet = llvm::SmallSet<parser::Label, 5>;
-using SymbolRef = common::Reference<const semantics::Symbol>;
-using SymbolLabelMap = llvm::DenseMap<SymbolRef, LabelSet>;
 
 template <typename A>
 struct MakeReferenceVariantHelper {};

--- a/flang/include/flang/Lower/Utils.h
+++ b/flang/include/flang/Lower/Utils.h
@@ -16,6 +16,36 @@
 #include "flang/Common/indirection.h"
 #include "flang/Parser/char-block.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallSet.h"
+
+namespace Fortran {
+namespace semantics {
+  class Symbol;
+}
+
+namespace evaluate {
+  template <typename A> class Expr;
+  struct SomeType;
+}
+
+namespace common {
+  template <typename A> class Reference;
+}
+
+namespace lower {
+namespace pft {
+struct Evaluation;
+
+using SomeExpr = Fortran::evaluate::Expr<Fortran::evaluate::SomeType>;
+using SymbolRef = Fortran::common::Reference<const Fortran::semantics::Symbol>;
+using Label = std::uint64_t;
+using LabelSet = llvm::SmallSet<Label, 4>;
+using SymbolLabelMap = llvm::DenseMap<SymbolRef, LabelSet>;
+using LabelEvalMap = llvm::DenseMap<Label, Evaluation *>;
+}  // namespace pft
+}  // namespace lower
+}  // namespace Fortran
 
 /// Convert an F18 CharBlock to an LLVM StringRef
 inline llvm::StringRef toStringRef(const Fortran::parser::CharBlock &cb) {

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -325,6 +325,25 @@ public:
     return fir::getBase(lookupSymbol(sym));
   }
 
+  bool lookupLabelSet(Fortran::lower::SymbolRef sym, Fortran::lower::pft::LabelSet &labelSet) override final {
+    auto &owningProc = *getEval().getOwningProcedure();
+    auto iter = owningProc.assignSymbolLabelMap.find(sym);
+    if (iter == owningProc.assignSymbolLabelMap.end()) {
+      return false;
+    }
+    labelSet = iter->second;
+    return true;
+  }
+
+  Fortran::lower::pft::Evaluation* lookupLabel(Fortran::lower::pft::Label label) override final {
+    auto &owningProc = *getEval().getOwningProcedure();
+    auto iter = owningProc.labelEvaluationMap.find(label);
+    if (iter == owningProc.labelEvaluationMap.end()) {
+      return nullptr;
+    }
+    return iter->second;
+  }
+
   mlir::Value genExprAddr(const Fortran::lower::SomeExpr &expr,
                           mlir::Location *loc = nullptr) override final {
     return createFIRAddr(loc ? *loc : toLocation(), &expr);
@@ -1184,14 +1203,10 @@ private:
     genIoConditionBranches(getEval(), stmt.v, iostat);
   }
   void genFIR(const Fortran::parser::PrintStmt &stmt) {
-    auto &owningProc = *getEval().getOwningProcedure();
-    genPrintStatement(*this, stmt, owningProc.labelEvaluationMap,
-                      owningProc.assignSymbolLabelMap);
+    genPrintStatement(*this, stmt);
   }
   void genFIR(const Fortran::parser::ReadStmt &stmt) {
-    auto &owningProc = *getEval().getOwningProcedure();
-    auto iostat = genReadStatement(*this, stmt, owningProc.labelEvaluationMap,
-                                   owningProc.assignSymbolLabelMap);
+    auto iostat = genReadStatement(*this, stmt);
     genIoConditionBranches(getEval(), stmt.controls, iostat);
   }
   void genFIR(const Fortran::parser::RewindStmt &stmt) {
@@ -1203,9 +1218,7 @@ private:
     genIoConditionBranches(getEval(), stmt.v, iostat);
   }
   void genFIR(const Fortran::parser::WriteStmt &stmt) {
-    auto &owningProc = *getEval().getOwningProcedure();
-    auto iostat = genWriteStatement(*this, stmt, owningProc.labelEvaluationMap,
-                                    owningProc.assignSymbolLabelMap);
+    auto iostat = genWriteStatement(*this, stmt);
     genIoConditionBranches(getEval(), stmt.controls, iostat);
   }
 

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -911,6 +911,86 @@ constexpr bool isDataTransferNamelist<Fortran::parser::PrintStmt>(
   return false;
 }
 
+/// Lowers a format statment that uses a assigned varible label reference as
+/// a select operation to allow for run-time selection of the format statement
+// Possible TODO: Instead of inlining a selectOp every time there is a format
+// statement a function with the selectOpcould be generated to reduce code size
+static std::tuple<mlir::Value, mlir::Value, mlir::Value>
+lowerReferenceAsStringSelect(Fortran::lower::AbstractConverter &converter,
+                             mlir::Location loc, const Fortran::evaluate::Expr
+                             <Fortran::evaluate::SomeType> &expr,
+                             mlir::Type strTy, mlir::Type lenTy) {
+
+  // Create the requisite blocks to inline a selectOp
+  auto &builder = converter.getFirOpBuilder();
+  auto* startBlock = builder.getBlock();
+  auto* endBlock = startBlock->splitBlock(builder.getInsertionPoint());
+  auto* block = startBlock->splitBlock(builder.getInsertionPoint());
+  builder.setInsertionPointToEnd(block);
+
+  llvm::SmallVector<int64_t, 4> indexList;
+  llvm::SmallVector<mlir::Block *, 4> blockList;
+
+  auto symbol = GetLastSymbol(&expr);
+  Fortran::lower::pft::LabelSet labels;
+  assert(converter.lookupLabelSet(*symbol, labels) &&
+         "ICE: Label not found in map");
+
+  for (auto label : labels) {
+    indexList.push_back(label);
+    auto eval = converter.lookupLabel(label);
+    assert(eval && "ICE: Label is missing from the table");
+
+    auto stringLit = lowerSourceTextAsStringLit
+      (converter, loc, toStringRef(eval->position), strTy, lenTy);
+    auto stringRef = std::get<0>(stringLit);
+    auto stringLen = std::get<1>(stringLit);
+
+    // Pass the format string reference and the string length out of the select
+    // statement
+    llvm::SmallVector<mlir::Value, 8> args;
+    args.push_back(stringRef);
+    args.push_back(stringLen);
+    builder.create<mlir::BranchOp>(loc, endBlock, args);
+
+    // Add block to the list of cases and make a new one
+    blockList.push_back(block);
+    block = block->splitBlock(builder.getInsertionPoint());
+    builder.setInsertionPointToEnd(block);
+  }
+
+  // Create the unit case which should result in an error
+  auto* unitBlock = block->splitBlock(builder.getInsertionPoint());
+  builder.setInsertionPointToEnd(unitBlock);
+
+  // TODO: Replace with instructions to crash the program
+  auto emptyString = fir::getBase(createStringLiteral(loc, converter, "", 0));
+  auto emptyStringRef = builder.createConvert(loc, strTy, emptyString);
+  auto zero = builder.create<mlir::ConstantIntOp>(loc, 0, builder.getI64Type());
+  llvm::SmallVector<mlir::Value, 8> args;
+  args.push_back(emptyStringRef);
+  args.push_back(zero);
+  builder.create<mlir::BranchOp>(loc, endBlock, args);
+
+  // Add unit case to the select statement
+  blockList.push_back(unitBlock);
+
+  // Lower the selectOp
+  builder.setInsertionPointToEnd(startBlock);
+  auto label = converter.genExprValue(&expr, loc);
+  builder.create<fir::SelectOp>(loc, label, indexList, blockList);
+
+  builder.setInsertionPointToEnd(endBlock);
+  endBlock->addArgument(strTy);
+  endBlock->addArgument(lenTy);
+
+  // Handle and return the string reference and length selected by the selectOp
+  auto buff = endBlock->getArgument(0);
+  auto len = endBlock->getArgument(1);
+
+  return {buff, len, mlir::Value{}};
+}
+
 /// Generate a reference to a format string.  There are four cases - a format
 /// statement label, a character format expression, an integer that holds the
 /// label of a format statement, and the * case.  The first three are done here.
@@ -918,14 +998,13 @@ constexpr bool isDataTransferNamelist<Fortran::parser::PrintStmt>(
 static std::tuple<mlir::Value, mlir::Value, mlir::Value>
 genFormat(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
           const Fortran::parser::Format &format, mlir::Type strTy,
-          mlir::Type lenTy, Fortran::lower::pft::LabelEvalMap &labelMap,
-          Fortran::lower::pft::SymbolLabelMap &assignMap) {
+          mlir::Type lenTy) {
   if (const auto *label = std::get_if<Fortran::parser::Label>(&format.u)) {
     // format statement label
-    auto iter = labelMap.find(*label);
-    assert(iter != labelMap.end() && "FORMAT not found in PROCEDURE");
+    auto eval = converter.lookupLabel(*label);
+    assert(eval && "FORMAT not found in PROCEDURE");
     return lowerSourceTextAsStringLit(
-        converter, loc, toStringRef(iter->second->position), strTy, lenTy);
+        converter, loc, toStringRef(eval->position), strTy, lenTy);
   }
   const auto *pExpr = std::get_if<Fortran::parser::Expr>(&format.u);
   assert(pExpr && "missing format expression");
@@ -934,35 +1013,29 @@ genFormat(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
           *e, Fortran::common::TypeCategory::Character))
     // character expression
     return lowerStringLit(converter, loc, *pExpr, strTy, lenTy);
+
   // integer variable containing an ASSIGN label
   assert(Fortran::semantics::ExprHasTypeCategory(
       *e, Fortran::common::TypeCategory::Integer));
-  // TODO - implement this
-  llvm::report_fatal_error(
-      "using a variable to reference a FORMAT statement; not implemented yet");
+  return lowerReferenceAsStringSelect(converter, loc, *e, strTy, lenTy);
 }
 
 template <typename A>
 std::tuple<mlir::Value, mlir::Value, mlir::Value>
 getFormat(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
-          const A &stmt, mlir::Type strTy, mlir::Type lenTy,
-          Fortran::lower::pft::LabelEvalMap &labelMap,
-          Fortran::lower::pft::SymbolLabelMap &assignMap) {
+          const A &stmt, mlir::Type strTy, mlir::Type lenTy) {
   if (stmt.format && !formatIsActuallyNamelist(*stmt.format))
-    return genFormat(converter, loc, *stmt.format, strTy, lenTy, labelMap,
-                     assignMap);
+    return genFormat(converter, loc, *stmt.format, strTy, lenTy);
   return genFormat(converter, loc, *getIOControl<Fortran::parser::Format>(stmt),
-                   strTy, lenTy, labelMap, assignMap);
+                   strTy, lenTy);
 }
 template <>
 std::tuple<mlir::Value, mlir::Value, mlir::Value>
 getFormat<Fortran::parser::PrintStmt>(
     Fortran::lower::AbstractConverter &converter, mlir::Location loc,
-    const Fortran::parser::PrintStmt &stmt, mlir::Type strTy, mlir::Type lenTy,
-    Fortran::lower::pft::LabelEvalMap &labelMap,
-    Fortran::lower::pft::SymbolLabelMap &assignMap) {
+    const Fortran::parser::PrintStmt &stmt, mlir::Type strTy, mlir::Type lenTy) {
   return genFormat(converter, loc, std::get<Fortran::parser::Format>(stmt.t),
-                   strTy, lenTy, labelMap, assignMap);
+                   strTy, lenTy);
 }
 
 /// Generate a reference to a buffer and the length of buffer.There are 3 cases
@@ -1238,9 +1311,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
                            mlir::Location loc, const A &stmt,
                            mlir::FunctionType ioFuncTy, bool isFormatted,
                            bool isList, bool isIntern, bool isOtherIntern,
-                           bool isAsynch, bool isNml,
-                           Fortran::lower::pft::LabelEvalMap &labelMap,
-                           Fortran::lower::pft::SymbolLabelMap &assignMap) {
+                           bool isAsynch, bool isNml) {
   auto &builder = converter.getFirOpBuilder();
   if constexpr (hasIOCtrl) {
     // READ/WRITE cases have a wide variety of argument permutations
@@ -1263,7 +1334,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
         // | [format, LEN], ...
         auto pair = getFormat(
             converter, loc, stmt, ioFuncTy.getInput(ioArgs.size()),
-            ioFuncTy.getInput(ioArgs.size() + 1), labelMap, assignMap);
+            ioFuncTy.getInput(ioArgs.size() + 1));
         ioArgs.push_back(std::get<0>(pair));
         ioArgs.push_back(std::get<1>(pair));
       }
@@ -1284,7 +1355,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
         // | [format, LEN], ...
         auto pair = getFormat(
             converter, loc, stmt, ioFuncTy.getInput(ioArgs.size()),
-            ioFuncTy.getInput(ioArgs.size() + 1), labelMap, assignMap);
+            ioFuncTy.getInput(ioArgs.size() + 1));
         ioArgs.push_back(std::get<0>(pair));
         ioArgs.push_back(std::get<1>(pair));
       }
@@ -1299,7 +1370,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
         // [format, LEN], ...
         auto pair = getFormat(
             converter, loc, stmt, ioFuncTy.getInput(ioArgs.size()),
-            ioFuncTy.getInput(ioArgs.size() + 1), labelMap, assignMap);
+            ioFuncTy.getInput(ioArgs.size() + 1));
         ioArgs.push_back(std::get<0>(pair));
         ioArgs.push_back(std::get<1>(pair));
       }
@@ -1314,7 +1385,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
       // [format, LEN], ...
       auto pair =
           getFormat(converter, loc, stmt, ioFuncTy.getInput(ioArgs.size()),
-                    ioFuncTy.getInput(ioArgs.size() + 1), labelMap, assignMap);
+                    ioFuncTy.getInput(ioArgs.size() + 1));
       ioArgs.push_back(std::get<0>(pair));
       ioArgs.push_back(std::get<1>(pair));
     }
@@ -1327,9 +1398,7 @@ void genBeginCallArguments(llvm::SmallVector<mlir::Value, 8> &ioArgs,
 
 template <bool isInput, bool hasIOCtrl = true, typename A>
 static mlir::Value
-genDataTransferStmt(Fortran::lower::AbstractConverter &converter, const A &stmt,
-                    Fortran::lower::pft::LabelEvalMap &labelMap,
-                    Fortran::lower::pft::SymbolLabelMap &assignMap) {
+genDataTransferStmt(Fortran::lower::AbstractConverter &converter, const A &stmt) {
   auto &builder = converter.getFirOpBuilder();
   auto loc = converter.getCurrentLocation();
   const bool isFormatted = isDataTransferFormatted(stmt);
@@ -1350,7 +1419,7 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter, const A &stmt,
   llvm::SmallVector<mlir::Value, 8> ioArgs;
   genBeginCallArguments<hasIOCtrl>(ioArgs, converter, loc, stmt, ioFuncTy,
                                    isFormatted, isList, isIntern, isOtherIntern,
-                                   isAsynch, isNml, labelMap, assignMap);
+                                   isAsynch, isNml);
   ioArgs.push_back(locationToFilename(converter, builder, loc,
                                       ioFuncTy.getInput(ioArgs.size())));
   ioArgs.push_back(
@@ -1389,31 +1458,22 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter, const A &stmt,
 
 void Fortran::lower::genPrintStatement(
     Fortran::lower::AbstractConverter &converter,
-    const Fortran::parser::PrintStmt &stmt,
-    Fortran::lower::pft::LabelEvalMap &labelMap,
-    Fortran::lower::pft::SymbolLabelMap &assignMap) {
+    const Fortran::parser::PrintStmt &stmt) {
   // PRINT does not take an io-control-spec. It only has a format specifier, so
   // it is a simplified case of WRITE.
-  genDataTransferStmt</*isInput=*/false, /*ioCtrl=*/false>(converter, stmt,
-                                                           labelMap, assignMap);
+  genDataTransferStmt</*isInput=*/false, /*ioCtrl=*/false>(converter, stmt);
 }
 
 mlir::Value Fortran::lower::genWriteStatement(
     Fortran::lower::AbstractConverter &converter,
-    const Fortran::parser::WriteStmt &stmt,
-    Fortran::lower::pft::LabelEvalMap &labelMap,
-    Fortran::lower::pft::SymbolLabelMap &assignMap) {
-  return genDataTransferStmt</*isInput=*/false>(converter, stmt, labelMap,
-                                                assignMap);
+    const Fortran::parser::WriteStmt &stmt) {
+  return genDataTransferStmt</*isInput=*/false>(converter, stmt);
 }
 
 mlir::Value Fortran::lower::genReadStatement(
     Fortran::lower::AbstractConverter &converter,
-    const Fortran::parser::ReadStmt &stmt,
-    Fortran::lower::pft::LabelEvalMap &labelMap,
-    Fortran::lower::pft::SymbolLabelMap &assignMap) {
-  return genDataTransferStmt</*isInput=*/true>(converter, stmt, labelMap,
-                                               assignMap);
+    const Fortran::parser::ReadStmt &stmt) {
+  return genDataTransferStmt</*isInput=*/true>(converter, stmt);
 }
 
 /// Get the file expression from the inquire spec list. Also return if the

--- a/flang/test/Lower/format.f90
+++ b/flang/test/Lower/format.f90
@@ -13,7 +13,7 @@ function formatAssign()
        assign 200 to label
     end if
 
-    ! CHECK: fir.select
+    ! CHECK: fir.select {{.*\[100, \^bb[0-9]+, 200, \^bb[0-9]+, unit, \^bb[0-9]+\]}}
     ! CHECK-LABEL: ^bb{{[0-9]+}}:
     ! CHECK: fir.address_of
     ! CHECK: br [[END_BLOCK:\^bb[0-9]+]]{{(.*)}}

--- a/flang/test/Lower/format.f90
+++ b/flang/test/Lower/format.f90
@@ -1,0 +1,39 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPformatassign
+function formatAssign()
+    real :: pi
+    integer :: label
+    logical :: flag
+
+    ! CHECK: select
+    if (flag) then
+       assign 100 to label
+    else
+       assign 200 to label
+    end if
+
+    ! CHECK: fir.select
+    ! CHECK-LABEL: ^bb{{[0-9]+}}:
+    ! CHECK: fir.address_of
+    ! CHECK: br [[END_BLOCK:\^bb[0-9]+]]{{(.*)}}
+    ! CHECK-LABEL: ^bb{{[0-9]+}}: //
+    ! CHECK: fir.address_of
+    ! CHECK: br [[END_BLOCK]]
+    ! CHECK-LABEL: ^bb{{[0-9]+}}: //
+    ! CHECK: fir.address_of
+    ! CHECK: br [[END_BLOCK]]
+    ! CHECK-LABEL: ^bb{{[0-9]+(.*)}}: //
+    ! CHECK: call{{.*}}BeginExternalFormattedOutput
+    ! CHECK-DAG: call{{.*}}OutputAscii
+    ! CHECK-DAG: call{{.*}}OutputReal32
+    ! CHECK: call{{.*}}EndIoStatement
+    pi = 3.141592653589
+    write(*, label) "PI=", pi
+ 
+
+100 format (A, F10.3)
+200 format (A,E8.1)
+300 format (A, E2.4)
+
+    end function


### PR DESCRIPTION
As described in #130 

As a side note does anyone know of a better way to get `localSymbols` to the `lowerReferenceAsStringSelect` function without propagating it down the call stack?