### PR TITLE
Fixes the issue where STOP 'text' was calling the wrong runtime.

### DIFF
--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -15,7 +15,9 @@
 #include "flang/Lower/Support/BoxValue.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/tools.h"
-#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "flang-lower-runtime"
 
 using namespace Fortran::runtime;
 #define mkRTKey(X) mkKey(RTNAME(X))
@@ -75,45 +77,61 @@ void Fortran::lower::genStopStatement(
     const Fortran::parser::StopStmt &stmt) {
   auto &builder = converter.getFirOpBuilder();
   auto loc = converter.getCurrentLocation();
-  auto callee = genRuntimeFunction<mkRTKey(StopStatement)>(loc, builder);
-  auto calleeType = callee.getType();
   llvm::SmallVector<mlir::Value, 8> operands;
-  assert(calleeType.getNumInputs() == 3 &&
-         "expected 3 arguments in STOP runtime");
+  mlir::FuncOp callee;
+  mlir::FunctionType calleeType;
   // First operand is stop code (zero if absent)
   if (const auto &code =
           std::get<std::optional<Fortran::parser::StopCode>>(stmt.t)) {
-    auto expr = Fortran::semantics::GetExpr(*code);
-    assert(expr && "failed getting typed expression");
-    operands.push_back(fir::getBase(converter.genExprValue(*expr)));
+    auto expr = converter.genExprValue(*Fortran::semantics::GetExpr(*code));
+    LLVM_DEBUG(llvm::dbgs() << "stop expression: "; expr.dump();
+               llvm::dbgs() << '\n');
+    expr.match(
+        [&](const fir::CharBoxValue &x) {
+          callee = genRuntimeFunction<mkRTKey(StopStatementText)>(loc, builder);
+          calleeType = callee.getType();
+          // Creates a pair of operands for the CHARACTER and its LEN.
+          operands.push_back(
+              builder.createConvert(loc, calleeType.getInput(0), x.getAddr()));
+          operands.push_back(
+              builder.createConvert(loc, calleeType.getInput(1), x.getLen()));
+        },
+        [&](fir::UnboxedValue x) {
+          callee = genRuntimeFunction<mkRTKey(StopStatement)>(loc, builder);
+          calleeType = callee.getType();
+          auto cast = builder.createConvert(loc, calleeType.getInput(0), x);
+          operands.push_back(cast);
+        },
+        [&](auto) {
+          mlir::emitError(loc, "unhandled expression in STOP");
+          std::exit(1);
+        });
   } else {
+    callee = genRuntimeFunction<mkRTKey(StopStatement)>(loc, builder);
+    calleeType = callee.getType();
     operands.push_back(
         builder.createIntegerConstant(loc, calleeType.getInput(0), 0));
   }
+
   // Second operand indicates ERROR STOP
   bool isError = std::get<Fortran::parser::StopStmt::Kind>(stmt.t) ==
                  Fortran::parser::StopStmt::Kind::ErrorStop;
-  operands.push_back(
-      builder.createIntegerConstant(loc, calleeType.getInput(1), isError));
+  operands.push_back(builder.createIntegerConstant(
+      loc, calleeType.getInput(operands.size()), isError));
 
   // Third operand indicates QUIET (default to false).
   if (const auto &quiet =
           std::get<std::optional<Fortran::parser::ScalarLogicalExpr>>(stmt.t)) {
     auto expr = Fortran::semantics::GetExpr(*quiet);
     assert(expr && "failed getting typed expression");
-    operands.push_back(fir::getBase(converter.genExprValue(*expr)));
-  } else {
+    auto q = fir::getBase(converter.genExprValue(*expr));
     operands.push_back(
-        builder.createIntegerConstant(loc, calleeType.getInput(2), 0));
+        builder.createConvert(loc, calleeType.getInput(operands.size()), q));
+  } else {
+    operands.push_back(builder.createIntegerConstant(
+        loc, calleeType.getInput(operands.size()), 0));
   }
 
-  // Cast operands in case they have different integer/logical types
-  // compare to runtime.
-  auto i = 0;
-  for (auto &op : operands) {
-    auto type = calleeType.getInput(i++);
-    op = builder.createConvert(loc, type, op);
-  }
   builder.create<fir::CallOp>(loc, callee, operands);
   genUnreachable(builder, loc);
 }

