### PR TITLE
Assumed length character return does not require explicit interface

### DIFF
--- a/flang/lib/Evaluate/characteristics.cpp
+++ b/flang/lib/Evaluate/characteristics.cpp
@@ -485,6 +485,8 @@ bool FunctionResult::CanBeReturnedViaImplicitInterface() const {
         if (const auto *param{type.charLength()}) {
           if (const auto &expr{param->GetExplicit()}) {
             return IsConstantExpr(*expr); // 15.4.2.2(4)(c)
+          } else if (param->isAssumed()) {
+            return true;
           }
         }
         return false;


### PR DESCRIPTION
Fixes #397
15.4.2.2(4)(c) says non-assumed non-constant length parameter requires explicit interface. The "nonassumed" part was missing in f18 characteristic analysis causing `CanBeReturnedViaImplicitInterface` to return false for `CHARACTER(*) function foo()` like interface. This caused lowering to abort on legal F77 program thinking it required F90 like support.