### PR TITLE
[flang][openacc] Lower parallel and data constructs

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -30,25 +30,79 @@ getDesignatorNameIfDataRef(const Fortran::parser::Designator &designator) {
 
 static void genObjectList(const Fortran::parser::AccObjectList &objectList,
                           Fortran::lower::AbstractConverter &converter,
-                          std::int32_t &objectsCount,
-                          SmallVector<Value, 8> &operands) {
+                          SmallVectorImpl<Value> &operands) {
   for (const auto &accObject : objectList.v) {
     std::visit(
         Fortran::common::visitors{
             [&](const Fortran::parser::Designator &designator) {
               if (const auto *name = getDesignatorNameIfDataRef(designator)) {
-                ++objectsCount;
                 const auto variable = converter.getSymbolAddress(*name->symbol);
                 operands.push_back(variable);
               }
             },
             [&](const Fortran::parser::Name &name) {
-              ++objectsCount;
               const auto variable = converter.getSymbolAddress(*name.symbol);
               operands.push_back(variable);
             }},
         accObject.u);
   }
+}
+
+template <typename Clause>
+static void genObjectListWithModifier(const Clause *x,
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::parser::AccDataModifier::Modifier mod,
+    SmallVectorImpl<Value> &operandsWithModifier,
+    SmallVectorImpl<Value> &operands) {
+  const Fortran::parser::AccObjectListWithModifier &listWithModifier = x->v;
+  const Fortran::parser::AccObjectList &accObjectList =
+      std::get<Fortran::parser::AccObjectList>(listWithModifier.t);
+  const auto &modifier =
+      std::get<std::optional<Fortran::parser::AccDataModifier>>(listWithModifier.t);
+  if (modifier && (*modifier).v == mod) {
+    genObjectList(accObjectList, converter, operandsWithModifier);
+  } else {
+    genObjectList(accObjectList, converter, operands);
+  }
+}
+
+static void addOperands(SmallVectorImpl<Value> &operands,
+                        SmallVectorImpl<int32_t> &operandSegments,
+                        const SmallVectorImpl<Value> &clauseOperands) {
+  operands.append(clauseOperands.begin(), clauseOperands.end());
+  operandSegments.push_back(clauseOperands.size());
+}
+
+static void addOperand(SmallVectorImpl<Value> &operands,
+                       SmallVectorImpl<int32_t> &operandSegments,
+                       const Value &clauseOperand) {
+  if (clauseOperand) {
+    operands.push_back(clauseOperand);
+    operandSegments.push_back(1);
+  } else {
+    operandSegments.push_back(0);
+  }
+}
+
+template<typename Op, typename Terminator>
+static Op createRegionOp(Fortran::lower::FirOpBuilder &builder,
+                         mlir::Location loc,
+                         const SmallVectorImpl<Value> &operands,
+                         const SmallVectorImpl<int32_t> &operandSegments) {
+  llvm::ArrayRef<mlir::Type> argTy;
+  Op op = builder.create<Op>(loc, argTy, operands);
+  builder.createBlock(&op.getRegion());
+  auto &block = op.getRegion().back();
+  builder.setInsertionPointToStart(&block);
+  builder.create<Terminator>(loc);
+
+  op.setAttr(Op::getOperandSegmentSizeAttr(),
+      builder.getI32VectorAttr(operandSegments));
+
+  // Place the insertion point to the start of the first block.
+  builder.setInsertionPointToStart(&block);
+
+  return op;
 }
 
 static void genACC(Fortran::lower::AbstractConverter &converter,
@@ -73,11 +127,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
     mlir::Value vectorLength;
     mlir::Value gangNum;
     mlir::Value gangStatic;
-    std::int32_t tileOperands = 0;
-    std::int32_t privateOperands = 0;
-    std::int32_t reductionOperands = 0;
+    SmallVector<Value, 2> tileOperands, privateOperands, reductionOperands;
     std::int64_t executionMapping = mlir::acc::OpenACCExecMapping::NONE;
-    SmallVector<Value, 8> operands;
 
     // Lower clauses values mapped to operands.
     for (const auto &clause : accClauseList.v) {
@@ -90,7 +141,6 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                       x.t)) {
             gangNum = fir::getBase(converter.genExprValue(
                 *Fortran::semantics::GetExpr(gangNumValue.value())));
-            operands.push_back(gangNum);
           }
           if (const auto &gangStaticValue =
                   std::get<std::optional<Fortran::parser::AccSizeExpr>>(x.t)) {
@@ -107,7 +157,6 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                   currentLocation, firOpBuilder.getIntegerType(32),
                   /* STAR */ -1);
             }