--- a/flang/runtime/stop.cpp
+++ b/flang/runtime/stop.cpp
@@ -64,7 +64,7 @@ static void CloseAllExternalUnits(const char *why) {
 }
 
 [[noreturn]] void RTNAME(StopStatementText)(
-    const char *code, bool isErrorStop, bool quiet) {
+      const char *code, size_t, bool isErrorStop, bool quiet) {
   CloseAllExternalUnits("STOP statement");
   if (!quiet) {
     std::fprintf(

--- a/flang/runtime/stop.h
+++ b/flang/runtime/stop.h
@@ -18,7 +18,7 @@ FORTRAN_EXTERN_C_BEGIN
 // Program-initiated image stop
 NORETURN void RTNAME(StopStatement)(int code DEFAULT_VALUE(EXIT_SUCCESS),
     bool isErrorStop DEFAULT_VALUE(false), bool quiet DEFAULT_VALUE(false));
-NORETURN void RTNAME(StopStatementText)(const char *,
+NORETURN void RTNAME(StopStatementText)(const char *, size_t,
     bool isErrorStop DEFAULT_VALUE(false), bool quiet DEFAULT_VALUE(false));
 void RTNAME(PauseStatement)(NO_ARGUMENTS);
 NORETURN void RTNAME(FailImageStatement)(NO_ARGUMENTS);

--- a/flang/test/Lower/stop.f90
+++ b/flang/test/Lower/stop.f90
@@ -4,7 +4,7 @@
 subroutine stop_test(b)
  ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
  ! CHECK-DAG: %[[false:.*]] = constant false
- ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[false]])
+ ! CHECK: fir.call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[false]])
  ! CHECK-NEXT: fir.unreachable
  stop
 end subroutine
@@ -14,7 +14,7 @@ subroutine stop_code()
   stop 42
  ! CHECK-DAG: %[[c42:.*]] = constant 42 : i32
  ! CHECK-DAG: %[[false:.*]] = constant false
- ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c42]], %[[false]], %[[false]])
+ ! CHECK: fir.call @_Fortran{{.*}}StopStatement(%[[c42]], %[[false]], %[[false]])
  ! CHECK-NEXT: fir.unreachable
 end subroutine
 
@@ -24,7 +24,7 @@ subroutine stop_error()
  ! CHECK-DAG: %[[c0:.*]] = constant 0 : i32
  ! CHECK-DAG: %[[true:.*]] = constant true
  ! CHECK-DAG: %[[false:.*]] = constant false
- ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[true]], %[[false]])
+ ! CHECK: fir.call @_Fortran{{.*}}StopStatement(%[[c0]], %[[true]], %[[false]])
  ! CHECK-NEXT: fir.unreachable
 end subroutine
 
@@ -36,7 +36,7 @@ subroutine stop_quiet(b)
  ! CHECK-DAG: %[[false:.*]] = constant false
  ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
  ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
- ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[bi1]])
+ ! CHECK: fir.call @_Fortran{{.*}}StopStatement(%[[c0]], %[[false]], %[[bi1]])
  ! CHECK-NEXT: fir.unreachable
 end subroutine
 
@@ -48,8 +48,22 @@ subroutine stop_error_code_quiet(b)
  ! CHECK-DAG: %[[true:.*]] = constant true
  ! CHECK-DAG: %[[b:.*]] = fir.load %arg0
  ! CHECK-DAG: %[[bi1:.*]] = fir.convert %[[b]] : (!fir.logical<4>) -> i1
- ! CHECK: call @_Fortran{{.*}}StopStatement(%[[c66]], %[[true]], %[[bi1]])
+ ! CHECK: fir.call @_Fortran{{.*}}StopStatement(%[[c66]], %[[true]], %[[bi1]])
  ! CHECK-NEXT: fir.unreachable
 end subroutine
 
-! CHECK: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none
+
+! CHECK-LABEL stop_char_lit
+subroutine stop_char_lit
+  ! CHECK-DAG: %[[false:.*]] = constant false
+  ! CHECK-DAG: %[[five:.*]] = constant 5 : index
+  ! CHECK-DAG: %[[lit:.*]] = fir.address_of(@_QQ{{.*}}) : !fir.ref<!fir.array<5x!fir.char<1>>>
+  ! CHECK-DAG: %[[buff:.*]] = fir.convert %[[lit]] : (!fir.ref<!fir.array<5x!fir.char<1>>>) -> !fir.ref<i8>
+  ! CHECK-DAG: %[[len:.*]] = fir.convert %[[five]] : (index) -> i64
+  ! CHECK: fir.call @{{.*}}StopStatementText(%[[buff]], %[[len]], %[[false]], %[[false]]) :
+  ! CHECK-NEXT: fir.unreachable
+  stop 'crash'
+end subroutine stop_char_lit
+
+! CHECK-DAG: func @_Fortran{{.*}}StopStatement(i32, i1, i1) -> none
+! CHECK-DAG: func @_Fortran{{.*}}StopStatementText(!fir.ref<i8>, i64, i1, i1) -> none


### PR DESCRIPTION
This patch hacks the runtime files simply so things will typecheck and compile. It does not change the runtime library.