### PR TITLE
Fix wrong character length in READ inputs

### DIFF
--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -153,6 +153,15 @@ public:
   /// previous.
   static bool isArray(mlir::Type type);
 
+  /// Temporary helper to help migrating towards properties of
+  /// ExtendedValue containing characters.
+  /// Mainly, this ensure that characters are always CharArrayBoxValue,
+  /// CharBoxValue, or BoxValue and that the base address is not a boxchar.
+  /// Return the argument if this is not a character.
+  /// TODO: Create and propagate ExtendedValue according to properties listed
+  /// above instead of fixing it when needed.
+  fir::ExtendedValue cleanUpCharacterExtendedValue(const fir::ExtendedValue &);
+
 private:
   fir::CharBoxValue materializeValue(mlir::Value str);
   fir::CharBoxValue toDataLengthPair(mlir::Value character);

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -76,15 +76,12 @@ subroutine assign_substring1(str, rhs, lb, ub)
   ! CHECK-DAG: %[[cmp_len:.*]] = cmpi "slt", %[[pre_lhs_len]], %[[c0]]
 
   ! CHECK-DAG: %[[lhs_len:.*]] = select %[[cmp_len]], %[[c0]], %[[pre_lhs_len]]
-  ! CHECK: %[[lhs_box:.*]] = fir.emboxchar %[[lhs_addr]], %[[lhs_len]]
 
   ! The rest of the assignment is just as the one above, only test that the
-  ! substring box is the one used
+  ! substring is the one used as lhs.
   ! ...
-  ! CHECK: %[[lhs:.*]]:2 = fir.unboxchar %[[lhs_box]]
-  ! ...
-  ! CHECK: %[[lhs2:.*]] = fir.convert %[[lhs]]#0
-  ! CHECK-NEXT: fir.coordinate_of %[[lhs2]], %arg4
+  ! CHECK: %[[lhs_addr3:.*]] = fir.convert %[[lhs_addr]]
+  ! CHECK-NEXT: fir.coordinate_of %[[lhs_addr3]], %arg4
   ! ...
 end subroutine
 

--- a/flang/test/Lower/concat.f90
+++ b/flang/test/Lower/concat.f90
@@ -39,11 +39,8 @@ subroutine concat_1(a, b)
     ! CHECK: fir.store %[[b_elt]] to %[[temp_addr2]]
   ! CHECK: }
 
-  ! CHECK: %[[embox_temp:.*]] = fir.emboxchar %[[temp]], %[[len]]
-
   ! IO runtime call
-  ! CHECK: %[[result:.*]]:2 = fir.unboxchar %[[embox_temp]]
-  ! CHECK-DAG: %[[raddr:.*]] = fir.convert %[[result]]#0
-  ! CHECK-DAG: %[[rlen:.*]] = fir.convert %[[result]]#1
+  ! CHECK-DAG: %[[raddr:.*]] = fir.convert %[[temp]]
+  ! CHECK-DAG: %[[rlen:.*]] = fir.convert %[[len]]
   ! CHECK: call @{{.*}}OutputAscii(%{{.*}}, %[[raddr]], %[[rlen]])
 end subroutine


### PR DESCRIPTION
Fixes #443 
The issue came from the IO code trying to get the length from the mlir value of a character address that cannot necessarily have a length.
Also fixe another other issue found while testing the code with more READ code: getDefiningOp on boxchar may fail if the boxchar is the argument.
Instead of adding yet more character special handling in the IO code to fix this, add  `cleanUpCharacterExtendedValue` to characterExprHelper that ensure that the base of an character ExtendedValue is not a boxchar. This avoid many ad-hoc handling when processing it.
Idealy I think we should enforce this at ExtendedValue creation but some places are relying on the fact that base addresses are boxchar, so in the meantime, just use the cleanUpCharacterExtendedValue when needed. I suspect Inquire and others may have similar issue, but I have not investigated yet. 