-            operands.push_back(gangStatic);
           }
         }
         executionMapping |= mlir::acc::OpenACCExecMapping::GANG;
@@ -117,7 +166,6 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
         if (workerClause->v) {
           workerNum = fir::getBase(converter.genExprValue(
               *Fortran::semantics::GetExpr(*workerClause->v)));
-          operands.push_back(workerNum);
         }
         executionMapping |= mlir::acc::OpenACCExecMapping::WORKER;
       } else if (const auto *vectorClause =
@@ -126,7 +174,6 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
         if (vectorClause->v) {
           vectorLength = fir::getBase(converter.genExprValue(
               *Fortran::semantics::GetExpr(*vectorClause->v)));
-          operands.push_back(vectorLength);
         }
         executionMapping |= mlir::acc::OpenACCExecMapping::VECTOR;
       } else if (const auto *tileClause =
@@ -136,9 +183,8 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
           const auto &expr =
               std::get<std::optional<Fortran::parser::ScalarIntConstantExpr>>(
                   accTileExpr.t);
-          ++tileOperands;
           if (expr) {
-            operands.push_back(fir::getBase(
+            tileOperands.push_back(fir::getBase(
                 converter.genExprValue(*Fortran::semantics::GetExpr(*expr))));
           } else {
             // * was passed as value and will be represented as a -1 constant
@@ -146,33 +192,31 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
             mlir::Value tileStar = firOpBuilder.createIntegerConstant(
                 currentLocation, firOpBuilder.getIntegerType(32),
                 /* STAR */ -1);
-            operands.push_back(tileStar);
+            tileOperands.push_back(tileStar);
           }
         }
       } else if (const auto *privateClause =
                      std::get_if<Fortran::parser::AccClause::Private>(
                          &clause.u)) {
-        const Fortran::parser::AccObjectList &accObjectList = privateClause->v;
-        genObjectList(accObjectList, converter, privateOperands, operands);
+        genObjectList(privateClause->v, converter, privateOperands);
       }
       // Reduction clause is left out for the moment as the clause will probably
       // end up having its own operation.
     }
 
-    auto loopOp = firOpBuilder.create<mlir::acc::LoopOp>(currentLocation, argTy,
-                                                         operands);
+    // Prepare the operand segement size attribute and the operands value range.
+    SmallVector<Value, 8> operands;
+    SmallVector<int32_t, 8> operandSegments;
+    addOperand(operands, operandSegments, gangNum);
+    addOperand(operands, operandSegments, gangStatic);
+    addOperand(operands, operandSegments, workerNum);
+    addOperand(operands, operandSegments, vectorLength);
+    addOperands(operands, operandSegments, tileOperands);
+    addOperands(operands, operandSegments, privateOperands);
+    addOperands(operands, operandSegments, reductionOperands);
 
-    firOpBuilder.createBlock(&loopOp.getRegion());
-    auto &block = loopOp.getRegion().back();
-    firOpBuilder.setInsertionPointToStart(&block);
-    // ensure the block is well-formed.
-    firOpBuilder.create<mlir::acc::YieldOp>(currentLocation);
-
-    loopOp.setAttr(mlir::acc::LoopOp::getOperandSegmentSizeAttr(),
-                   firOpBuilder.getI32VectorAttr(
-                       {gangNum ? 1 : 0, gangStatic ? 1 : 0, workerNum ? 1 : 0,
-                        vectorLength ? 1 : 0, tileOperands, privateOperands,
-                        reductionOperands}));
+    auto loopOp = createRegionOp<mlir::acc::LoopOp, mlir::acc::YieldOp>(
+        firOpBuilder, currentLocation, operands, operandSegments);
 
     loopOp.setAttr(mlir::acc::LoopOp::getExecutionMappingAttrName(),
                    firOpBuilder.getI64IntegerAttr(executionMapping));
@@ -199,9 +243,270 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
                        firOpBuilder.getUnitAttr());
       }
     }
+  }
+}
 
