### PR TITLE
Draft implementation for BLOCK DATA support.  This will lower BLOCK D…

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -64,7 +64,7 @@ public:
 
   template <typename B>
   constexpr BaseType<B> &get() const {
-    return std::get<Ref<B>> > (u).get();
+    return std::get<Ref<B>>> (u).get();
   }
   template <typename B>
   constexpr BaseType<B> *getIf() const {
@@ -543,11 +543,17 @@ struct ModuleLikeUnit : public ProgramUnit {
   std::list<FunctionLikeUnit> nestedFunctions;
 };
 
+/// Block data units contain the variables and data initializers for common
+/// blocks, etc.
 struct BlockDataUnit : public ProgramUnit {
-  BlockDataUnit(const parser::BlockData &bd,
-                const ParentVariant &parentVariant);
+  BlockDataUnit(const parser::BlockData &bd, const ParentVariant &parentVariant,
+                const Fortran::semantics::SemanticsContext &semanticsContext);
   BlockDataUnit(BlockDataUnit &&) = default;
   BlockDataUnit(const BlockDataUnit &) = delete;
+
+  LLVM_DUMP_METHOD void dump() const;
+  
+  const Fortran::semantics::Scope &symTab; // symbol table
 };
 
 /// A Program is the top-level root of the PFT.

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -737,7 +737,8 @@ private:
           [&](Fortran::lower::FirOpBuilder &builder) {
             auto str = consLit();
             builder.create<fir::HasValueOp>(getLoc(), str);
-          }, builder.createLinkOnceLinkage());
+          },
+          builder.createLinkOnceLinkage());
     auto addr = builder.create<fir::AddrOfOp>(getLoc(), global.resultType(),
                                               global.getSymbol());
     auto lenp = builder.createIntegerConstant(

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -118,7 +118,8 @@ public:
 
   // Block data
   bool Pre(const parser::BlockData &node) {
-    addUnit(lower::pft::BlockDataUnit{node, parentVariantStack.back()});
+    addUnit(lower::pft::BlockDataUnit{node, parentVariantStack.back(),
+                                      semanticsContext});
     return false;
   }
 
@@ -1259,8 +1260,12 @@ Fortran::lower::pft::ModuleLikeUnit::ModuleLikeUnit(
       endStmt{getModuleStmt<parser::EndSubmoduleStmt>(m)} {}
 
 Fortran::lower::pft::BlockDataUnit::BlockDataUnit(
-    const parser::BlockData &bd, const lower::pft::ParentVariant &parent)
-    : ProgramUnit{bd, parent} {}
+    const parser::BlockData &bd, const lower::pft::ParentVariant &parent,
+    const semantics::SemanticsContext &semanticsContext)
+    : ProgramUnit{bd, parent},
+      symTab{semanticsContext.FindScope(
+          std::get<parser::Statement<parser::EndBlockDataStmt>>(bd.t).source)} {
+}
 
 std::unique_ptr<lower::pft::Program>
 Fortran::lower::createPFT(const parser::Program &root,
@@ -1291,6 +1296,7 @@ void Fortran::lower::pft::Variable::dump() const {
                  << std::get<1>(*store) << "]:";
   else
     llvm_unreachable("not a Variable");
+  
   llvm::errs() << " depth: " << depth;
   if (global)
     llvm::errs() << ", global";
@@ -1311,4 +1317,9 @@ void Fortran::lower::pft::FunctionLikeUnit::dump() const {
 
 void Fortran::lower::pft::ModuleLikeUnit::dump() const {
   PFTDumper{}.dumpModuleLikeUnit(llvm::errs(), *this);
+}
+
+/// The BlockDataUnit dump is just the associated symbol table.
+void Fortran::lower::pft::BlockDataUnit::dump() const {
+  llvm::errs() << "block data {\n" << symTab << "\n}\n";
 }


### PR DESCRIPTION
…ATA program units that initialize global variables, such as those placed into COMMON blocks. Some refactoring was done to start to consolidate the various and disparate code that instantiates data.  More cleanup is TODO.

Issue #117