### PR TITLE
Enable the assertion checking that a BoxValue has an address and resides

### DIFF
--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -54,8 +54,8 @@ class AbstractBox {
 public:
   AbstractBox() = delete;
   AbstractBox(mlir::Value addr) : addr{addr} {
-    //assert(isa_passbyref_type(addr.getType()) &&
-    //       "box values must be references");
+    assert(isa_passbyref_type(addr.getType()) &&
+           "box values must be references");
   }
 
   /// An abstract box always contains a memory reference to a value.
@@ -225,7 +225,11 @@ public:
   using VT = std::variant<UnboxedValue, CharBoxValue, ArrayBoxValue,
                           CharArrayBoxValue, BoxValue, ProcBoxValue>;
 
-  template <typename A>
+  ExtendedValue() : box{UnboxedValue{}} {}
+  ExtendedValue(const ExtendedValue &) = default;
+  ExtendedValue(ExtendedValue &&) = default;
+  template <typename A, typename = std::enable_if_t<
+                            !std::is_same_v<std::decay_t<A>, ExtendedValue>>>
   constexpr ExtendedValue(A &&box) : box{std::forward<A>(box)} {}
 
   template <typename A>

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1484,8 +1484,10 @@ private:
               if (isCharacterCategory(lhsType->category())) {
                 // Fortran 2018 10.2.1.3 p10 and p11
                 // Generating value for lhs to get fir.boxchar.
+                Fortran::lower::ExpressionContext context;
                 auto lhs = genExprAddr(assign.lhs);
-                auto rhs = genExprValue(assign.rhs);
+                auto rhs = createSomeExtendedExpression(
+                    toLocation(), *this, assign.rhs, localSymbols, context);
                 Fortran::lower::CharacterExprHelper{*builder, loc}.createAssign(
                     lhs, rhs);
                 return;
@@ -1798,11 +1800,11 @@ private:
           // Assume that the members of the COMMON block will appear in an order
           // that is sorted by offset.
           [[maybe_unused]] std::int64_t lastByteOff = -1;
-          LLVM_DEBUG(llvm::errs() << "block {\n");
+          LLVM_DEBUG(llvm::dbgs() << "block {\n");
           for (const auto &obj : details->objects()) {
             assert(lastByteOff < static_cast<std::int64_t>(obj->offset()));
             lastByteOff = static_cast<std::int64_t>(obj->offset());
-            LLVM_DEBUG(llvm::errs() << "offset: " << obj->offset() << '\n');
+            LLVM_DEBUG(llvm::dbgs() << "offset: " << obj->offset() << '\n');
             if (const auto *objDet =
                     obj->detailsIf<Fortran::semantics::ObjectEntityDetails>())
               if (objDet->init()) {
@@ -1814,7 +1816,7 @@ private:
                                                         castVal, off);
               }
           }
-          LLVM_DEBUG(llvm::errs() << "}\n");
+          LLVM_DEBUG(llvm::dbgs() << "}\n");
           builder.create<fir::HasValueOp>(loc, cb);
         };
         global = builder->createGlobal(loc, commonTy, globalName,

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -242,13 +242,12 @@ private:
                                 const fir::ExtendedValue &left,
                                 const fir::ExtendedValue &right) {
     if (auto *lhs = left.getUnboxed()) {
-      if (auto *rhs = right.getUnboxed()) {
+      if (auto *rhs = right.getUnboxed())
         return Fortran::lower::genBoxCharCompare(converter, getLoc(), pred,
                                                  *lhs, *rhs);
-      } else if (auto *rhs = right.getCharBox()) {
+      if (auto *rhs = right.getCharBox())
         return Fortran::lower::genBoxCharCompare(converter, getLoc(), pred,
                                                  *lhs, rhs->getBuffer());
-      }
     }
     if (auto *lhs = left.getCharBox()) {
       if (auto *rhs = right.getCharBox()) {
@@ -256,10 +255,10 @@ private:
         // addresses
         return Fortran::lower::genBoxCharCompare(
             converter, getLoc(), pred, lhs->getBuffer(), rhs->getBuffer());
-      } else if (auto *rhs = right.getUnboxed()) {
+      }
+      if (auto *rhs = right.getUnboxed())
         return Fortran::lower::genBoxCharCompare(converter, getLoc(), pred,
                                                  lhs->getBuffer(), *rhs);
-      }
     }
 
     // Error if execution reaches this point
@@ -1269,7 +1268,7 @@ private:
       return converter.genType(dt.category(), dt.kind());
     llvm::report_fatal_error("derived types not implemented");
   }
