### PR TITLE
Do not try allocate references in genref

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1596,7 +1596,8 @@ private:
     } else {
       auto val = fir::getBase(genval(a));
       // Functions are always referent.
-      if (val.getType().template isa<mlir::FunctionType>())
+      if (val.getType().template isa<mlir::FunctionType>() ||
+          fir::isa_ref_type(val.getType()))
         return val;
       // Since `a` is not itself a valid referent, determine its value and
       // create a temporary location for referencing.


### PR DESCRIPTION
Fixes #453 
Do not allocate references that may still come from genval in genref. That was at least the case for string literals.
An alternative would be to modify genval(Constant) to load character constant. I went for genref fix that looked more generic and robust to me and avoid ever generating a useless alloca.