### PR TITLE
Support for target specific lowering in the Tilikum bridge.

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -17,8 +17,27 @@
 include "mlir/Pass/PassBase.td"
 
 def CodeGenRewrite : FunctionPass<"cg-rewrite"> {
-  let summary = "Rewrite some FIR ops into their code-gen forms.";
+  let summary = "Rewrite some FIR ops into their code-gen forms. "
+                "Fuse specific subgraphs into single Ops for code generation.";
   let constructor = "fir::createFirCodeGenRewritePass()";
+  let dependentDialects = ["fir::FIROpsDialect"];
+}
+
+def TargetRewrite : Pass<"target-rewrite", "mlir::ModuleOp"> {
+  let summary = "Rewrite some FIR dialect into target specific forms. "
+                "Certain abstractions in the FIR dialect need to be rewritten "
+                "to reflect representations that may differ based on the "
+                "target machine.";
+  let constructor = "fir::createFirTargetRewritePass()";
+  let dependentDialects = ["fir::FIROpsDialect"];
+  let options = [
+    Option<"noCharacterConversion", "no-character-conversion",
+           "bool", /*default=*/"false",
+           "Disable target-specific conversion of CHARACTER.">,
+    Option<"noComplexConversion", "no-complex-conversion",
+           "bool", /*default=*/"false",
+           "Disable target-specific conversion of COMPLEX.">
+  ];
 }
 
 #endif // FLANG_OPTIMIZER_CODEGEN_PASSES

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -9,6 +9,7 @@
 #ifndef OPTIMIZER_CODEGEN_CODEGEN_H
 #define OPTIMIZER_CODEGEN_CODEGEN_H
 
+#include "mlir/IR/Module.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include <memory>
@@ -20,6 +21,17 @@ struct NameUniquer;
 /// Prerequiste pass for code gen. Perform intermediate rewrites to perform
 /// the code gen (to LLVM-IR dialect) conversion.
 std::unique_ptr<mlir::Pass> createFirCodeGenRewritePass();
+
+/// FirTargetRewritePass options.
+struct TargetRewriteOptions {
+  bool noCharacterConversion{};
+  bool noComplexConversion{};
+};
+
+/// Prerequiste pass for code gen. Perform intermediate rewrites to tailor the
+/// IR for the chosen target.
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createFirTargetRewritePass(
+    const TargetRewriteOptions &options = TargetRewriteOptions());
 
 /// Convert FIR to the LLVM IR dialect
 std::unique_ptr<mlir::Pass> createFIRToLLVMPass(NameUniquer &uniquer);

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -9,14 +9,14 @@
 #ifndef OPTIMIZER_DIALECT_FIRDIALECT_H
 #define OPTIMIZER_DIALECT_FIRDIALECT_H
 
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
-#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/LocationSnapshot.h"
-#include "mlir/Dialect/Affine/Passes.h"
-#include "mlir/Conversion/Passes.h"
+#include "mlir/Transforms/Passes.h"
 
 namespace fir {
 
@@ -81,9 +81,7 @@ inline void registerGeneralPasses() {
   mlir::registerConvertAffineToStandardPass();
 }
 
-inline void registerFIRPasses() {
-  registerGeneralPasses();
-}
+inline void registerFIRPasses() { registerGeneralPasses(); }
 
 } // namespace fir
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -30,14 +30,16 @@ def fir_Type : Type<CPred<"fir::isa_fir_or_std_type($_self)">,
 // Fortran intrinsic types
 def fir_CharacterType : Type<CPred<"$_self.isa<fir::CharacterType>()">,
     "FIR character type">;
-def fir_ComplexType : Type<CPred<"$_self.isa<fir::CplxType>()">,
+def fir_ComplexType : Type<CPred<"$_self.isa<fir::ComplexType>()">,
     "FIR complex type">;
-def fir_IntegerType : Type<CPred<"$_self.isa<fir::IntType>()">,
+def fir_IntegerType : Type<CPred<"$_self.isa<fir::IntegerType>()">,
     "FIR integer type">;
 def fir_LogicalType : Type<CPred<"$_self.isa<fir::LogicalType>()">,
     "FIR logical type">;
 def fir_RealType : Type<CPred<"$_self.isa<fir::RealType>()">,
     "FIR real type">;
+def fir_VectorType : Type<CPred<"$_self.isa<fir::VectorType>()">,
+    "FIR vector type">;
 
 // Generalized FIR and standard dialect types representing intrinsic types
 def AnyIntegerLike : TypeConstraint<Or<[SignlessIntegerLike.predicate,
@@ -59,7 +61,7 @@ def fir_SequenceType : Type<CPred<"$_self.isa<fir::SequenceType>()">,
 // Composable types
 def AnyCompositeLike : TypeConstraint<Or<[fir_RecordType.predicate,
     fir_SequenceType.predicate, fir_ComplexType.predicate,
-    IsTupleTypePred]>, "any composite">;
+    fir_VectorType.predicate, IsTupleTypePred]>, "any composite">;
 
 // Reference to an entity type
 def fir_ReferenceType : Type<CPred<"$_self.isa<fir::ReferenceType>()">,
@@ -76,6 +78,10 @@ def fir_PointerType : Type<CPred<"$_self.isa<fir::PointerType>()">,
 // Reference types
 def AnyReferenceLike : TypeConstraint<Or<[fir_ReferenceType.predicate,
     fir_HeapType.predicate, fir_PointerType.predicate]>, "any reference">;
+
+// The legal types of global symbols
+def AnyAddressableLike : TypeConstraint<Or<[fir_ReferenceType.predicate,
+    FunctionType.predicate]>, "any addressable">;
 
 // A descriptor tuple (captures a reference to an entity and other information)
 def fir_BoxType : Type<CPred<"$_self.isa<fir::BoxType>()">, "box type">;
@@ -723,7 +729,7 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
   let verifier = [{
     if (!(getSelector().getType().isa<mlir::IntegerType>() ||
           getSelector().getType().isa<mlir::IndexType>() ||
-          getSelector().getType().isa<fir::IntType>()))
+          getSelector().getType().isa<fir::IntegerType>()))
       return emitOpError("must be an integer");
     auto cases = getAttrOfType<mlir::ArrayAttr>(getCasesAttr()).getValue();
     auto count = getNumDest();