-  
+
   template <typename A>
   fir::ExtendedValue gen(const Fortran::evaluate::FunctionRef<A> &func) {
     assert(func.GetType().has_value() && "function has no type");
@@ -1353,7 +1352,7 @@ private:
       symMap.addSymbol(dummySymbol, genExtAddr(*expr));
     }
     auto result = genval(details.stmtFunction().value());
-    LLVM_DEBUG(llvm::errs() << "stmt-function: " << result << '\n');
+    LLVM_DEBUG(llvm::dbgs() << "stmt-function: " << result << '\n');
     // Remove dummy local arguments from the map.
     for (const auto *dummySymbol : details.dummyArgs())
       symMap.erase(*dummySymbol);
@@ -1594,8 +1593,8 @@ mlir::Value Fortran::lower::createSomeExpression(
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     Fortran::lower::SymMap &symMap) {
   Fortran::lower::ExpressionContext unused;
-  LLVM_DEBUG(llvm::errs() << "expr: "; expr.AsFortran(llvm::errs());
-             llvm::errs() << '\n');
+  LLVM_DEBUG(llvm::dbgs() << "expr: "; expr.AsFortran(llvm::dbgs());
+             llvm::dbgs() << '\n');
   return ExprLowering{loc, converter, symMap, unused}.genValue(expr);
 }
 
@@ -1604,8 +1603,8 @@ fir::ExtendedValue Fortran::lower::createSomeExtendedExpression(
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     Fortran::lower::SymMap &symMap,
     const Fortran::lower::ExpressionContext &context) {
-  LLVM_DEBUG(llvm::errs() << "expr: "; expr.AsFortran(llvm::errs());
-             llvm::errs() << '\n');
+  LLVM_DEBUG(llvm::dbgs() << "expr: "; expr.AsFortran(llvm::dbgs());
+             llvm::dbgs() << '\n');
   return ExprLowering{loc, converter, symMap, context}.genExtValue(expr);
 }
 
@@ -1614,8 +1613,8 @@ mlir::Value Fortran::lower::createSomeAddress(
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     Fortran::lower::SymMap &symMap) {
   Fortran::lower::ExpressionContext unused;
-  LLVM_DEBUG(llvm::errs() << "address: "; expr.AsFortran(llvm::errs());
-             llvm::errs() << '\n');
+  LLVM_DEBUG(llvm::dbgs() << "address: "; expr.AsFortran(llvm::dbgs());
+             llvm::dbgs() << '\n');
   return ExprLowering{loc, converter, symMap, unused}.genAddr(expr);
 }
 
@@ -1624,8 +1623,8 @@ fir::ExtendedValue Fortran::lower::createSomeExtendedAddress(
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     Fortran::lower::SymMap &symMap,
     const Fortran::lower::ExpressionContext &context) {
-  LLVM_DEBUG(llvm::errs() << "address: "; expr.AsFortran(llvm::errs());
-             llvm::errs() << '\n');
+  LLVM_DEBUG(llvm::dbgs() << "address: "; expr.AsFortran(llvm::dbgs());
+             llvm::dbgs() << '\n');
   return ExprLowering{loc, converter, symMap, context}.genExtAddr(expr);
 }
 
@@ -1635,7 +1634,7 @@ fir::ExtendedValue Fortran::lower::createStringLiteral(
   assert(str.size() == len);
   Fortran::lower::SymMap unused1;
   Fortran::lower::ExpressionContext unused2;
-  LLVM_DEBUG(llvm::errs() << "string-lit: \"" << str << "\"\n");
+  LLVM_DEBUG(llvm::dbgs() << "string-lit: \"" << str << "\"\n");
   return ExprLowering{loc, converter, unused1, unused2}.genStringLit(str, len);
 }
 

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1271,7 +1271,7 @@ mlir::Value IntrinsicLibrary::genIchar(mlir::Type resultType,
     auto cast = builder.createConvert(loc, toTy, dataAndLen.first);
     charVal = builder.create<fir::LoadOp>(loc, cast);
   }
-  LLVM_DEBUG(llvm::errs() << "ichar(" << charVal << ")\n");
+  LLVM_DEBUG(llvm::dbgs() << "ichar(" << charVal << ")\n");
   return builder.createConvert(loc, resultType, charVal);
 }
 

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -96,7 +96,7 @@ public:
     auto xbox = rewriter.create<XEmboxOp>(loc, embox.getType(), embox.memref(),
                                           shapeOpers, llvm::None, llvm::None,
                                           llvm::None, attrs);
