### PR TITLE
Update intrinsic lowering framework for subroutine and DATE_AND_TIME lowering (but VALUES arg)

### DIFF
--- a/flang/include/flang/Lower/IntrinsicCall.h
+++ b/flang/include/flang/Lower/IntrinsicCall.h
@@ -10,6 +10,7 @@
 #define FORTRAN_LOWER_INTRINSICCALL_H
 
 #include "flang/Lower/FIRBuilder.h"
+#include "llvm/ADT/Optional.h"
 
 namespace fir {
 class ExtendedValue;
@@ -32,7 +33,8 @@ namespace Fortran::lower {
 /// with arguments \p args and expected result type \p resultType.
 /// Returned mlir::Value is the returned Fortran intrinsic value.
 fir::ExtendedValue genIntrinsicCall(FirOpBuilder &, mlir::Location,
-                                    llvm::StringRef name, mlir::Type resultType,
+                                    llvm::StringRef name,
+                                    llvm::Optional<mlir::Type> resultType,
                                     llvm::ArrayRef<fir::ExtendedValue> args);
 
 /// Get SymbolRefAttr of runtime (or wrapper function containing inlined

--- a/flang/include/flang/Lower/Runtime.h
+++ b/flang/include/flang/Lower/Runtime.h
@@ -20,6 +20,19 @@
 #ifndef FORTRAN_LOWER_RUNTIME_H
 #define FORTRAN_LOWER_RUNTIME_H
 
+namespace llvm {
+template <typename T>
+class Optional;
+}
+
+namespace mlir {
+class Location;
+}
+
+namespace fir {
+class CharBoxValue;
+}
+
 namespace Fortran {
 
 namespace parser {
@@ -38,6 +51,7 @@ struct UnlockStmt;
 namespace lower {
 
 class AbstractConverter;
+class FirOpBuilder;
 
 // Lowering of Fortran statement related runtime (other than IO and maths)
 
@@ -54,6 +68,9 @@ void genSyncMemoryStatement(AbstractConverter &,
 void genSyncTeamStatement(AbstractConverter &, const parser::SyncTeamStmt &);
 void genUnlockStatement(AbstractConverter &, const parser::UnlockStmt &);
 void genPauseStatement(AbstractConverter &, const parser::PauseStmt &);
+
+void genDateAndTime(FirOpBuilder &, mlir::Location,
+                    llvm::Optional<fir::CharBoxValue> date);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/Runtime.h
+++ b/flang/include/flang/Lower/Runtime.h
@@ -70,7 +70,9 @@ void genUnlockStatement(AbstractConverter &, const parser::UnlockStmt &);
 void genPauseStatement(AbstractConverter &, const parser::PauseStmt &);
 
 void genDateAndTime(FirOpBuilder &, mlir::Location,
-                    llvm::Optional<fir::CharBoxValue> date);
+                    llvm::Optional<fir::CharBoxValue> date,
+                    llvm::Optional<fir::CharBoxValue> time,
+                    llvm::Optional<fir::CharBoxValue> zone);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1277,9 +1277,10 @@ private:
   fir::ExtendedValue
   genIntrinsicRef(const Fortran::evaluate::ProcedureRef &procRef,
                   const Fortran::evaluate::SpecificIntrinsic &intrinsic,
-                  mlir::ArrayRef<mlir::Type> resultType) {
-    if (resultType.size() != 1)
-      TODO(); // Intrinsic subroutine
+                  mlir::ArrayRef<mlir::Type> resultTypes) {
+    llvm::Optional<mlir::Type> resultType;
+    if (resultTypes.size() == 1)
+      resultType = resultTypes[0];
 
     llvm::SmallVector<fir::ExtendedValue, 2> operands;
     // Lower arguments
@@ -1297,8 +1298,8 @@ private:
     }
     // Let the intrinsic library lower the intrinsic procedure call
     llvm::StringRef name = intrinsic.name;
-    return Fortran::lower::genIntrinsicCall(builder, getLoc(), name,
-                                            resultType[0], operands);
+    return Fortran::lower::genIntrinsicCall(builder, getLoc(), name, resultType,
+                                            operands);
   }
 
   template <typename A>
@@ -1356,7 +1357,7 @@ private:
   genProcedureRef(const Fortran::evaluate::ProcedureRef &procRef,
                   mlir::ArrayRef<mlir::Type> resultType) {
     if (const auto *intrinsic = procRef.proc().GetSpecificIntrinsic())
-      return genIntrinsicRef(procRef, *intrinsic, resultType[0]);
+      return genIntrinsicRef(procRef, *intrinsic, resultType);
 
     if (isStatementFunctionCall(procRef))
       return genStmtFunctionRef(procRef, resultType);

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1167,15 +1167,17 @@ mlir::Value IntrinsicLibrary::genConjg(mlir::Type resultType,
 // DATE_AND_TIME
 void IntrinsicLibrary::genDateAndTime(llvm::ArrayRef<fir::ExtendedValue> args) {
   assert(args.size() == 4 && "date_and_time has 4 args");
-  llvm::Optional<fir::CharBoxValue> date;
-  if (auto *charBox = args[0].getCharBox())
-    date = *charBox;
-  for (auto i = 1; i < 4; ++i)
-    if (fir::getBase(args[i]))
-      llvm::errs() << "TODO: lowering of DATE_AND_TIME arguments other than "
-                      "DATE not yet implemented\n";
+  llvm::SmallVector<llvm::Optional<fir::CharBoxValue>, 3> charArgs(3);
+  for (auto i = 0; i < 3; ++i)
+    if (auto *charBox = args[i].getCharBox())
+      charArgs[i] = *charBox;
+  // TODO: build descriptor for VALUES (also update runtime)
+  if (fir::getBase(args[3]))
+    mlir::emitError(loc, "TODO: lowering of DATE_AND_TIME VALUES argument not "
+                         "yet implemented\n");
 
-  Fortran::lower::genDateAndTime(builder, loc, date);
+  Fortran::lower::genDateAndTime(builder, loc, charArgs[0], charArgs[1],
+                                 charArgs[2]);
 }
 
 // DIM

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -248,9 +248,11 @@ struct IntrinsicLibrary {
   mlir::Value outlineInWrapper(GeneratorType, llvm::StringRef name,
                                mlir::Type resultType,
                                llvm::ArrayRef<mlir::Value> args);
-  fir::ExtendedValue outlineInWrapper(ExtendedGenerator, llvm::StringRef name,
-                                      mlir::Type resultType,
-                                      llvm::ArrayRef<fir::ExtendedValue> args);
+  template <typename GeneratorType>
+  fir::ExtendedValue
+  outlineInExtendedWrapper(GeneratorType, llvm::StringRef name,
+                           llvm::Optional<mlir::Type> resultType,
+                           llvm::ArrayRef<fir::ExtendedValue> args);
 
   template <typename GeneratorType>
   mlir::FuncOp getWrapper(GeneratorType, llvm::StringRef name,
@@ -273,7 +275,6 @@ struct IntrinsicLibrary {
                               mlir::Type resultType,
                               llvm::ArrayRef<mlir::Value> args);
   mlir::Value invokeGenerator(SubroutineGenerator generator,
-                              mlir::Type resultType,
                               llvm::ArrayRef<mlir::Value> args);
 
   /// Get pointer to unrestricted intrinsic. Generate the related unrestricted
@@ -662,12 +663,16 @@ static mlir::FuncOp getRuntimeFunction(mlir::Location loc,
 
 /// Helpers to get function type from arguments and result type.
 static mlir::FunctionType
-getFunctionType(mlir::Type resultType, llvm::ArrayRef<mlir::Value> arguments,
+getFunctionType(llvm::Optional<mlir::Type> resultType,
+                llvm::ArrayRef<mlir::Value> arguments,
                 Fortran::lower::FirOpBuilder &builder) {
   llvm::SmallVector<mlir::Type, 2> argumentTypes;
   for (auto &arg : arguments)
     argumentTypes.push_back(arg.getType());
-  return mlir::FunctionType::get(argumentTypes, resultType,
+  llvm::SmallVector<mlir::Type, 1> resultTypes;
+  if (resultType)
+    resultTypes.push_back(*resultType);
+  return mlir::FunctionType::get(argumentTypes, resultTypes,
                                  builder.getModule().getContext());
 }
 
@@ -765,12 +770,12 @@ IntrinsicLibrary::genElementalCall<IntrinsicLibrary::ExtendedGenerator>(
       exit(1);
     }
   if (outline)
-    return outlineInWrapper(generator, name, resultType, args);
+    return outlineInExtendedWrapper(generator, name, resultType, args);
   return std::invoke(generator, *this, resultType, args);
 }
 
 static fir::ExtendedValue
-invokeHanlder(IntrinsicLibrary::ElementalGenerator generator,
+invokeHandler(IntrinsicLibrary::ElementalGenerator generator,
               const IntrinsicHandler &handler,
               llvm::Optional<mlir::Type> resultType,
               llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
@@ -781,7 +786,7 @@ invokeHanlder(IntrinsicLibrary::ElementalGenerator generator,
 }
 
 static fir::ExtendedValue
-invokeHanlder(IntrinsicLibrary::ExtendedGenerator generator,
+invokeHandler(IntrinsicLibrary::ExtendedGenerator generator,
               const IntrinsicHandler &handler,
               llvm::Optional<mlir::Type> resultType,
               llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
@@ -791,18 +796,19 @@ invokeHanlder(IntrinsicLibrary::ExtendedGenerator generator,
     return lib.genElementalCall(generator, handler.name, *resultType, args,
                                 outline);
   if (outline)
-    return lib.outlineInWrapper(generator, handler.name, *resultType, args);
+    return lib.outlineInExtendedWrapper(generator, handler.name, *resultType,
+                                        args);
   return std::invoke(generator, lib, *resultType, args);
 }
 static fir::ExtendedValue
-invokeHanlder(IntrinsicLibrary::SubroutineGenerator generator,
+invokeHandler(IntrinsicLibrary::SubroutineGenerator generator,
               const IntrinsicHandler &handler,
               llvm::Optional<mlir::Type> resultType,
               llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
               IntrinsicLibrary &lib) {
-  // TODO
-  // if (outline)
-  //  return outlineInWrapper(generator, handler.name, *resultType, args);
+  if (outline)
+    return lib.outlineInExtendedWrapper(generator, handler.name, resultType,
+                                        args);
   std::invoke(generator, lib, args);
   return mlir::Value{};
 }
@@ -824,7 +830,7 @@ IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name,
       bool outline = handler.outline || outlineAllIntrinsics;
       return std::visit(
           [&](auto &generator) -> fir::ExtendedValue {
-            return invokeHanlder(generator, handler, resultType, args, outline,
+            return invokeHandler(generator, handler, resultType, args, outline,
                                  *this);
           },
           handler.generator);
@@ -884,7 +890,6 @@ IntrinsicLibrary::invokeGenerator(ExtendedGenerator generator,
 
 mlir::Value
 IntrinsicLibrary::invokeGenerator(SubroutineGenerator generator,
-                                  mlir::Type resultType,
                                   llvm::ArrayRef<mlir::Value> args) {
   llvm::SmallVector<fir::ExtendedValue, 2> extendedArgs;
   for (auto arg : args)
@@ -928,12 +933,18 @@ mlir::FuncOp IntrinsicLibrary::getWrapper(GeneratorType generator,
     }
 
     IntrinsicLibrary localLib{*localBuilder, localLoc};
-    mlir::Type resultType;
-    if (funcType.getNumResults() == 1)
-      resultType = funcType.getResult(0);
-    auto result =
-        localLib.invokeGenerator(generator, resultType, localArguments);
-    localBuilder->create<mlir::ReturnOp>(localLoc, result);
+
+    if constexpr (std::is_same_v<GeneratorType, SubroutineGenerator>) {
+      localLib.invokeGenerator(generator, localArguments);
+      localBuilder->create<mlir::ReturnOp>(localLoc);
+    } else {
+      assert(funcType.getNumResults() == 1 &&
+             "expect one result for intrinsic function wrapper type");
+      auto resultType = funcType.getResult(0);
+      auto result =
+          localLib.invokeGenerator(generator, resultType, localArguments);
+      localBuilder->create<mlir::ReturnOp>(localLoc, result);
+    }
   } else {
     // Wrapper was already built, ensure it has the sought type
     assert(function.getType() == funcType &&
@@ -977,10 +988,11 @@ IntrinsicLibrary::outlineInWrapper(GeneratorType generator,
   return builder.create<fir::CallOp>(loc, wrapper, args).getResult(0);
 }
 
-fir::ExtendedValue
-IntrinsicLibrary::outlineInWrapper(ExtendedGenerator generator,
-                                   llvm::StringRef name, mlir::Type resultType,
-                                   llvm::ArrayRef<fir::ExtendedValue> args) {
+template <typename GeneratorType>
+fir::ExtendedValue IntrinsicLibrary::outlineInExtendedWrapper(
+    GeneratorType generator, llvm::StringRef name,
+    llvm::Optional<mlir::Type> resultType,
+    llvm::ArrayRef<fir::ExtendedValue> args) {
   if (hasAbsentOptional(args)) {
     // TODO
     mlir::emitError(loc, "todo: cannot outline call to intrinsic " +
@@ -993,9 +1005,11 @@ IntrinsicLibrary::outlineInWrapper(ExtendedGenerator generator,
     mlirArgs.emplace_back(toValue(extendedVal, builder, loc));
   auto funcType = getFunctionType(resultType, mlirArgs, builder);
   auto wrapper = getWrapper(generator, name, funcType);
-  auto mlirResult =
-      builder.create<fir::CallOp>(loc, wrapper, mlirArgs).getResult(0);
-  return toExtendedValue(mlirResult, builder, loc);
+  auto call = builder.create<fir::CallOp>(loc, wrapper, mlirArgs);
+  if (resultType)
+    return toExtendedValue(call.getResult(0), builder, loc);
+  // Subroutine calls
+  return mlir::Value{};
 }
 
 IntrinsicLibrary::RuntimeCallGenerator

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -183,7 +183,7 @@ struct IntrinsicLibrary {
   /// Generate FIR for call to Fortran intrinsic \p name with arguments \p arg
   /// and expected result type \p resultType.
   fir::ExtendedValue genIntrinsicCall(llvm::StringRef name,
-                                      mlir::Type resultType,
+                                      llvm::Optional<mlir::Type> resultType,
                                       llvm::ArrayRef<fir::ExtendedValue> arg);
 
   /// Search a runtime function that is associated to the generic intrinsic name
@@ -209,6 +209,7 @@ struct IntrinsicLibrary {
   mlir::Value genAnint(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genCeiling(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genConjg(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  void genDateAndTime(llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genDim(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genDprod(mlir::Type, llvm::ArrayRef<mlir::Value>);
   template <Extremum, ExtremumBehavior>
@@ -233,7 +234,9 @@ struct IntrinsicLibrary {
   /// generate the related code.
   using ElementalGenerator = decltype(&IntrinsicLibrary::genAbs);
   using ExtendedGenerator = decltype(&IntrinsicLibrary::genLenTrim);
-  using Generator = std::variant<ElementalGenerator, ExtendedGenerator>;
+  using SubroutineGenerator = decltype(&IntrinsicLibrary::genDateAndTime);
+  using Generator =
+      std::variant<ElementalGenerator, ExtendedGenerator, SubroutineGenerator>;
 
   /// All generators can be outlined. This will build a function named
   /// "fir."+ <generic name> + "." + <result type code> and generate the
@@ -269,6 +272,9 @@ struct IntrinsicLibrary {
   mlir::Value invokeGenerator(ExtendedGenerator generator,
                               mlir::Type resultType,
                               llvm::ArrayRef<mlir::Value> args);
+  mlir::Value invokeGenerator(SubroutineGenerator generator,
+                              mlir::Type resultType,
+                              llvm::ArrayRef<mlir::Value> args);
 
   /// Get pointer to unrestricted intrinsic. Generate the related unrestricted
   /// intrinsic if it is not defined yet.
@@ -292,6 +298,7 @@ struct IntrinsicHandler {
   /// more readable.
   bool outline = false;
 };
+
 using I = IntrinsicLibrary;
 static constexpr IntrinsicHandler handlers[]{
     {"abs", &I::genAbs},
@@ -302,6 +309,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"ceiling", &I::genCeiling},
     {"char", &I::genConversion},
     {"conjg", &I::genConjg},
+    {"date_and_time", &I::genDateAndTime},
     {"dim", &I::genDim},
     {"dble", &I::genConversion},
     {"dprod", &I::genDprod},
@@ -761,23 +769,70 @@ IntrinsicLibrary::genElementalCall<IntrinsicLibrary::ExtendedGenerator>(
   return std::invoke(generator, *this, resultType, args);
 }
 
+static fir::ExtendedValue
+invokeHanlder(IntrinsicLibrary::ElementalGenerator generator,
+              const IntrinsicHandler &handler,
+              llvm::Optional<mlir::Type> resultType,
+              llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
+              IntrinsicLibrary &lib) {
+  assert(resultType && "expect elemental intrinsic to be functions");
+  return lib.genElementalCall(generator, handler.name, *resultType, args,
+                              outline);
+}
+
+static fir::ExtendedValue
+invokeHanlder(IntrinsicLibrary::ExtendedGenerator generator,
+              const IntrinsicHandler &handler,
+              llvm::Optional<mlir::Type> resultType,
+              llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
+              IntrinsicLibrary &lib) {
+  assert(resultType && "expect intrinsic function");
+  if (handler.isElemental)
+    return lib.genElementalCall(generator, handler.name, *resultType, args,
+                                outline);
+  if (outline)
+    return lib.outlineInWrapper(generator, handler.name, *resultType, args);
+  return std::invoke(generator, lib, *resultType, args);
+}
+static fir::ExtendedValue
+invokeHanlder(IntrinsicLibrary::SubroutineGenerator generator,
+              const IntrinsicHandler &handler,
+              llvm::Optional<mlir::Type> resultType,
+              llvm::ArrayRef<fir::ExtendedValue> args, bool outline,
+              IntrinsicLibrary &lib) {
+  // TODO
+  // if (outline)
+  //  return outlineInWrapper(generator, handler.name, *resultType, args);
+  std::invoke(generator, lib, args);
+  return mlir::Value{};
+}
+
+/// Many intrinsics are not yet lowered, provide a clear error message to user
+/// instead of hitting harder to understand asserts.
+static void crashOnMissingIntrinsic(mlir::Location loc, llvm::StringRef name) {
+  mlir::emitError(loc,
+                  "TODO: missing intrinsic lowering: " + llvm::Twine(name));
+  exit(1);
+}
+
 fir::ExtendedValue
-IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
+IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name,
+                                   llvm::Optional<mlir::Type> resultType,
                                    llvm::ArrayRef<fir::ExtendedValue> args) {
   for (auto &handler : handlers)
     if (name == handler.name) {
       bool outline = handler.outline || outlineAllIntrinsics;
-      if (const auto *elementalGenerator =
-              std::get_if<ElementalGenerator>(&handler.generator))
-        return genElementalCall(*elementalGenerator, name, resultType, args,
-                                outline);
-      const auto &generator = std::get<ExtendedGenerator>(handler.generator);
-      if (handler.isElemental)
-        return genElementalCall(generator, name, resultType, args, outline);
-      if (outline)
-        return outlineInWrapper(generator, name, resultType, args);
-      return std::invoke(generator, *this, resultType, args);
+      return std::visit(
+          [&](auto &generator) -> fir::ExtendedValue {
+            return invokeHanlder(generator, handler, resultType, args, outline,
+                                 *this);
+          },
+          handler.generator);
     }
+
+  if (!resultType)
+    // Subroutine should have a handler, they are likely missing for now.
+    crashOnMissingIntrinsic(loc, name);
 
   // Try the runtime if no special handler was defined for the
   // intrinsic being called. Maths runtime only has numerical elemental.
@@ -788,20 +843,17 @@ IntrinsicLibrary::genIntrinsicCall(llvm::StringRef name, mlir::Type resultType,
   llvm::SmallVector<mlir::Value, 2> mlirArgs;
   for (const auto &extendedVal : args) {
     auto val = toValue(extendedVal, builder, loc);
-    if (!val) {
+    if (!val)
       // If an absent optional gets there, most likely its handler has just
       // not yet been defined.
-      mlir::emitError(loc,
-                      "TODO: missing intrinsic lowering: " + llvm::Twine(name));
-      exit(1);
-    }
+      crashOnMissingIntrinsic(loc, name);
     mlirArgs.emplace_back(val);
   }
   mlir::FunctionType soughtFuncType =
-      getFunctionType(resultType, mlirArgs, builder);
+      getFunctionType(*resultType, mlirArgs, builder);
 
   auto runtimeCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
-  return genElementalCall(runtimeCallGenerator, name, resultType, args,
+  return genElementalCall(runtimeCallGenerator, name, *resultType, args,
                           /* outline */ true);
 }
 
@@ -830,14 +882,22 @@ IntrinsicLibrary::invokeGenerator(ExtendedGenerator generator,
   return toValue(extendedResult, builder, loc);
 }
 
+mlir::Value
+IntrinsicLibrary::invokeGenerator(SubroutineGenerator generator,
+                                  mlir::Type resultType,
+                                  llvm::ArrayRef<mlir::Value> args) {
+  llvm::SmallVector<fir::ExtendedValue, 2> extendedArgs;
+  for (auto arg : args)
+    extendedArgs.emplace_back(toExtendedValue(arg, builder, loc));
+  std::invoke(generator, *this, extendedArgs);
+  return mlir::Value{};
+}
+
 template <typename GeneratorType>
 mlir::FuncOp IntrinsicLibrary::getWrapper(GeneratorType generator,
                                           llvm::StringRef name,
                                           mlir::FunctionType funcType,
                                           bool loadRefArguments) {
-  assert(funcType.getNumResults() == 1 &&
-         "expect one result for intrinsic functions");
-  auto resultType = funcType.getResult(0);
   std::string wrapperName = fir::mangleIntrinsicProcedure(name, funcType);
   auto function = builder.getNamedFunction(wrapperName);
   if (!function) {
@@ -868,6 +928,9 @@ mlir::FuncOp IntrinsicLibrary::getWrapper(GeneratorType generator,
     }
 
     IntrinsicLibrary localLib{*localBuilder, localLoc};
+    mlir::Type resultType;
+    if (funcType.getNumResults() == 1)
+      resultType = funcType.getResult(0);
     auto result =
         localLib.invokeGenerator(generator, resultType, localArguments);
     localBuilder->create<mlir::ReturnOp>(localLoc, result);
@@ -1101,6 +1164,20 @@ mlir::Value IntrinsicLibrary::genConjg(mlir::Type resultType,
       cplx, negImag, /*isImagPart=*/true);
 }
 
+// DATE_AND_TIME
+void IntrinsicLibrary::genDateAndTime(llvm::ArrayRef<fir::ExtendedValue> args) {
+  assert(args.size() == 4 && "date_and_time has 4 args");
+  llvm::Optional<fir::CharBoxValue> date;
+  if (auto *charBox = args[0].getCharBox())
+    date = *charBox;
+  for (auto i = 1; i < 4; ++i)
+    if (fir::getBase(args[i]))
+      llvm::errs() << "TODO: lowering of DATE_AND_TIME arguments other than "
+                      "DATE not yet implemented\n";
+
+  Fortran::lower::genDateAndTime(builder, loc, date);
+}
+
 // DIM
 mlir::Value IntrinsicLibrary::genDim(mlir::Type resultType,
                                      llvm::ArrayRef<mlir::Value> args) {
@@ -1153,7 +1230,7 @@ mlir::Value IntrinsicLibrary::genIAnd(mlir::Type resultType,
 mlir::Value IntrinsicLibrary::genIchar(mlir::Type resultType,
                                        llvm::ArrayRef<mlir::Value> args) {
   // There can be an optional kind in second argument.
-  assert(args.size() >= 1 && args.size() <= 2);
+  assert(args.size() == 2);
 
   auto arg = args[0];
   auto argTy = arg.getType();
@@ -1360,7 +1437,7 @@ mlir::Value IntrinsicLibrary::genExtremum(mlir::Type,
 fir::ExtendedValue
 Fortran::lower::genIntrinsicCall(Fortran::lower::FirOpBuilder &builder,
                                  mlir::Location loc, llvm::StringRef name,
-                                 mlir::Type resultType,
+                                 llvm::Optional<mlir::Type> resultType,
                                  llvm::ArrayRef<fir::ExtendedValue> args) {
   return IntrinsicLibrary{builder, loc}.genIntrinsicCall(name, resultType,
                                                          args);

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -7,20 +7,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Runtime.h"
+#include "../runtime/clock.h"
 #include "../runtime/stop.h"
 #include "RTBuilder.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/Support/BoxValue.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/tools.h"
 #include "llvm/ADT/SmallVector.h"
 
+using namespace Fortran::runtime;
 #define mkRTKey(X) mkKey(RTNAME(X))
 
-static constexpr std::tuple<mkRTKey(StopStatementText),
+static constexpr std::tuple<mkRTKey(DateAndTime), mkRTKey(FailImageStatement),
+                            mkRTKey(PauseStatement),
                             mkRTKey(ProgramEndStatement),
-                            mkRTKey(StopStatement), mkRTKey(FailImageStatement),
-                            mkRTKey(PauseStatement)>
+                            mkRTKey(StopStatement), mkRTKey(StopStatementText)>
     newRTTable;
 
 template <typename A>
@@ -176,4 +179,27 @@ void Fortran::lower::genPauseStatement(
   auto loc = converter.getCurrentLocation();
   auto callee = genRuntimeFunction<mkRTKey(PauseStatement)>(loc, bldr);
   bldr.create<fir::CallOp>(loc, callee, llvm::None);
+}
+
+void Fortran::lower::genDateAndTime(Fortran::lower::FirOpBuilder &builder,
+                                    mlir::Location loc,
+                                    llvm::Optional<fir::CharBoxValue> date) {
+  auto callee = genRuntimeFunction<mkRTKey(DateAndTime)>(loc, builder);
+  mlir::Type idxTy = builder.getIndexType();
+  mlir::Value dateBuffer;
+  mlir::Value dateLen;
+  if (date) {
+    dateBuffer = date->getBuffer();
+    dateLen = date->getLen();
+  } else {
+    auto zero = builder.createIntegerConstant(loc, idxTy, 0);
+    dateBuffer = zero;
+    dateLen = zero;
+  }
+  llvm::SmallVector<mlir::Value, 2> args{dateBuffer, dateLen};
+  llvm::SmallVector<mlir::Value, 2> operands;
+  for (const auto &op : llvm::zip(args, callee.getType().getInputs()))
+    operands.emplace_back(
+        builder.convertWithSemantics(loc, std::get<1>(op), std::get<0>(op)));
+  builder.create<fir::CallOp>(loc, callee, operands);
 }

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -29,6 +29,7 @@ add_flang_library(FortranRuntime
   ISO_Fortran_binding.cpp
   allocatable.cpp
   buffer.cpp
+  clock.cpp
   character.cpp
   connection.cpp
   derived-type.cpp

--- a/flang/runtime/clock.cpp
+++ b/flang/runtime/clock.cpp
@@ -12,30 +12,59 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <stdio.h>
 #include <time.h>
-// FIXME: windows
+// TODO: windows, localtime_r/gettimeofday do not exists/ are different.
+#ifndef _WIN32
 #include <sys/time.h>
 
 namespace Fortran::runtime {
 
-void RTNAME(DateAndTime)(char *date, std::size_t dateChars) {
+void RTNAME(DateAndTime)(char *date, char *time, char *zone,
+    std::size_t dateChars, std::size_t timeChars, std::size_t zoneChars) {
+  timeval t;
+  ::gettimeofday(&t, nullptr);
+  time_t timer{t.tv_sec};
+  tm localTime;
+  ::localtime_r(&timer, &localTime);
+
   static constexpr int buffSize{16};
   char buffer[buffSize];
-  timeval t;
-  time_t timer;
-  tm time;
-
-  gettimeofday(&t, nullptr);
-  timer = t.tv_sec;
-  // TODO windows
-  localtime_r(&timer, &time);
+  auto copyBufferAndPad{
+      [&](char *dest, std::size_t destChars, std::size_t len) {
+        auto copyLen{std::min(len, destChars)};
+        std::memcpy(dest, buffer, copyLen);
+        for (auto i{copyLen}; i < destChars; ++i) {
+          dest[i] = ' ';
+        }
+      }};
   if (date) {
-    auto len = strftime(buffer, buffSize, "%Y%m%d", &time);
-    auto copyLen = std::min(len, dateChars);
-    std::memcpy(date, buffer, copyLen);
-    for (auto i{copyLen}; i < dateChars; ++i) {
-      date[i] = ' ';
-    }
+    auto len = ::strftime(buffer, buffSize, "%Y%m%d", &localTime);
+    copyBufferAndPad(date, dateChars, len);
+  }
+  if (time) {
+    auto ms{t.tv_usec / 1000};
+    auto len{::snprintf(buffer, buffSize, "%02d%02d%02d.%03ld",
+        localTime.tm_hour, localTime.tm_min, localTime.tm_sec, ms)};
+    copyBufferAndPad(time, timeChars, len);
+  }
+  if (zone) {
+    // Note: this may leave the buffer empty on many platforms. Classic flang
+    // has a much more complex way of doing this (see __io_timezone in classic
+    // flang).
+    auto len{::strftime(buffer, buffSize, "%z", &localTime)};
+    copyBufferAndPad(zone, zoneChars, len);
   }
 }
 } // namespace Fortran::runtime
+
+#else /* Windows */
+// TODO: implement windows version (probably best to try merging implementations
+// as much as possible).
+namespace Fortran::runtime {
+void RTNAME(DateAndTime)(
+    char *, char *, char *, std::size_t, std::size_t, std::size_t) {
+  // TODO
+}
+} // namespace Fortran::runtime
+#endif

--- a/flang/runtime/clock.cpp
+++ b/flang/runtime/clock.cpp
@@ -1,0 +1,41 @@
+//===-- runtime/clock.cpp ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Implement time measurement intrinsic functions
+
+#include "clock.h"
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <time.h>
+// FIXME: windows
+#include <sys/time.h>
+
+namespace Fortran::runtime {
+
+void RTNAME(DateAndTime)(char *date, std::size_t dateChars) {
+  static constexpr int buffSize{16};
+  char buffer[buffSize];
+  timeval t;
+  time_t timer;
+  tm time;
+
+  gettimeofday(&t, nullptr);
+  timer = t.tv_sec;
+  // TODO windows
+  localtime_r(&timer, &time);
+  if (date) {
+    auto len = strftime(buffer, buffSize, "%Y%m%d", &time);
+    auto copyLen = std::min(len, dateChars);
+    std::memcpy(date, buffer, copyLen);
+    for (auto i{copyLen}; i < dateChars; ++i) {
+      date[i] = ' ';
+    }
+  }
+}
+} // namespace Fortran::runtime

--- a/flang/runtime/clock.h
+++ b/flang/runtime/clock.h
@@ -1,0 +1,26 @@
+//===-- runtime/clock.h -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Defines API between compiled code and the time measurement
+// support functions in the runtime library.
+
+#ifndef FORTRAN_RUNTIME_CLOCK_H_
+#define FORTRAN_RUNTIME_CLOCK_H_
+#include "entry-names.h"
+#include <cstddef>
+
+namespace Fortran::runtime {
+
+class Descriptor;
+
+extern "C" {
+
+void RTNAME(DateAndTime)(char *date, std::size_t dateChars);
+}
+} // namespace Fortran::runtime
+#endif // FORTRAN_RUNTIME_CLOCK_H_

--- a/flang/runtime/clock.h
+++ b/flang/runtime/clock.h
@@ -1,4 +1,4 @@
-//===-- runtime/clock.h -------------------------------------*- C++ -*-===//
+//===-- runtime/clock.h -----------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -20,7 +20,14 @@ class Descriptor;
 
 extern "C" {
 
-void RTNAME(DateAndTime)(char *date, std::size_t dateChars);
+/// Implement runtime for DATE_AND_TIME intrinsic.
+/// TODO:
+/// - Add VALUES argument (through descriptor).
+/// - Windows implementation (currently does nothing)
+void RTNAME(DateAndTime)(char *date, char *time, char *zone,
+    std::size_t dateChars, std::size_t timeChars, std::size_t zoneChars);
 }
+
+// TODO: CPU_TIME, SYSTEM_CLOCK
 } // namespace Fortran::runtime
 #endif // FORTRAN_RUNTIME_CLOCK_H_


### PR DESCRIPTION
Fix #365 : DATE_AND_TIME intrinsic. Intrinsic subroutine in general were a TODO.

- Update intrinsic framework for subroutines. Note that one could also have just used what was there for intrinsic function lowering with an "empty" result mlir::Type/Value + some ad-hoc handling of null Type/Value here and there. That is the way it is done in other places. I start to feel that makes it hard for newcomers (like me after a month) to know when to expect/guard against empty mlir::Type/Value in nominal scenario (as opposed as a compiler bug). Hence I introduced the usage of `llvm::Optional` that could be avoided functionally but makes future code extensions safer in my opinion. MLIR code also tends to use `llvm::Optional` in function interfaces around mlir::Value that can be null in nominal scenarios.

- Add runtime for DATE_AND_TIME and lower it (but for VALUES argument that will require a descriptor). The runtime implementation does nothing on windows (local time functions are not standard C/C+, they are POSIX functions).