### PR TITLE
Add internal linkage to intrinsics wrappers

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -799,10 +799,8 @@ IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
       getFunctionType(resultType, mlirArgs, builder);
 
   auto runtimeCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
-  // FIXME: set outline back to true and use linkOnce for the wrapper
-  // instead.
   return genElementalCall(runtimeCallGenerator, name, resultType, args,
-                          /* outline */ false);
+                          /* outline */ true);
 }
 
 mlir::Value
@@ -844,6 +842,7 @@ mlir::FuncOp IntrinsicLibrary::getWrapper(GeneratorType generator,
     // First time this wrapper is needed, build it.
     function = builder.createFunction(loc, wrapperName, funcType);
     function.setAttr("fir.intrinsic", builder.getUnitAttr());
+    function.setAttr("linkName", builder.createInternalLinkage());
     function.addEntryBlock();
 
     // Create local context to emit code into the newly created function

--- a/flang/test/Lower/intrinsic-wrappers.f90
+++ b/flang/test/Lower/intrinsic-wrappers.f90
@@ -1,0 +1,13 @@
+! RUN: bbc -emit-llvm -outline-intrinsics %s -o - | FileCheck %s
+
+! Test properties of intrinsic function wrappers
+
+! Test that intrinsic wrappers have internal linkage
+function foo(x)
+  foo = acos(x)
+end function
+
+! CHECK: llvm.func internal @fir.acos.f32.f32
+
+
+! TODO: test wrapper mangling, attributes ...


### PR DESCRIPTION
Actual #287 fix. This PR needs #299 to produce the intended results.

Intrinsic wrappers can be emitted in several compilation unit so they cannot
have external linkage to avoid conflicting.
linkonce would also be an option but LLVM LangRef says regarding linkonce:
 "Note that linkonce linkage does not actually allow the optimizer to
  inline the body of this function into callers"
So stick to internal linkage since we do want wrappers to be inlinable.

With this done, revert the workaround of disabling wrappers for runtime functions.