### PR TITLE
Fix for issue #403 (and duplicates).

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -431,9 +431,10 @@ locationToFilename(Fortran::lower::AbstractConverter &converter,
                    mlir::Location loc, mlir::Type toType) {
   auto &builder = converter.getFirOpBuilder();
   if (auto flc = loc.dyn_cast<mlir::FileLineColLoc>()) {
-    auto fn = flc.getFilename();
+    // must be encoded as asciiz, C string
+    auto fn = flc.getFilename().str() + '\0';
     auto addr =
-        fir::getBase(createStringLiteral(loc, converter, fn.data(), fn.size()));
+        fir::getBase(createStringLiteral(loc, converter, fn, fn.size()));
     return builder.createConvert(loc, toType, addr);
   }
   mlir::Value null =


### PR DESCRIPTION
Generalize string literal creation to handle data with NUL characters and to properly support CHARACTER of KIND=2 and KIND=4. This allows the creation of ASCIIZ strings (needed for Fortran runtime support functions requiring C style strings).