### PR TITLE
[flang][openacc] Lower rest of clauses for the loop construct

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/OpenACC.h"
+#include "SymbolMap.h"
+#include "flang/Common/idioms.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/FIRBuilder.h"
 #include "flang/Lower/PFTBuilder.h"
@@ -21,7 +23,36 @@
 
 #define TODO() llvm_unreachable("not yet implemented")
 
-static void genACC(Fortran::lower::AbstractConverter &absConv,
+static const Fortran::parser::Name *
+GetDesignatorNameIfDataRef(const Fortran::parser::Designator &designator) {
+  const auto *dataRef{std::get_if<Fortran::parser::DataRef>(&designator.u)};
+  return dataRef ? std::get_if<Fortran::parser::Name>(&dataRef->u) : nullptr;
+}
+
+static void genObjectList(const Fortran::parser::AccObjectList &objectList,
+                          Fortran::lower::AbstractConverter &converter,
+                          std::int32_t &objectsCount,
+                          SmallVector<Value, 8> &operands) {
+  for (const auto &accObject : objectList.v) {
+    std::visit(
+        Fortran::common::visitors{
+            [&](const Fortran::parser::Designator &designator) {
+              if (const auto *name = GetDesignatorNameIfDataRef(designator)) {
+                ++objectsCount;
+                const auto variable = converter.getSymbolAddress(*name->symbol);
+                operands.push_back(variable);
+              }
+            },
+            [&](const Fortran::parser::Name &name) {
+              ++objectsCount;
+              const auto variable = converter.getSymbolAddress(*name.symbol);
+              operands.push_back(variable);
+            }},
+        accObject.u);
+  }
+}
+
+static void genACC(Fortran::lower::AbstractConverter &converter,
                    Fortran::lower::pft::Evaluation &eval,
                    const Fortran::parser::OpenACCLoopConstruct &loopConstruct) {
 
@@ -31,53 +62,142 @@ static void genACC(Fortran::lower::AbstractConverter &absConv,
       std::get<Fortran::parser::AccLoopDirective>(beginLoopDirective.t);
 
   if (loopDirective.v == llvm::acc::ACCD_loop) {
-    auto &firOpBuilder = absConv.getFirOpBuilder();
-    auto currentLocation = absConv.getCurrentLocation();
+    auto &firOpBuilder = converter.getFirOpBuilder();
+    auto currentLocation = converter.getCurrentLocation();
     llvm::ArrayRef<mlir::Type> argTy;
-    mlir::ValueRange range;
-    // Temporarly set to default 0 as operands are not generated yet.
-    llvm::SmallVector<int32_t, 2> operandSegmentSizes(/*Size=*/7,
-                                                      /*Value=*/0);
-    auto loopOp =
-        firOpBuilder.create<mlir::acc::LoopOp>(currentLocation, argTy, range);
-    loopOp.setAttr(mlir::acc::LoopOp::getOperandSegmentSizeAttr(),
-                   firOpBuilder.getI32VectorAttr(operandSegmentSizes));
+
+    // Add attribute extracted from clauses.
+    const auto &accClauseList =
+        std::get<Fortran::parser::AccClauseList>(beginLoopDirective.t);
+
+    mlir::Value workerNum;
+    mlir::Value vectorLength;
+    mlir::Value gangNum;
+    mlir::Value gangStatic;
+    std::int32_t tileOperands = 0;
+    std::int32_t privateOperands = 0;
+    std::int32_t reductionOperands = 0;
+    std::int64_t executionMapping = mlir::acc::OpenACCExecMapping::NONE;
+    SmallVector<Value, 8> operands;
+
+    // Lower clauses values mapped to operands.
+    for (const auto &clause : accClauseList.v) {
+      if (const auto *gangClause =
+              std::get_if<Fortran::parser::AccClause::Gang>(&clause.u)) {
+        if (gangClause->v) {
+          const Fortran::parser::AccGangArgument &x = *gangClause->v;
+          if (const auto &gangNumValue =
+                  std::get<std::optional<Fortran::parser::ScalarIntExpr>>(
+                      x.t)) {
+            gangNum = converter.genExprValue(
+                *Fortran::semantics::GetExpr(gangNumValue.value()));
+            operands.push_back(gangNum);
+          }
+          if (const auto &gangStaticValue =
+                  std::get<std::optional<Fortran::parser::AccSizeExpr>>(x.t)) {
+            const auto &expr =
+                std::get<std::optional<Fortran::parser::ScalarIntExpr>>(
+                    gangStaticValue.value().t);
+            if (expr) {
+              gangStatic = converter.genExprValue(
+                  *Fortran::semantics::GetExpr(*expr));
+            } else {
+              // * was passed as value and will be represented as a -1 constant
+              // integer.
+              gangStatic = firOpBuilder.createIntegerConstant(
+                  currentLocation, firOpBuilder.getIntegerType(32),
+                  /* STAR */ -1);
+            }
+            operands.push_back(gangStatic);
+          }
+        }
+        executionMapping |= mlir::acc::OpenACCExecMapping::GANG;
+      } else if (const auto *workerClause =
+                     std::get_if<Fortran::parser::AccClause::Worker>(
+                         &clause.u)) {
+        if (workerClause->v) {
+          workerNum = converter.genExprValue(
+              *Fortran::semantics::GetExpr(*workerClause->v));
+          operands.push_back(workerNum);
+        }
+        executionMapping |= mlir::acc::OpenACCExecMapping::WORKER;
+      } else if (const auto *vectorClause =
+                     std::get_if<Fortran::parser::AccClause::Vector>(
+                         &clause.u)) {
+        if (vectorClause->v) {
+          vectorLength = converter.genExprValue(
+              *Fortran::semantics::GetExpr(*vectorClause->v));
+          operands.push_back(vectorLength);
+        }
+        executionMapping |= mlir::acc::OpenACCExecMapping::VECTOR;
+      } else if (const auto *tileClause =
+                     std::get_if<Fortran::parser::AccClause::Tile>(&clause.u)) {
+        const Fortran::parser::AccTileExprList &accTileExprList = tileClause->v;
+        for (const auto &accTileExpr : accTileExprList.v) {
+          const auto &expr =
+              std::get<std::optional<Fortran::parser::ScalarIntConstantExpr>>(
+                  accTileExpr.t);
+          ++tileOperands;
+          if (expr) {
+            operands.push_back(converter.genExprValue(
+                *Fortran::semantics::GetExpr(*expr)));
+          } else {
+            // * was passed as value and will be represented as a -1 constant
+            // integer.
+            mlir::Value tileStar = firOpBuilder.createIntegerConstant(
+                currentLocation, firOpBuilder.getIntegerType(32),
+                /* STAR */ -1);
+            operands.push_back(tileStar);
+          }
+        }
+      } else if (const auto *privateClause =
+                     std::get_if<Fortran::parser::AccClause::Private>(
+                         &clause.u)) {
+        const Fortran::parser::AccObjectList &accObjectList = privateClause->v;
+        genObjectList(accObjectList, converter, privateOperands, operands);
+      }
+      // Reduction clause is left out for the moment as the clause will probably
+      // end up having its own operation.
+    }
+
+    auto loopOp = firOpBuilder.create<mlir::acc::LoopOp>(currentLocation, argTy,
+                                                         operands);
+
     firOpBuilder.createBlock(&loopOp.getRegion());
     auto &block = loopOp.getRegion().back();
     firOpBuilder.setInsertionPointToStart(&block);
     // ensure the block is well-formed.
     firOpBuilder.create<mlir::acc::YieldOp>(currentLocation);
 
-    // Add attribute extracted from clauses.
-    const auto &accClauseList =
-        std::get<Fortran::parser::AccClauseList>(beginLoopDirective.t);
+    loopOp.setAttr(mlir::acc::LoopOp::getOperandSegmentSizeAttr(),
+                   firOpBuilder.getI32VectorAttr(
+                       {gangNum ? 1 : 0, gangStatic ? 1 : 0, workerNum ? 1 : 0,
+                        vectorLength ? 1 : 0, tileOperands, privateOperands,
+                        reductionOperands}));
 
+    loopOp.setAttr(mlir::acc::LoopOp::getExecutionMappingAttrName(),
+                   firOpBuilder.getI64IntegerAttr(executionMapping));
+
+    // Lower clauses mapped to attributes
     for (const auto &clause : accClauseList.v) {
       if (const auto *collapseClause =
               std::get_if<Fortran::parser::AccClause::Collapse>(&clause.u)) {
-
         const auto *expr = Fortran::semantics::GetExpr(collapseClause->v);
         const auto collapseValue = Fortran::evaluate::ToInt64(*expr);
-        if (collapseValue.has_value()) {
+        if (collapseValue) {
           loopOp.setAttr(mlir::acc::LoopOp::getCollapseAttrName(),
-                         firOpBuilder.getI64IntegerAttr(collapseValue.value()));
+                         firOpBuilder.getI64IntegerAttr(*collapseValue));
         }
-      } else if (const auto *seqClause =
-                     std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
-        (void)seqClause;
-      } else if (const auto *gangClause =
-                     std::get_if<Fortran::parser::AccClause::Gang>(&clause.u)) {
-        (void)gangClause;
-      } else if (const auto *vectorClause =
-                     std::get_if<Fortran::parser::AccClause::Vector>(
-                         &clause.u)) {
-        (void)vectorClause;
-      } else if (const auto *workerClause =
-                     std::get_if<Fortran::parser::AccClause::Worker>(
-                         &clause.u)) {
-        (void)workerClause;
-      } else {
-        TODO();
+      } else if (std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
+        loopOp.setAttr(mlir::acc::LoopOp::getSeqAttrName(),
+                       firOpBuilder.getUnitAttr());
+      } else if (std::get_if<Fortran::parser::AccClause::Independent>(
+                     &clause.u)) {
+        loopOp.setAttr(mlir::acc::LoopOp::getIndependentAttrName(),
+                       firOpBuilder.getUnitAttr());
+      } else if (std::get_if<Fortran::parser::AccClause::Auto>(&clause.u)) {
+        loopOp.setAttr(mlir::acc::LoopOp::getAutoAttrName(),
+                       firOpBuilder.getUnitAttr());
       }
     }
 

--- a/flang/test/Lower/OpenACC/acc-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-loop.f90
@@ -8,6 +8,10 @@ program acc_loop
   integer, parameter :: n = 10
   real, dimension(n) :: a, b
   real, dimension(n, n) :: c, d
+  integer :: gangNum = 8
+  integer :: gangStatic = 8
+  integer :: vectorLength = 128
+  integer, parameter :: tileSize = 2
 
 
   !$acc loop
@@ -18,7 +22,218 @@ program acc_loop
 !CHECK:      acc.loop {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
-!CHECK-NEXT: }
+!CHECK-NEXT: }{{$}}
+
+ !$acc loop seq
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {seq}
+
+  !$acc loop auto
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {auto}
+
+  !$acc loop independent
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {independent}
+
+  !$acc loop gang
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop gang {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop gang(num: 8)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      [[GANGNUM1:%.*]] = constant 8 : i32
+!CHECK-NEXT: acc.loop gang(num: [[GANGNUM1]]) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop gang(num: gangNum)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK-NEXT: acc.loop gang(num: [[GANGNUM2]]) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+ !$acc loop gang(num: gangNum, static: gangStatic)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK: acc.loop gang(num: %{{.*}}, static: %{{.*}}) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop vector
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop vector {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop vector(128)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK: [[CONSTANT128:%.*]] = constant 128 : i32
+!CHECK:      acc.loop vector([[CONSTANT128]]) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop vector(vectorLength)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      [[VECTORLENGTH:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.loop vector([[VECTORLENGTH]]) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+!$acc loop worker
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop worker {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop worker(128)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK: [[WORKER128:%.*]] = constant 128 : i32
+!CHECK:      acc.loop worker([[WORKER128]]) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop private(c)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop private(%{{.*}}: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop private(c, d)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop private(%{{.*}}: !fir.ref<!fir.array<10x10xf32>>, %{{.*}}: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop private(c) private(d)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop private(%{{.*}}: !fir.ref<!fir.array<10x10xf32>>, %{{.*}}: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop tile(2)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+!CHECK:      [[TILESIZE:%.*]] = constant 2 : i32
+!CHECK:      acc.loop tile([[TILESIZE]]: i32) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+ !$acc loop tile(*)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+!CHECK:      [[TILESIZEM1:%.*]] = constant -1 : i32
+!CHECK:      acc.loop tile([[TILESIZEM1]]: i32) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop tile(2, 2)
+  DO i = 1, n
+    DO j = 1, n
+      c(i, j) = d(i, j)
+    END DO
+  END DO
+
+!CHECK:      [[TILESIZE1:%.*]] = constant 2 : i32
+!CHECK:      [[TILESIZE2:%.*]] = constant 2 : i32
+!CHECK:      acc.loop tile([[TILESIZE1]]: i32, [[TILESIZE2]]: i32) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop tile(tileSize)
+  DO i = 1, n
+    a(i) = b(i)
+  END DO
+
+!CHECK:      acc.loop tile(%{{.*}}: i32) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc loop tile(tileSize, tileSize)
+  DO i = 1, n
+    DO j = 1, n
+      c(i, j) = d(i, j)
+    END DO
+  END DO
+
+!CHECK:      acc.loop tile(%{{.*}}: i32, %{{.*}}: i32) {
+!CHECK:        fir.do_loop
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
 
   !$acc loop collapse(2)
   DO i = 1, n
@@ -46,9 +261,9 @@ program acc_loop
 !CHECK:          acc.loop {
 !CHECK:            fir.do_loop
 !CHECK:            acc.yield
-!CHECK-NEXT:   }
+!CHECK-NEXT:   }{{$}}
 !CHECK:        acc.yield
-!CHECK-NEXT: }
+!CHECK-NEXT: }{{$}}
 
 end program
 


### PR DESCRIPTION
Lower rest of the clauses for the loop Construct besides `reduction`. The `reduction` in the `acc.loop` operation will probably move to its own operation therefore it will be lowered once the operation is defined. 