### PR TITLE
Pre-declare FuncOp of all procedures declared in a program unit before lowering bodies

### DIFF
--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -87,11 +87,6 @@ subroutine test_acos(x)
   call foo_acos(acos)
 end subroutine
 
-! CHECK-LABEL: func @fir.acos.f32.ref_f32(%arg0: !fir.ref<f32>) -> f32
-  !CHECK: %[[load:.*]] = fir.load %arg0
-  !CHECK: %[[res:.*]] = call @__fs_acos_1(%[[load]]) : (f32) -> f32
-  !CHECK: return %[[res]] : f32
-
 ! Intrinsic implemented inlined
 ! CHECK-LABEL: func @_QPtest_aimag
 subroutine test_aimag()
@@ -101,13 +96,6 @@ subroutine test_aimag()
   !CHECK: fir.call @_QPfoo_aimag(%[[fcast]]) : (() -> ()) -> ()
   call foo_aimag(aimag)
 end subroutine
-
-!CHECK-LABEL: func @fir.aimag.f32.ref_z4(%arg0: !fir.ref<!fir.complex<4>>)
-  !CHECK: %[[load:.*]] = fir.load %arg0
-  !CHECK: %[[cst1:.*]] = constant 1
-  !CHECK: %[[imag:.*]] = fir.extract_value %[[load]], %[[cst1]] : (!fir.complex<4>, index) -> f32
-  !CHECK: return %[[imag]] : f32
-
 
 ! Character Intrinsic implemented inlined
 ! CHECK-LABEL: func @_QPtest_len
@@ -119,10 +107,6 @@ subroutine test_len()
   call foo_len(len)
 end subroutine
 
-!CHECK-LABEL: func @fir.len.i32.bc1(%arg0: !fir.boxchar<1>)
-  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
-  !CHECK: %[[len:.*]] = fir.convert %[[unboxed]]#1 : (index) -> i32
-  !CHECK: return %[[len]] : i32
 
 ! Intrinsic implemented inlined with specific name different from generic
 ! CHECK-LABEL: func @_QPtest_iabs
@@ -150,3 +134,19 @@ subroutine todo3(dummy_proc)
   intrinsic :: acos
   procedure(acos) :: dummy_proc
 end subroutine
+
+! CHECK-LABEL: func @fir.acos.f32.ref_f32(%arg0: !fir.ref<f32>) -> f32
+  !CHECK: %[[load:.*]] = fir.load %arg0
+  !CHECK: %[[res:.*]] = call @__fs_acos_1(%[[load]]) : (f32) -> f32
+  !CHECK: return %[[res]] : f32
+
+!CHECK-LABEL: func @fir.aimag.f32.ref_z4(%arg0: !fir.ref<!fir.complex<4>>)
+  !CHECK: %[[load:.*]] = fir.load %arg0
+  !CHECK: %[[cst1:.*]] = constant 1
+  !CHECK: %[[imag:.*]] = fir.extract_value %[[load]], %[[cst1]] : (!fir.complex<4>, index) -> f32
+  !CHECK: return %[[imag]] : f32
+
+!CHECK-LABEL: func @fir.len.i32.bc1(%arg0: !fir.boxchar<1>)
+  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
+  !CHECK: %[[len:.*]] = fir.convert %[[unboxed]]#1 : (index) -> i32
+  !CHECK: return %[[len]] : i32

--- a/flang/test/Lower/global-init.f90
+++ b/flang/test/Lower/global-init.f90
@@ -2,7 +2,6 @@
 
 program bar
 ! CHECK: fir.address_of(@[[name1:.*]]my_data)
-! CHECK: fir.global internal @[[name1]]
   integer, save :: my_data = 1
   print *, my_data
 contains
@@ -10,7 +9,6 @@ contains
 ! CHECK-LABEL: func @_QPfoo
 subroutine foo()
 ! CHECK: fir.address_of(@[[name2:.*foo.*my_data]])
-! CHECK: fir.global internal @[[name2]]
   integer, save :: my_data = 2
   print *, my_data + 1
 end subroutine
