### PR TITLE
Workaround mlir conversion materialization (D82831)

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -125,6 +125,30 @@ public:
     addConversion([&](mlir::NoneType none) {
       return mlir::LLVM::LLVMType::getStructTy(llvmDialect, {});
     });
+
+    // FIXME: https://reviews.llvm.org/D82831 introduced an automatic
+    // materliazation of conversion around function calls that is not working
+    // well with fir lowering to llvm (incorrect llvm.mlir.cast are inserted).
+    // Workaround until better analysis: register a handler that does not insert
+    // any conversions.
+    addSourceMaterialization(
+        [&](mlir::OpBuilder &builder, mlir::Type resultType,
+            mlir::ValueRange inputs,
+            mlir::Location loc) -> llvm::Optional<mlir::Value> {
+          if (inputs.size() != 1)
+            return llvm::None;
+          return inputs[0];
+        });
+    // Similar FIXME workaround here (needed for compare.fir/select-type.fir
+    // tests).
+    addTargetMaterialization(
+        [&](mlir::OpBuilder &builder, mlir::Type resultType,
+            mlir::ValueRange inputs,
+            mlir::Location loc) -> llvm::Optional<mlir::Value> {
+          if (inputs.size() != 1)
+            return llvm::None;
+          return inputs[0];
+        });
   }
 
   // This returns the type of a single column. Rows are added by the caller.


### PR DESCRIPTION
Fix fir-dev regression after latest rebase with mlir. Source of the regression is https://reviews.llvm.org/D82831.

Simply add a source and target materialization handler that do nothing
and that override the default handlers that would add illegal
`LLVM::DialectCastOp` otherwise.

This is the simplest workaround, but not an actual fix, something may be
wrong with D82831 (most likely fir lowering to llvm happens in a way that
mlir infrastructure is not expecting in D82831).


Here is a minimal reproducer of what the issue was:
```
func @foop(%a : !fir.real<4>) -> ()
func @bar(%a : !fir.real<2>) {
  %1 = fir.convert %a : (!fir.real<2>) -> !fir.real<4>
  call @foop(%1) : (!fir.real<4>) -> ()
  return
}
```
`tco -o -` output was:
```
error: 'llvm.mlir.cast' op type must be non-index integer types, float types, or vector of mentioned types.
llvm.func @foop(!llvm.float)
llvm.func @bar(%arg0: !llvm.half) {
  %0 = llvm.fpext %arg0 : !llvm.half to !llvm.float
  %1 = llvm.mlir.cast %0 : !llvm.float to !fir.real<4>
  llvm.call @foop(%1) : (!fir.real<4>) -> ()
  llvm.return
} 
```

This patch disable the introduction of the `llvm.mlir.cast` and preserve the previous behavior.