### PR TITLE
Added InsertOnRangeOp to FIR

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1965,7 +1965,7 @@ def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoSideEffect]> {
   }];
 
   let arguments = (ins fir_SequenceType:$seq, AnyType:$val,
-                       Index:$start, Index:$end);
+                       Variadic<Index>:$coor);
   let results = (outs fir_SequenceType);
 
   let assemblyFormat = [{

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1638,13 +1638,83 @@ struct InsertValueOpConversion
 
 /// InsertOnRange inserts a value into a sequence over a range of offsets.
 struct InsertOnRangeOpConversion
-    : public FIROpAndTypeConversion<fir::InsertOnRangeOp> {
+    : public FIROpAndTypeConversion<fir::InsertOnRangeOp>,
+      public ValueOpCommon {
   using FIROpAndTypeConversion::FIROpAndTypeConversion;
+
+  // Increments an array of subscripts in a row major fasion.
+  void incrementSubscripts(const SmallVector<uint64_t, 8> &dims,
+                     SmallVector<uint64_t, 8> &subscripts) const {
+    for (size_t i = dims.size(); i > 0; --i) {
+      if (++subscripts[i - 1] < dims[i - 1]) {
+        return;
+      }
+      subscripts[i - 1] = 0;
+    }
+  }
 
   mlir::LogicalResult
   doRewrite(fir::InsertOnRangeOp range, mlir::Type ty, OperandTy operands,
             mlir::ConversionPatternRewriter &rewriter) const override {
-    TODO("");
+    assert(fir::allConstants(operands.drop_front(2)));
+
+    llvm::SmallVector<mlir::Attribute, 8> lowerBound;
+    llvm::SmallVector<mlir::Attribute, 8> upperBound;
+    llvm::SmallVector<uint64_t, 8> dims;
+    auto type = operands[0].getType().dyn_cast<mlir::LLVM::LLVMType>();
+
+    // Iterativly extract the array dimensions from it's type.
+    while (type.isArrayTy()) {
+      dims.push_back(type.getArrayNumElements());
+      type = type.getArrayElementType();
+    }
+
+    // Unzip the upper and lower bound subscripts.
+    for (std::size_t i = 2; i + 1 < operands.size(); i += 2) {
+      lowerBound.push_back(ExtractValueOpConversion::getValue(operands[i]));
+      upperBound.push_back(ExtractValueOpConversion::getValue(operands[i + 1]));
+    }
+
+    llvm::SmallVector<uint64_t, 8> lBounds;
+    llvm::SmallVector<uint64_t, 8> uBounds;
+
+    // Extract the integer value from the attribute bounds and convert to row
+    // major format.
+    for (size_t i = lowerBound.size(); i > 0; --i) {
+      lBounds.push_back(lowerBound[i - 1].cast<IntegerAttr>().getInt());
+      uBounds.push_back(upperBound[i - 1].cast<IntegerAttr>().getInt());
+    }
+
+    auto subscripts(lBounds);
+    auto loc = range.getLoc();
+    mlir::Value lastOp = operands[0];
+    mlir::Value insertVal = operands[1];
+
+    while (subscripts != uBounds) {
+      // Convert uint64_t's to Attribute's.
+      llvm::SmallVector<mlir::Attribute, 8> subscriptAttrs;
+      for (const auto &subscript : subscripts)
+        subscriptAttrs.push_back(
+            IntegerAttr::get(rewriter.getI64Type(), subscript));
+      mlir::ArrayRef<mlir::Attribute> arrayRef(subscriptAttrs);
+      lastOp = rewriter.create<mlir::LLVM::InsertValueOp>(
+          loc, ty, lastOp, insertVal,
+          ArrayAttr::get(arrayRef, range.getContext()));
+
+      incrementSubscripts(dims, subscripts);
+    }
+
+    // Convert uint64_t's to Attribute's.
+    llvm::SmallVector<mlir::Attribute, 8> subscriptAttrs;
+    for (const auto &subscript : subscripts)
+      subscriptAttrs.push_back(
+          IntegerAttr::get(rewriter.getI64Type(), subscript));
+    mlir::ArrayRef<mlir::Attribute> arrayRef(subscriptAttrs);
+
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(
+        range, ty, lastOp, insertVal,
+        ArrayAttr::get(arrayRef, range.getContext()));
+
     return success();
   }
 };

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -14,6 +14,7 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   integer a6(6:i,j:*)
   real a7(i:70,7:j,k:80)
 
+ 
   ! CHECK-LABEL: BeginExternalListOutput
   ! CHECK-DAG: fir.load %arg3 :
   ! CHECK-DAG: %[[i1:.*]] = subi %{{.*}}, %[[one:c1.*]] :
@@ -72,4 +73,62 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   ! CHECK: fir.coordinate_of %[[a7]], %[[t7]] :
   ! CHECK-LABEL: EndIoStatement
   print *, a7(kk, jj, ii)
+  
 end subroutine s
+
+! CHECK-LABEL range
+subroutine range()
+  ! Compile-time initalized arrays
+  ! CHECK-DAG: %[[c3_i32:.*]] = constant 3 : i32
+  ! CHECK-DAG: %[[c9_i32:.*]] = constant 9 : i32
+  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
+  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
+  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
+  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
+  ! CHECK-DAG: %[[c9:.*]] = constant 9 : index
+  integer, dimension(10) :: a0
+  real, dimension(2,3) ::  a1
+  integer, dimension(3,4) :: a2
+ 
+  ! CHECK: %[[r1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, %{{.*}} :
+  ! CHECK: %[[r2:.*]] = fir.insert_value %[[r1]], %{{.*}}, %{{.*}} :
+  ! CHECK: %[[r3:.*]] = fir.insert_on_range %[[r2]], %[[c3_i32]], %[[c2]], %[[c9]] :
+  a0 = (/1, 2, 3, 3, 3, 3, 3, 3, 3, 3/)
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{[0-9]+}}, %{{.*}}, %[[c0]], %[[c1]], %[[c0]], %[[c2]] :
+  a1 = reshape((/3.5, 3.5, 3.5, 3.5, 3.5, 3.5/), shape(a1))
+  ! CHECK: %[[r4:.*]] = fir.insert_value %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
+  ! CHECK: %[[r5:.*]] = fir.insert_on_range %[[r4]], %[[c3_i32]], %[[c1]], %[[c2]], %[[c0]], %[[c0]] :
+  ! CHECK: %[[r6:.*]] = fir.insert_value %[[r5]], %{{.*}}, %{{.*}}, %{{.*}} :
+  ! CHECK: %[[r7:.*]] = fir.insert_on_range %[[r6]], %[[c3_i32]], %[[c1]], %[[c1]], %[[c1]], %[[c2]] :
+  ! CHECK: %[[r8:.*]] = fir.insert_on_range %[[r7]], %[[c9_i32]], %[[c2]], %[[c1]], %[[c2]], %[[c3]] :
+  ! CHECK: %[[r9:.*]] = fir.insert_value %[[r8]], %{{.*}}, %{{.*}}, %{{.*}} :
+  a2 = reshape((/1, 3, 3, 5, 3, 3, 3, 3, 9, 9, 9, 8/), shape(a2))
+
+end subroutine range
+
+! CHECK-LABEL rangeGlobal
+subroutine rangeGlobal()
+  ! CHECK-DAG: %[[c1_i32:.*]] = constant 1 : i32
+  ! CHECK-DAG: %[[c2_i32:.*]] = constant 2 : i32
+  ! CHECK-DAG: %[[c3_i32:.*]] = constant 3 : i32
+  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
+  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
+  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
+  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
+  ! CHECK-DAG: %[[c4:.*]] = constant 4 : index
+  ! CHECK-DAG: %[[c5:.*]] = constant 5 : index
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c1_i32]], %[[c0]], %[[c1]] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c2_i32]], %[[c2]], %[[c3]] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c3_i32]], %[[c4]], %[[c5]] :
+  integer, dimension(6) :: a0 = (/ 1, 1, 2, 2, 3, 3 /)
+
+end subroutine rangeGlobal
+
+block data
+  real :: x(5,5)
+  common /block/ x
+  data x(1,1), x(2,1), x(3,1) / 1, 1, 0 /
+  data x(1,2), x(2,2), x(4,2) / 1, 1, 2.4 /
+  data x(1,3), x(2,3), x(4,3) / 1, 1, 2.4 /
+  data x(4,4) / 2.4 /
+end


### PR DESCRIPTION
The InsertOnRangeOp has been created and added to the fir dialect. This
operation is used to condence a series of identical InsertValueOps into
a single operation.