### PR TITLE
Do not reflect the size of character array in implicit interface boxchar length

### DIFF
--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -75,7 +75,8 @@ public:
   /// \p len is converted to the integer type for character lengths if needed.
   mlir::Value createEmboxChar(mlir::Value addr, mlir::Value len);
   mlir::Value createEmbox(const fir::CharBoxValue &str);
-  /// Embox a string array. The length is sizeof(str)*len(str).
+  /// Embox a string array. Note that the size/shape of the array is not
+  /// retrievable from the resulting mlir::Value.
   mlir::Value createEmbox(const fir::CharArrayBoxValue &str);
 
   /// Convert character array to a scalar by reducing the extents into the

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1486,7 +1486,7 @@ private:
         if (!argVal)
           mlir::emitError(
               getLoc(),
-              "Lowering internal error: passing non trivial value by by value");
+              "Lowering internal error: passing non trivial value by value");
         else
           caller.placeInput(arg, *argVal);
         continue;

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -6,10 +6,22 @@ function char_return_callee(i)
   integer :: i
 end function
 
-! CHECK-LABEL: func @_QPchar_return_caller(!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK-LABEL: @_QPtest_char_return_caller()
 subroutine test_char_return_caller
   character(10) :: char_return_caller
+  ! CHECK: fir.call @_QPchar_return_caller({{.*}}) : (!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   print *, char_return_caller(5)
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_passing_char_array()
+subroutine test_passing_char_array
+  character(len=3) :: x(4)
+  call sub_taking_a_char_array(x)
+  ! CHECK-DAG: %[[xarray:.*]] = fir.alloca !fir.array<3x4x!fir.char<1>>
+  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
+  ! CHECK-DAG: %[[xbuff:.*]] = fir.convert %[[xarray]] : (!fir.ref<!fir.array<3x4x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[xbuff]], %[[c3]] : (!fir.ref<!fir.char<1>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPsub_taking_a_char_array(%[[boxchar]]) : (!fir.boxchar<1>) -> () 
 end subroutine
 
 ! TODO more implicit interface cases with/without explicit interface


### PR DESCRIPTION
When passing a character array in an implicit interface we were multiplying the array size with the length to compute the
boxchar length. It gives the actual storage length, but was not in line with what other compilers do, leading to link time
incompatibility on F77 programs.
We were anyway not dividing back the length for character array dummy on the callee size so this did not work correctly between flang compiled programs.