@@ -847,7 +853,7 @@ def fir_SelectCaseOp : fir_SwitchTerminatorOp<"select_case"> {
   let verifier = [{
     if (!(getSelector().getType().isa<mlir::IntegerType>() ||
           getSelector().getType().isa<mlir::IndexType>() ||
-          getSelector().getType().isa<fir::IntType>() ||
+          getSelector().getType().isa<fir::IntegerType>() ||
           getSelector().getType().isa<fir::LogicalType>() ||
           getSelector().getType().isa<fir::CharacterType>()))
       return emitOpError("must be an integer, character, or logical");
@@ -2349,6 +2355,8 @@ def fir_CallOp : fir_Op<"call", [CallOpInterface]> {
   let extraClassDeclaration = [{
     static constexpr StringRef calleeAttrName() { return "callee"; }
 
+    mlir::FunctionType getFunctionType();
+
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {
       if (auto calling = getAttrOfType<SymbolRefAttr>(calleeAttrName()))
@@ -2410,7 +2418,6 @@ def fir_DispatchOp : fir_Op<"dispatch", []> {
         parser.resolveOperands(
             operands, calleeType.getInputs(), calleeLoc, result.operands))
       return mlir::failure();
-    result.addAttribute("fn_type", mlir::TypeAttr::get(calleeType));
     return mlir::success();
   }];
 
@@ -2422,10 +2429,8 @@ def fir_DispatchOp : fir_Op<"dispatch", []> {
       p.printOperands(args());
     }
     p << ')';
-    p.printOptionalAttrDict(getAttrs(), {"fn_type", "method"});
-    auto resTy{getResultTypes()};
-    llvm::SmallVector<mlir::Type, 8> argTy(getOperandTypes());
-    p << " : " << mlir::FunctionType::get(argTy, resTy, getContext());
+    p.printOptionalAttrDict(getAttrs(), {"method"});
+    p << " : " << getFunctionType();
   }];
 
   let extraClassDeclaration = [{
@@ -2676,7 +2681,7 @@ def fir_ConstcOp : fir_Op<"constc", [NoSideEffect]> {
   }];
 
   let verifier = [{
-    if (!getType().isa<fir::CplxType>())
+    if (!getType().isa<fir::ComplexType>())
       return emitOpError("must be a !fir.complex type");
     return mlir::success();
   }];
@@ -2747,7 +2752,8 @@ def fir_AddrOfOp : fir_OneResultOp<"address_of", [NoSideEffect]> {
 
   let description = [{
     Convert a symbol (a function or global reference) to an SSA-value to be
-    used in other Operations.
+    used in other Operations. References to Fortran symbols are distinguished
+    via this operation from other arbitrary constant values.
 
     ```mlir
       %p = fir.address_of(@symbol) : !fir.ref<f64>
@@ -2756,7 +2762,7 @@ def fir_AddrOfOp : fir_OneResultOp<"address_of", [NoSideEffect]> {
 
   let arguments = (ins SymbolRefAttr:$symbol);
 
-  let results = (outs fir_ReferenceType:$resTy);
+  let results = (outs AnyAddressableLike:$resTy);
 
   let assemblyFormat = "`(` $symbol `)` attr-dict `:` type($resTy)";
 }
@@ -2814,8 +2820,8 @@ def fir_ConvertOp : fir_OneResultOp<"convert", [NoSideEffect]> {
 
 def FortranTypeAttr : Attr<And<[CPred<"$_self.isa<TypeAttr>()">,
     Or<[CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::CharacterType>()">,
-        CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::CplxType>()">,
-        CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::IntType>()">,
+        CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::ComplexType>()">,
+        CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::IntegerType>()">,
         CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::LogicalType>()">,
         CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::RealType>()">,
         CPred<"$_self.cast<TypeAttr>().getValue().isa<fir::RecordType>()">]>]>,

--- a/flang/include/flang/Optimizer/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Support/FIRContext.h
@@ -29,21 +29,24 @@ namespace fir {
 class KindMapping;
 struct NameUniquer;
 
-/// Set the target triple for the module.
+/// Set the target triple for the module. `triple` must not be deallocated while
+/// module `mod` is still live.
 void setTargetTriple(mlir::ModuleOp mod, llvm::Triple &triple);
 
 /// Get a pointer to the Triple instance from the Module. If none was set,
 /// returns a nullptr.
 llvm::Triple *getTargetTriple(mlir::ModuleOp mod);
 
-/// Set the name uniquer for the module.
+/// Set the name uniquer for the module. `uniquer` must not be deallocated while
+/// module `mod` is still live.
 void setNameUniquer(mlir::ModuleOp mod, NameUniquer &uniquer);
 
 /// Get a pointer to the NameUniquer instance from the Module. If none was set,
 /// returns a nullptr.
 NameUniquer *getNameUniquer(mlir::ModuleOp mod);
 
-/// Set the kind mapping for the module.
+/// Set the kind mapping for the module. `kindMap` must not be deallocated while
+/// module `mod` is still live.
 void setKindMapping(mlir::ModuleOp mod, KindMapping &kindMap);
 
 /// Get a pointer to the KindMapping instance from the Module. If none was set,
@@ -53,6 +56,9 @@ KindMapping *getKindMapping(mlir::ModuleOp mod);
 /// Helper for determining the target from the host, etc. Tools may use this
 /// function to provide a consistent interpretation of the `--target=<string>`
 /// command-line option.
+/// An empty string ("") or "default" will specify that the default triple
+/// should be used. "native" will specify that the host machine be used to
+/// construct the triple.
 std::string determineTargetTriple(llvm::StringRef triple);
 
 } // namespace fir

--- a/flang/include/flang/Optimizer/Transforms/RewritePatterns.td
+++ b/flang/include/flang/Optimizer/Transforms/RewritePatterns.td
@@ -51,8 +51,9 @@ def createConstantOp
                      "rewriter.getIndexAttr($1.dyn_cast<IntegerAttr>().getInt()))">;
 
 def ForwardConstantConvertPattern
-    : Pat<(fir_ConvertOp:$res (ConstantOp $attr)),
+    : Pat<(fir_ConvertOp:$res (ConstantOp:$cnt $attr)),
           (createConstantOp $res, $attr),
-          [(IndexTypePred $res)]>;
+          [(IndexTypePred $res)
+          ,(IntegerTypePred $cnt)]>;
 
 #endif // FIR_REWRITE_PATTERNS

--- a/flang/lib/Lower/ComplexExpr.cpp
+++ b/flang/lib/Lower/ComplexExpr.cpp
@@ -16,7 +16,7 @@
 mlir::Type
 Fortran::lower::ComplexExprHelper::getComplexPartType(mlir::Type complexType) {
   return Fortran::lower::convertReal(
-      builder.getContext(), complexType.cast<fir::CplxType>().getFKind());
+      builder.getContext(), complexType.cast<fir::ComplexType>().getFKind());
 }
 
 mlir::Type
@@ -27,7 +27,7 @@ Fortran::lower::ComplexExprHelper::getComplexPartType(mlir::Value cplx) {
 mlir::Value Fortran::lower::ComplexExprHelper::createComplex(fir::KindTy kind,
                                                              mlir::Value real,
                                                              mlir::Value imag) {
-  auto complexTy = fir::CplxType::get(builder.getContext(), kind);
+  auto complexTy = fir::ComplexType::get(builder.getContext(), kind);
   mlir::Value und = builder.create<fir::UndefOp>(loc, complexTy);
   return insert<Part::Imag>(insert<Part::Real>(und, real), imag);
 }

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -167,7 +167,7 @@ genFIRType<Fortran::common::TypeCategory::Complex>(mlir::MLIRContext *context,
                                                    int KIND) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Complex, KIND))
-    return fir::CplxType::get(context, KIND);
+    return fir::ComplexType::get(context, KIND);
   return {};
 }
 

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -153,7 +153,7 @@ mlir::Value Fortran::lower::FirOpBuilder::convertWithSemantics(
     auto eleTy = helper.getComplexPartType(toTy);
     auto cast = createConvert(loc, eleTy, val);
     llvm::APFloat zero{
-        kindMap.getFloatSemantics(toTy.cast<fir::CplxType>().getFKind()), 0};
+        kindMap.getFloatSemantics(toTy.cast<fir::ComplexType>().getFKind()), 0};
     auto imag = createRealConstant(loc, eleTy, zero);
     return helper.createComplex(toTy, cast, imag);
   }

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -202,7 +202,7 @@ static mlir::FuncOp getOutputFunc(mlir::Location loc,
     return ty.getWidth() <= 32
                ? getIORuntimeFunc<mkIOKey(OutputReal32)>(loc, builder)
                : getIORuntimeFunc<mkIOKey(OutputReal64)>(loc, builder);
-  if (auto ty = type.dyn_cast<fir::CplxType>())
+  if (auto ty = type.dyn_cast<fir::ComplexType>())
     return ty.getFKind() <= 4
                ? getIORuntimeFunc<mkIOKey(OutputComplex32)>(loc, builder)
                : getIORuntimeFunc<mkIOKey(OutputComplex64)>(loc, builder);
@@ -282,7 +282,7 @@ static mlir::FuncOp getInputFunc(mlir::Location loc,
     return ty.getWidth() <= 32
                ? getIORuntimeFunc<mkIOKey(InputReal32)>(loc, builder)
                : getIORuntimeFunc<mkIOKey(InputReal64)>(loc, builder);
-  if (auto ty = type.dyn_cast<fir::CplxType>())
+  if (auto ty = type.dyn_cast<fir::ComplexType>())
     return ty.getFKind() <= 4
                ? getIORuntimeFunc<mkIOKey(InputComplex32)>(loc, builder)
                : getIORuntimeFunc<mkIOKey(InputComplex64)>(loc, builder);

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -517,7 +517,7 @@ private:
     // - or use evaluate/type.h
     if (auto r{t.dyn_cast<fir::RealType>()})
       return r.getFKind() * 4;
-    if (auto cplx{t.dyn_cast<fir::CplxType>()})
+    if (auto cplx{t.dyn_cast<fir::ComplexType>()})
       return cplx.getFKind() * 4;
     llvm_unreachable("not a floating-point type");
   }
@@ -537,8 +537,8 @@ private:
                  ? Conversion::Narrow
                  : Conversion::Extend;
     }
-    if (auto fromCplxTy{from.dyn_cast<fir::CplxType>()}) {
-      if (auto toCplxTy{to.dyn_cast<fir::CplxType>()}) {
+    if (auto fromCplxTy{from.dyn_cast<fir::ComplexType>()}) {
+      if (auto toCplxTy{to.dyn_cast<fir::ComplexType>()}) {
         return getFloatingPointWidth(fromCplxTy) >
                        getFloatingPointWidth(toCplxTy)
                    ? Conversion::Narrow
@@ -909,7 +909,7 @@ IntrinsicLibrary::outlineInWrapper(GeneratorType generator,
 
   auto funcType = getFunctionType(resultType, args, builder);
   auto wrapper = getWrapper(generator, name, funcType);
-  return builder.create<mlir::CallOp>(loc, wrapper, args).getResult(0);
+  return builder.create<fir::CallOp>(loc, wrapper, args).getResult(0);
 }
 
 fir::ExtendedValue
@@ -929,7 +929,7 @@ IntrinsicLibrary::outlineInWrapper(ExtendedGenerator generator,
   auto funcType = getFunctionType(resultType, mlirArgs, builder);
   auto wrapper = getWrapper(generator, name, funcType);
   auto mlirResult =
-      builder.create<mlir::CallOp>(loc, wrapper, mlirArgs).getResult(0);
+      builder.create<fir::CallOp>(loc, wrapper, mlirArgs).getResult(0);
   return toExtendedValue(mlirResult, builder, loc);
 }
 
@@ -956,7 +956,7 @@ IntrinsicLibrary::getRuntimeCallGenerator(llvm::StringRef name,
     for (const auto &pair : llvm::zip(actualFuncType.getInputs(), args))
       convertedArguments.push_back(
           builder.createConvert(loc, std::get<0>(pair), std::get<1>(pair)));
-    auto call = builder.create<mlir::CallOp>(loc, funcOp, convertedArguments);
+    auto call = builder.create<fir::CallOp>(loc, funcOp, convertedArguments);
     mlir::Type soughtType = soughtFuncType.getResult(0);
     return builder.createConvert(loc, soughtType, call.getResult(0));
   };

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -136,7 +136,7 @@ static std::string typeToString(mlir::Type t) {
   if (auto i{t.dyn_cast<mlir::IntegerType>()}) {
     return "i" + std::to_string(i.getWidth());
   }
-  if (auto cplx{t.dyn_cast<fir::CplxType>()}) {
+  if (auto cplx{t.dyn_cast<fir::ComplexType>()}) {
     return "z" + std::to_string(cplx.getFKind());
   }
   if (auto real{t.dyn_cast<fir::RealType>()}) {

--- a/flang/lib/Lower/RTBuilder.h
+++ b/flang/lib/Lower/RTBuilder.h
@@ -193,13 +193,13 @@ constexpr TypeBuilderFunc getModel<bool &>() {
 template <>
 constexpr TypeBuilderFunc getModel<c_float_complex_t>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return fir::CplxType::get(context, sizeof(float));
+    return fir::ComplexType::get(context, sizeof(float));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<c_double_complex_t>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return fir::CplxType::get(context, sizeof(double));
+    return fir::ComplexType::get(context, sizeof(double));
   };
 }
 template <>

--- a/flang/lib/Optimizer/CMakeLists.txt
+++ b/flang/lib/Optimizer/CMakeLists.txt
@@ -15,6 +15,7 @@ add_flang_library(FIROptimizer
 
   CodeGen/CodeGen.cpp
   CodeGen/PreCGRewrite.cpp
+  CodeGen/Target.cpp
 
   Transforms/ControlFlowConverter.cpp
   Transforms/CSE.cpp

--- a/flang/lib/Optimizer/CodeGen/PassDetail.h
+++ b/flang/lib/Optimizer/CodeGen/PassDetail.h
@@ -9,6 +9,7 @@
 #ifndef OPTMIZER_CODEGEN_PASSDETAIL_H
 #define OPTMIZER_CODEGEN_PASSDETAIL_H
 
+#include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -11,17 +11,27 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "Target.h"
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/FIRContext.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
-#define DEBUG_TYPE "flang-codegen-rewrite"
+#include <memory>
+
+//===----------------------------------------------------------------------===//
+// Codegen rewrite: rewriting of subgraphs of ops
+//===----------------------------------------------------------------------===//
 
 using namespace fir;
+
+#define DEBUG_TYPE "flang-codegen-rewrite"
 
 static void populateShape(llvm::SmallVectorImpl<mlir::Value> &vec,
                           ShapeOp shape) {
@@ -54,7 +64,7 @@ public:
     if (shapeVal)
       return rewriteDynamicShape(embox, rewriter, shapeVal);
     if (auto boxTy = embox.getType().dyn_cast<BoxType>())
-      if (auto seqTy = boxTy.getEleTy().dyn_cast<fir::SequenceType>())
+      if (auto seqTy = boxTy.getEleTy().dyn_cast<SequenceType>())
         if (seqTy.hasConstantShape())
           return rewriteStaticShape(embox, rewriter, seqTy);
     return mlir::failure();
@@ -62,7 +72,7 @@ public:
 
   mlir::LogicalResult rewriteStaticShape(EmboxOp embox,
                                          mlir::PatternRewriter &rewriter,
-                                         fir::SequenceType seqTy) const {
+                                         SequenceType seqTy) const {
     auto loc = embox.getLoc();
     llvm::SmallVector<mlir::Value, 8> shapeOpers;
     auto idxTy = rewriter.getIndexType();
@@ -202,9 +212,8 @@ public:
     target.addLegalDialect<FIROpsDialect, mlir::StandardOpsDialect>();
     target.addIllegalOp<ArrayCoorOp>();
     target.addDynamicallyLegalOp<EmboxOp>([](EmboxOp embox) {
-      return !(
-          embox.getShape() ||
-          embox.getType().cast<BoxType>().getEleTy().isa<fir::SequenceType>());
+      return !(embox.getShape() ||
+               embox.getType().cast<BoxType>().getEleTy().isa<SequenceType>());
     });
 
     // Do the conversions.
@@ -272,9 +281,682 @@ private:
 
 } // namespace
 
-/// Convert FIR's structured control flow ops to CFG ops.  This
-/// conversion enables the `createLowerToCFGPass` to transform these to CFG
-/// form.
+/// Convert FIR's structured control flow ops to CFG ops.  This conversion
+/// enables the `createLowerToCFGPass` to transform these to CFG form.
 std::unique_ptr<mlir::Pass> fir::createFirCodeGenRewritePass() {
   return std::make_unique<CodeGenRewrite>();
+}
+
+//===----------------------------------------------------------------------===//
+// Target rewrite: reriting of ops to make target-specific lowerings manifest.
+//===----------------------------------------------------------------------===//
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "flang-target-rewrite"
+
+namespace {
+
+/// Fixups for updating a FuncOp's arguments and return values.
+struct FixupTy {
+  // clang-format off
+  enum class Codes {
+    ArgumentAsLoad, ArgumentType, CharPair, ReturnAsStore, ReturnType,
+    Split, Trailing
+  };
+  // clang-format on
+
+  FixupTy(Codes code, std::size_t index, std::size_t second = 0)
+      : code{code}, index{index}, second{second} {}
+  FixupTy(Codes code, std::size_t index,
+          std::function<void(mlir::FuncOp)> &&finalizer)
+      : code{code}, index{index}, finalizer{finalizer} {}
+  FixupTy(Codes code, std::size_t index, std::size_t second,
+          std::function<void(mlir::FuncOp)> &&finalizer)
+      : code{code}, index{index}, second{second}, finalizer{finalizer} {}
+
+  Codes code;
+  std::size_t index;
+  std::size_t second{};
+  llvm::Optional<std::function<void(mlir::FuncOp)>> finalizer{};
+}; // namespace
+
+/// Target-specific rewriting of the IR. This is a prerequisite pass to code
+/// generation that traverses the IR and modifies types and operations to a
+/// form that appropriate for the specific target. LLVM IR has specific idioms
+/// that are used for distinct target processor and ABI combinations.
+class TargetRewrite : public TargetRewriteBase<TargetRewrite> {
+public:
+  TargetRewrite(const TargetRewriteOptions &options) {
+    noCharacterConversion = options.noCharacterConversion;
+    noComplexConversion = options.noComplexConversion;
+  }
+
+  void runOnOperation() override final {
+    auto &context = getContext();
+    mlir::OpBuilder rewriter(&context);
+    auto mod = getModule();
+    auto specifics = CodeGenSpecifics::get(getOperation().getContext(),
+                                           *getTargetTriple(getOperation()),
+                                           *getKindMapping(getOperation()));
+    setMembers(specifics.get(), &rewriter);
+
+    // Perform type conversion on signatures and call sites.
+    if (mlir::failed(convertTypes(mod))) {
+      mlir::emitError(mlir::UnknownLoc::get(&context),
+                      "error in converting types to target abi");
+      signalPassFailure();
+    }
+
+    // Convert ops in target-specific patterns.
+    mod.walk([&](mlir::Operation *op) {
+      if (auto call = dyn_cast<fir::CallOp>(op)) {
+        if (!hasPortableSignature(call.getFunctionType()))
+          convertCallOp(call);
+      } else if (auto dispatch = dyn_cast<DispatchOp>(op)) {
+        if (!hasPortableSignature(dispatch.getFunctionType()))
+          convertCallOp(dispatch);
+      } else if (auto addr = dyn_cast<AddrOfOp>(op)) {
+        if (addr.getType().isa<mlir::FunctionType>() &&
+            !hasPortableSignature(addr.getType()))
+          convertAddrOp(addr);
+      }
+    });
+
+    clearMembers();
+  }
+
+  mlir::ModuleOp getModule() { return getOperation(); }
+
+  template <typename A, typename B, typename C>
+  std::function<mlir::Value(mlir::Operation *)>
+  rewriteCallComplexResultType(A ty, B &newResTys, B &newInTys, C &newOpers) {
+    auto m = specifics->complexReturnType(ty.getElementType());
+    // Currently targets mandate COMPLEX is a single aggregate or packed
+    // scalar, included the sret case.
+    assert(m.size() == 1 && "target lowering of complex return not supported");
+    auto resTy = std::get<mlir::Type>(m[0]);
+    auto attr = std::get<CodeGenSpecifics::Attributes>(m[0]);
+    auto loc = mlir::UnknownLoc::get(resTy.getContext());
+    if (attr.isSRet()) {
+      assert(isa_ref_type(resTy));
+      mlir::Value stack =
+          rewriter->create<fir::AllocaOp>(loc, dyn_cast_ptrEleTy(resTy));
+      newInTys.push_back(resTy);
+      newOpers.push_back(stack);
+      return [=](mlir::Operation *) -> mlir::Value {
+        auto memTy = ReferenceType::get(ty);
+        auto cast = rewriter->create<ConvertOp>(loc, memTy, stack);
+        return rewriter->create<fir::LoadOp>(loc, cast);
+      };
+    }
+    newResTys.push_back(resTy);
+    return [=](mlir::Operation *call) -> mlir::Value {
+      auto mem = rewriter->create<fir::AllocaOp>(loc, resTy);
+      rewriter->create<fir::StoreOp>(loc, call->getResult(0), mem);
+      auto memTy = ReferenceType::get(ty);
+      auto cast = rewriter->create<ConvertOp>(loc, memTy, mem);
+      return rewriter->create<fir::LoadOp>(loc, cast);
+    };
+  }
+
+  template <typename A, typename B, typename C>
+  void rewriteCallComplexInputType(A ty, mlir::Value oper, B &newInTys,
+                                   C &newOpers) {
+    auto m = specifics->complexArgumentType(ty.getElementType());
+    auto *ctx = ty.getContext();
+    auto loc = mlir::UnknownLoc::get(ctx);
+    if (m.size() == 1) {
+      // COMPLEX is a single aggregate
+      auto resTy = std::get<mlir::Type>(m[0]);
+      auto attr = std::get<CodeGenSpecifics::Attributes>(m[0]);
+      auto oldRefTy = ReferenceType::get(ty);
+      if (attr.isByVal()) {
+        auto mem = rewriter->create<fir::AllocaOp>(loc, ty);
+        rewriter->create<fir::StoreOp>(loc, oper, mem);
+        newOpers.push_back(rewriter->create<ConvertOp>(loc, resTy, mem));
+      } else {
+        auto mem = rewriter->create<fir::AllocaOp>(loc, resTy);
+        auto cast = rewriter->create<ConvertOp>(loc, oldRefTy, mem);
+        rewriter->create<fir::StoreOp>(loc, oper, cast);
+        newOpers.push_back(rewriter->create<fir::LoadOp>(loc, mem));
+      }
+      newInTys.push_back(resTy);
+    } else {
+      assert(m.size() == 2);
+      // COMPLEX is split into 2 separate arguments
+      auto iTy = rewriter->getIntegerType(32);
+      for (auto e : llvm::enumerate(m)) {
+        auto &tup = e.value();
+        auto ty = std::get<mlir::Type>(tup);
+        auto index = e.index();
+        mlir::Value idx = rewriter->create<mlir::ConstantOp>(
+            loc, iTy, mlir::IntegerAttr::get(iTy, index));
+        auto val = rewriter->create<ExtractValueOp>(loc, ty, oper, idx);
+        newInTys.push_back(ty);
+        newOpers.push_back(val);
+      }
+    }
+  }
+
+  // Convert fir.call and fir.dispatch Ops.
+  template <typename A>
+  void convertCallOp(A callOp) {
+    auto fnTy = callOp.getFunctionType();
+    auto loc = callOp.getLoc();
+    rewriter->setInsertionPoint(callOp);
+    llvm::SmallVector<mlir::Type, 8> newResTys;
+    llvm::SmallVector<mlir::Type, 8> newInTys;
+    llvm::SmallVector<mlir::Value, 8> newOpers;
+    // FIXME: if the call is indirect, the first argument must still be the
+    // function to call.
+    llvm::Optional<std::function<mlir::Value(mlir::Operation *)>> wrap;
+    if (fnTy.getResults().size() == 1) {
+      mlir::Type ty = fnTy.getResult(0);
+      llvm::TypeSwitch<mlir::Type>(ty)
+        .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+            wrap = rewriteCallComplexResultType(cmplx, newResTys, newInTys,
+                                                newOpers);
+          })
+          .template Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
+            wrap = rewriteCallComplexResultType(cmplx, newResTys, newInTys,
+                                                newOpers);
+          })
+          .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
+    } else if (fnTy.getResults().size() > 1) {
+      // If the function is returning more than 1 result, do not perform any
+      // target-specific lowering. (FIXME?) This may need to be revisited.
+      newResTys.insert(newResTys.end(), fnTy.getResults().begin(),
+                       fnTy.getResults().end());
+    }
+    llvm::SmallVector<mlir::Type, 8> trailingInTys;
+    llvm::SmallVector<mlir::Value, 8> trailingOpers;
+    for (auto e :
+         llvm::enumerate(llvm::zip(fnTy.getInputs(), callOp.getOperands()))) {
+      mlir::Type ty = std::get<0>(e.value());
+      mlir::Value oper = std::get<1>(e.value());
+      unsigned index = e.index();
+      llvm::TypeSwitch<mlir::Type>(ty)
+          .template Case<BoxCharType>([&](BoxCharType boxTy) {
+            bool sret;
+            if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
+              sret = callOp.callee() &&
+                     functionArgIsSRet(index,
+                                       getModule().lookupSymbol<mlir::FuncOp>(
+                                           *callOp.callee()));
+            } else {
+              // TODO: dispatch case; how do we put arguments on a call?
+              sret = false;
+              llvm_unreachable("not implemented");
+            }
+            auto m = specifics->boxcharArgumentType(boxTy.getEleTy(), sret);
+            auto unbox =
+                rewriter->create<UnboxCharOp>(loc, std::get<mlir::Type>(m[0]),
+                                              std::get<mlir::Type>(m[1]), oper);
+            // unboxed CHARACTER arguments
+            for (auto e : llvm::enumerate(m)) {
+              unsigned idx = e.index();
+              auto attr = std::get<CodeGenSpecifics::Attributes>(e.value());
+              auto argTy = std::get<mlir::Type>(e.value());
+              if (attr.isAppend()) {
+                trailingInTys.push_back(argTy);
+                trailingOpers.push_back(unbox.getResult(idx));
+              } else {
+                newInTys.push_back(argTy);
+                newOpers.push_back(unbox.getResult(idx));
+              }
+            }
+          })
+        .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+            rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
+          })
+          .template Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
+            rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
+          })
+          .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
+    }
+    newInTys.insert(newInTys.end(), trailingInTys.begin(), trailingInTys.end());
+    newOpers.insert(newOpers.end(), trailingOpers.begin(), trailingOpers.end());
+    if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
+      assert(callOp.callee().hasValue() && "indirect call not implemented");
+      auto newCall = rewriter->create<A>(loc, callOp.callee().getValue(),
+                                         newResTys, newOpers);
+      LLVM_DEBUG(llvm::errs() << "replacing call with " << newCall << '\n');
+      if (wrap.hasValue())
+        replaceOp(callOp, (*wrap)(newCall.getOperation()));
+      else
+        replaceOp(callOp, newCall.getResults());
+    } else {
+      // A is fir::DispatchOp
+      llvm_unreachable("not implemented"); // TODO
+    }
+  }
+
+  // Result type fixup for fir::ComplexType and mlir::ComplexType
+  template <typename A, typename B>
+  void lowerComplexSignatureRes(A cmplx, B &newResTys, B &newInTys) {
+    if (noComplexConversion) {
+      newResTys.push_back(cmplx);
+    } else {
+      for (auto &tup : specifics->complexReturnType(cmplx.getElementType())) {
+        auto argTy = std::get<mlir::Type>(tup);
+        if (std::get<CodeGenSpecifics::Attributes>(tup).isSRet())
+          newInTys.push_back(argTy);
+        else
+          newResTys.push_back(argTy);
+      }
+    }
+  }
+
+  // Argument type fixup for fir::ComplexType and mlir::ComplexType
+  template <typename A, typename B>
+  void lowerComplexSignatureArg(A cmplx, B &newInTys) {
+    if (noComplexConversion)
+      newInTys.push_back(cmplx);
+    else
+      for (auto &tup : specifics->complexArgumentType(cmplx.getElementType()))
+        newInTys.push_back(std::get<mlir::Type>(tup));
+  }
+
+  /// Taking the address of a function. Modify the signature as needed.
+  void convertAddrOp(AddrOfOp addrOp) {
+    auto addrTy = addrOp.getType().cast<mlir::FunctionType>();
+    llvm::SmallVector<mlir::Type, 8> newResTys;
+    llvm::SmallVector<mlir::Type, 8> newInTys;
+    for (mlir::Type ty : addrTy.getResults()) {
+      llvm::TypeSwitch<mlir::Type>(ty)
+        .Case<fir::ComplexType>([&](fir::ComplexType ty) {
+            lowerComplexSignatureRes(ty, newResTys, newInTys);
+          })
+          .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
+            lowerComplexSignatureRes(ty, newResTys, newInTys);
+          })
+          .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
+    }
+    llvm::SmallVector<mlir::Type, 8> trailingInTys;
+    for (mlir::Type ty : addrTy.getInputs()) {
+      llvm::TypeSwitch<mlir::Type>(ty)
+          .Case<BoxCharType>([&](BoxCharType box) {
+            if (noCharacterConversion) {
+              newInTys.push_back(box);
+            } else {
+              for (auto &tup : specifics->boxcharArgumentType(box.getEleTy())) {
+                auto attr = std::get<CodeGenSpecifics::Attributes>(tup);
+                auto argTy = std::get<mlir::Type>(tup);
+                auto &vec = attr.isAppend() ? trailingInTys : newInTys;
+                vec.push_back(argTy);
+              }
+            }
+          })
+        .Case<fir::ComplexType>(
+            [&](fir::ComplexType ty) { lowerComplexSignatureArg(ty, newInTys); })
+          .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
+            lowerComplexSignatureArg(ty, newInTys);
+          })
+          .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
+    }
+    // append trailing input types
+    newInTys.insert(newInTys.end(), trailingInTys.begin(), trailingInTys.end());
+    // replace this op with a new one with the updated signature
+    auto newTy = rewriter->getFunctionType(newInTys, newResTys);
+    auto newOp =
+        rewriter->create<AddrOfOp>(addrOp.getLoc(), newTy, addrOp.symbol());
+    replaceOp(addrOp, newOp.getOperation()->getResults());
+  }
+
+  /// Convert the type signatures on all the functions present in the module.
+  /// As the type signature is being changed, this must also update the
+  /// function itself to use any new arguments, etc.
+  mlir::LogicalResult convertTypes(mlir::ModuleOp mod) {
+    for (auto fn : mod.getOps<mlir::FuncOp>())
+      convertSignature(fn);
+    return mlir::success();
+  }
+
+  /// If the signature does not need any special target-specific converions,
+  /// then it is considered portable for any target, and this function will
+  /// return `true`. Otherwise, the signature is not portable and `false` is
+  /// returned.
+  bool hasPortableSignature(mlir::Type signature) {
+    assert(signature.isa<mlir::FunctionType>());
+    auto func = signature.dyn_cast<mlir::FunctionType>();
+    for (auto ty : func.getResults())
+      if ((ty.isa<BoxCharType>() && !noCharacterConversion) ||
+          (isa_complex(ty) && !noComplexConversion)) {
+        LLVM_DEBUG(llvm::errs() << "rewrite " << signature << " for target\n");
+        return false;
+      }
+    for (auto ty : func.getInputs())
+      if ((ty.isa<BoxCharType>() && !noCharacterConversion) ||
+          (isa_complex(ty) && !noComplexConversion)) {
+        LLVM_DEBUG(llvm::errs() << "rewrite " << signature << " for target\n");
+        return false;
+      }
+    return true;
+  }
+
+  /// Rewrite the signatures and body of the `FuncOp`s in the module for
+  /// the immediately subsequent target code gen.
+  void convertSignature(mlir::FuncOp func) {
+    auto funcTy = func.getType().cast<mlir::FunctionType>();
+    if (hasPortableSignature(funcTy))
+      return;
+    llvm::SmallVector<mlir::Type, 8> newResTys;
+    llvm::SmallVector<mlir::Type, 8> newInTys;
+    llvm::SmallVector<FixupTy, 8> fixups;
+
+    // Convert return value(s)
+    for (auto ty : funcTy.getResults())
+      llvm::TypeSwitch<mlir::Type>(ty)
+        .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+            if (noComplexConversion)
+              newResTys.push_back(cmplx);
+            else
+              doComplexReturn(func, cmplx, newResTys, newInTys, fixups);
+          })
+          .Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
+            if (noComplexConversion)
+              newResTys.push_back(cmplx);
+            else
+              doComplexReturn(func, cmplx, newResTys, newInTys, fixups);
+          })
+          .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
+
+    // Convert arguments
+    llvm::SmallVector<mlir::Type, 8> trailingTys;
+    for (auto e : llvm::enumerate(funcTy.getInputs())) {
+      auto ty = e.value();
+      unsigned index = e.index();
+      llvm::TypeSwitch<mlir::Type>(ty)
+          .Case<BoxCharType>([&](BoxCharType boxTy) {
+            if (noCharacterConversion) {
+              newInTys.push_back(boxTy);
+            } else {
+              // Convert a CHARACTER argument type. This can involve separating
+              // the pointer and the LEN into two arguments and moving the LEN
+              // argument to the end of the arg list.
+              bool sret = functionArgIsSRet(index, func);
+              for (auto e : llvm::enumerate(specifics->boxcharArgumentType(
+                       boxTy.getEleTy(), sret))) {
+                auto &tup = e.value();
+                auto index = e.index();
+                auto attr = std::get<CodeGenSpecifics::Attributes>(tup);
+                auto argTy = std::get<mlir::Type>(tup);
+                if (attr.isAppend()) {
+                  trailingTys.push_back(argTy);
+                } else {
+                  if (sret) {
+                    fixups.emplace_back(FixupTy::Codes::CharPair,
+                                        newInTys.size(), index);
+                  } else {
+                    fixups.emplace_back(FixupTy::Codes::Trailing,
+                                        newInTys.size(), trailingTys.size());
+                  }
+                  newInTys.push_back(argTy);
+                }
+              }
+            }
+          })
+        .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+            if (noComplexConversion)
+              newInTys.push_back(cmplx);
+            else
+              doComplexArg(func, cmplx, newInTys, fixups);
+          })
+          .Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
+            if (noComplexConversion)
+              newInTys.push_back(cmplx);
+            else
+              doComplexArg(func, cmplx, newInTys, fixups);
+          })
+          .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
+    }
+
+    if (!func.empty()) {
+      // If the function has a body, then apply the fixups to the arguments and
+      // return ops as required. These fixups are done in place.
+      auto loc = func.getLoc();
+      const auto fixupSize = fixups.size();
+      const auto oldArgTys = func.getType().getInputs();
+      int offset = 0;
+      for (std::remove_const_t<decltype(fixupSize)> i = 0; i < fixupSize; ++i) {
+        const auto &fixup = fixups[i];
+        switch (fixup.code) {
+        case FixupTy::Codes::ArgumentAsLoad: {
+          // Argument was pass-by-value, but is now pass-by-reference and
+          // possibly with a different element type.
+          auto newArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          rewriter->setInsertionPointToStart(&func.front());
+          auto oldArgTy = ReferenceType::get(oldArgTys[fixup.index - offset]);
+          auto cast = rewriter->create<ConvertOp>(loc, oldArgTy, newArg);
+          auto load = rewriter->create<fir::LoadOp>(loc, cast);
+          func.getArgument(fixup.index + 1).replaceAllUsesWith(load);
+          func.front().eraseArgument(fixup.index + 1);
+        } break;
+        case FixupTy::Codes::ArgumentType: {
+          // Argument is pass-by-value, but its type is likely been modified to
+          // suit the target ABI convention.
+          auto newArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          rewriter->setInsertionPointToStart(&func.front());
+          auto mem =
+              rewriter->create<fir::AllocaOp>(loc, newInTys[fixup.index]);
+          rewriter->create<fir::StoreOp>(loc, newArg, mem);
+          auto oldArgTy = ReferenceType::get(oldArgTys[fixup.index - offset]);
+          auto cast = rewriter->create<ConvertOp>(loc, oldArgTy, mem);
+          mlir::Value load = rewriter->create<fir::LoadOp>(loc, cast);
+          func.getArgument(fixup.index + 1).replaceAllUsesWith(load);
+          func.front().eraseArgument(fixup.index + 1);
+          LLVM_DEBUG(llvm::errs()
+                     << "old argument: " << oldArgTy.getEleTy()
+                     << ", repl: " << load << ", new argument: "
+                     << func.getArgument(fixup.index).getType() << '\n');
+        } break;
+        case FixupTy::Codes::CharPair: {
+          // The FIR boxchar argument has been split into a pair of distinct
+          // arguments that are in juxtaposition to each other.
+          auto newArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          if (fixup.second == 1) {
+            rewriter->setInsertionPointToStart(&func.front());
+            auto boxTy = oldArgTys[fixup.index - offset - fixup.second];
+            auto box = rewriter->create<EmboxCharOp>(
+                loc, boxTy, func.front().getArgument(fixup.index - 1), newArg);
+            func.getArgument(fixup.index + 1).replaceAllUsesWith(box);
+            func.front().eraseArgument(fixup.index + 1);
+            offset++;
+          }
+        } break;
+        case FixupTy::Codes::ReturnAsStore: {
+          // The value being returned is now being returned in memory (callee
+          // stack space) through a hidden reference argument.
+          auto newArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          offset++;
+          func.walk([&](mlir::ReturnOp ret) {
+            rewriter->setInsertionPoint(ret);
+            auto oldOper = ret.getOperand(0);
+            auto oldOperTy = ReferenceType::get(oldOper.getType());
+            auto cast = rewriter->create<ConvertOp>(loc, oldOperTy, newArg);
+            rewriter->create<fir::StoreOp>(loc, oldOper, cast);
+            rewriter->create<mlir::ReturnOp>(loc);
+            ret.erase();
+          });
+        } break;
+        case FixupTy::Codes::ReturnType: {
+          // The function is still returning a value, but its type has likely
+          // changed to suit the target ABI convention.
+          func.walk([&](mlir::ReturnOp ret) {
+            rewriter->setInsertionPoint(ret);
+            auto oldOper = ret.getOperand(0);
+            auto oldOperTy = ReferenceType::get(oldOper.getType());
+            auto mem =
+                rewriter->create<fir::AllocaOp>(loc, newResTys[fixup.index]);
+            auto cast = rewriter->create<ConvertOp>(loc, oldOperTy, mem);
+            rewriter->create<fir::StoreOp>(loc, oldOper, cast);
+            mlir::Value load = rewriter->create<fir::LoadOp>(loc, mem);
+            rewriter->create<mlir::ReturnOp>(loc, load);
+            ret.erase();
+          });
+        } break;
+        case FixupTy::Codes::Split: {
+          // The FIR argument has been split into a pair of distinct arguments
+          // that are in juxtaposition to each other. (For COMPLEX value.)
+          auto newArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          if (fixup.second == 1) {
+            rewriter->setInsertionPointToStart(&func.front());
+            auto cplxTy = oldArgTys[fixup.index - offset - fixup.second];
+            auto undef = rewriter->create<UndefOp>(loc, cplxTy);
+            auto iTy = rewriter->getIntegerType(32);
+            mlir::Value zero = rewriter->create<mlir::ConstantOp>(
+                loc, iTy, mlir::IntegerAttr::get(iTy, 0));
+            mlir::Value one = rewriter->create<mlir::ConstantOp>(
+                loc, iTy, mlir::IntegerAttr::get(iTy, 1));
+            auto cplx1 = rewriter->create<InsertValueOp>(
+                loc, cplxTy, undef, func.front().getArgument(fixup.index - 1),
+                zero);
+            auto cplx = rewriter->create<InsertValueOp>(loc, cplxTy, cplx1,
+                                                        newArg, one);
+            func.getArgument(fixup.index + 1).replaceAllUsesWith(cplx);
+            func.front().eraseArgument(fixup.index + 1);
+            offset++;
+          }
+        } break;
+        case FixupTy::Codes::Trailing: {
+          // The FIR argument has been split into a pair of distinct arguments.
+          // The first part of the pair appears in the original argument
+          // position. The second part of the pair is appended after all the
+          // original arguments. (Boxchar arguments.)
+          auto newBufArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          auto newLenArg = func.front().addArgument(trailingTys[fixup.second]);
+          auto boxTy = oldArgTys[fixup.index - offset];
+          rewriter->setInsertionPointToStart(&func.front());
+          auto box =
+              rewriter->create<EmboxCharOp>(loc, boxTy, newBufArg, newLenArg);
+          func.getArgument(fixup.index + 1).replaceAllUsesWith(box);
+          func.front().eraseArgument(fixup.index + 1);
+        } break;
+        }
+      }
+    }
+
+    // Set the new type and finalize the arguments, etc.
+    newInTys.insert(newInTys.end(), trailingTys.begin(), trailingTys.end());
+    auto newFuncTy =
+        mlir::FunctionType::get(newInTys, newResTys, func.getContext());
+    LLVM_DEBUG(llvm::errs() << "new func: " << newFuncTy << '\n');
+    func.setType(newFuncTy);
+
+    for (auto &fixup : fixups)
+      if (fixup.finalizer)
+        (*fixup.finalizer)(func);
+  }
+
+  inline bool functionArgIsSRet(unsigned index, mlir::FuncOp func) {
+    if (auto attr = func.getArgAttrOfType<mlir::BoolAttr>(index, "llvm.sret"))
+      return attr.getValue();
+    return false;
+  }
+
+  /// Convert a complex return value. This can involve converting the return
+  /// value to a "hidden" first argument or packing the complex into a wide
+  /// GPR.
+  template <typename A, typename B, typename C>
+  void doComplexReturn(mlir::FuncOp func, A cmplx, B &newResTys, B &newInTys,
+                       C &fixups) {
+    if (noComplexConversion) {
+      newResTys.push_back(cmplx);
+      return;
+    }
+    auto m = specifics->complexReturnType(cmplx.getElementType());
+    assert(m.size() == 1);
+    auto &tup = m[0];
+    auto attr = std::get<CodeGenSpecifics::Attributes>(tup);
+    auto argTy = std::get<mlir::Type>(tup);
+    if (attr.isSRet()) {
+      bool argNo = newInTys.size();
+      fixups.emplace_back(
+          FixupTy::Codes::ReturnAsStore, argNo, [=](mlir::FuncOp func) {
+            func.setArgAttr(argNo, "llvm.sret", rewriter->getBoolAttr(true));
+          });
+      newInTys.push_back(argTy);
+      return;
+    }
+    fixups.emplace_back(FixupTy::Codes::ReturnType, newResTys.size());
+    newResTys.push_back(argTy);
+  }
+
+  /// Convert a complex argument value. This can involve storing the value to
+  /// a temporary memory location or factoring the value into two distinct
+  /// arguments.
+  template <typename A, typename B, typename C>
+  void doComplexArg(mlir::FuncOp func, A cmplx, B &newInTys, C &fixups) {
+    if (noComplexConversion) {
+      newInTys.push_back(cmplx);
+      return;
+    }
+    auto m = specifics->complexArgumentType(cmplx.getElementType());
+    const auto fixupCode =
+        m.size() > 1 ? FixupTy::Codes::Split : FixupTy::Codes::ArgumentType;
+    for (auto e : llvm::enumerate(m)) {
+      auto &tup = e.value();
+      auto index = e.index();
+      auto attr = std::get<CodeGenSpecifics::Attributes>(tup);
+      auto argTy = std::get<mlir::Type>(tup);
+      auto argNo = newInTys.size();
+      if (attr.isByVal()) {
+        if (auto align = attr.getAlignment())
+          fixups.emplace_back(
+              FixupTy::Codes::ArgumentAsLoad, argNo, [=](mlir::FuncOp func) {
+                func.setArgAttr(argNo, "llvm.byval",
+                                rewriter->getBoolAttr(true));
+                func.setArgAttr(argNo, "llvm.align",
+                                rewriter->getIntegerAttr(
+                                    rewriter->getIntegerType(32), align));
+              });
+        else
+          fixups.emplace_back(FixupTy::Codes::ArgumentAsLoad, newInTys.size(),
+                              [=](mlir::FuncOp func) {
+                                func.setArgAttr(argNo, "llvm.byval",
+                                                rewriter->getBoolAttr(true));
+                              });
+      } else {
+        if (auto align = attr.getAlignment())
+          fixups.emplace_back(fixupCode, argNo, index, [=](mlir::FuncOp func) {
+            func.setArgAttr(
+                argNo, "llvm.align",
+                rewriter->getIntegerAttr(rewriter->getIntegerType(32), align));
+          });
+        else
+          fixups.emplace_back(fixupCode, argNo, index);
+      }
+      newInTys.push_back(argTy);
+    }
+  }
+
+private:
+  // Replace `op` and remove it.
+  void replaceOp(mlir::Operation *op, mlir::ValueRange newValues) {
+    op->replaceAllUsesWith(newValues);
+    op->dropAllReferences();
+    op->erase();
+  }
+
+  inline void setMembers(CodeGenSpecifics *s, mlir::OpBuilder *r) {
+    specifics = s;
+    rewriter = r;
+  }
+
+  inline void clearMembers() { setMembers(nullptr, nullptr); }
+
+  CodeGenSpecifics *specifics{};
+  mlir::OpBuilder *rewriter;
+}; // namespace
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+fir::createFirTargetRewritePass(const TargetRewriteOptions &options) {
+  return std::make_unique<TargetRewrite>(options);
 }

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -453,7 +453,7 @@ public:
     if (fnTy.getResults().size() == 1) {
       mlir::Type ty = fnTy.getResult(0);
       llvm::TypeSwitch<mlir::Type>(ty)
-        .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+          .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
             wrap = rewriteCallComplexResultType(cmplx, newResTys, newInTys,
                                                 newOpers);
           })
@@ -506,13 +506,16 @@ public:
               }
             }
           })
-        .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+          .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
             rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
           })
           .template Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
             rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
           })
-          .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
+          .Default([&](mlir::Type ty) {
+            newInTys.push_back(ty);
+            newOpers.push_back(oper);
+          });
     }
     newInTys.insert(newInTys.end(), trailingInTys.begin(), trailingInTys.end());
     newOpers.insert(newOpers.end(), trailingOpers.begin(), trailingOpers.end());
@@ -564,7 +567,7 @@ public:
     llvm::SmallVector<mlir::Type, 8> newInTys;
     for (mlir::Type ty : addrTy.getResults()) {
       llvm::TypeSwitch<mlir::Type>(ty)
-        .Case<fir::ComplexType>([&](fir::ComplexType ty) {
+          .Case<fir::ComplexType>([&](fir::ComplexType ty) {
             lowerComplexSignatureRes(ty, newResTys, newInTys);
           })
           .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
@@ -587,8 +590,9 @@ public:
               }
             }
           })
-        .Case<fir::ComplexType>(
-            [&](fir::ComplexType ty) { lowerComplexSignatureArg(ty, newInTys); })
+          .Case<fir::ComplexType>([&](fir::ComplexType ty) {
+            lowerComplexSignatureArg(ty, newInTys);
+          })
           .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
             lowerComplexSignatureArg(ty, newInTys);
           })
@@ -647,7 +651,7 @@ public:
     // Convert return value(s)
     for (auto ty : funcTy.getResults())
       llvm::TypeSwitch<mlir::Type>(ty)
-        .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+          .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
             if (noComplexConversion)
               newResTys.push_back(cmplx);
             else
@@ -696,7 +700,7 @@ public:
               }
             }
           })
-        .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
+          .Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
             if (noComplexConversion)
               newInTys.push_back(cmplx);
             else

--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -1,0 +1,189 @@
+//===-- Target.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#include "Target.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/KindMapping.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/TypeRange.h"
+#include "llvm/ADT/Triple.h"
+
+#define DEBUG_TYPE "flang-codegen-target"
+
+using namespace fir;
+
+// Reduce a REAL/float type to the floating point semantics.
+static const llvm::fltSemantics &floatToSemantics(KindMapping &kindMap,
+                                                  mlir::Type type) {
+  assert(isa_real(type));
+  if (auto ty = type.dyn_cast<fir::RealType>())
+    return kindMap.getFloatSemantics(ty.getFKind());
+  return type.cast<mlir::FloatType>().getFloatSemantics();
+}
+
+namespace {
+template <typename S>
+struct GenericTarget : public CodeGenSpecifics {
+  using CodeGenSpecifics::CodeGenSpecifics;
+  using AT = CodeGenSpecifics::Attributes;
+
+  mlir::Type complexMemoryType(mlir::Type eleTy) const override {
+    assert(fir::isa_real(eleTy));
+    // { t, t }   struct of 2 eleTy
+    mlir::TypeRange range = {eleTy, eleTy};
+    return mlir::TupleType::get(range, eleTy.getContext());
+  }
+
+  mlir::Type boxcharMemoryType(mlir::Type eleTy) const override {
+    auto idxTy = mlir::IntegerType::get(S::defaultWidth, eleTy.getContext());
+    auto ptrTy = fir::ReferenceType::get(eleTy);
+    // { t*, index }
+    mlir::TypeRange range = {ptrTy, idxTy};
+    return mlir::TupleType::get(range, eleTy.getContext());
+  }
+
+  Marshalling boxcharArgumentType(mlir::Type eleTy, bool sret) const override {
+    CodeGenSpecifics::Marshalling marshal;
+    auto idxTy = mlir::IntegerType::get(S::defaultWidth, eleTy.getContext());
+    auto ptrTy = fir::ReferenceType::get(eleTy);
+    marshal.emplace_back(ptrTy, AT{});
+    // Return value arguments are grouped as a pair. Others are passed in a
+    // split format with all pointers first (in the declared position) and all
+    // LEN arguments appended after all of the dummy arguments.
+    // NB: Other conventions/ABIs can/should be supported via options.
+    marshal.emplace_back(idxTy, AT{0, {}, {}, /*append=*/!sret});
+    return marshal;
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// i386 (x86 32 bit) linux target specifics.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TargetI386 : public GenericTarget<TargetI386> {
+  using GenericTarget::GenericTarget;
+
+  static constexpr int defaultWidth = 32;
+
+  CodeGenSpecifics::Marshalling
+  complexArgumentType(mlir::Type eleTy) const override {
+    assert(fir::isa_real(eleTy));
+    CodeGenSpecifics::Marshalling marshal;
+    // { t, t }   struct of 2 eleTy, byval, align 4
+    mlir::TypeRange range = {eleTy, eleTy};
+    auto structTy = mlir::TupleType::get(range, eleTy.getContext());
+    marshal.emplace_back(fir::ReferenceType::get(structTy),
+                         AT{4, /*byval=*/true, {}});
+    return marshal;
+  }
+
+  CodeGenSpecifics::Marshalling
+  complexReturnType(mlir::Type eleTy) const override {
+    assert(fir::isa_real(eleTy));
+    CodeGenSpecifics::Marshalling marshal;
+    const auto *sem = &floatToSemantics(kindMap, eleTy);
+    if (sem == &llvm::APFloat::IEEEsingle()) {
+      // i64   pack both floats in a 64-bit GPR
+      marshal.emplace_back(mlir::IntegerType::get(64, eleTy.getContext()),
+                           AT{});
+    } else if (sem == &llvm::APFloat::IEEEdouble()) {
+      // { t, t }   struct of 2 eleTy, sret, align 4
+      mlir::TypeRange range = {eleTy, eleTy};
+      auto structTy = mlir::TupleType::get(range, eleTy.getContext());
+      marshal.emplace_back(fir::ReferenceType::get(structTy),
+                           AT{4, {}, /*sret=*/true});
+    } else {
+      llvm_unreachable("not implemented");
+    }
+    return marshal;
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// x86_64 (x86 64 bit) linux target specifics.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TargetX86_64 : public GenericTarget<TargetX86_64> {
+  using GenericTarget::GenericTarget;
+
+  static constexpr int defaultWidth = 64;
+
+  CodeGenSpecifics::Marshalling
+  complexArgumentType(mlir::Type eleTy) const override {
+    CodeGenSpecifics::Marshalling marshal;
+    const auto *sem = &floatToSemantics(kindMap, eleTy);
+    if (sem == &llvm::APFloat::IEEEsingle()) {
+      // <2 x t>   vector of 2 eleTy
+      marshal.emplace_back(fir::VectorType::get(2, eleTy), AT{});
+    } else if (sem == &llvm::APFloat::IEEEdouble()) {
+      // two distinct double arguments
+      marshal.emplace_back(eleTy, AT{});
+      marshal.emplace_back(eleTy, AT{});
+    } else {
+      llvm_unreachable("not implemented");
+    }
+    return marshal;
+  }
+
+  CodeGenSpecifics::Marshalling
+  complexReturnType(mlir::Type eleTy) const override {
+    CodeGenSpecifics::Marshalling marshal;
+    const auto *sem = &floatToSemantics(kindMap, eleTy);
+    if (sem == &llvm::APFloat::IEEEsingle()) {
+      // <2 x t>   vector of 2 eleTy
+      marshal.emplace_back(fir::VectorType::get(2, eleTy), AT{});
+    } else if (sem == &llvm::APFloat::IEEEdouble()) {
+      // { double, double }   struct of 2 double
+      mlir::TypeRange range = {eleTy, eleTy};
+      marshal.emplace_back(mlir::TupleType::get(range, eleTy.getContext()),
+                           AT{});
+    } else {
+      llvm_unreachable("not implemented");
+    }
+    return marshal;
+  }
+};
+} // namespace
+
+// Instantiate the overloaded target instance based on the triple value.
+// Currently, the implementation only instantiates `i386-unknown-linux-gnu` and
+// `x86_64-unknown-linux-gnu` like triples. Other targets should be added to
+// this file as needed.
+std::unique_ptr<fir::CodeGenSpecifics>
+fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &trp,
+                           KindMapping &kindMap) {
+  switch (trp.getArch()) {
+  default:
+    break;
+  case llvm::Triple::ArchType::x86:
+    switch (trp.getOS()) {
+    default:
+      break;
+    case llvm::Triple::OSType::Linux:
+      return std::make_unique<TargetI386>(ctx, trp, kindMap);
+    }
+    break;
+  case llvm::Triple::ArchType::x86_64:
+    switch (trp.getOS()) {
+    default:
+      break;
+    case llvm::Triple::OSType::Linux:
+      return std::make_unique<TargetX86_64>(ctx, trp, kindMap);
+    }
+    break;
+  }
+  llvm::report_fatal_error("target not implemented");
+}

--- a/flang/lib/Optimizer/CodeGen/Target.h
+++ b/flang/lib/Optimizer/CodeGen/Target.h
@@ -1,0 +1,108 @@
+//===- Target.h - target specific details -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OPTMIZER_CODEGEN_TARGET_H
+#define OPTMIZER_CODEGEN_TARGET_H
+
+#include "mlir/IR/Types.h"
+#include <memory>
+#include <tuple>
+#include <vector>
+
+namespace llvm {
+class Triple;
+} // namespace llvm
+
+namespace fir {
+class KindMapping;
+
+namespace details {
+/// Extra information about how to marshal an argument or return value that
+/// modifies a signature per a particular ABI's calling convention.
+/// Note: llvm::Attribute is not used directly, because its use depends on an
+/// LLVMContext.
+class Attributes {
+public:
+  Attributes() : alignment{0}, byval{false}, sret{false}, append{false} {}
+  Attributes(unsigned short alignment, bool byval = false, bool sret = false,
+             bool append = false)
+      : alignment{alignment}, byval{byval}, sret{sret}, append{append} {}
+
+  unsigned getAlignment() const { return alignment; }
+  bool hasAlignment() const { return alignment != 0; }
+  bool isByVal() const { return byval; }
+  bool returnValueAsArgument() const { return isSRet(); }
+  bool isSRet() const { return sret; }
+  bool isAppend() const { return append; }
+
+private:
+  unsigned short alignment{};
+  bool byval : 1;
+  bool sret : 1;
+  bool append : 1;
+};
+
+} // namespace details
+
+/// Some details of how to represent certain features depend on the target and
+/// ABI that is being used.  These specifics are captured here and guide the
+/// lowering of FIR to LLVM-IR dialect.
+class CodeGenSpecifics {
+public:
+  using Attributes = details::Attributes;
+  using Marshalling = std::vector<std::tuple<mlir::Type, Attributes>>;
+
+  static std::unique_ptr<CodeGenSpecifics>
+  get(mlir::MLIRContext *ctx, llvm::Triple &trp, KindMapping &kindMap);
+
+  CodeGenSpecifics(mlir::MLIRContext *ctx, llvm::Triple &trp,
+                   KindMapping &kindMap)
+      : context{*ctx}, triple{trp}, kindMap{kindMap} {}
+  CodeGenSpecifics() = delete;
+  virtual ~CodeGenSpecifics() {}
+
+  /// Type presentation of a `complex<ele>` type value in memory.
+  virtual mlir::Type complexMemoryType(mlir::Type eleTy) const = 0;
+
+  /// Type presentation of a `complex<ele>` type argument when passed by
+  /// value. An argument value may need to be passed as a (safe) reference
+  /// argument.
+  virtual Marshalling complexArgumentType(mlir::Type eleTy) const = 0;
+
+  /// Type presentation of a `complex<ele>` type return value. Such a return
+  /// value may need to be converted to a hidden reference argument.
+  virtual Marshalling complexReturnType(mlir::Type eleTy) const = 0;
+
+  /// Type presentation of a `boxchar<n>` type value in memory.
+  virtual mlir::Type boxcharMemoryType(mlir::Type eleTy) const = 0;
+
+  /// Type presentation of a `boxchar<n>` type argument when passed by value. An
+  /// argument value may need to be passed as a (safe) reference argument.
+  ///
+  /// A function that returns a `boxchar<n>` type value must already have
+  /// converted that return value to an sret argument. This requirement is in
+  /// keeping with Fortran semantics, which require the caller to allocate the
+  /// space for the return CHARACTER value and pass a pointer and the length of
+  /// that space (a boxchar) to the called function. Such functions should be
+  /// annotated with an Attribute to distinguish the sret argument.
+  virtual Marshalling boxcharArgumentType(mlir::Type eleTy,
+                                          bool sret = false) const = 0;
+
+protected:
+  mlir::MLIRContext &context;
+  llvm::Triple &triple;
+  KindMapping &kindMap;
+};
+
+} // namespace fir
+
+#endif // OPTMIZER_CODEGEN_TARGET_H

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -43,10 +43,11 @@ struct FIRInlinerInterface : public mlir::DialectInlinerInterface {
 
 fir::FIROpsDialect::FIROpsDialect(mlir::MLIRContext *ctx)
     : mlir::Dialect("fir", ctx, mlir::TypeID::get<FIROpsDialect>()) {
-  addTypes<BoxType, BoxCharType, BoxProcType, CharacterType, CplxType,
-           FieldType, HeapType, IntType, LenType, LogicalType, PointerType,
-           RealType, RecordType, ReferenceType, SequenceType, ShapeType,
-           ShapeShiftType, SliceType, TypeDescType>();
+  addTypes<BoxType, BoxCharType, BoxProcType, CharacterType, fir::ComplexType,
+           FieldType, HeapType, fir::IntegerType, LenType, LogicalType,
+           PointerType, RealType, RecordType, ReferenceType, SequenceType,
+           ShapeType, ShapeShiftType, SliceType, TypeDescType,
+           fir::VectorType>();
   addAttributes<ClosedIntervalAttr, ExactTypeAttr, LowerBoundAttr, OpaqueAttr,
                 PointIntervalAttr, RealAttr, SubclassAttr, UpperBoundAttr>();
   addOperations<

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -167,6 +167,11 @@ mlir::Type fir::BoxDimsOp::getTupleType() {
 // CallOp
 //===----------------------------------------------------------------------===//
 
+mlir::FunctionType fir::CallOp::getFunctionType() {
+  return mlir::FunctionType::get(getOperandTypes(), getResultTypes(),
+                                 getContext());
+}
+
 static void printCallOp(mlir::OpAsmPrinter &p, fir::CallOp &op) {
   auto callee = op.callee();
   bool isDirect = callee.hasValue();
@@ -323,7 +328,8 @@ mlir::ParseResult fir::parseCmpcOp(mlir::OpAsmParser &parser,
 void fir::ConvertOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<ConvertConvertOptPattern, RedundantConvertOptPattern,
-                 CombineConvertOptPattern, ForwardConstantConvertPattern>(context);
+                 CombineConvertOptPattern, ForwardConstantConvertPattern>(
+      context);
 }
 
 mlir::OpFoldResult fir::ConvertOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
@@ -348,7 +354,7 @@ mlir::OpFoldResult fir::ConvertOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
 
 bool fir::ConvertOp::isIntegerCompatible(mlir::Type ty) {
   return ty.isa<mlir::IntegerType>() || ty.isa<mlir::IndexType>() ||
-         ty.isa<fir::IntType>() || ty.isa<fir::LogicalType>() ||
+         ty.isa<fir::IntegerType>() || ty.isa<fir::LogicalType>() ||
          ty.isa<fir::CharacterType>();
 }
 
@@ -412,8 +418,8 @@ void fir::CoordinateOp::build(OpBuilder &builder, OperationState &result,
 //===----------------------------------------------------------------------===//
 
 mlir::FunctionType fir::DispatchOp::getFunctionType() {
-  auto attr = getAttr("fn_type").cast<mlir::TypeAttr>();
-  return attr.getValue().cast<mlir::FunctionType>();
+  return mlir::FunctionType::get(getOperandTypes(), getResultTypes(),
+                                 getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -999,7 +999,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&... additionalArgs) {
+                        AdditionalArgs &&...additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();

--- a/flang/lib/Optimizer/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Support/FIRContext.cpp
@@ -23,7 +23,7 @@ void fir::setTargetTriple(mlir::ModuleOp mod, llvm::Triple &triple) {
   mod.setAttr(tripleName, fir::OpaqueAttr::get(mod.getContext(), &triple));
 }
 
-llvm::Triple *getTargetTriple(mlir::ModuleOp mod) {
+llvm::Triple *fir::getTargetTriple(mlir::ModuleOp mod) {
   if (auto triple = mod.getAttrOfType<fir::OpaqueAttr>(tripleName))
     return static_cast<llvm::Triple *>(triple.getPointer());
   return nullptr;
@@ -35,7 +35,7 @@ void fir::setNameUniquer(mlir::ModuleOp mod, fir::NameUniquer &uniquer) {
   mod.setAttr(uniquerName, fir::OpaqueAttr::get(mod.getContext(), &uniquer));
 }
 
-fir::NameUniquer *getNameUniquer(mlir::ModuleOp mod) {
+fir::NameUniquer *fir::getNameUniquer(mlir::ModuleOp mod) {
   if (auto triple = mod.getAttrOfType<fir::OpaqueAttr>(uniquerName))
     return static_cast<fir::NameUniquer *>(triple.getPointer());
   return nullptr;
@@ -47,16 +47,19 @@ void fir::setKindMapping(mlir::ModuleOp mod, fir::KindMapping &kindMap) {
   mod.setAttr(kindMapName, fir::OpaqueAttr::get(mod.getContext(), &kindMap));
 }
 
-fir::KindMapping *getKindMapping(mlir::ModuleOp mod) {
+fir::KindMapping *fir::getKindMapping(mlir::ModuleOp mod) {
   if (auto triple = mod.getAttrOfType<fir::OpaqueAttr>(kindMapName))
     return static_cast<fir::KindMapping *>(triple.getPointer());
   return nullptr;
 }
 
 std::string fir::determineTargetTriple(llvm::StringRef triple) {
-  // Treat "native" and "" as stand-ins for the host machine.
-  if (triple.empty() || (triple == "native"))
-    return llvm::sys::getHostCPUName().str();
+  // Treat "" or "default" as stand-ins for the default machine.
+  if (triple.empty() || triple == "default")
+    return llvm::sys::getDefaultTargetTriple();
+  // Treat "native" as stand-in for the host machine.
+  if (triple == "native")
+    return llvm::sys::getProcessTriple();
   // TODO: normalize the triple?
   return triple.str();
 }

--- a/flang/test/Fir/boxchar.fir
+++ b/flang/test/Fir/boxchar.fir
@@ -1,7 +1,6 @@
-// RUN: tco %s | FileCheck %s
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s
 
 // Test of building and passing boxchar.
-// TODO: split argument into two distinct parameters.
 
 func @callee(%x : !fir.boxchar<1>)
 
@@ -11,7 +10,7 @@ func @get_name() {
   %2 = constant 9 : i64
   %3 = fir.convert %1 : (!fir.ref<!fir.array<9x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
   %4 = fir.emboxchar %3, %2 : (!fir.ref<!fir.char<1>>, i64) -> !fir.boxchar<1>
-  // CHECK: call void @callee({ i8*, i64 } { i8* getelementptr inbounds ([9 x i8], [9 x i8]* @name, i32 0, i32 0), i64 9 })
+  // CHECK: call void @callee(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @name, i32 0, i32 0), i64 9)
   fir.call @callee(%4) : (!fir.boxchar<1>) -> ()
   return
 }

--- a/flang/test/Fir/compare.fir
+++ b/flang/test/Fir/compare.fir
@@ -1,4 +1,4 @@
-// RUN: tco -emit-fir %s | tco | FileCheck %s
+// RUN: tco -emit-fir %s | tco --target=x86_64-unknown-linux-gnu | FileCheck %s
 
 // CHECK-LABEL: define i1 @cmp(x86_fp80 %0, x86_fp80 %1)
 func @cmp(%a : !fir.real<10>, %b : !fir.real<10>) -> i1 {
@@ -14,7 +14,7 @@ func @cmp2(%a : !fir.real<16>, %b : !fir.real<16>) -> i1 {
   return %1 : i1
 }
 
-// CHECK-LABEL: define i1 @cmp3({ float, float } %0, { float, float } %1)
+// CHECK-LABEL: define i1 @cmp3(<2 x float> %0, <2 x float> %1)
 func @cmp3(%a : !fir.complex<4>, %b : !fir.complex<4>) -> i1 {
   // CHECK: fcmp ueq float
   %1 = fir.cmpc "ueq", %a, %b : !fir.complex<4>
@@ -35,10 +35,11 @@ func @neg2(%a : !fir.real<8>) -> !fir.real<8> {
   return %1 : !fir.real<8>
 }
 
-// CHECK-LABEL: define { double, double } @neg3({ double, double } %0)
+// CHECK-LABEL: define { double, double } @neg3(double %0, double %1)
 func @neg3(%a : !fir.complex<8>) -> !fir.complex<8> {
-// CHECK: %[[r3:.*]] = fneg double
-// CHECK: insertvalue { double, double } %0, double %[[r3]]
+  // CHECK: %[[g2:.*]] = insertvalue { double, double } %
+  // CHECK: %[[r3:.*]] = fneg double
+  // CHECK: insertvalue { double, double } %[[g2]], double %[[r3]]
   %1 = fir.negc %a : !fir.complex<8>
   return %1 : !fir.complex<8>
 }

--- a/flang/test/Fir/complex.fir
+++ b/flang/test/Fir/complex.fir
@@ -1,12 +1,12 @@
 // RUN: cc -c %S/print_complex.c
-// RUN: tco %s | FileCheck %s --check-prefix=LLVMIR
-// RUN: tco %s | llc | as -o %t
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s --check-prefix=LLVMIR
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | llc | as -o %t
 // RUN: cc %t print_complex.o
 // RUN: ./a.out | FileCheck %s --check-prefix=EXECHECK
 
 // EXECHECK: <0.935893, 2.252526>
 
-// LLVMIR-LABEL: define { float, float } @foo
+// LLVMIR-LABEL: define <2 x float> @foo(<2 x float> %
 func @foo(%a : !fir.complex<4>, %b : !fir.complex<4>, %c : !fir.complex<4>, %d : !fir.complex<4>, %e : !fir.complex<4>) -> !fir.complex<4> {
   // LLVMIR-COUNT-2: extractvalue
   // LLVMIR: fadd float
@@ -23,7 +23,7 @@ func @foo(%a : !fir.complex<4>, %b : !fir.complex<4>, %c : !fir.complex<4>, %d :
   return %4 : !fir.complex<4>
 }
 
-// LLVMIR-LABEL: define float @real_part({ float, float } %0)
+// LLVMIR-LABEL: define float @real_part(<2 x float> %0)
 func @real_part(%a : !fir.complex<4>) -> f32 {
   %0 = constant 0 : i32
   // LLVMIR: extractvalue
@@ -31,7 +31,7 @@ func @real_part(%a : !fir.complex<4>) -> f32 {
   return %1 : f32
 }
 
-// LLVMIR-LABEL: define { float, float } @conj
+// LLVMIR-LABEL: define <2 x float> @conj(<2 x float> %
 func @conj(%a : !fir.complex<4>) -> !fir.complex<4> {
   %0 = constant 1 : i32
   // LLVMIR: extractvalue

--- a/flang/test/Fir/convert.fir
+++ b/flang/test/Fir/convert.fir
@@ -1,6 +1,6 @@
-// RUN: tco %s | FileCheck %s
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s
 
-// CHECK-LABEL: define { double, double } @c({ float, float }
+// CHECK-LABEL: define { double, double } @c(<2 x float> %
 func @c(%x : !fir.complex<4>) -> !fir.complex<8> {
 // CHECK: %[[R:.*]] = extractvalue { float, float } %{{.*}}, 0
 // CHECK: %[[I:.*]] = extractvalue { float, float } %{{.*}}, 1

--- a/flang/test/Fir/target.fir
+++ b/flang/test/Fir/target.fir
@@ -1,0 +1,117 @@
+// RUN: tco --target=i386-unknown-linux-gnu %s | FileCheck %s --check-prefix=I32
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s --check-prefix=X64
+
+// I32-LABEL: define i64 @gen4()
+// X64-LABEL: define <2 x float> @gen4()
+func @gen4() -> !fir.complex<4> {
+  %1 = fir.undefined !fir.complex<4>
+  %2 = constant 2.0 : f32
+  %3 = fir.convert %2 : (f32) -> !fir.real<4>
+  %c0 = constant 0 : i32
+  %4 = fir.insert_value %1, %3, %c0 : (!fir.complex<4>, !fir.real<4>, i32) -> !fir.complex<4>
+  %c1 = constant 1 : i32
+  %5 = constant -42.0 : f32
+  %6 = fir.insert_value %4, %5, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  // I32: store { float, float } { float 2.000000e+00, float -4.200000e+01 }
+  // I32: %[[load:.*]] = load i64, i64*
+  // I32: ret i64 %[[load]]
+  // X64: store { float, float } { float 2.000000e+00, float -4.200000e+01 }
+  // X64: %[[load:.*]] = load <2 x float>, <2 x float>*
+  // X64: ret <2 x float> %[[load]]
+  return %6 : !fir.complex<4>
+}
+
+// I32-LABEL: define void @gen8({ double, double }* sret %
+// X64-LABEL: define { double, double } @gen8()
+func @gen8() -> !fir.complex<8> {
+  %1 = fir.undefined !fir.complex<8>
+  %2 = constant 1.0 : f64
+  %3 = constant -4.0 : f64
+  %c0 = constant 0 : i32
+  %4 = fir.insert_value %1, %3, %c0 : (!fir.complex<8>, f64, i32) -> !fir.complex<8>
+  %c1 = constant 1 : i32
+  %5 = fir.insert_value %4, %2, %c1 : (!fir.complex<8>, f64, i32) -> !fir.complex<8>
+  // I32: store { double, double } { double -4.000000e+00, double 1.000000e+00 }
+  // I64: store { double, double } { double -4.000000e+00, double 1.000000e+00 }
+  // I64: %[[load:.*]] = load { double, double }
+  // I64: ret { double, double } %[[load]]
+  return %5 : !fir.complex<8>
+}
+
+// I32: declare void @sink4({ float, float }*)
+// X64: declare void @sink4(<2 x float>)
+func @sink4(!fir.complex<4>) -> ()
+
+// I32: declare void @sink8({ double, double }*)
+// X64: declare void @sink8(double, double)
+func @sink8(!fir.complex<8>) -> ()
+
+// I32-LABEL: define void @call4()
+// X64-LABEL: define void @call4()
+func @call4() {
+  // I32: = call i64 @gen4()
+  // X64: = call <2 x float> @gen4()
+  %1 = fir.call @gen4() : () -> !fir.complex<4>
+  // I32: call void @sink4({ float, float }* %
+  // X64: call void @sink4(<2 x float> %
+  fir.call @sink4(%1) : (!fir.complex<4>) -> ()
+  return
+}
+
+// I32-LABEL: define void @call8()
+// X64-LABEL: define void @call8()
+func @call8() {
+  // I32: call void @gen8({ double, double }* %
+  // X64: = call { double, double } @gen8()
+  %1 = fir.call @gen8() : () -> !fir.complex<8>
+  // I32: call void @sink8({ double, double }* %
+  // X64: call void @sink8(double %4, double %5)
+  fir.call @sink8(%1) : (!fir.complex<8>) -> ()
+  return
+}
+
+// I32-LABEL: define i64 @char1lensum(i8* %0, i8* %1, i32 %2, i32 %3)
+// X64-LABEL: define i64 @char1lensum(i8* %0, i8* %1, i64 %2, i64 %3)
+func @char1lensum(%arg0 : !fir.boxchar<1>, %arg1 : !fir.boxchar<1>) -> i64 {
+  // X64-DAG: %[[p0:.*]] = insertvalue { i8*, i64 } undef, i8* %1, 0
+  // X64-DAG: = insertvalue { i8*, i64 } %[[p0]], i64 %3, 1
+  // X64-DAG: %[[p1:.*]] = insertvalue { i8*, i64 } undef, i8* %0, 0
+  // X64-DAG: = insertvalue { i8*, i64 } %[[p1]], i64 %2, 1
+  %1:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, i64)
+  %2:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, i64)
+  // I32: %[[add:.*]] = add i64 %
+  // X64: %[[add:.*]] = add i64 %
+  %3 = addi %1#1, %2#1 : i64
+  // I32: ret i64 %[[add]]
+  // X64: ret i64 %[[add]]
+  return %3 : i64
+}
+
+// I32-LABEL: define void @char1copy(i8* sret %0, i32 %1, i8* %2, i32 %3)
+// I64-LABEL: define void @char1copy(i8* sret %0, i64 %1, i8* %2, i64 %3)
+func @char1copy(%arg0 : !fir.boxchar<1> {llvm.sret = true}, %arg1 : !fir.boxchar<1>) {
+  // I32-DAG: %[[p0:.*]] = insertvalue { i8*, i32 } undef, i8* %2, 0
+  // I32-DAG: = insertvalue { i8*, i32 } %[[p0]], i32 %3, 1
+  // I32-DAG: %[[p1:.*]] = insertvalue { i8*, i32 } undef, i8* %0, 0
+  // I32-DAG: = insertvalue { i8*, i32 } %[[p1]], i32 %1, 1
+  // X64-DAG: %[[p0:.*]] = insertvalue { i8*, i64 } undef, i8* %2, 0
+  // X64-DAG: = insertvalue { i8*, i64 } %[[p0]], i64 %3, 1
+  // X64-DAG: %[[p1:.*]] = insertvalue { i8*, i64 } undef, i8* %0, 0
+  // X64-DAG: = insertvalue { i8*, i64 } %[[p1]], i64 %1, 1
+  %1:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, i64)
+  %2:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, i64)
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %3 = fir.convert %1#1 : (i64) -> index
+  %last = subi %3, %c1 : index
+  fir.do_loop %i = %c0 to %last step %c1 {
+    %in_pos = fir.coordinate_of %2#0, %i : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+    %out_pos = fir.coordinate_of %1#0, %i : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+    %ch = fir.load %in_pos : !fir.ref<!fir.char<1>>
+    fir.store %ch to %out_pos : !fir.ref<!fir.char<1>>
+  }
+  // I32: ret void
+  // X64: ret void
+  return
+}
+

--- a/flang/test/Lower/bbcnull.f90
+++ b/flang/test/Lower/bbcnull.f90
@@ -1,0 +1,4 @@
+! RUN: bbc --version | FileCheck %s
+! CHECK: LLVM version
+
+! This test is intentionally empty.

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -33,8 +33,8 @@ end function
 real function test_func()
   real :: func, prefoo
   external :: func
-  !CHECK: %[[f:.*]] = constant @_QPfunc : (!fir.ref<f32>) -> f32
-  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<f32>) -> f32) -> (() -> ())
+  !CHECK: %[[f:.*]] = fir.address_of(@_QPfunc) : (!fir.ref<f32>) -> f32
+  !CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.ref<f32>) -> f32) -> (() -> ())
   !CHECK: fir.call @_QPprefoo(%[[fcast]]) : (() -> ()) -> f32
   test_func = prefoo(func)
 end function
@@ -69,8 +69,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPtest_sub
 subroutine test_sub()
   external :: sub
-  !CHECK: %[[f:.*]] = constant @_QPsub : (!fir.ref<f32>) -> ()
-  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<f32>) -> ()) -> (() -> ())
+  !CHECK: %[[f:.*]] = fir.address_of(@_QPsub) : (!fir.ref<f32>) -> ()
+  !CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.ref<f32>) -> ()) -> (() -> ())
   !CHECK: fir.call @_QPprefoo_sub(%[[fcast]]) : (() -> ()) -> ()
   call prefoo_sub(sub)
 end subroutine
@@ -81,8 +81,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPtest_acos
 subroutine test_acos(x)
   intrinsic :: acos
-  !CHECK: %[[f:.*]] = constant @fir.acos.f32.ref_f32 : (!fir.ref<f32>) -> f32
-  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<f32>) -> f32) -> (() -> ())
+  !CHECK: %[[f:.*]] = fir.address_of(@fir.acos.f32.ref_f32) : (!fir.ref<f32>) -> f32
+  !CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.ref<f32>) -> f32) -> (() -> ())
   !CHECK: fir.call @_QPfoo_acos(%[[fcast]]) : (() -> ()) -> ()
   call foo_acos(acos)
 end subroutine
@@ -91,8 +91,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPtest_aimag
 subroutine test_aimag()
   intrinsic :: aimag
-  !CHECK: %[[f:.*]] = constant @fir.aimag.f32.ref_z4 : (!fir.ref<!fir.complex<4>>) -> f32
-  !CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<!fir.complex<4>>) -> f32) -> (() -> ())
+  !CHECK: %[[f:.*]] = fir.address_of(@fir.aimag.f32.ref_z4) : (!fir.ref<!fir.complex<4>>) -> f32
+  !CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.ref<!fir.complex<4>>) -> f32) -> (() -> ())
   !CHECK: fir.call @_QPfoo_aimag(%[[fcast]]) : (() -> ()) -> ()
   call foo_aimag(aimag)
 end subroutine
@@ -101,8 +101,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPtest_len
 subroutine test_len()
   intrinsic :: len
-  ! CHECK: %[[f:.*]] = constant @fir.len.i32.bc1 : (!fir.boxchar<1>) -> i32
-  ! CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.boxchar<1>) -> i32) -> (() -> ())
+  ! CHECK: %[[f:.*]] = fir.address_of(@fir.len.i32.bc1) : (!fir.boxchar<1>) -> i32
+  ! CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.boxchar<1>) -> i32) -> (() -> ())
   !CHECK: fir.call @_QPfoo_len(%[[fcast]]) : (() -> ()) -> ()
   call foo_len(len)
 end subroutine
@@ -112,8 +112,8 @@ end subroutine
 ! CHECK-LABEL: func @_QPtest_iabs
 subroutine test_iabs()
   intrinsic :: iabs
-  ! CHECK: %[[f:.*]] = constant @fir.abs.i32.ref_i32 : (!fir.ref<i32>) -> i32
-  ! CHECK: %[[fcast:.*]] = fir.convert %f : ((!fir.ref<i32>) -> i32) -> (() -> ())
+  ! CHECK: %[[f:.*]] = fir.address_of(@fir.abs.i32.ref_i32) : (!fir.ref<i32>) -> i32
+  ! CHECK: %[[fcast:.*]] = fir.convert %[[f]] : ((!fir.ref<i32>) -> i32) -> (() -> ())
   ! CHECK: fir.call @_QPfoo_iabs(%[[fcast]]) : (() -> ()) -> ()
   call foo_iabs(iabs)
 end subroutine
@@ -137,7 +137,7 @@ end subroutine
 
 ! CHECK-LABEL: func @fir.acos.f32.ref_f32(%arg0: !fir.ref<f32>) -> f32
   !CHECK: %[[load:.*]] = fir.load %arg0
-  !CHECK: %[[res:.*]] = call @__fs_acos_1(%[[load]]) : (f32) -> f32
+  !CHECK: %[[res:.*]] = fir.call @__fs_acos_1(%[[load]]) : (f32) -> f32
   !CHECK: return %[[res]] : f32
 
 !CHECK-LABEL: func @fir.aimag.f32.ref_z4(%arg0: !fir.ref<!fir.complex<4>>)

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -13,7 +13,7 @@ end subroutine
 ! CHECK-LABEL: abs_testr
 subroutine abs_testr(a, b)
   real :: a, b
-  ! CHECK: call @llvm.fabs.f32
+  ! CHECK: fir.call @llvm.fabs.f32
   b = abs(a)
 end subroutine
 
@@ -23,7 +23,7 @@ subroutine abs_testz(a, b)
   real :: b
   ! CHECK: fir.extract_value
   ! CHECK: fir.extract_value
-  ! CHECK: call @{{.*}}hypot
+  ! CHECK: fir.call @{{.*}}hypot
   b = abs(a)
 end subroutine
 
@@ -40,7 +40,7 @@ end subroutine
 ! CHECK-LABEL: aint_test
 subroutine aint_test(a, b)
   real :: a, b
-  ! CHECK: call @llvm.trunc.f32
+  ! CHECK: fir.call @llvm.trunc.f32
   b = aint(a)
 end subroutine
 
@@ -48,7 +48,7 @@ end subroutine
 ! CHECK-LABEL: anint_test
 subroutine anint_test(a, b)
   real :: a, b
-  ! CHECK: call @llvm.round.f32
+  ! CHECK: fir.call @llvm.round.f32
   b = anint(a)
 end subroutine
 
@@ -106,7 +106,7 @@ subroutine ceiling_test1(i, a)
   integer :: i
   real :: a
   i = ceiling(a)
-  ! CHECK: %[[f:.*]] = call @llvm.ceil.f32
+  ! CHECK: %[[f:.*]] = fir.call @llvm.ceil.f32
   ! CHECK: fir.convert %[[f]] : (f32) -> i32
 end subroutine
 ! CHECK-LABEL: ceiling_test2
@@ -114,7 +114,7 @@ subroutine ceiling_test2(i, a)
   integer(8) :: i
   real :: a
   i = ceiling(a, 8)
-  ! CHECK: %[[f:.*]] = call @llvm.ceil.f32
+  ! CHECK: %[[f:.*]] = fir.call @llvm.ceil.f32
   ! CHECK: fir.convert %[[f]] : (f32) -> i64
 end subroutine
 
@@ -135,7 +135,7 @@ subroutine floor_test1(i, a)
   integer :: i
   real :: a
   i = floor(a)
-  ! CHECK: %[[f:.*]] = call @llvm.floor.f32
+  ! CHECK: %[[f:.*]] = fir.call @llvm.floor.f32
   ! CHECK: fir.convert %[[f]] : (f32) -> i32
 end subroutine
 ! CHECK-LABEL: floor_test2
@@ -143,7 +143,7 @@ subroutine floor_test2(i, a)
   integer(8) :: i
   real :: a
   i = floor(a, 8)
-  ! CHECK: %[[f:.*]] = call @llvm.floor.f32
+  ! CHECK: %[[f:.*]] = fir.call @llvm.floor.f32
   ! CHECK: fir.convert %[[f]] : (f32) -> i64
 end subroutine
 
@@ -242,14 +242,14 @@ subroutine nint_test1(i, a)
   integer :: i
   real :: a
   i = nint(a)
-  ! CHECK: call @llvm.lround.i32.f32
+  ! CHECK: fir.call @llvm.lround.i32.f32
 end subroutine
 ! CHECK-LABEL: nint_test2
 subroutine nint_test2(i, a)
   integer(8) :: i
   real(8) :: a
   i = nint(a, 8)
-  ! CHECK: call @llvm.lround.i64.f64
+  ! CHECK: fir.call @llvm.lround.i64.f64
 end subroutine
 
 
@@ -270,7 +270,7 @@ end subroutine
 ! CHECK-LABEL: sign_testr
 subroutine sign_testr(a, b, c)
   real a, b, c
-  ! CHECK-DAG: call {{.*}}fabs
+  ! CHECK-DAG: fir.call {{.*}}fabs
   ! CHECK-DAG: fir.negf
   ! CHECK-DAG: fir.cmpf "olt"
   ! CHECK: select
@@ -281,6 +281,6 @@ end subroutine
 ! CHECK-LABEL: sqrt_testr
 subroutine sqrt_testr(a, b)
   real :: a, b
-  ! CHECK: call {{.*}}sqrt
+  ! CHECK: fir.call {{.*}}sqrt
   b = sqrt(a)
 end subroutine

--- a/flang/test/Lower/procedure-declarations.f90
+++ b/flang/test/Lower/procedure-declarations.f90
@@ -14,7 +14,7 @@
 ! CHECK-LABEL: func @_QPpass_foo() {
 subroutine pass_foo()
   external :: foo
-  ! CHECK: %[[f:.*]] = constant @_QPfoo
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo)
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo)
 end subroutine
@@ -42,7 +42,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPpass_foo2() {
 subroutine pass_foo2()
   external :: foo2
-  ! CHECK: %[[f:.*]] = constant @_QPfoo2
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo2)
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo2)
 end subroutine
@@ -68,7 +68,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPpass_foo3() {
 subroutine pass_foo3()
   external :: foo3
-  ! CHECK: %[[f:.*]] = constant @_QPfoo3
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo3)
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo3)
 end subroutine
@@ -89,7 +89,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPpass_foo4() {
 subroutine pass_foo4()
   external :: foo4
-  ! CHECK: %[[f:.*]] = constant @_QPfoo4
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo4)
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo4)
 end subroutine
@@ -103,7 +103,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPpass_foo5() {
 subroutine pass_foo5()
   external :: foo5
-  ! CHECK: %[[f:.*]] = constant @_QPfoo5
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo5)
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo5)
 end subroutine
@@ -129,7 +129,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPpass_foo6() {
 subroutine pass_foo6()
   external :: foo6
-  ! CHECK: %[[f:.*]] = constant @_QPfoo6 : (!fir.ref<!fir.array<10xi32>>) -> ()
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo6) : (!fir.ref<!fir.array<10xi32>>) -> ()
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<10xi32>>) -> ()) -> (() -> ())
   call bar(foo6)
 end subroutine
@@ -144,7 +144,7 @@ end subroutine
 ! CHECK-LABEL: func @_QPcall_foo7(%arg0: !fir.ref<!fir.array<10xi32>>) -> f32 {
 function call_foo7(i)
   integer :: i(10)
-  ! CHECK: %[[f:.*]] = constant @_QPfoo7 : () -> ()
+  ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo7) : () -> ()
   ! CHECK: %[[funccast:.*]] = fir.convert %[[f]] : (() -> ()) -> ((!fir.ref<!fir.array<10xi32>>) -> f32)
   ! CHECK: fir.call %[[funccast]](%arg0) : (!fir.ref<!fir.array<10xi32>>) -> f32
   call_foo7 =  foo7(i)

--- a/flang/test/Lower/stmt-function.f90
+++ b/flang/test/Lower/stmt-function.f90
@@ -92,7 +92,7 @@ integer function test_stmt_character(c, j)
    func(argc, argj) = len_trim(argc, 4) + argj
    !CHECK-DAG: %[[j:.*]] = fir.load %arg1
    !CHECK-DAG: %[[c4:.*]] = constant 4 :
-   !CHECK-DAG: %[[len_trim:.*]] = call @fir.len_trim.i32.bc1.i32(%[[c]], %[[c4]])
+   !CHECK-DAG: %[[len_trim:.*]] = fir.call @fir.len_trim.i32.bc1.i32(%[[c]], %[[c4]])
    !CHECK: addi %[[len_trim]], %[[j]]
    test_stmt_character = func(c, j)
 end function  
@@ -101,7 +101,7 @@ end function
 ! CHECK-LABEL: @_QPbug247
 subroutine bug247(r)
   I(R) = R
-  ! CHECK: call {{.*}}OutputInteger
+  ! CHECK: fir.call {{.*}}OutputInteger
   PRINT *, I(2.5)
-  ! CHECK: call {{.*}}EndIo
+  ! CHECK: fir.call {{.*}}EndIo
 END subroutine bug247

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -264,7 +264,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(fir::createCSEPass());
-    pm.addPass(fir::createPromoteToAffinePass());
+    // pm.addPass(fir::createPromoteToAffinePass());
     pm.addPass(fir::createFirToCfgPass());
     pm.addPass(fir::createControlFlowLoweringPass());
     pm.addPass(mlir::createLowerToCFGPass());

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -116,6 +116,7 @@ static int compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
 
     // pm.addPass(fir::createMemToRegPass());
     pm.addPass(fir::createFirCodeGenRewritePass());
+    pm.addPass(fir::createFirTargetRewritePass());
     pm.addPass(fir::createFIRToLLVMPass(uniquer));
     pm.addPass(fir::createLLVMDialectToLLVMPass(out.os()));
   }

--- a/flang/unittests/Lower/RTBuilder.cpp
+++ b/flang/unittests/Lower/RTBuilder.cpp
@@ -29,7 +29,7 @@ TEST(RTBuilderTest, ComplexRuntimeInterface) {
   auto c99_cacosf_funcTy = c99_cacosf_signature.cast<mlir::FunctionType>();
   EXPECT_EQ(c99_cacosf_funcTy.getNumInputs(), 1u);
   EXPECT_EQ(c99_cacosf_funcTy.getNumResults(), 1u);
-  auto cplx_ty = fir::CplxType::get(&ctx, 4);
+  auto cplx_ty = fir::ComplexType::get(&ctx, 4);
   EXPECT_EQ(c99_cacosf_funcTy.getInput(0), cplx_ty);
   EXPECT_EQ(c99_cacosf_funcTy.getResult(0), cplx_ty);
 }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -849,6 +849,24 @@ LogicalResult ModuleTranslation::convertOneFunction(LLVMFuncOp func) {
           llvm::AttrBuilder().addAlignmentAttr(llvm::Align(attr.getInt())));
     }
 
+    if (auto attr = func.getArgAttrOfType<BoolAttr>(argIdx, "llvm.sret")) {
+      auto argTy = mlirArg.getType().dyn_cast<LLVM::LLVMType>();
+      if (!argTy.isPointerTy())
+        return func.emitError(
+            "llvm.sret attribute attached to LLVM non-pointer argument");
+      if (attr.getValue())
+        llvmArg.addAttr(llvm::Attribute::AttrKind::StructRet);
+    }
+        
+    if (auto attr = func.getArgAttrOfType<BoolAttr>(argIdx, "llvm.byval")) {
+      auto argTy = mlirArg.getType().dyn_cast<LLVM::LLVMType>();
+      if (!argTy.isPointerTy())
+        return func.emitError(
+            "llvm.byval attribute attached to LLVM non-pointer argument");
+      if (attr.getValue())
+        llvmArg.addAttr(llvm::Attribute::AttrKind::ByVal);
+    }
+
     valueMapping[mlirArg] = &llvmArg;
     argIdx++;
   }


### PR DESCRIPTION
To generate correct code for a chosen target, the Tilikum bridge must know
what the selected target is and the conventions used for the specific target
ABI. The properties of the target influence the calling conventions and LLVM
IR that must be generated. Tilikum is the last point before any high-level
abstractions must be considered and correctly translated to LLVM IR.

These changed rework the Tilikum bridge to use a target specifier and convert
the calling conventions and memory layouts appropriate for the selected target.

Two target specifications are implemented. i386-unknown-linux-gnu and
x86_64-unknown-linux-gnu. Others can be added as needed.

Two high-level type abstractions are considered: COMPLEX and CHARACTER.

Moving these target specific lowerings to a common place in code gen eliminates
the need to perform heroics with custom code in lowering and/or reliance on
assuming the target is known by implication at compiler compile-time.