### PR TITLE
Fix some problems on macos

### DIFF
--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -173,6 +173,7 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &trp,
     default:
       break;
     case llvm::Triple::OSType::Linux:
+    case llvm::Triple::OSType::Darwin:
       return std::make_unique<TargetI386>(ctx, trp, kindMap);
     }
     break;
@@ -181,6 +182,7 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &trp,
     default:
       break;
     case llvm::Triple::OSType::Linux:
+    case llvm::Triple::OSType::Darwin:
       return std::make_unique<TargetX86_64>(ctx, trp, kindMap);
     }
     break;

--- a/flang/runtime/clock.cpp
+++ b/flang/runtime/clock.cpp
@@ -10,6 +10,7 @@
 
 #include "clock.h"
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <stdio.h>
@@ -43,8 +44,8 @@ void RTNAME(DateAndTime)(char *date, char *time, char *zone,
     copyBufferAndPad(date, dateChars, len);
   }
   if (time) {
-    auto ms{t.tv_usec / 1000};
-    auto len{::snprintf(buffer, buffSize, "%02d%02d%02d.%03ld",
+    std::intmax_t ms{t.tv_usec / 1000};
+    auto len{::snprintf(buffer, buffSize, "%02d%02d%02d.%03jd",
         localTime.tm_hour, localTime.tm_min, localTime.tm_sec, ms)};
     copyBufferAndPad(time, timeChars, len);
   }


### PR DESCRIPTION
`timeval.tv_usec` is int on macos, not long, so there was a warning about
using `snprintf` with %03ld format conversion. Use an explicit type of long
for `ms` to prevent this.

`OSType::Darwin` was an unknown target. Do the same thing for it as for Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flang-compiler/f18-llvm-project/429)
<!-- Reviewable:end -->
