### PR TITLE
Turn on the assertion to check that the Value bound to a Symbol in the

### DIFF
--- a/flang/include/flang/Evaluate/expression.h
+++ b/flang/include/flang/Evaluate/expression.h
@@ -26,6 +26,7 @@
 #include "flang/Common/indirection.h"
 #include "flang/Common/template.h"
 #include "flang/Parser/char-block.h"
+#include "llvm/Support/Compiler.h"
 #include <algorithm>
 #include <list>
 #include <tuple>
@@ -93,6 +94,9 @@ public:
   std::optional<DynamicType> GetType() const;
   int Rank() const;
   std::string AsFortran() const;
+  LLVM_DUMP_METHOD void dump() const {
+    llvm::errs() << "Ev::Expr is <{" << AsFortran() << "}>\n";
+  }
   llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   static Derived Rewrite(FoldingContext &, Derived &&);
 };
@@ -129,8 +133,8 @@ private:
 
 public:
   CLASS_BOILERPLATE(Operation)
-  explicit Operation(const Expr<OPERANDS> &...x) : operand_{x...} {}
-  explicit Operation(Expr<OPERANDS> &&...x) : operand_{std::move(x)...} {}
+  explicit Operation(const Expr<OPERANDS> &... x) : operand_{x...} {}
+  explicit Operation(Expr<OPERANDS> &&... x) : operand_{std::move(x)...} {}
 
   Derived &derived() { return *static_cast<Derived *>(this); }
   const Derived &derived() const { return *static_cast<const Derived *>(this); }

--- a/flang/include/flang/Optimizer/Support/Matcher.h
+++ b/flang/include/flang/Optimizer/Support/Matcher.h
@@ -1,0 +1,34 @@
+//===-- Optimizer/Support/Matcher.h -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OPTIMIZER_SUPPORT_MATCHER_H
+#define OPTIMIZER_SUPPORT_MATCHER_H
+
+#include <variant>
+
+// Boilerplate CRTP class for a simplified type-casing syntactic sugar.
+namespace fir::details {
+// clang-format off
+template<class... Ts> struct matches : Ts... { using Ts::operator()...; };
+template<class... Ts> matches(Ts...) -> matches<Ts...>;
+template<typename N> struct matcher {
+  template<typename... Ts> auto match(Ts... ts) {
+    return std::visit(matches{ts...}, static_cast<N*>(this)->matchee());
+  }
+  template<typename... Ts> auto match(Ts... ts) const {
+    return std::visit(matches{ts...}, static_cast<N const*>(this)->matchee());
+  }
+};
+// clang-format on
+} // namespace fir::details
+
+#endif // OPTIMIZER_SUPPORT_MATCHER_H

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <utility>
 
+#define DEBUG_TYPE "flang-lower-intrinsic"
+
 #define PGMATH_DECLARE
 #include "../runtime/pgmath.h.inc"
 
