### PR TITLE
Support callee/caller result type mismatch in lowering

### DIFF
--- a/flang/test/Lower/non-standard.f90
+++ b/flang/test/Lower/non-standard.f90
@@ -1,0 +1,16 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test lowering of non standard features.
+
+! Test mismatch on result type between callee/caller
+! CHECK-LABEL: func @_QPexpect_i32
+subroutine expect_i32()
+  external :: returns_i32
+  real(4) :: returns_i32
+  ! CHECK: %[[funcAddr:.*]] = fir.address_of(@_QPreturns_i32) : () -> i32
+  ! CHECK: %[[funcCast:.*]] = fir.convert %[[funcAddr]] : (() -> i32) -> (() -> f32)
+  ! CHECK: fir.call %[[funcCast]]() : () -> f32
+  print *, returns_i32()
+end subroutine
+integer(4) function returns_i32()
+end function


### PR DESCRIPTION
Related to #490. That may just be a bad idea to support this. Argument type mismatch around implicit interface are already very debatable, but from an ABI perspective, they doesn't really matter since arguments are pointers (I do not know any ABI that says, if it's a integer pointer, pass this way, but if it is a pointer to a float, pass that other way). However, since F77 results are in most case returned by value, telling something  returns a real when it returns a integer is most likely not behaving like a cast, it will crash.

Just to be clear, this patch is safe in the sense that we do not cast the function type in case lowering faces a result type mismatch that the front-end is not catching (we cast the result, and use the function definition type we trust). I am just not sure result type mismatch are actually a feature we want support. Maybe we should better keep crashing in lowering as we do now.