-    // Place the insertion point to the start of the first block.
-    firOpBuilder.setInsertionPointToStart(&block);
+static void genACCParallelOp(Fortran::lower::AbstractConverter &converter,
+                             const Fortran::parser::AccClauseList &accClauseList) {
+  mlir::Value async;
+  mlir::Value numGangs;
+  mlir::Value numWorkers;
+  mlir::Value vectorLength;
+  mlir::Value ifCond;
+  mlir::Value selfCond;
+  SmallVector<Value, 2> waitOperands, reductionOperands, copyOperands,
+      copyinOperands, copyinReadonlyOperands, copyoutOperands,
+      copyoutZeroOperands, createOperands, createZeroOperands,
+      noCreateOperands, presentOperands, devicePtrOperands, attachOperands,
+      privateOperands, firstprivateOperands;
+
+  // Async, wait and self clause have optional values but can be present with
+  // no value as well. When there is no value, the op has an attribute to
+  // represent the clause.
+  bool addAsyncAttr = false;
+  bool addWaitAttr = false;
+  bool addSelfAttr = false;
+
+  // Lower clauses values mapped to operands.
+  // Keep track of each group of operands separatly as clauses can appear
+  // more than once.
+  for (const auto &clause : accClauseList.v) {
+    if (const auto *asyncClause =
+            std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
+      const auto &asyncClauseValue = asyncClause->v;
+      if(asyncClauseValue) { // async has a value.
+        async = fir::getBase(converter.genExprValue(
+            *Fortran::semantics::GetExpr(*asyncClauseValue)));
+      } else {
+        addAsyncAttr = true;
+      }
+    } else if (const auto *waitClause =
+                   std::get_if<Fortran::parser::AccClause::Wait>(&clause.u)) {
+      const auto &waitClauseValue = waitClause->v;
+      if (waitClauseValue) { // wait has a value.
+        const Fortran::parser::AccWaitArgument &waitArg = *waitClauseValue;
+        const std::list<Fortran::parser::ScalarIntExpr> &waitList =
+            std::get<std::list<Fortran::parser::ScalarIntExpr>>(waitArg.t);
+        for (const Fortran::parser::ScalarIntExpr &value : waitList) {
+          Value v = fir::getBase(converter.genExprValue(
+              *Fortran::semantics::GetExpr(value)));
+          waitOperands.push_back(v);
+        }
+      } else {
+        addWaitAttr = true;
+      }
+    } else if (const auto *numGangsClause =
+                   std::get_if<Fortran::parser::AccClause::NumGangs>(
+                       &clause.u)) {
+      numGangs = fir::getBase(converter.genExprValue(
+          *Fortran::semantics::GetExpr(numGangsClause->v)));
+    } else if (const auto *numWorkersClause =
+                   std::get_if<Fortran::parser::AccClause::NumWorkers>(
+                       &clause.u)) {
+      numWorkers = fir::getBase(converter.genExprValue(
+          *Fortran::semantics::GetExpr(numWorkersClause->v)));
+    } else if (const auto *vectorLengthClause =
+                   std::get_if<Fortran::parser::AccClause::VectorLength>(
+                       &clause.u)) {
+      vectorLength = fir::getBase(converter.genExprValue(
+          *Fortran::semantics::GetExpr(vectorLengthClause->v)));
+    } else if (const auto *ifClause =
+                   std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
+      ifCond = fir::getBase(converter.genExprValue(
+          *Fortran::semantics::GetExpr(ifClause->v)));
+    } else if (const auto *selfClause =
+                   std::get_if<Fortran::parser::AccClause::Self>(&clause.u)) {
+      if (selfClause->v) {
+        selfCond = fir::getBase(converter.genExprValue(
+            *Fortran::semantics::GetExpr(*(selfClause->v))));
+      } else {
+        addSelfAttr = true;
+      }
+    } else if (const auto *copyClause =
+                   std::get_if<Fortran::parser::AccClause::Copy>(&clause.u)) {
+      genObjectList(copyClause->v, converter, copyOperands);
+    } else if (const auto *copyinClause =
+                   std::get_if<Fortran::parser::AccClause::Copyin>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Copyin>(
+          copyinClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::ReadOnly,
+          copyinReadonlyOperands, copyinOperands);
+    } else if (const auto *copyoutClause =
+                   std::get_if<Fortran::parser::AccClause::Copyout>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Copyout>(
+          copyoutClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::Zero,
+          copyoutZeroOperands, copyoutOperands);
+    } else if (const auto *createClause =
+                   std::get_if<Fortran::parser::AccClause::Create>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Create>(
+          createClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::Zero,
+          createZeroOperands, createOperands);
+    } else if (const auto *noCreateClause =
+                   std::get_if<Fortran::parser::AccClause::NoCreate>(
+                       &clause.u)) {
+      genObjectList(noCreateClause->v, converter, noCreateOperands);
+    } else if (const auto *presentClause =
+                   std::get_if<Fortran::parser::AccClause::Present>(
+                       &clause.u)) {
+      genObjectList(presentClause->v, converter, presentOperands);
+    } else if (const auto *devicePtrClause =
+                   std::get_if<Fortran::parser::AccClause::Deviceptr>(
+                       &clause.u)) {
+      genObjectList(devicePtrClause->v, converter, devicePtrOperands);
+    } else if (const auto *attachClause =
+                   std::get_if<Fortran::parser::AccClause::Attach>(
+                       &clause.u)) {
+      genObjectList(attachClause->v, converter, attachOperands);
+    } else if (const auto *privateClause =
+                   std::get_if<Fortran::parser::AccClause::Private>(
+                       &clause.u)) {
+      genObjectList(privateClause->v, converter, privateOperands);
+    } else if (const auto *firstprivateClause =
+                   std::get_if<Fortran::parser::AccClause::Firstprivate>(
+                       &clause.u)) {
+      genObjectList(firstprivateClause->v, converter, firstprivateOperands);
+    }
+  }
+
+  // Prepare the operand segement size attribute and the operands value range.
+  SmallVector<Value, 8> operands;
+  SmallVector<int32_t, 8> operandSegments;
+  addOperand(operands, operandSegments, async);
+  addOperands(operands, operandSegments, waitOperands);
+  addOperand(operands, operandSegments, numGangs);
+  addOperand(operands, operandSegments, numWorkers);
+  addOperand(operands, operandSegments, vectorLength);
+  addOperand(operands, operandSegments, ifCond);
+  addOperand(operands, operandSegments, selfCond);
+  addOperands(operands, operandSegments, reductionOperands);
+  addOperands(operands, operandSegments, copyOperands);
+  addOperands(operands, operandSegments, copyinOperands);
+  addOperands(operands, operandSegments, copyinReadonlyOperands);
+  addOperands(operands, operandSegments, copyoutOperands);
+  addOperands(operands, operandSegments, copyoutZeroOperands);
+  addOperands(operands, operandSegments, createOperands);
+  addOperands(operands, operandSegments, createZeroOperands);
+  addOperands(operands, operandSegments, noCreateOperands);
+  addOperands(operands, operandSegments, presentOperands);
+  addOperands(operands, operandSegments, devicePtrOperands);
+  addOperands(operands, operandSegments, attachOperands);
+  addOperands(operands, operandSegments, privateOperands);
+  addOperands(operands, operandSegments, firstprivateOperands);
+
+  auto &firOpBuilder = converter.getFirOpBuilder();
+  auto currentLocation = converter.getCurrentLocation();
+  auto parallelOp = createRegionOp<mlir::acc::ParallelOp, mlir::acc::YieldOp>(
+      firOpBuilder, currentLocation, operands, operandSegments);
+
+  if (addAsyncAttr)
+    parallelOp.setAttr(mlir::acc::ParallelOp::getAsyncAttrName(),
+        firOpBuilder.getUnitAttr());
+  if (addWaitAttr)
+    parallelOp.setAttr(mlir::acc::ParallelOp::getWaitAttrName(),
+        firOpBuilder.getUnitAttr());
+  if (addSelfAttr)
+    parallelOp.setAttr(mlir::acc::ParallelOp::getSelfAttrName(),
+        firOpBuilder.getUnitAttr());
+}
+
+static void genACCDataOp(Fortran::lower::AbstractConverter &converter,
+                         const Fortran::parser::AccClauseList &accClauseList) {
+  SmallVector<Value, 2> presentOperands, copyOperands,
+      copyinOperands, copyinReadonlyOperands, copyoutOperands,
+      copyoutZeroOperands, createOperands, createZeroOperands,
+      noCreateOperands, deleteOperands, attachOperands, detachOperands;
+
+  // Lower clauses values mapped to operands.
+  // Keep track of each group of operands separatly as clauses can appear
+  // more than once.
+  for (const auto &clause : accClauseList.v) {
+    if (const auto *presentClause =
+                   std::get_if<Fortran::parser::AccClause::Present>(
+                       &clause.u)) {
+      genObjectList(presentClause->v, converter, presentOperands);
+    } else if (const auto *copyClause =
+                   std::get_if<Fortran::parser::AccClause::Copy>(&clause.u)) {
+      genObjectList(copyClause->v, converter, copyOperands);
+    } else if (const auto *copyinClause =
+                   std::get_if<Fortran::parser::AccClause::Copyin>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Copyin>(
+          copyinClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::ReadOnly,
+          copyinReadonlyOperands, copyinOperands);
+    } else if (const auto *copyoutClause =
+                   std::get_if<Fortran::parser::AccClause::Copyout>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Copyout>(
+          copyoutClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::Zero,
+          copyoutZeroOperands, copyoutOperands);
+    } else if (const auto *createClause =
+                   std::get_if<Fortran::parser::AccClause::Create>(
+                       &clause.u)) {
+      genObjectListWithModifier<Fortran::parser::AccClause::Create>(
+          createClause, converter,
+          Fortran::parser::AccDataModifier::Modifier::Zero,
+          createZeroOperands, createOperands);
+    } else if (const auto *noCreateClause =
+                   std::get_if<Fortran::parser::AccClause::NoCreate>(
+                       &clause.u)) {
+      genObjectList(noCreateClause->v, converter, noCreateOperands);
+    } else if (const auto *deleteClause =
+                   std::get_if<Fortran::parser::AccClause::Delete>(
+                       &clause.u)) {
+      genObjectList(deleteClause->v, converter, deleteOperands);
+    } else if (const auto *attachClause =
+                   std::get_if<Fortran::parser::AccClause::Attach>(
+                       &clause.u)) {
+      genObjectList(attachClause->v, converter, attachOperands);
+    } else if (const auto *detachClause =
+                   std::get_if<Fortran::parser::AccClause::Detach>(
+                       &clause.u)) {
+      genObjectList(detachClause->v, converter, detachOperands);
+    }
+  }
+
+  // Prepare the operand segement size attribute and the operands value range.
+  SmallVector<Value, 8> operands;
+  SmallVector<int32_t, 8> operandSegments;
+  addOperands(operands, operandSegments, presentOperands);
+  addOperands(operands, operandSegments, copyOperands);
+  addOperands(operands, operandSegments, copyinOperands);
+  addOperands(operands, operandSegments, copyinReadonlyOperands);
+  addOperands(operands, operandSegments, copyoutOperands);
+  addOperands(operands, operandSegments, copyoutZeroOperands);
+  addOperands(operands, operandSegments, createOperands);
+  addOperands(operands, operandSegments, createZeroOperands);
+  addOperands(operands, operandSegments, noCreateOperands);
+  addOperands(operands, operandSegments, deleteOperands);
+  addOperands(operands, operandSegments, attachOperands);
+  addOperands(operands, operandSegments, detachOperands);
+  auto &firOpBuilder = converter.getFirOpBuilder();
+  auto currentLocation = converter.getCurrentLocation();
+  createRegionOp<mlir::acc::DataOp, mlir::acc::TerminatorOp>(
+      firOpBuilder, currentLocation, operands, operandSegments);
+}
+
+static void genACC(Fortran::lower::AbstractConverter &converter,
+                   Fortran::lower::pft::Evaluation &eval,
+                   const Fortran::parser::OpenACCBlockConstruct &blockConstruct) {
+  const auto &beginBlockDirective =
+      std::get<Fortran::parser::AccBeginBlockDirective>(blockConstruct.t);
+  const auto &blockDirective =
+      std::get<Fortran::parser::AccBlockDirective>(beginBlockDirective.t);
+  const auto &accClauseList =
+      std::get<Fortran::parser::AccClauseList>(beginBlockDirective.t);
+
+  if (blockDirective.v == llvm::acc::ACCD_parallel) {
+    genACCParallelOp(converter, accClauseList);
+  } else if (blockDirective.v == llvm::acc::ACCD_data) {
+    genACCDataOp(converter, accClauseList);
   }
 }
 
