### PR TITLE
selectively disable the -Wc99-extensions warning

### DIFF
--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -1,3 +1,7 @@
+check_cxx_compiler_flag("-Werror -Wc99-extensions" HAS_WC99_EXTENSIONS_FLAG)
+if (HAS_WC99_EXTENSIONS_FLAG)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-extensions")
+endif()
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -3,6 +3,12 @@ include(CheckCXXSymbolExists)
 include(CheckCXXSourceCompiles)
 check_cxx_symbol_exists(strerror string.h HAVE_STRERROR)
 check_cxx_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
+
+check_cxx_compiler_flag("-Werror -Wc99-extensions" HAS_WC99_EXTENSIONS_FLAG)
+if (HAS_WC99_EXTENSIONS_FLAG)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-extensions")
+endif()
+
 # Can't use symbol exists here as the function is overloaded in C++
 check_cxx_source_compiles(
   "#include <string.h>


### PR DESCRIPTION
Temporarily silence the _Complex warnings until Jean can get to his fix.