### PR TITLE
Reworking character lowering so that they are easier to handle

### DIFF
--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -11,15 +11,20 @@
 
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
+namespace fir {
+class ExtendedValue;
+}
+
 namespace Fortran {
 namespace lower {
 class AbstractConverter;
 
 /// Generate call to a character comparison for two ssa-values of type
 /// `boxchar`.
-mlir::Value genBoxCharCompare(AbstractConverter &converter, mlir::Location loc,
-                              mlir::CmpIPredicate cmp, mlir::Value lhs,
-                              mlir::Value rhs);
+mlir::Value genCharCompare(AbstractConverter &converter, mlir::Location loc,
+                           mlir::CmpIPredicate cmp,
+                           const fir::ExtendedValue &lhs,
+                           const fir::ExtendedValue &rhs);
 
 /// Generate call to a character comparison op for two unboxed variables. There
 /// are 4 arguments, 2 for the lhs and 2 for the rhs. Each CHARACTER must pass a

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -48,6 +48,7 @@ struct SomeKind;
 struct SomeType;
 template <common::TypeCategory, int>
 class Type;
+class FoldingContext;
 } // namespace evaluate
 
 namespace semantics {
@@ -95,10 +96,9 @@ inline mlir::Type translateDesignatorToFIRType(
 }
 
 /// Translate a SomeExpr to an mlir::Type.
-mlir::Type
-translateSomeExprToFIRType(mlir::MLIRContext *ctxt,
-                           common::IntrinsicTypeDefaultKinds const &defaults,
-                           const SomeExpr *expr);
+mlir::Type translateSomeExprToFIRType(mlir::MLIRContext *ctxt,
+                                      evaluate::FoldingContext &,
+                                      const SomeExpr *expr);
 
 /// Translate a Fortran::semantics::Symbol to an mlir::Type.
 mlir::Type

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -53,11 +53,10 @@ using UnboxedValue = mlir::Value;
 class AbstractBox {
 public:
   AbstractBox() = delete;
-  AbstractBox(mlir::Value addr) : addr{addr} {
-    assert(isa_passbyref_type(addr.getType()) &&
-           "box values must be references");
-  }
+  AbstractBox(mlir::Value addr) : addr{addr} {}
 
+  /// FIXME: this comment is not true anymore since genLoad
+  /// is loading constant length characters. What is the impact  /// ?
   /// An abstract box always contains a memory reference to a value.
   mlir::Value getAddr() const { return addr; }
 
@@ -70,7 +69,10 @@ protected:
 class CharBoxValue : public AbstractBox {
 public:
   CharBoxValue(mlir::Value addr, mlir::Value len)
-      : AbstractBox{addr}, len{len} {}
+      : AbstractBox{addr}, len{len} {
+    if (addr && addr.getType().template isa<fir::BoxCharType>())
+      llvm::report_fatal_error("BoxChar should not be in CharBoxValue");
+  }
 
   CharBoxValue clone(mlir::Value newBase) const { return {newBase, len}; }
 
@@ -230,7 +232,22 @@ public:
   ExtendedValue(ExtendedValue &&) = default;
   template <typename A, typename = std::enable_if_t<
                             !std::is_same_v<std::decay_t<A>, ExtendedValue>>>
-  constexpr ExtendedValue(A &&box) : box{std::forward<A>(box)} {}
+  constexpr ExtendedValue(A &&a) : box{std::forward<A>(a)} {
+    if (auto b = getUnboxed()) {
+      if (*b) {
+        auto type = b->getType();
+        if (type.template isa<fir::BoxCharType>())
+          llvm::report_fatal_error("BoxChar should be unboxed");
+        if (auto refType = type.template dyn_cast<fir::ReferenceType>())
+          type = refType.getEleTy();
+        if (auto seqType = type.template dyn_cast<fir::SequenceType>())
+          type = seqType.getEleTy();
+        if (type.template isa<fir::CharacterType>())
+          llvm::report_fatal_error(
+              "character buffer should be in CharBoxValue");
+      }
+    }
+  }
 
   template <typename A>
   constexpr const A *getBoxOf() const {

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -12,6 +12,8 @@
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/CharacterExpr.h"
 #include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/Support/BoxValue.h"
+#include "flang/Lower/Todo.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace Fortran::runtime;
@@ -117,13 +119,22 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
 }
 
 mlir::Value
-Fortran::lower::genBoxCharCompare(Fortran::lower::AbstractConverter &converter,
-                                  mlir::Location loc, mlir::CmpIPredicate cmp,
-                                  mlir::Value lhs, mlir::Value rhs) {
+Fortran::lower::genCharCompare(Fortran::lower::AbstractConverter &converter,
+                               mlir::Location loc, mlir::CmpIPredicate cmp,
+                               const fir::ExtendedValue &lhs,
+                               const fir::ExtendedValue &rhs) {
   auto &builder = converter.getFirOpBuilder();
-  Fortran::lower::CharacterExprHelper helper{builder, loc};
-  auto lhsPair = helper.materializeCharacter(lhs);
-  auto rhsPair = helper.materializeCharacter(rhs);
-  return genRawCharCompare(converter, loc, cmp, lhsPair.first, lhsPair.second,
-                           rhsPair.first, rhsPair.second);
+  if (lhs.getBoxOf<fir::BoxValue>() || rhs.getBoxOf<fir::BoxValue>())
+    TODO("character compare from descriptors");
+  auto allocateIfNotInMemory = [&](mlir::Value base) -> mlir::Value {
+    if (fir::isa_ref_type(base.getType()))
+      return base;
+    auto mem = builder.create<fir::AllocaOp>(loc, base.getType());
+    builder.create<fir::StoreOp>(loc, base, mem);
+    return mem;
+  };
+  auto lhsBuffer = allocateIfNotInMemory(fir::getBase(lhs));
+  auto rhsBuffer = allocateIfNotInMemory(fir::getBase(rhs));
+  return genRawCharCompare(converter, loc, cmp, lhsBuffer, fir::getLen(lhs),
+                           rhsBuffer, fir::getLen(rhs));
 }

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -208,6 +208,7 @@ struct IntrinsicLibrary {
   mlir::Value genAint(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genAnint(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genCeiling(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  fir::ExtendedValue genChar(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genConjg(mlir::Type, llvm::ArrayRef<mlir::Value>);
   void genDateAndTime(llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genDim(mlir::Type, llvm::ArrayRef<mlir::Value>);
@@ -303,12 +304,12 @@ struct IntrinsicHandler {
 using I = IntrinsicLibrary;
 static constexpr IntrinsicHandler handlers[]{
     {"abs", &I::genAbs},
-    {"achar", &I::genConversion},
+    {"achar", &I::genChar},
     {"aimag", &I::genAimag},
     {"aint", &I::genAint},
     {"anint", &I::genAnint},
     {"ceiling", &I::genCeiling},
-    {"char", &I::genConversion},
+    {"char", &I::genChar},
     {"conjg", &I::genConjg},
     {"date_and_time", &I::genDateAndTime},
     {"dim", &I::genDim},
@@ -688,7 +689,8 @@ fir::ExtendedValue toExtendedValue(mlir::Value val,
   llvm::SmallVector<mlir::Value, 2> extents;
 
   Fortran::lower::CharacterExprHelper charHelper{builder, loc};
-  if (charHelper.isCharacter(type))
+  // FIXME: we may want to allow non character scalar here.
+  if (charHelper.isCharacterScalar(type))
     return charHelper.toExtendedValue(val);
 
   if (auto refType = type.dyn_cast<fir::ReferenceType>())
@@ -1162,6 +1164,27 @@ mlir::Value IntrinsicLibrary::genCeiling(mlir::Type resultType,
   return builder.createConvert(loc, resultType, ceil);
 }
 
+fir::ExtendedValue
+IntrinsicLibrary::genChar(mlir::Type type,
+                          llvm::ArrayRef<fir::ExtendedValue> args) {
+  // Optional KIND argument.
+  assert(args.size() >= 1);
+  auto *arg = args[0].getUnboxed();
+  // expect argument to be a scalar integer
+  if (!arg)
+    mlir::emitError(loc, "CHAR intrinsic argument not unboxed");
+  Fortran::lower::CharacterExprHelper helper{builder, loc};
+  auto eleType = helper.getCharacterType(type);
+  auto cast = builder.createConvert(loc, eleType, *arg);
+  auto charType = fir::SequenceType::get({1}, eleType);
+  auto undef = builder.create<fir::UndefOp>(loc, charType);
+  auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
+  auto val =
+      builder.create<fir::InsertValueOp>(loc, charType, undef, cast, zero);
+  auto len = builder.createIntegerConstant(loc, helper.getLengthType(), 1);
+  return fir::CharBoxValue{val, len};
+}
+
 // CONJG
 mlir::Value IntrinsicLibrary::genConjg(mlir::Type resultType,
                                        llvm::ArrayRef<mlir::Value> args) {
@@ -1250,7 +1273,7 @@ mlir::Value IntrinsicLibrary::genIchar(mlir::Type resultType,
 
   auto arg = args[0];
   auto argTy = arg.getType();
-  assert(Fortran::lower::CharacterExprHelper::isCharacter(argTy) &&
+  assert(Fortran::lower::CharacterExprHelper::isCharacterScalar(argTy) &&
          "Error: Unhandled type passed to ICHAR");
   mlir::Value charVal;
   if (auto charTy = argTy.dyn_cast<fir::CharacterType>()) {

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -70,10 +70,6 @@ struct SymbolBox : public fir::details::matcher<SymbolBox> {
 
   operator bool() const { return !std::holds_alternative<None>(box); }
 
-  // This operator returns the address of the boxed value. TODO: consider
-  // eliminating this in favor of explicit conversion.
-  operator mlir::Value() const { return getAddr(); }
-
   //===--------------------------------------------------------------------===//
   // Accessors
   //===--------------------------------------------------------------------===//

--- a/flang/test/Lower/concat.f90
+++ b/flang/test/Lower/concat.f90
@@ -4,16 +4,16 @@
 
 ! CHECK-LABEL: concat_1
 subroutine concat_1(a, b)
-  character(*) :: a, b
-  ! CHECK: call @{{.*}}BeginExternalListOutput
   ! CHECK-DAG: %[[a:.*]]:2 = fir.unboxchar %arg0
   ! CHECK-DAG: %[[b:.*]]:2 = fir.unboxchar %arg1
+  character(*) :: a, b
 
+  ! CHECK: call @{{.*}}BeginExternalListOutput
   print *, a // b
   ! Concatenation
 
   ! CHECK: %[[len:.*]] = addi %[[a]]#1, %[[b]]#1
-  ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1>, %[[len]]
+  ! CHECK: %[[temp:.*]] = fir.alloca !fir.array<?x!fir.char<1>>, %[[len]]
 
   ! CHECK-DAG: %[[c0:.*]] = constant 0
   ! CHECK-DAG: %[[c1:.*]] = constant 1
@@ -22,8 +22,7 @@ subroutine concat_1(a, b)
     ! CHECK: %[[a_addr2:.*]] = fir.convert %[[a]]#0
     ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a_addr2]], %[[index]]
     ! CHECK-DAG: %[[a_elt:.*]] = fir.load %[[a_addr]]
-    ! CHECK-DAG: %[[temp2:.*]] = fir.convert %[[temp]]
-    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp2]], %[[index]]
+    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp]], %[[index]]
     ! CHECK: fir.store %[[a_elt]] to %[[temp_addr]]
   ! CHECK: }
 
@@ -34,8 +33,7 @@ subroutine concat_1(a, b)
     ! CHECK: %[[b_addr2:.*]] = fir.convert %[[b]]#0
     ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b_addr2]], %[[b_index]]
     ! CHECK-DAG: %[[b_elt:.*]] = fir.load %[[b_addr]]
-    ! CHECK-DAG: %[[temp2:.*]] = fir.convert %[[temp]]
-    ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp2]], %[[index2]]
+    ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp]], %[[index2]]
     ! CHECK: fir.store %[[b_elt]] to %[[temp_addr2]]
   ! CHECK: }
 

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -212,7 +212,9 @@ end subroutine ior_test
 subroutine len_test(i, c)
   integer :: i
   character(*) :: c
-  ! CHECK: fir.boxchar_len
+  ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1
+  ! CHECK: %[[x:.*]] = fir.convert %[[c]]#1 : (index) -> i32
+  ! CHECK: fir.store %[[x]] to %arg0
   i = len(c)
 end subroutine
 


### PR DESCRIPTION
This is a draft, I did not fix all tests yet.
DONE:
- Ensure that `fir::boxchar` are not propagated in fir::ExtendedValue and that they are not stored in the symbolMap once instantiateVar  is passed.
- Prevent implicit cast from SymbolBox to mlir::Value to avoid loosing the lenght.
- Some CharacterExprHelper functions with mlir::Value have been deleted.
- Remove some ad-hoc boxchar handling and use CharBoxValue instead

TODO:
- Fix tests that now produces different IR
- Fix character buffer type to be `fir.array<len x [dim1 x ... x] fir.char<kind>>` like
- Finish porting CharacterExprHelper and use site to CharBoxValue.