### PR TITLE
Pass around extended values so that they can be used in more places.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -14,14 +14,16 @@
 #define FORTRAN_LOWER_ABSTRACTCONVERTER_H
 
 #include "flang/Common/Fortran.h"
+#include "flang/Lower/Support/BoxValue.h"
+#include "flang/Lower/Utils.h"
 #include "mlir/IR/Module.h"
-#include "Utils.h"
 
 namespace Fortran {
 namespace common {
 template <typename>
 class Reference;
 }
+
 namespace evaluate {
 struct DataRef;
 template <typename>
@@ -66,25 +68,26 @@ public:
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;
 
   /// Get the code defined by a label
-  virtual Fortran::lower::pft::Evaluation* lookupLabel(pft::Label label) = 0;
+  virtual Fortran::lower::pft::Evaluation *lookupLabel(pft::Label label) = 0;
 
   //===--------------------------------------------------------------------===//
   // Expressions
   //===--------------------------------------------------------------------===//
 
   /// Generate the address of the location holding the expression, someExpr
-  virtual mlir::Value genExprAddr(const SomeExpr &,
-                                  mlir::Location *loc = nullptr) = 0;
+  virtual fir::ExtendedValue genExprAddr(const SomeExpr &,
+                                         mlir::Location *loc = nullptr) = 0;
   /// Generate the address of the location holding the expression, someExpr
-  mlir::Value genExprAddr(const SomeExpr *someExpr, mlir::Location loc) {
+  fir::ExtendedValue genExprAddr(const SomeExpr *someExpr, mlir::Location loc) {
     return genExprAddr(*someExpr, &loc);
   }
 
   /// Generate the computations of the expression to produce a value
-  virtual mlir::Value genExprValue(const SomeExpr &,
-                                   mlir::Location *loc = nullptr) = 0;
+  virtual fir::ExtendedValue genExprValue(const SomeExpr &,
+                                          mlir::Location *loc = nullptr) = 0;
   /// Generate the computations of the expression, someExpr, to produce a value
-  mlir::Value genExprValue(const SomeExpr *someExpr, mlir::Location loc) {
+  fir::ExtendedValue genExprValue(const SomeExpr *someExpr,
+                                  mlir::Location loc) {
     return genExprValue(*someExpr, &loc);
   }
 

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -31,7 +31,6 @@
 #include "mlir/IR/Function.h"
 #include <memory>
 #include <optional>
-#include <string>
 
 namespace Fortran::semantics {
 class Symbol;

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -26,6 +26,10 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 
+namespace fir {
+class ExtendedValue;
+}
+
 namespace Fortran::lower {
 
 class AbstractConverter;
@@ -142,21 +146,13 @@ public:
   // Linkage helpers (inline). The default linkage is external.
   //===--------------------------------------------------------------------===//
 
-  mlir::StringAttr createCommonLinkage() {
-    return getStringAttr("common");
-  }
+  mlir::StringAttr createCommonLinkage() { return getStringAttr("common"); }
 
-  mlir::StringAttr createInternalLinkage() {
-    return getStringAttr("internal");
-  }
+  mlir::StringAttr createInternalLinkage() { return getStringAttr("internal"); }
 
-  mlir::StringAttr createLinkOnceLinkage() {
-    return getStringAttr("linkonce");
-  }
+  mlir::StringAttr createLinkOnceLinkage() { return getStringAttr("linkonce"); }
 
-  mlir::StringAttr createWeakLinkage() {
-    return getStringAttr("weak");
-  }
+  mlir::StringAttr createWeakLinkage() { return getStringAttr("weak"); }
 
   /// Get a function by name. If the function exists in the current module, it
   /// is returned. Otherwise, a null FuncOp is returned.
@@ -211,6 +207,9 @@ public:
   mlir::Value convertToIndexType(mlir::Location loc, mlir::Value val) {
     return createConvert(loc, getIndexType(), val);
   }
+
+  /// Create one of the shape ops given an extended value.
+  mlir::Value createShape(mlir::Location loc, const fir::ExtendedValue &exv);
 
 private:
   const fir::KindMapping &kindMap;

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2181,27 +2181,27 @@ def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
   let results = (outs Variadic<AnyType>:$results);
 
   let regions = (region
-    SizedRegion<1>:$whereRegion,
-    AnyRegion:$otherRegion
+    SizedRegion<1>:$thenRegion,
+    AnyRegion:$elseRegion
   );
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<"OpBuilder &builder, OperationState &result, "
-              "Value cond, bool withOtherRegion">,
+              "Value cond, bool withElseRegion">,
     OpBuilder<"OpBuilder &builder, OperationState &result, "
-              "TypeRange resultTypes, Value cond, bool withOtherRegion">
+              "TypeRange resultTypes, Value cond, bool withElseRegion">
   ];
 
   let extraClassDeclaration = [{
     mlir::OpBuilder getWhereBodyBuilder() {
-      assert(!whereRegion().empty() && "Unexpected empty 'where' region.");
-      mlir::Block &body = whereRegion().front();
+      assert(!thenRegion().empty() && "Unexpected empty 'where' region.");
+      mlir::Block &body = thenRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
     mlir::OpBuilder getOtherBodyBuilder() {
-      assert(!otherRegion().empty() && "Unexpected empty 'other' region.");
-      mlir::Block &body = otherRegion().front();
+      assert(!elseRegion().empty() && "Unexpected empty 'other' region.");
+      mlir::Block &body = elseRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
   }];

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -144,7 +144,7 @@ mlir::Value Fortran::lower::CallerInterface::getResultLength() {
   assert(typeAndShape && "no result type");
   auto expr = AsGenericExpr(typeAndShape->LEN().value());
   if (Fortran::evaluate::IsConstantExpr(expr))
-    return converter.genExprValue(expr);
+    return fir::getBase(converter.genExprValue(expr));
   llvm_unreachable(
       "non constant result length on caller side not yet safely handled");
 }

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -89,8 +89,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
           if (const auto &gangNumValue =
                   std::get<std::optional<Fortran::parser::ScalarIntExpr>>(
                       x.t)) {
-            gangNum = converter.genExprValue(
-                *Fortran::semantics::GetExpr(gangNumValue.value()));
+            gangNum = fir::getBase(converter.genExprValue(
+                *Fortran::semantics::GetExpr(gangNumValue.value())));
             operands.push_back(gangNum);
           }
           if (const auto &gangStaticValue =
@@ -99,8 +99,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                 std::get<std::optional<Fortran::parser::ScalarIntExpr>>(
                     gangStaticValue.value().t);
             if (expr) {
-              gangStatic = converter.genExprValue(
-                  *Fortran::semantics::GetExpr(*expr));
+              gangStatic = fir::getBase(
+                  converter.genExprValue(*Fortran::semantics::GetExpr(*expr)));
             } else {
               // * was passed as value and will be represented as a -1 constant
               // integer.
@@ -116,8 +116,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                      std::get_if<Fortran::parser::AccClause::Worker>(
                          &clause.u)) {
         if (workerClause->v) {
-          workerNum = converter.genExprValue(
-              *Fortran::semantics::GetExpr(*workerClause->v));
+          workerNum = fir::getBase(converter.genExprValue(
+              *Fortran::semantics::GetExpr(*workerClause->v)));
           operands.push_back(workerNum);
         }
         executionMapping |= mlir::acc::OpenACCExecMapping::WORKER;
@@ -125,8 +125,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                      std::get_if<Fortran::parser::AccClause::Vector>(
                          &clause.u)) {
         if (vectorClause->v) {
-          vectorLength = converter.genExprValue(
-              *Fortran::semantics::GetExpr(*vectorClause->v));
+          vectorLength = fir::getBase(converter.genExprValue(
+              *Fortran::semantics::GetExpr(*vectorClause->v)));
           operands.push_back(vectorLength);
         }
         executionMapping |= mlir::acc::OpenACCExecMapping::VECTOR;
@@ -139,8 +139,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                   accTileExpr.t);
           ++tileOperands;
           if (expr) {
-            operands.push_back(converter.genExprValue(
-                *Fortran::semantics::GetExpr(*expr)));
+            operands.push_back(fir::getBase(
+                converter.genExprValue(*Fortran::semantics::GetExpr(*expr))));
           } else {
             // * was passed as value and will be represented as a -1 constant
             // integer.

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -99,8 +99,8 @@ genOMP(Fortran::lower::AbstractConverter &absConv,
       if (const auto &numThreadsClause =
               std::get_if<Fortran::parser::OmpClause::NumThreads>(&clause.u)) {
         // OMPIRBuilder expects `NUM_THREAD` clause as a `Value`.
-        numThreads = absConv.genExprValue(
-            *Fortran::semantics::GetExpr(numThreadsClause->v));
+        numThreads = fir::getBase(absConv.genExprValue(
+            *Fortran::semantics::GetExpr(numThreadsClause->v)));
       }
     }
     llvm::ArrayRef<mlir::Type> argTy;

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -85,7 +85,7 @@ void Fortran::lower::genStopStatement(
           std::get<std::optional<Fortran::parser::StopCode>>(stmt.t)) {
     auto expr = Fortran::semantics::GetExpr(*code);
     assert(expr && "failed getting typed expression");
-    operands.push_back(converter.genExprValue(*expr));
+    operands.push_back(fir::getBase(converter.genExprValue(*expr)));
   } else {
     operands.push_back(
         builder.createIntegerConstant(loc, calleeType.getInput(0), 0));
@@ -101,7 +101,7 @@ void Fortran::lower::genStopStatement(
           std::get<std::optional<Fortran::parser::ScalarLogicalExpr>>(stmt.t)) {
     auto expr = Fortran::semantics::GetExpr(*quiet);
     assert(expr && "failed getting typed expression");
-    operands.push_back(converter.genExprValue(*expr));
+    operands.push_back(fir::getBase(converter.genExprValue(*expr)));
   } else {
     operands.push_back(
         builder.createIntegerConstant(loc, calleeType.getInput(2), 0));

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1402,7 +1402,7 @@ static mlir::ParseResult parseIfOp(OpAsmParser &parser,
 }
 
 static LogicalResult verify(fir::IfOp op) {
-  if (op.getNumResults() != 0 && op.otherRegion().empty())
+  if (op.getNumResults() != 0 && op.elseRegion().empty())
     return op.emitOpError("must have an else block if defining values");
 
   return mlir::success();
@@ -1415,11 +1415,11 @@ static void print(mlir::OpAsmPrinter &p, fir::IfOp op) {
     p << " -> (" << op.getResultTypes() << ')';
     printBlockTerminators = true;
   }
-  p.printRegion(op.whereRegion(), /*printEntryBlockArgs=*/false,
+  p.printRegion(op.thenRegion(), /*printEntryBlockArgs=*/false,
                 printBlockTerminators);
 
   // Print the 'else' regions if it exists and has a block.
-  auto &otherReg = op.otherRegion();
+  auto &otherReg = op.elseRegion();
   if (!otherReg.empty()) {
     p << " else";
     p.printRegion(otherReg, /*printEntryBlockArgs=*/false,

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -507,7 +507,7 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     LLVM_DEBUG(llvm::dbgs() << "AffineIfConversion: rewriting if:\n";
                op.dump(););
-    auto &ifOps = op.whereRegion().front().getOperations();
+    auto &ifOps = op.thenRegion().front().getOperations();
     auto affineCondition = AffineIfCondition(op.condition());
     if (!affineCondition.integerSet) {
       LLVM_DEBUG(
@@ -517,12 +517,12 @@ public:
     }
     auto affineIf = rewriter.create<mlir::AffineIfOp>(
         op.getLoc(), affineCondition.integerSet.getValue(),
-        affineCondition.affineArgs, !op.otherRegion().empty());
+        affineCondition.affineArgs, !op.elseRegion().empty());
     rewriter.startRootUpdate(affineIf);
     affineIf.getThenBlock()->getOperations().splice(
         --affineIf.getThenBlock()->end(), ifOps, ifOps.begin(), --ifOps.end());
-    if (!op.otherRegion().empty()) {
-      auto &otherOps = op.otherRegion().front().getOperations();
+    if (!op.elseRegion().empty()) {
+      auto &otherOps = op.elseRegion().front().getOperations();
       affineIf.getElseBlock()->getOperations().splice(
           --affineIf.getElseBlock()->end(), otherOps, otherOps.begin(),
           --otherOps.end());

--- a/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
+++ b/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
@@ -157,7 +157,7 @@ public:
 
     // Move blocks from the "then" region to the region containing 'fir.if',
     // place it before the continuation block, and branch to it.
-    auto &ifOpRegion = ifOp.whereRegion();
+    auto &ifOpRegion = ifOp.thenRegion();
     auto *ifOpBlock = &ifOpRegion.front();
     auto *ifOpTerminator = ifOpRegion.back().getTerminator();
     auto ifOpTerminatorOperands = ifOpTerminator->getOperands();
@@ -170,7 +170,7 @@ public:
     // 'fir.if', place it before the continuation block and branch to it.  It
     // will be placed after the "then" regions.
     auto *otherwiseBlock = continueBlock;
-    auto &otherwiseRegion = ifOp.otherRegion();
+    auto &otherwiseRegion = ifOp.elseRegion();
     if (!otherwiseRegion.empty()) {
       otherwiseBlock = &otherwiseRegion.front();
       auto *otherwiseTerm = otherwiseRegion.back().getTerminator();


### PR DESCRIPTION
This implements the various TODO items in IO.cpp that needed extended values to construct correct code.

Fixes #371 #372 #373 #376 #385 #389