### PR TITLE
Handle HostAssociated symbols better and fix undefined behavior

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2165,7 +2165,8 @@ private:
     }
     if (auto passedResult = callee.getPassedResult()) {
       mapPassedEntity(*passedResult);
-      if (*passedResult->entity != *funit.primaryResult)
+      if (funit.primaryResult &&
+          passedResult->entity.get() != *funit.primaryResult)
         addSymbol(*funit.primaryResult, lookupSymbol(passedResult->entity));
     }
   }

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -229,7 +229,13 @@ public:
   /// Find `symbol` and return its value if it appears in the current mappings.
   SymbolBox lookupSymbol(semantics::SymbolRef sym) {
     auto iter = symbolMap.find(&*sym);
-    return (iter == symbolMap.end()) ? SymbolBox() : iter->second;
+    if (iter != symbolMap.end())
+      return iter->second;
+    // Follow host association
+    if (const auto *details =
+            sym->detailsIf<Fortran::semantics::HostAssocDetails>())
+      return lookupSymbol(details->symbol());
+    return SymbolBox::None{};
   }
 
   /// Remove `sym` from the map.


### PR DESCRIPTION
- Prepare for the next rebase with llvm containing a change related to host associated symbols (https://reviews.llvm.org/D84889).
Symbols with HostAssociatedDetails are now created in more cases, to accommodate this follow host association in symbol lookups  in case the host associated symbol is not in the map.

- This exposed a bug that was there before. A dereference of funit.primaryResulty was always done. It should only be done its non null).