@@ -18,7 +16,6 @@ end subroutine
 ! CHECK-LABEL: func @_QPfoo2
 subroutine foo2()
 ! CHECK: fir.address_of(@[[name3:.*foo2.*my_data]])
-! CHECK: fir.global internal @[[name3]]
   integer, save :: my_data
   my_data = 4
   print *, my_data
@@ -27,11 +24,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPfoo3
 subroutine foo3()
 ! CHECK-DAG: fir.address_of(@[[name4:.*foo3.*idata]]){{.*}}fir.array<5xi32>
-! CHECK-DAG: fir.global internal @[[name4]]{{.*}}fir.array<5xi32>
 ! CHECK-DAG: fir.address_of(@[[name5:.*foo3.*rdata]]){{.*}}fir.array<3xf16>
-! CHECK-DAG: fir.global internal @[[name5]]{{.*}}fir.array<3xf16>
 ! CHECK-DAG: fir.address_of(@[[name6:.*foo3.*my_data]]){{.*}}fir.array<2x4xi64>
-! CHECK-DAG: fir.global internal @[[name6]]{{.*}}fir.array<2x4xi64>
   integer*4, dimension(5), save :: idata = (/ (i*i, i=1,5) /)
   integer*8, dimension(2, 10:13), save :: my_data = reshape((/1,2,3,4,5,6,7,8/), shape(my_data))
   real*2, dimension(7:9), save :: rdata = (/100., 99., 98./)
@@ -40,3 +34,10 @@ subroutine foo3()
   print *, my_data(1,11)
 end subroutine
 end program
+
+! CHECK: fir.global internal @[[name1]]
+! CHECK: fir.global internal @[[name2]]
+! CHECK: fir.global internal @[[name3]]
+! CHECK-DAG: fir.global internal @[[name4]]{{.*}}fir.array<5xi32>
+! CHECK-DAG: fir.global internal @[[name5]]{{.*}}fir.array<3xf16>
+! CHECK-DAG: fir.global internal @[[name6]]{{.*}}fir.array<2x4xi64>

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -17,7 +17,6 @@ function foo()
 ! CHECK: }
 end function
 
-! CHECK-LABEL: fir.global internal @_QFfooEpi : f32 {
 
 ! CHECK-LABEL: func @_QPfunctn() -> f32 {
 function functn
@@ -25,7 +24,6 @@ function functn
 ! CHECK: }
 end function
 
-! CHECK-LABEL: fir.global internal @_QFfunctnECpi constant : f32 {
 
 module testMod
 contains
@@ -126,3 +124,7 @@ end submodule
 program test
 ! CHECK: }
 end program
+
+! CHECK-LABEL: fir.global internal @_QFfooEpi : f32 {
+! CHECK-LABEL: fir.global internal @_QFfunctnECpi constant : f32 {
+

--- a/flang/test/Lower/stop.f90
+++ b/flang/test/Lower/stop.f90
@@ -7,7 +7,6 @@ subroutine stop_test(b)
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[false]])
  stop
 end subroutine
-! CHECK: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none
 
 ! CHECK-LABEL stop_code
 subroutine stop_code()
@@ -47,3 +46,5 @@ subroutine stop_error_code_quiet(b)
  ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c66]], %[[true]], %[[bi1]])
 end subroutine
+
+! CHECK: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none


### PR DESCRIPTION
The need to do this arise from the implicit interface rules that lead to situation where
the signature of a a function on call site is different from the definition signature.
This is particularly important when the first usage of a function is to be passed as
dummy argument, in which case we do know how many arguments the FuncOp must have,
leading to crashes if we later try to define it with one or more arguments.

To ensure that the definition signature prevail if it is accessible, pre-declare all
mlir::FuncOp before lowering the bodies. This is done by making a pass on the top
level of the PFT before the pass to lower the bodies. The CallInterface is refactored a
bit to help do that.

A side effect of this is that all the globals belonging to functions are now emitted after all user functions. Tests are aligned to reflect this.

This is needed to safely implement the TODO in #286