@@ -1144,7 +1146,6 @@ mlir::Value IntrinsicLibrary::genFloor(mlir::Type resultType,
 mlir::Value IntrinsicLibrary::genIAnd(mlir::Type resultType,
                                       llvm::ArrayRef<mlir::Value> args) {
   assert(args.size() == 2);
-
   return builder.create<mlir::AndOp>(loc, args[0], args[1]);
 }
 
@@ -1155,22 +1156,29 @@ mlir::Value IntrinsicLibrary::genIchar(mlir::Type resultType,
   assert(args.size() >= 1 && args.size() <= 2);
 
   auto arg = args[0];
-  assert(Fortran::lower::CharacterExprHelper::isCharacter(arg.getType()) &&
+  auto argTy = arg.getType();
+  assert(Fortran::lower::CharacterExprHelper::isCharacter(argTy) &&
          "Error: Unhandled type passed to ICHAR");
-  Fortran::lower::CharacterExprHelper helper{builder, loc};
-  auto dataAndLen = helper.createUnboxChar(arg);
-  auto charType = helper.getCharacterType(arg.getType());
   mlir::Value charVal;
-  if (fir::isa_ref_type(dataAndLen.first.getType())) {
-    auto refType = builder.getRefType(charType);
-    auto charAddr = builder.createConvert(loc, refType, dataAndLen.first);
-    charVal = builder.create<fir::LoadOp>(loc, charType, charAddr);
+  if (auto charTy = argTy.dyn_cast<fir::CharacterType>()) {
+    assert(charTy.singleton());
+    charVal = arg;
+  } else if (auto seqTy = argTy.dyn_cast<fir::SequenceType>()) {
+    auto zero =
+        builder.createIntegerConstant(loc, builder.getIntegerType(32), 0);
+    charVal = builder.create<fir::ExtractValueOp>(loc, seqTy.getEleTy(), arg,
+                                                  mlir::ValueRange{zero});
   } else {
-    charVal = builder.create<fir::ExtractValueOp>(
-        loc, charType, dataAndLen.first,
-        llvm::ArrayRef<mlir::Value>{
-            builder.createIntegerConstant(loc, builder.getIntegerType(32), 0)});
+    using H = Fortran::lower::CharacterExprHelper;
+    H helper{builder, loc};
+    auto dataAndLen = helper.createUnboxChar(arg);
+    // Strip away any sequence type residual.
+    auto toTy =
+        builder.getRefType(H::getCharacterType(dataAndLen.first.getType()));
+    auto cast = builder.createConvert(loc, toTy, dataAndLen.first);
+    charVal = builder.create<fir::LoadOp>(loc, cast);
   }
+  LLVM_DEBUG(llvm::errs() << "ichar(" << charVal << ")\n");
   return builder.createConvert(loc, resultType, charVal);
 }
 

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -172,6 +172,20 @@ struct SymbolBox {
 /// etc.
 class SymMap {
 public:
+  /// Add an extended value to the symbol table.
+  void addSymbol(semantics::SymbolRef sym, const fir::ExtendedValue &ext,
+                 bool force = false) {
+    ext.match([&](const fir::UnboxedValue &v) { addSymbol(sym, v, force); },
+              [&](const fir::CharBoxValue &v) { makeSym(sym, v, force); },
+              [&](const fir::ArrayBoxValue &v) { makeSym(sym, v, force); },
+              [&](const fir::CharArrayBoxValue &v) { makeSym(sym, v, force); },
+              [&](const fir::BoxValue &v) { makeSym(sym, v, force); },
+              [](auto) {
+                llvm::report_fatal_error(
+                    "box value should not be added to symbol table");
+              });
+  }
+
   /// Add a trivial symbol mapping to an address.
   void addSymbol(semantics::SymbolRef sym, mlir::Value value,
                  bool force = false) {

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -984,7 +984,8 @@ bool isa_box_type(mlir::Type t) {
 }
 
 bool isa_passbyref_type(mlir::Type t) {
-  return t.isa<ReferenceType>() || isa_box_type(t);
+  return t.isa<ReferenceType>() || isa_box_type(t) ||
+         t.isa<mlir::FunctionType>();
 }
 
 bool isa_aggregate(mlir::Type t) {

--- a/flang/test/Lower/stmt-function.f90
+++ b/flang/test/Lower/stmt-function.f90
@@ -3,19 +3,19 @@
 ! Test statement function lowering
 
 ! Simple case
-!CHECK-LABEL: func @_QPtest_stmt_0(%arg0: !fir.ref<f32>) -> f32
+! CHECK-LABEL: func @_QPtest_stmt_0(%arg0: !fir.ref<f32>) -> f32
 real function test_stmt_0(x)
   real :: x, func, arg
   func(arg) = arg + 0.123456
 
-  !CHECK: %[[x:.*]] = fir.load %arg0
-  !CHECK: %[[cst:.*]] = constant 1.234560e-01
-  !CHECK: %[[eval:.*]] = fir.addf %[[x]], %[[cst]]
-  !CHECK: fir.store %[[eval]] to %[[resmem:.*]] : !fir.ref<f32>
+  ! CHECK: %[[x:.*]] = fir.load %arg0
+  ! CHECK: %[[cst:.*]] = constant 1.234560e-01
+  ! CHECK: %[[eval:.*]] = fir.addf %[[x]], %[[cst]]
+  ! CHECK: fir.store %[[eval]] to %[[resmem:.*]] : !fir.ref<f32>
   test_stmt_0 = func(x)
 
-  !CHECK: %[[res:.*]] = fir.load %[[resmem]]
-  !CHECK: return %[[res]]
+  ! CHECK: %[[res:.*]] = fir.load %[[resmem]]
+  ! CHECK: return %[[res]]
 end function
 
 ! Check this is not lowered as a simple macro: e.g. argument is only
@@ -25,8 +25,13 @@ end function
 real(4) function test_stmt_only_eval_arg_once()
   real(4) :: only_once, x1
   func(x1) = x1 + x1
-  !CHECK: %[[x1:.*]] = fir.call @_QPonly_once()
-  !CHECK: fir.addf %[[x1]], %[[x1]]
+  ! CHECK: %[[x1:.*]] = fir.call @_QPonly_once()
+  ! Note: using -emit-fir, so the faked pass-by-reference is exposed
+  ! CHECK: %[[x2:.*]] = fir.alloca f32
+  ! CHECK: fir.store %[[x1]] to %[[x2]]
+  ! CHECK-DAG: %[[x3:.*]] = fir.load %[[x2]]
+  ! CHECK-DAG: %[[x4:.*]] = fir.load %[[x2]]
+  ! CHECK: fir.addf %[[x3]], %[[x4]]
   test_stmt_only_eval_arg_once = func(only_once())
 end function
 
@@ -38,45 +43,47 @@ real function test_stmt_1(x, a)
   real :: res1, res2
   func1(arg1) = a + foo(arg1)
   func2(arg2) = func1(arg2) + b
-  !CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {name = "b"}
-  !CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {name = "res1"}
-  !CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {name = "res2"}
+  ! CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {name = "b"}
+  ! CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {name = "res1"}
+  ! CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {name = "res2"}
 
   b = 5
 
-  !CHECK-DAG: %[[cst_8:.*]] = constant 8.000000e+00
-  !CHECK-DAG: fir.store %[[cst_8]] to %[[tmp1:.*]] : !fir.ref<f32>
-  !CHECK-DAG: %[[foocall1:.*]] = fir.call @_QPfoo(%[[tmp1]])
-  !CHECK-DAG: %[[aload1:.*]] = fir.load %arg1
-  !CHECK: %[[add1:.*]] = fir.addf %[[aload1]], %[[foocall1]]
-  !CHECK: fir.store %[[add1]] to %[[res1]]
+  ! CHECK-DAG: %[[cst_8:.*]] = constant 8.000000e+00
+  ! CHECK-DAG: fir.store %[[cst_8]] to %[[tmp1:.*]] : !fir.ref<f32>
+  ! CHECK-DAG: %[[foocall1:.*]] = fir.call @_QPfoo(%[[tmp1]])
+  ! CHECK-DAG: %[[aload1:.*]] = fir.load %arg1
+  ! CHECK: %[[add1:.*]] = fir.addf %[[aload1]], %[[foocall1]]
+  ! CHECK: fir.store %[[add1]] to %[[res1]]
   res1 =  func1(8.)
 
-  !CHECK-DAG: %[[x:.*]] = fir.load %arg0
-  !CHECK-DAG: fir.store %[[x]] to %[[tmp2:.*]] : !fir.ref<f32>
-  !CHECK-DAG: %[[foocall2:.*]] = fir.call @_QPfoo(%[[tmp2]])
-  !CHECK-DAG: %[[aload2:.*]] = fir.load %arg1
-  !CHECK-DAG: %[[add2:.*]] = fir.addf %[[aload2]], %[[foocall2]]
-  !CHECK-DAG: %[[b:.*]] = fir.load %[[bmem]]
-  !CHECK: %[[add3:.*]] = fir.addf %[[add2]], %[[b]]
-  !CHECK: fir.store %[[add3]] to %[[res2]]
+  ! CHECK-DAG: %[[a2:.*]] = fir.load %arg1
+  ! CHECK-DAG: %[[foocall2:.*]] = fir.call @_QPfoo(%arg0)
+  ! CHECK-DAG: %[[add2:.*]] = fir.addf %[[a2]], %[[foocall2]]
+  ! CHECK-DAG: %[[b:.*]] = fir.load %[[bmem]]
+  ! CHECK: %[[add3:.*]] = fir.addf %[[add2]], %[[b]]
+  ! CHECK: fir.store %[[add3]] to %[[res2]]
   res2 = func2(x)
 
+  ! CHECK-DAG: %[[res12:.*]] = fir.load %[[res1]]
+  ! CHECK-DAG: %[[res22:.*]] = fir.load %[[res2]]
+  ! CHECK: = fir.addf %[[res12]], %[[res22]] : f32
   test_stmt_1 = res1 + res2
+  ! CHECK: return %{{.*}} : f32
 end function
 
 
 ! Test statement functions with no argument.
 ! Test that they are not pre-evaluated.
-!CHECK-LABEL: func @_QPtest_stmt_no_args
+! CHECK-LABEL: func @_QPtest_stmt_no_args
 real function test_stmt_no_args(x, y)
   func() = x + y
-  !CHECK: fir.addf
+  ! CHECK: fir.addf
   a = func()
-  !CHECK: fir.call @_QPfoo_may_modify_xy
+  ! CHECK: fir.call @_QPfoo_may_modify_xy
   call foo_may_modify_xy(x, y)
-  !CHECK: fir.addf
-  !CHECK: fir.addf
+  ! CHECK: fir.addf
+  ! CHECK: fir.addf
   test_stmt_no_args = func() + a
 end function
   
@@ -85,15 +92,15 @@ end function
 integer function test_stmt_character(c, j)
    integer :: i, j, func, argj
    character(10) :: c, argc
-   !CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
-   !CHECK-DAG: %[[c10:.*]] = constant 10 :
-   !CHECK: %[[c:.*]] = fir.emboxchar %[[unboxed]]#0, %[[c10]] 
+   ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
+   ! CHECK-DAG: %[[c10:.*]] = constant 10 :
+   ! CHECK: %[[c:.*]] = fir.emboxchar %[[unboxed]]#0, %[[c10]] 
 
    func(argc, argj) = len_trim(argc, 4) + argj
-   !CHECK-DAG: %[[j:.*]] = fir.load %arg1
-   !CHECK-DAG: %[[c4:.*]] = constant 4 :
-   !CHECK-DAG: %[[len_trim:.*]] = fir.call @fir.len_trim.i32.bc1.i32(%[[c]], %[[c4]])
-   !CHECK: addi %[[len_trim]], %[[j]]
+   ! CHECK-DAG: %[[j:.*]] = fir.load %arg1
+   ! CHECK-DAG: %[[c4:.*]] = constant 4 :
+   ! CHECK-DAG: %[[len_trim:.*]] = fir.call @fir.len_trim.i32.bc1.i32(%[[c]], %[[c4]])
+   ! CHECK: addi %[[len_trim]], %[[j]]
    test_stmt_character = func(c, j)
 end function  
 


### PR DESCRIPTION
lowering symbol table has a legal type.

Corrects a number of bugs associated with fixing the symbol table, etc.
