### PR TITLE
Passing pointer to functions not defined in the program unit

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -290,6 +290,17 @@ mlir::FunctionType
 translateSignature(const Fortran::evaluate::ProcedureDesignator &,
                    Fortran::lower::AbstractConverter &);
 
+/// Declare or find the mlir::FuncOp named \p name. If the mlir::FuncOp does
+/// not exist yet, declare it with the signature translated from the
+/// ProcedureDesignator argument.
+/// Due to Fortran implicit function typing rules, the returned FuncOp is not
+/// guaranteed to have the signature from ProcedureDesignator if the FuncOp was
+/// already declared.
+mlir::FuncOp
+getOrDeclareFunction(llvm::StringRef name,
+                     const Fortran::evaluate::ProcedureDesignator &,
+                     Fortran::lower::AbstractConverter &);
+
 } // namespace Fortran::lower
 
 #endif // FORTRAN_LOWER_FIRBUILDER_H

--- a/flang/test/Lower/procedure-declarations.f90
+++ b/flang/test/Lower/procedure-declarations.f90
@@ -1,0 +1,169 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test procedure declarations. Change appearance order of definition and usages
+! (passing a procedure and calling it), with and without definitions.
+! Check that the definition type prevail if available and that casts are inserted to
+! accommodate for the signature mismatch in the different location due to implicit
+! typing rules and Fortran loose interface compatibility rule history. 
+
+
+! Note: all the cases where their is a definition are exactly the same,
+! since definition should be processed first regardless.
+
+! pass, call, define
+! CHECK-LABEL: func @_QPpass_foo() {
+subroutine pass_foo()
+  external :: foo
+  ! CHECK: %[[f:.*]] = constant @_QPfoo
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  call bar(foo)
+end subroutine
+! CHECK-LABEL: func @_QPcall_foo(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo(i)
+  integer :: i(10)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  ! fir.call @_QPfoo(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
+  call foo(i)
+end subroutine 
+! CHECK-LABEL: func @_QPfoo(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine foo(i)
+  integer :: i(2, 5)
+  call do_something(i)
+end subroutine
+
+! call, pass, define
+! CHECK-LABEL: func @_QPcall_foo2(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo2(i)
+  integer :: i(10)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  ! fir.call @_QPfoo2(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
+  call foo2(i)
+end subroutine 
+! CHECK-LABEL: func @_QPpass_foo2() {
+subroutine pass_foo2()
+  external :: foo2
+  ! CHECK: %[[f:.*]] = constant @_QPfoo2
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  call bar(foo2)
+end subroutine
+! CHECK-LABEL: func @_QPfoo2(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine foo2(i)
+  integer :: i(2, 5)
+  call do_something(i)
+end subroutine
+
+! call, define, pass
+! CHECK-LABEL: func @_QPcall_foo3(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo3(i)
+  integer :: i(10)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  ! fir.call @_QPfoo3(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
+  call foo3(i)
+end subroutine 
+! CHECK-LABEL: func @_QPfoo3(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine foo3(i)
+  integer :: i(2, 5)
+  call do_something(i)
+end subroutine
+! CHECK-LABEL: func @_QPpass_foo3() {
+subroutine pass_foo3()
+  external :: foo3
+  ! CHECK: %[[f:.*]] = constant @_QPfoo3
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  call bar(foo3)
+end subroutine
+
+! define, call, pass
+! CHECK-LABEL: func @_QPfoo4(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine foo4(i)
+  integer :: i(2, 5)
+  call do_something(i)
+end subroutine
+! CHECK-LABEL: func @_QPcall_foo4(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo4(i)
+  integer :: i(10)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  ! fir.call @_QPfoo4(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
+  call foo4(i)
+end subroutine 
+! CHECK-LABEL: func @_QPpass_foo4() {
+subroutine pass_foo4()
+  external :: foo4
+  ! CHECK: %[[f:.*]] = constant @_QPfoo4
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  call bar(foo4)
+end subroutine
+
+! define, pass, call
+! CHECK-LABEL: func @_QPfoo5(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine foo5(i)
+  integer :: i(2, 5)
+  call do_something(i)
+end subroutine
+! CHECK-LABEL: func @_QPpass_foo5() {
+subroutine pass_foo5()
+  external :: foo5
+  ! CHECK: %[[f:.*]] = constant @_QPfoo5
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  call bar(foo5)
+end subroutine
+! CHECK-LABEL: func @_QPcall_foo5(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo5(i)
+  integer :: i(10)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  ! fir.call @_QPfoo5(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
+  call foo5(i)
+end subroutine 
+
+
+! Test when there is no definition (declaration at the end of the mlir module)
+! First use gives the function type
+
+! call, pass
+! CHECK-LABEL: func @_QPcall_foo6(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo6(i)
+  integer :: i(10)
+  ! CHECK-NOT: convert
+  call foo6(i)
+end subroutine 
+! CHECK-LABEL: func @_QPpass_foo6() {
+subroutine pass_foo6()
+  external :: foo6
+  ! CHECK: %[[f:.*]] = constant @_QPfoo6 : (!fir.ref<!fir.array<10xi32>>) -> ()
+  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<10xi32>>) -> ()) -> (() -> ())
+  call bar(foo6)
+end subroutine
+
+! pass, call
+! CHECK-LABEL: func @_QPpass_foo7() {
+subroutine pass_foo7()
+  external :: foo7
+  ! CHECK-NOT: convert
+  call bar(foo7)
+end subroutine
+! CHECK-LABEL: func @_QPcall_foo7(%arg0: !fir.ref<!fir.array<10xi32>>) -> f32 {
+function call_foo7(i)
+  integer :: i(10)
+  ! CHECK: %[[f:.*]] = constant @_QPfoo7 : () -> ()
+  ! CHECK: %[[funccast:.*]] = fir.convert %[[f]] : (() -> ()) -> ((!fir.ref<!fir.array<10xi32>>) -> f32)
+  ! CHECK: fir.call %[[funccast]](%arg0) : (!fir.ref<!fir.array<10xi32>>) -> f32
+  call_foo7 =  foo7(i)
+end function 
+
+
+! call, call with different type
+! CHECK-LABEL: func @_QPcall_foo8(%arg0: !fir.ref<!fir.array<10xi32>>) {
+subroutine call_foo8(i)
+  integer :: i(10)
+  ! CHECK-NOT: convert
+  call foo8(i)
+end subroutine 
+! CHECK-LABEL: func @_QPcall_foo8_2(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+subroutine call_foo8_2(i)
+  integer :: i(2, 5)
+  ! %[[argconvert:*]] = fir.convert %arg0 :
+  call foo8(i)
+end subroutine 
+
+! CHECK: func @_QPfoo6(!fir.ref<!fir.array<10xi32>>)
+! CHECK: func @_QPfoo7()


### PR DESCRIPTION
Add an interface to CallInterface.h to delcareFunction from a ProcedureDesignator.
This allow creating mlir::FuncOp when lowering indirection to the ProcedureDesignator
if this function was never seen before.

On call sites, add a way to handle argument number mismatch. This is now needed to handle
cases where a procedure is first pass with no type information (the created mlir::FuncOp
has no arguments), and a call to it is later lowered with arguments. This is dealt with
by introducing a function type cast on the the calling site. This is not ideal, but the
alternative that would be to analyze all call site before lowering anything requires
more expensive analysis. If the front-end does this at some point to provide error messages
regarding incompatibles calls, we would take advantage of this.

This implements the TODO blocking #286.