@@ -213,7 +518,7 @@ void Fortran::lower::genOpenACCConstruct(
   std::visit(
       common::visitors{
           [&](const Fortran::parser::OpenACCBlockConstruct &blockConstruct) {
-            TODO();
+            genACC(converter, eval, blockConstruct);
           },
           [&](const Fortran::parser::OpenACCCombinedConstruct
                   &combinedConstruct) { TODO(); },

--- a/flang/test/Lower/OpenACC/acc-data.f90
+++ b/flang/test/Lower/OpenACC/acc-data.f90
@@ -1,0 +1,69 @@
+! This test checks lowering of OpenACC data directive.
+
+! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+
+program acc_data
+  real, dimension(10, 10) :: a, b, c
+
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "a"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "b"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "c"}
+
+  !$acc data copy(a, b, c)
+  !$acc end data
+
+!CHECK:      acc.data copy([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data copy(a) copy(b) copy(c)
+  !$acc end data
+
+!CHECK:      acc.data copy([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data copyin(a) copyin(readonly: b, c)
+  !$acc end data
+
+!CHECK:      acc.data copyin([[A]]: !fir.ref<!fir.array<10x10xf32>>) copyin_readonly([[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data copyout(a) copyout(zero: b) copyout(c)
+  !$acc end data
+
+!CHECK:      acc.data copyout([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) copyout_zero([[B]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data create(a, b) create(zero: c)
+  !$acc end data
+
+!CHECK:      acc.data create([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>) create_zero([[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data no_create(a, b) create(zero: c)
+  !$acc end data
+
+!CHECK:      acc.data create_zero([[C]]: !fir.ref<!fir.array<10x10xf32>>) no_create([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data present(a, b, c)
+  !$acc end data
+
+!CHECK:      acc.data present([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+  !$acc data attach(b, c)
+  !$acc end data
+
+!CHECK:      acc.data attach([[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.terminator
+!CHECK-NEXT: }{{$}}
+
+end program
+

--- a/flang/test/Lower/OpenACC/acc-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-loop.f90
@@ -70,7 +70,7 @@ program acc_loop
   END DO
 
 !CHECK:      [[GANGNUM1:%.*]] = constant 8 : i32
-!CHECK-NEXT: acc.loop gang(num: [[GANGNUM1]]) {
+!CHECK-NEXT: acc.loop gang(num=[[GANGNUM1]]: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
@@ -81,7 +81,7 @@ program acc_loop
   END DO
 
 !CHECK:      [[GANGNUM2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
-!CHECK-NEXT: acc.loop gang(num: [[GANGNUM2]]) {
+!CHECK-NEXT: acc.loop gang(num=[[GANGNUM2]]: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
@@ -91,7 +91,7 @@ program acc_loop
     a(i) = b(i)
   END DO
 
-!CHECK: acc.loop gang(num: %{{.*}}, static: %{{.*}}) {
+!CHECK: acc.loop gang(num=%{{.*}}: i32, static=%{{.*}}: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
@@ -112,7 +112,7 @@ program acc_loop
   END DO
 
 !CHECK: [[CONSTANT128:%.*]] = constant 128 : i32
-!CHECK:      acc.loop vector([[CONSTANT128]]) {
+!CHECK:      acc.loop vector([[CONSTANT128]]: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
@@ -123,7 +123,7 @@ program acc_loop
   END DO
 
 !CHECK:      [[VECTORLENGTH:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
-!CHECK:      acc.loop vector([[VECTORLENGTH]]) {
+!CHECK:      acc.loop vector([[VECTORLENGTH]]: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
@@ -144,7 +144,7 @@ program acc_loop
   END DO
 
 !CHECK: [[WORKER128:%.*]] = constant 128 : i32
-!CHECK:      acc.loop worker([[WORKER128]]) {
+!CHECK:      acc.loop worker([[WORKER128]]: i32) {
 !CHECK:        fir.do_loop
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}

--- a/flang/test/Lower/OpenACC/acc-parallel.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel.f90
@@ -1,0 +1,234 @@
+! This test checks lowering of OpenACC parallel directive.
+
+! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+
+program acc_parallel
+  integer :: i, j
+
+  integer :: async = 1
+  integer :: wait1 = 1
+  integer :: wait2 = 2
+  integer :: numGangs = 1
+  integer :: numWorkers = 10
+  integer :: vectorLength = 128
+  logical :: ifCondition = .TRUE.
+  real, dimension(10, 10) :: a, b, c
+
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "a"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "b"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "c"}
+
+  !$acc parallel
+  !$acc end parallel
+
+!CHECK:      acc.parallel {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel async
+  !$acc end parallel
+
+!CHECK:      acc.parallel {
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {asyncAttr}
+
+  !$acc parallel async(1)
+  !$acc end parallel
+
+!CHECK:      [[ASYNC1:%.*]] = constant 1 : i32
+!CHECK:      acc.parallel async([[ASYNC1]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel async(async)
+  !$acc end parallel
+
+!CHECK:      [[ASYNC2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.parallel async([[ASYNC2]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel wait
+  !$acc end parallel
+
+!CHECK:      acc.parallel {
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {waitAttr}
+
+  !$acc parallel wait(1)
+  !$acc end parallel
+
+!CHECK:      [[WAIT1:%.*]] = constant 1 : i32
+!CHECK:      acc.parallel wait([[WAIT1]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel wait(1, 2)
+  !$acc end parallel
+
+!CHECK:      [[WAIT2:%.*]] = constant 1 : i32
+!CHECK:      [[WAIT3:%.*]] = constant 2 : i32
+!CHECK:      acc.parallel wait([[WAIT2]]: i32, [[WAIT3]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel wait(wait1, wait2)
+  !$acc end parallel
+
+!CHECK:      [[WAIT4:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      [[WAIT5:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.parallel wait([[WAIT4]]: i32, [[WAIT5]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel num_gangs(1)
+  !$acc end parallel
+
+!CHECK:      [[NUMGANGS1:%.*]] = constant 1 : i32
+!CHECK:      acc.parallel num_gangs([[NUMGANGS1]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel num_gangs(numGangs)
+  !$acc end parallel
+
+!CHECK:      [[NUMGANGS2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.parallel num_gangs([[NUMGANGS2]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel num_workers(10)
+  !$acc end parallel
+
+!CHECK:      [[NUMWORKERS1:%.*]] = constant 10 : i32
+!CHECK:      acc.parallel num_workers([[NUMWORKERS1]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel num_workers(numWorkers)
+  !$acc end parallel
+
+!CHECK:      [[NUMWORKERS2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.parallel num_workers([[NUMWORKERS2]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel vector_length(128)
+  !$acc end parallel
+
+!CHECK:      [[VECTORLENGTH1:%.*]] = constant 128 : i32
+!CHECK:      acc.parallel vector_length([[VECTORLENGTH1]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel vector_length(vectorLength)
+  !$acc end parallel
+
+!CHECK:      [[VECTORLENGTH2:%.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK:      acc.parallel vector_length([[VECTORLENGTH2]]: i32) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel if(.TRUE.)
+  !$acc end parallel
+
+!CHECK:      [[IF1:%.*]] = constant true
+!CHECK:      acc.parallel if([[IF1]]) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+! NOT WORKING YET
+!  !$acc parallel if(ifCondition)
+!  !$acc end parallel
+
+  !$acc parallel self(.TRUE.)
+  !$acc end parallel
+
+!CHECK:      [[SELF1:%.*]] = constant true
+!CHECK:      acc.parallel self([[SELF1]]) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel self
+  !$acc end parallel
+
+!CHECK:      acc.parallel {
+!CHECK:        acc.yield
+!CHECK-NEXT: } attributes {selfAttr}
+
+! NOT WORKING YET
+!  !$acc parallel self(ifCondition)
+!  !$acc end parallel
+
+  !$acc parallel copy(a, b, c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel copy([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel copy(a) copy(b) copy(c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel copy([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel copyin(a) copyin(readonly: b, c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel copyin([[A]]: !fir.ref<!fir.array<10x10xf32>>) copyin_readonly([[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel copyout(a) copyout(zero: b) copyout(c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel copyout([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) copyout_zero([[B]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel create(a, b) create(zero: c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel create([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>) create_zero([[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel no_create(a, b) create(zero: c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel create_zero([[C]]: !fir.ref<!fir.array<10x10xf32>>) no_create([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel present(a, b, c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel present([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel deviceptr(a) deviceptr(c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel deviceptr([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel attach(b, c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel attach([[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+  !$acc parallel private(a) firstprivate(b) private(c)
+  !$acc end parallel
+
+!CHECK:      acc.parallel private([[A]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) firstprivate([[B]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:        acc.yield
+!CHECK-NEXT: }{{$}}
+
+end program
+


### PR DESCRIPTION
This PR enable the lowering of the parallel and data construct and update the loop construct lowering. 

This cannot be merged before https://reviews.llvm.org/D87991 has been merged upstream and the `fir-dev` branch has been rebased. 