### PR TITLE
Fix undefined behaviour in ShapeShiftOp rewrite 

### DIFF
--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -108,16 +108,18 @@ public:
     auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp());
     llvm::SmallVector<mlir::Value, 8> shapeOpers;
     llvm::SmallVector<mlir::Value, 8> shiftOpers;
+    unsigned rank;
     if (shapeOp) {
       populateShape(shapeOpers, shapeOp);
+      rank = shapeOp.getType().cast<ShapeType>().getRank();
     } else {
       auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp());
       assert(shiftOp && "shape is neither fir.shape nor fir.shape_shift");
       populateShapeAndShift(shapeOpers, shiftOpers, shiftOp);
+      rank = shiftOp.getType().cast<ShapeShiftType>().getRank();
     }
     mlir::NamedAttrList attrs;
     auto idxTy = rewriter.getIndexType();
-    auto rank = shapeOp.getType().cast<ShapeType>().getRank();
     auto rankAttr = rewriter.getIntegerAttr(idxTy, rank);
     attrs.push_back(rewriter.getNamedAttr(XEmboxOp::rankAttrName(), rankAttr));
     auto lenParamSize = embox.lenParams().size();
@@ -159,16 +161,18 @@ public:
     auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp());
     llvm::SmallVector<mlir::Value, 8> shapeOpers;
     llvm::SmallVector<mlir::Value, 8> shiftOpers;
+    unsigned rank;
     if (shapeOp) {
       populateShape(shapeOpers, shapeOp);
+      rank = shapeOp.getType().cast<ShapeType>().getRank();
     } else {
       auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp());
       if (shiftOp)
         populateShapeAndShift(shapeOpers, shiftOpers, shiftOp);
+      rank = shiftOp.getType().cast<ShapeShiftType>().getRank();
     }
     mlir::NamedAttrList attrs;
     auto idxTy = rewriter.getIndexType();
-    auto rank = shapeOp.getType().cast<ShapeType>().getRank();
     auto rankAttr = rewriter.getIntegerAttr(idxTy, rank);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::rankAttrName(), rankAttr));
@@ -180,8 +184,7 @@ public:
     auto idxAttr = rewriter.getIntegerAttr(idxTy, indexSize);
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::indexAttrName(), idxAttr));
-    auto shapeSize = shapeOp.getNumOperands();
-    auto dimAttr = rewriter.getIntegerAttr(idxTy, shapeSize);
+    auto dimAttr = rewriter.getIntegerAttr(idxTy, shapeOpers.size());
     attrs.push_back(
         rewriter.getNamedAttr(XArrayCoorOp::shapeAttrName(), dimAttr));
     llvm::SmallVector<mlir::Value, 8> sliceOpers;


### PR DESCRIPTION
This PR fixes issue #434. `shapeOp` was used to get the rank even though it may be null in some cases. The segfault came from `rewriteDynamicShape` but `matchAndRewrite(ArrayCoorOp arrCoor, /* ... */)` had the same pattern so I fixed it there too. I am not very familiar with this part of the code, but while changing this I wondered if `XEmboxOp::shiftAttrName()` should be set in `matchAndRewrite` based on `shiftOpers.size()` just like it is done in `rewriteDynamicShape` (I did not change this as I do not fully understand what happens with this attributes).