### PR TITLE
Array coordinate changes for lowering

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1600,29 +1600,19 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect, AttrSizedOperandSegmen
   let arguments = (ins AnyReferenceLike:$memref,
                        Optional<AnyShapeType>:$shape, Optional<fir_SliceType>:$slice,
                        Variadic<AnyCoordinateType>:$indices,
-                       Variadic<AnyIntegerType>:$lens);
+                       Variadic<AnyIntegerType>:$lenParams);
 
   let results = (outs fir_ReferenceType);
   let assemblyFormat = [{
-    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? $indices (`typeparams` $lens^)? `:` functional-type(operands, results) attr-dict
+    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? $indices (`typeparams` $lenParams^)? `:` functional-type(operands, results) attr-dict
   }];
 
   let verifier = [{
     auto eleTy = fir::dyn_cast_ptrEleTy(memref().getType());
-    if (!eleTy)
-       return emitOpError("must be a reference type");
     auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
     if (!arrTy)
       return emitOpError("must be a reference to an array");
-    auto shapeOp = shape();
-    auto shapeTy = shapeOp.getType();
-    if (!(shapeTy.isa<fir::ShapeType>() || shapeTy.isa<ShapeShiftType>()))
-      return emitOpError("must be a shape or shapeshift type");
-    if (auto sliceOp = slice()) {
-      auto sliceTy = sliceOp.getType();
-      if (!sliceTy.isa<fir::SliceType>())
-        return emitOpError("must be slice type");
-    }
+
     auto arrDim = arrTy.getDimension();
     unsigned shapeTyRank = 0;
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
@@ -1636,15 +1626,6 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect, AttrSizedOperandSegmen
     if (shapeTyRank != indices().size())
       return emitOpError("number of indices do not match dim rank");
     return mlir::success();
-  }];
-
-  let extraClassDeclaration = [{
-    unsigned numLenParams() {
-      return 0;
-    }
-    operand_range getLenParams() {
-        return {operand_end(), operand_end()};
-    }
   }];
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1572,8 +1572,7 @@ def fir_BoxTypeDescOp : fir_SimpleOneResultOp<"box_tdesc", [NoSideEffect]> {
 }
 
 // Record and array type operations