-    LLVM_DEBUG(llvm::errs() << "rewriting " << embox << " to " << xbox << '\n');
+    LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
   }
@@ -140,7 +140,7 @@ public:
     auto xbox = rewriter.create<XEmboxOp>(loc, embox.getType(), embox.memref(),
                                           shapeOpers, shiftOpers, sliceOpers,
                                           embox.getLenParams(), attrs);
-    LLVM_DEBUG(llvm::errs() << "rewriting " << embox << " to " << xbox << '\n');
+    LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
   }
@@ -194,7 +194,7 @@ public:
     auto xArrCoor = rewriter.create<XArrayCoorOp>(
         loc, arrCoor.getType(), arrCoor.memref(), shapeOpers, shiftOpers,
         sliceOpers, arrCoor.indices(), arrCoor.lenParams(), attrs);
-    LLVM_DEBUG(llvm::errs()
+    LLVM_DEBUG(llvm::dbgs()
                << "rewriting " << arrCoor << " to " << xArrCoor << '\n');
     rewriter.replaceOp(arrCoor, xArrCoor.getOperation()->getResults());
     return mlir::success();
@@ -523,7 +523,7 @@ public:
       assert(callOp.callee().hasValue() && "indirect call not implemented");
       auto newCall = rewriter->create<A>(loc, callOp.callee().getValue(),
                                          newResTys, newOpers);
-      LLVM_DEBUG(llvm::errs() << "replacing call with " << newCall << '\n');
+      LLVM_DEBUG(llvm::dbgs() << "replacing call with " << newCall << '\n');
       if (wrap.hasValue())
         replaceOp(callOp, (*wrap)(newCall.getOperation()));
       else
@@ -626,13 +626,13 @@ public:
     for (auto ty : func.getResults())
       if ((ty.isa<BoxCharType>() && !noCharacterConversion) ||
           (isa_complex(ty) && !noComplexConversion)) {
-        LLVM_DEBUG(llvm::errs() << "rewrite " << signature << " for target\n");
+        LLVM_DEBUG(llvm::dbgs() << "rewrite " << signature << " for target\n");
         return false;
       }
     for (auto ty : func.getInputs())
       if ((ty.isa<BoxCharType>() && !noCharacterConversion) ||
           (isa_complex(ty) && !noComplexConversion)) {
-        LLVM_DEBUG(llvm::errs() << "rewrite " << signature << " for target\n");
+        LLVM_DEBUG(llvm::dbgs() << "rewrite " << signature << " for target\n");
         return false;
       }
     return true;
@@ -751,7 +751,7 @@ public:
           mlir::Value load = rewriter->create<fir::LoadOp>(loc, cast);
           func.getArgument(fixup.index + 1).replaceAllUsesWith(load);
           func.front().eraseArgument(fixup.index + 1);
-          LLVM_DEBUG(llvm::errs()
+          LLVM_DEBUG(llvm::dbgs()
                      << "old argument: " << oldArgTy.getEleTy()
                      << ", repl: " << load << ", new argument: "
                      << func.getArgument(fixup.index).getType() << '\n');
@@ -850,7 +850,7 @@ public:
     newInTys.insert(newInTys.end(), trailingTys.begin(), trailingTys.end());
     auto newFuncTy =
         mlir::FunctionType::get(newInTys, newResTys, func.getContext());
-    LLVM_DEBUG(llvm::errs() << "new func: " << newFuncTy << '\n');
+    LLVM_DEBUG(llvm::dbgs() << "new func: " << newFuncTy << '\n');
     func.setType(newFuncTy);
 
     for (auto &fixup : fixups)

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -21,7 +21,7 @@ subroutine assign1(lhs, rhs)
 
   ! Copy of rhs into temp
   ! CHECK: fir.do_loop %[[i:.*]] =
-    ! CHECK: %[[rhs_addr2:.*]] = fir.convert %[[rhs]]#0
+    ! CHECK: %[[rhs_addr2:.*]] = fir.convert %{{[0-9]+}}#0
     ! CHECK-DAG: %[[rhs_addr:.*]] = fir.coordinate_of %[[rhs_addr2]], %[[i]]
     ! CHECK-DAG: %[[rhs_elt:.*]] = fir.load %[[rhs_addr]]
     ! CHECK-DAG: %[[tmp2:.*]] = fir.convert %[[tmp]]


### PR DESCRIPTION
in memory. The remaining issues were problems with the lowering of
CHARACTER variables and values. This patch attempts to clean up some of
that, passing CharBoxValue and Value where appropriate, etc.

Use llvm::dbgs() consistently.

Some clean up of other small TODOs and FIXMEs.