### PR TITLE
Finish a TODO in IO lowering for generating unreachable op.

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -1021,18 +1021,12 @@ lowerReferenceAsStringSelect(
     builder.setInsertionPointToEnd(block);
   }
 
-  // Create the unit case which should result in an error
+  // Create the unit case which should result in an error.
   auto *unitBlock = block->splitBlock(builder.getInsertionPoint());
   builder.setInsertionPointToEnd(unitBlock);
-
-  // TODO: Replace with instructions to crash the program
-  auto emptyString = fir::getBase(createStringLiteral(loc, converter, "", 0));
-  auto emptyStringRef = builder.createConvert(loc, strTy, emptyString);
-  auto zero = builder.create<mlir::ConstantIntOp>(loc, 0, builder.getI64Type());
-  llvm::SmallVector<mlir::Value, 8> args;
-  args.push_back(emptyStringRef);
-  args.push_back(zero);
-  builder.create<mlir::BranchOp>(loc, endBlock, args);
+  
+  // Crash the program.
+  builder.create<fir::UnreachableOp>(loc);
 
   // Add unit case to the select statement
   blockList.push_back(unitBlock);

--- a/flang/test/Lower/format.f90
+++ b/flang/test/Lower/format.f90
@@ -6,28 +6,29 @@ function formatAssign()
     integer :: label
     logical :: flag
 
-    ! CHECK: select
+    ! CHECK-DAG: %[[ONE:.*]] = constant 100 : i32
+    ! CHECK-DAG: %[[TWO:.*]] = constant 200 : i32
+    ! CHECK: %{{.*}} = select %{{.*}}, %[[ONE]], %[[TWO]] : i32
     if (flag) then
        assign 100 to label
     else
        assign 200 to label
     end if
 
-    ! CHECK: fir.select {{.*\[100, \^bb[0-9]+, 200, \^bb[0-9]+, unit, \^bb[0-9]+\]}}
-    ! CHECK-LABEL: ^bb{{[0-9]+}}:
-    ! CHECK: fir.address_of
-    ! CHECK: br [[END_BLOCK:\^bb[0-9]+]]{{(.*)}}
-    ! CHECK-LABEL: ^bb{{[0-9]+}}: //
-    ! CHECK: fir.address_of
-    ! CHECK: br [[END_BLOCK]]
-    ! CHECK-LABEL: ^bb{{[0-9]+}}: //
-    ! CHECK: fir.address_of
-    ! CHECK: br [[END_BLOCK]]
-    ! CHECK-LABEL: ^bb{{[0-9]+(.*)}}: //
-    ! CHECK: call{{.*}}BeginExternalFormattedOutput
-    ! CHECK-DAG: call{{.*}}OutputAscii
-    ! CHECK-DAG: call{{.*}}OutputReal32
-    ! CHECK: call{{.*}}EndIoStatement
+    ! CHECK: fir.select %{{.*}} [100, ^bb[[BLK1:.*]], 200, ^bb[[BLK2:.*]], unit, ^bb[[BLK3:.*]]]
+    ! CHECK: ^bb[[BLK1]]:
+    ! CHECK: fir.address_of(@_QQcl
+    ! CHECK: br ^bb[[END_BLOCK:.*]](
+    ! CHECK: ^bb[[BLK2]]:
+    ! CHECK: fir.address_of(@_QQcl
+    ! CHECK: br ^bb[[END_BLOCK]](
+    ! CHECK: ^bb[[BLK3]]:
+    ! CHECK-NEXT: fir.unreachable
+    ! CHECK: ^bb[[END_BLOCK]](
+    ! CHECK: fir.call @{{.*}}BeginExternalFormattedOutput
+    ! CHECK: fir.call @{{.*}}OutputAscii
+    ! CHECK: fir.call @{{.*}}OutputReal32
+    ! CHECK: fir.call @{{.*}}EndIoStatement
     pi = 3.141592653589
     write(*, label) "PI=", pi
  

--- a/flang/test/Lower/stop.f90
+++ b/flang/test/Lower/stop.f90
@@ -5,6 +5,7 @@ subroutine stop_test(b)
  ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
  ! CHECK-DAG: %[[false:.*]] = constant false
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[false]])
+ ! CHECK-NEXT: fir.unreachable
  stop
 end subroutine
 
@@ -14,6 +15,7 @@ subroutine stop_code()
  ! CHECK-DAG: %[[c42:.*]] = constant 42 : i32
  ! CHECK-DAG: %[[false:.*]] = constant false
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c42]], %[[false]], %[[false]])
+ ! CHECK-NEXT: fir.unreachable
 end subroutine
 
 ! CHECK-LABEL stop_error
@@ -23,6 +25,7 @@ subroutine stop_error()
  ! CHECK-DAG: %[[true:.*]] = constant true
  ! CHECK-DAG: %[[false:.*]] = constant false
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[true]], %[[false]])
+ ! CHECK-NEXT: fir.unreachable
 end subroutine
 
 ! CHECK-LABEL stop_quiet
@@ -34,6 +37,7 @@ subroutine stop_quiet(b)
  ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
  ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[bi1]])
+ ! CHECK-NEXT: fir.unreachable
 end subroutine
 
 ! CHECK-LABEL stop_error_code_quiet
@@ -45,6 +49,7 @@ subroutine stop_error_code_quiet(b)
  ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
  ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
  ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c66]], %[[true]], %[[bi1]])
+ ! CHECK-NEXT: fir.unreachable
 end subroutine
 
 ! CHECK: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none


### PR DESCRIPTION
Fixes regressions introduced in lowering runtime calls that do not return.