-
-def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect]> {
+def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect, AttrSizedOperandSegments]> {
   let summary = "Find the coordinate of an element of an array";
 
   let description = [{
@@ -1598,34 +1597,14 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect]> {
     ```
   }];
 
-  let arguments = (ins AnyReferenceLike:$memref, Variadic<AnyEmboxArg>:$args);
+  let arguments = (ins AnyReferenceLike:$memref,
+                       Optional<AnyShapeType>:$shape, Optional<fir_SliceType>:$slice,
+                       Variadic<AnyCoordinateType>:$indices,
+                       Variadic<AnyIntegerType>:$lens);
 
   let results = (outs fir_ReferenceType);
-
-  let parser = "return parseArrayCoorOp(parser, result);";
-
-  let printer = [{
-    p << getOperationName() << ' ';
-    p.printOperand(memref());
-    if (auto shape = getShape()) {
-      p << '(';
-      p.printOperand(shape);
-      p << ')';
-    }
-    if (auto slice = getSlice()) {
-      p << '[';
-      p.printOperand(slice);
-      p << ']';
-    }
-    p << ' ';
-    p.printOperands(getIndices());
-    if (hasLenParams()) {
-      p << " typeparams ";
-      p.printOperands(getLenParams());
-    }
-    p.printOptionalAttrDict(getAttrs(), {indicesName(), lenpName(), shapeName(), sliceName()});
-    p << " : ";
-    p.printFunctionalType(getOperation());
+  let assemblyFormat = [{
+    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? $indices (`typeparams` $lens^)? `:` functional-type(operands, results) attr-dict
   }];
 
   let verifier = [{
@@ -1635,14 +1614,12 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect]> {
     auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
     if (!arrTy)
       return emitOpError("must be a reference to an array");
-    auto shape = getShape();
-    if (!shape)
-      return emitOpError("must have a shape");
-    auto shapeTy = shape.getType();
+    auto shapeOp = shape();
+    auto shapeTy = shapeOp.getType();
     if (!(shapeTy.isa<fir::ShapeType>() || shapeTy.isa<ShapeShiftType>()))
       return emitOpError("must be a shape or shapeshift type");
-    if (auto slice = getSlice()) {
-      auto sliceTy = slice.getType();
+    if (auto sliceOp = slice()) {
+      auto sliceTy = sliceOp.getType();
       if (!sliceTy.isa<fir::SliceType>())
         return emitOpError("must be slice type");
     }
@@ -1656,56 +1633,17 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect]> {
     }
     if (arrDim && arrDim != shapeTyRank)
       return emitOpError("rank of dimension mismatched");
-    if (shapeTyRank != getIndices().size())
+    if (shapeTyRank != indices().size())
       return emitOpError("number of indices do not match dim rank");
     return mlir::success();
   }];
 
   let extraClassDeclaration = [{
-    static constexpr llvm::StringRef indicesName() { return "indices"; }
-    static constexpr llvm::StringRef lenpName() { return "len_param_count"; }
-    static constexpr llvm::StringRef shapeName() { return "shape"; }
-    static constexpr llvm::StringRef sliceName() { return "slice"; }
-    bool hasLenParams() { return bool{getAttr(lenpName())}; }
-    mlir::Value getShape() {
-      if (auto x = getAttrOfType<mlir::UnitAttr>(shapeName()))
-        return *std::next(operand_begin());
-      return {};
-    }
-    mlir::Value getSlice() {
-      if (auto x = getAttrOfType<mlir::UnitAttr>(sliceName())) {
-        auto iter = std::next(operand_begin());
-        if (getShape())
-          iter = std::next(iter);
-        return *iter;
-      }
-      return {};
-    }
-    unsigned numIndices() {
-      if (auto x = getAttrOfType<mlir::IntegerAttr>(indicesName()))
-        return x.getInt();
-      return 0;
-    }
-    operand_range getIndices() {
-      auto iter = std::next(operand_begin());
-      if (getShape())
-        iter = std::next(iter);
-      if (getSlice())
-        iter = std::next(iter);
-      return {iter, iter + numIndices()};
-    }
     unsigned numLenParams() {
-      if (auto x = getAttrOfType<mlir::IntegerAttr>(lenpName()))
-        return x.getInt();
       return 0;
     }
     operand_range getLenParams() {
-      auto offset = numIndices();
-      if (getShape())
-        ++offset;
-      if (getSlice())
-        ++offset;
-      return {std::next(operand_begin()) + offset, operand_end()};
+        return {operand_end(), operand_end()};
     }
   }];
 }
@@ -1908,7 +1846,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
   }];
 }
 
-def fir_ShapeOp : fir_OneResultOp<"shape", [NoSideEffect]> {
+def fir_ShapeOp : fir_Op<"shape", [NoSideEffect]> {
 
   let summary = "generate an abstract shape vector of type `!fir.shape`";
 
@@ -1942,7 +1880,7 @@ def fir_ShapeOp : fir_OneResultOp<"shape", [NoSideEffect]> {
   }];
 }
 
-def fir_ShapeShiftOp : fir_OneResultOp<"shape_shift", [NoSideEffect]> {
+def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
 
   let summary = [{
     generate an abstract shape and shift vector of type `!fir.shapeshift`
@@ -1983,7 +1921,7 @@ def fir_ShapeShiftOp : fir_OneResultOp<"shape_shift", [NoSideEffect]> {
   }];
 }
 
-def fir_SliceOp : fir_OneResultOp<"slice", [NoSideEffect]> {
+def fir_SliceOp : fir_Op<"slice", [NoSideEffect]> {
 
   let summary = "generate an abstract slice vector of type `!fir.slice`";
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1609,22 +1609,35 @@ def fir_ArrayCoorOp : fir_Op<"array_coor", [NoSideEffect, AttrSizedOperandSegmen
 
   let verifier = [{
     auto eleTy = fir::dyn_cast_ptrEleTy(memref().getType());
+    if (!eleTy)
+       return emitOpError("must be a reference type");
     auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
     if (!arrTy)
       return emitOpError("must be a reference to an array");
-
     auto arrDim = arrTy.getDimension();
-    unsigned shapeTyRank = 0;
-    if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
-      shapeTyRank = s.getRank();
-    } else {
-      auto ss = shapeTy.cast<fir::ShapeShiftType>();
-      shapeTyRank = ss.getRank();
+
+    if (auto shapeOp = shape()) {
+      auto shapeTy = shapeOp.getType();
+      unsigned shapeTyRank = 0;
+      if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
+        shapeTyRank = s.getRank();
+      } else {
+        auto ss = shapeTy.cast<fir::ShapeShiftType>();
+        shapeTyRank = ss.getRank();
+      }
+      if (arrDim && arrDim != shapeTyRank)
+        return emitOpError("rank of dimension mismatched");
+      if (shapeTyRank != indices().size())
+        return emitOpError("number of indices do not match dim rank");
     }
-    if (arrDim && arrDim != shapeTyRank)
-      return emitOpError("rank of dimension mismatched");
-    if (shapeTyRank != indices().size())
-      return emitOpError("number of indices do not match dim rank");
+
+    if (auto sliceOp = slice()) {
+      if (auto sliceTy = sliceOp.getType().dyn_cast<fir::SliceType>()) {
+        if (sliceTy.getRank() != arrDim)
+          return emitOpError("rank of dimension in slice mismatched");
+      }
+    }
+
     return mlir::success();
   }];
 }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1119,16 +1119,15 @@ private:
         auto shapeType =
             fir::ShapeType::get(builder.getContext(), arr.getExtents().size());
         return builder.create<fir::ShapeOp>(loc, shapeType, arr.getExtents());
-      } else {
-        auto shapeType = fir::ShapeShiftType::get(builder.getContext(),
-                                                  arr.getExtents().size());
-        SmallVector<mlir::Value, 8> shapeArgs;
-        for (const auto &pair : llvm::zip(arr.getLBounds(), arr.getExtents())) {
-          shapeArgs.push_back(std::get<0>(pair));
-          shapeArgs.push_back(std::get<1>(pair));
-        }
-        return builder.create<fir::ShapeShiftOp>(loc, shapeType, shapeArgs);
       }
+      auto shapeType = fir::ShapeShiftType::get(builder.getContext(),
+                                                arr.getExtents().size());
+      SmallVector<mlir::Value, 8> shapeArgs;
+      for (const auto &pair : llvm::zip(arr.getLBounds(), arr.getExtents())) {
+        shapeArgs.push_back(std::get<0>(pair));
+        shapeArgs.push_back(std::get<1>(pair));
+      }
+      return builder.create<fir::ShapeShiftOp>(loc, shapeType, shapeArgs);
     };
     auto genWithShape = [&](const auto &arr) -> mlir::Value {
       auto shape = arrShape(arr);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -38,7 +38,7 @@
 static llvm::cl::opt<bool> generateArrayCoordinate(
     "gen-array-coor",
     llvm::cl::desc("in lowering create ArrayCoorOp instead of CoordinateOp"),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 
 namespace {
 

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -29,10 +29,16 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "llvm/ADT/APFloat.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
 #define TODO() llvm_unreachable("not yet implemented")
+
+static llvm::cl::opt<bool> generateArrayCoordinate(
+    "gen-array-coor",
+    llvm::cl::desc("in lowering create ArrayCoorOp instead of CoordinateOp"),
+    llvm::cl::init(true));
 
 namespace {
 
@@ -1101,11 +1107,79 @@ private:
         si.box);
   }
 
+  fir::ExtendedValue genArrayCoorOp(const Fortran::lower::SymbolBox &si,
+                                    const Fortran::evaluate::ArrayRef &aref) {
+    auto loc = getLoc();
+    auto addr = si.getAddr();
+    auto arrTy = fir::dyn_cast_ptrEleTy(addr.getType());
+    auto eleTy = arrTy.cast<fir::SequenceType>().getEleTy();
+    auto refTy = builder.getRefType(eleTy);
+    auto arrShape = [&](const auto &arr) -> mlir::Value {
+      if (arr.getLBounds().empty()) {
+        auto shapeType =
+            fir::ShapeType::get(builder.getContext(), arr.getExtents().size());
+        return builder.create<fir::ShapeOp>(loc, shapeType, arr.getExtents());
+      } else {
+        auto shapeType = fir::ShapeShiftType::get(builder.getContext(),
+                                                  arr.getExtents().size());
+        SmallVector<mlir::Value, 8> shapeArgs;
+        for (const auto &pair : llvm::zip(arr.getLBounds(), arr.getExtents())) {
+          shapeArgs.push_back(std::get<0>(pair));
+          shapeArgs.push_back(std::get<1>(pair));
+        }
+        return builder.create<fir::ShapeShiftOp>(loc, shapeType, shapeArgs);
+      }
+    };
+    auto genWithShape = [&](const auto &arr) -> mlir::Value {
+      auto shape = arrShape(arr);
+      llvm::SmallVector<mlir::Value, 8> arrayCoorArgs;
+      for (const auto &sub : aref.subscript()) {
+        auto subVal = genComponent(sub);
+        if (auto *ev = std::get_if<fir::ExtendedValue>(&subVal)) {
+          if (auto *sval = ev->getUnboxed()) {
+            arrayCoorArgs.push_back(*sval);
+          } else {
+            TODO();
+          }
+        } else {
+          // RangedBoxValue
+          TODO();
+        }
+      }
+      return builder.create<fir::ArrayCoorOp>(
+          loc, refTy, addr, shape, mlir::Value{}, arrayCoorArgs, ValueRange());
+    };
+    return std::visit(
+        Fortran::common::visitors{
+            [&](const Fortran::lower::SymbolBox::FullDim &arr) {
+              if (!inArrayContext() && isSlice(aref)) {
+                TODO();
+                return mlir::Value{};
+              }
+              return genWithShape(arr);
+            },
+            [&](const Fortran::lower::SymbolBox::CharFullDim &arr) {
+              TODO();
+              return mlir::Value{};
+            },
+            [&](const Fortran::lower::SymbolBox::Derived &arr) {
+              TODO();
+              return mlir::Value{};
+            },
+            [&](const auto &) {
+              TODO();
+              return mlir::Value{};
+            }},
+        si.box);
+  }
+
   // Return the coordinate of the array reference
   fir::ExtendedValue gen(const Fortran::evaluate::ArrayRef &aref) {
     if (aref.base().IsSymbol()) {
       auto &symbol = aref.base().GetFirstSymbol();
       auto si = symMap.lookupSymbol(symbol);
+      if (generateArrayCoordinate)
+        return genArrayCoorOp(si, aref);
       if (!si.hasConstantShape())
         return gen(si, aref);
       auto box = gen(symbol);

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -140,7 +140,7 @@ public:
   matchAndRewrite(ArrayCoorOp arrCoor,
                   mlir::PatternRewriter &rewriter) const override {
     auto loc = arrCoor.getLoc();
-    auto shapeVal = arrCoor.getShape();
+    auto shapeVal = arrCoor.shape();
     auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp());
     llvm::SmallVector<mlir::Value, 8> shapeOpers;
     llvm::SmallVector<mlir::Value, 8> shiftOpers;
@@ -161,7 +161,7 @@ public:
     auto lenParamAttr = rewriter.getIntegerAttr(idxTy, lenParamSize);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::lenParamAttrName(), lenParamAttr));
-    auto indexSize = arrCoor.getIndices().size();
+    auto indexSize = arrCoor.indices().size();
     auto idxAttr = rewriter.getIntegerAttr(idxTy, indexSize);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::indexAttrName(), idxAttr));
@@ -170,7 +170,7 @@ public:
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::shapeAttrName(), dimAttr));
     llvm::SmallVector<mlir::Value, 8> sliceOpers;
-    if (auto s = arrCoor.getSlice())
+    if (auto s = arrCoor.slice())
       if (auto sliceOp = dyn_cast_or_null<SliceOp>(s.getDefiningOp()))
         sliceOpers.append(sliceOp.triples().begin(), sliceOp.triples().end());
     auto sliceAttr = rewriter.getIntegerAttr(idxTy, sliceOpers.size());
@@ -178,7 +178,7 @@ public:
         rewriter.getNamedAttr(XArrayCoorOp::sliceAttrName(), sliceAttr));
     auto xArrCoor = rewriter.create<XArrayCoorOp>(
         loc, arrCoor.getType(), arrCoor.memref(), shapeOpers, shiftOpers,
-        sliceOpers, arrCoor.getIndices(), arrCoor.getLenParams(), attrs);
+        sliceOpers, arrCoor.indices(), arrCoor.getLenParams(), attrs);
     rewriter.replaceOp(arrCoor, xArrCoor.getOperation()->getResults());
     return mlir::success();
   }

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -157,7 +157,7 @@ public:
     auto rankAttr = rewriter.getIntegerAttr(idxTy, rank);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::rankAttrName(), rankAttr));
-    auto lenParamSize = arrCoor.getLenParams().size();
+    auto lenParamSize = arrCoor.lenParams().size();
     auto lenParamAttr = rewriter.getIntegerAttr(idxTy, lenParamSize);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::lenParamAttrName(), lenParamAttr));
@@ -178,7 +178,7 @@ public:
         rewriter.getNamedAttr(XArrayCoorOp::sliceAttrName(), sliceAttr));
     auto xArrCoor = rewriter.create<XArrayCoorOp>(
         loc, arrCoor.getType(), arrCoor.memref(), shapeOpers, shiftOpers,
-        sliceOpers, arrCoor.indices(), arrCoor.getLenParams(), attrs);
+        sliceOpers, arrCoor.indices(), arrCoor.lenParams(), attrs);
     rewriter.replaceOp(arrCoor, xArrCoor.getOperation()->getResults());
     return mlir::success();
   }

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -121,57 +121,6 @@ mlir::Type fir::AllocMemOp::wrapResultType(mlir::Type intype) {
 }
 
 //===----------------------------------------------------------------------===//
-// ArrayCoorOp
-//===----------------------------------------------------------------------===//
-
-/// Custom parser for the fir.embox operation.
-static mlir::ParseResult parseArrayCoorOp(mlir::OpAsmParser &parser,
-                                          mlir::OperationState &result) {
-  mlir::FunctionType type;
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> operands;
-  mlir::OpAsmParser::OperandType memref;
-  unsigned argCounter = 1;
-  if (parser.parseOperand(memref))
-    return mlir::failure();
-  operands.push_back(memref);
-  auto &builder = parser.getBuilder();
-  if (mlir::succeeded(parser.parseOptionalLParen())) {
-    mlir::OpAsmParser::OperandType shape;
-    if (parser.parseOperand(shape) || parser.parseRParen())
-      return mlir::failure();
-    operands.push_back(shape);
-    result.addAttribute(fir::ArrayCoorOp::shapeName(), builder.getUnitAttr());
-    argCounter++;
-  }
-  if (mlir::succeeded(parser.parseOptionalLSquare())) {
-    mlir::OpAsmParser::OperandType slice;
-    if (parser.parseOperand(slice) || parser.parseRSquare())
-      return mlir::failure();
-    operands.push_back(slice);
-    result.addAttribute(fir::ArrayCoorOp::sliceName(), builder.getUnitAttr());
-    argCounter++;
-  }
-  if (parser.parseOperandList(operands, mlir::OpAsmParser::Delimiter::None))
-    return mlir::failure();
-  auto indices = builder.getI32IntegerAttr(operands.size() - argCounter);
-  result.addAttribute(fir::ArrayCoorOp::indicesName(), indices);
-  argCounter = operands.size();
-  if (mlir::succeeded(parser.parseOptionalKeyword("typeparams"))) {
-    if (parser.parseOperandList(operands, mlir::OpAsmParser::Delimiter::None))
-      return mlir::failure();
-    auto lens = builder.getI32IntegerAttr(operands.size() - argCounter);
-    result.addAttribute(fir::ArrayCoorOp::lenpName(), lens);
-  }
-  if (parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseColonType(type) ||
-      parser.resolveOperands(operands, type.getInputs(), parser.getNameLoc(),
-                             result.operands) ||
-      parser.addTypesToList(type.getResults(), result.types))
-    return mlir::failure();
-  return mlir::success();
-}
-
-//===----------------------------------------------------------------------===//
 // BoxAddrOp
 //===----------------------------------------------------------------------===//
 

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -236,7 +236,7 @@ bool analyzeCoordinate(mlir::Value coordinate) {
 bool AffineLoopAnalysis::analyzeArrayReference(mlir::Value arrayRef) {
   bool canPromote = true;
   if (auto acoOp = arrayRef.getDefiningOp<ArrayCoorOp>()) {
-    for (auto coordinate : acoOp.getIndices())
+    for (auto coordinate : acoOp.indices())
       canPromote = canPromote && analyzeCoordinate(coordinate);
   } else {
     LLVM_DEBUG(llvm::dbgs() << "AffineLoopAnalysis: cannot promote loop, "
@@ -311,12 +311,12 @@ mlir::Type coordinateArrayElement(fir::ArrayCoorOp op) {
 std::pair<mlir::AffineApplyOp, fir::ConvertOp>
 createAffineOps(mlir::Value arrayRef, mlir::PatternRewriter &rewriter) {
   auto acoOp = arrayRef.getDefiningOp<ArrayCoorOp>();
-  assert(acoOp.getShape() && isa<ShapeOp>(acoOp.getShape().getDefiningOp()));
-  auto genDim = acoOp.getShape().getDefiningOp<ShapeOp>();
+  assert(acoOp.shape() && isa<ShapeOp>(acoOp.shape().getDefiningOp()));
+  auto genDim = acoOp.shape().getDefiningOp<ShapeOp>();
   auto affineMap =
-      createArrayIndexAffineMap(acoOp.getIndices().size(), acoOp.getContext());
+      createArrayIndexAffineMap(acoOp.indices().size(), acoOp.getContext());
   SmallVector<mlir::Value, 4> indexArgs;
-  indexArgs.append(acoOp.getIndices().begin(), acoOp.getIndices().end());
+  indexArgs.append(acoOp.indices().begin(), acoOp.indices().end());
 
   // FIXME: quick hack for now (assumes 1 for the shift and stride)
   auto iter = genDim.extents().begin();

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -627,7 +627,7 @@ func @array_access(%arr : !fir.ref<!fir.array<?x?xf32>>) {
   fir.do_loop %i = %c0 to %c99 step %c1 {
     %c49 = constant 49 : index
     fir.do_loop %j = %c0 to %c49 step %c1 {
-      // CHECK: fir.array_coor %{{.*}}(%[[sh]])[%[[sl]]] %{{.*}}, %{{.*}} :
+      // CHECK: fir.array_coor %{{.*}}(%[[sh]]) [%[[sl]]] %{{.*}}, %{{.*}} :
       %p = fir.array_coor %arr(%shape)[%slice] %i, %j : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
       %x = constant 42.0 : f32
       fir.store %x to %p : !fir.ref<f32>


### PR DESCRIPTION
> The previous #349 pull request was closed somehow so creating a new one.
There are two separate changes
    array coor operation itself for separate shape and slice values
    this removes the need for custom parser and unit attributes for flagging shape and slice.
    convertExpr for creating array coor with gen-array-coor flag

example fortran:
```
subroutine index_d1(arr,size,i,ret)
  integer size,i
  real arr(size)
  real ret
  ret = arr(i)
end subroutine index_d1
```
example output:
```
func @_QPindex_d1(%arg0: !fir.ref<!fir.array<?xf32>>, %arg1: !fir.ref<i32>, %arg2: !fir.ref<i32>, %arg3: !fir.ref<f32>) {
  %c1_i64 = constant 1 : i64
  %0 = fir.load %arg1 : !fir.ref<i32>
  %1 = fir.convert %0 : (i32) -> i64
  %2 = subi %1, %c1_i64 : i64
  %c1_i64_0 = constant 1 : i64
  %3 = addi %2, %c1_i64_0 : i64
  %4 = fir.convert %3 : (i64) -> index
  %5 = fir.shape_shift %c1_i64, %4 : (i64, index) -> !fir.shapeshift<1>
  %6 = fir.load %arg2 : !fir.ref<i32>
  %7 = fir.convert %6 : (i32) -> i64
  %8 = fir.array_coor %arg0(%5) %7 : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, i64) -> !fir.ref<f32>
  %9 = fir.load %8 : !fir.ref<f32>
  fir.store %9 to %arg3 : !fir.ref<f32>
  return
}
```