### PR TITLE
Regroup all emboxing boilerplate in FirOpBuilder::createBox and lower character desc with dynamic lenght 

### DIFF
--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -104,6 +104,10 @@ public:
   /// - fir.array<len x fir.char<kind>>
   static bool isCharacterScalar(mlir::Type type);
 
+  /// Does this extended value holds a !fir.array<len x ... fir.char<kind>>
+  /// where len is not the unknown extent ?
+  static bool hasConstantLengthInType(const fir::ExtendedValue &);
+
   /// Extract the kind of a character type
   static fir::KindTy getCharacterKind(mlir::Type type);
 

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -211,6 +211,13 @@ public:
   /// Create one of the shape ops given an extended value.
   mlir::Value createShape(mlir::Location loc, const fir::ExtendedValue &exv);
 
+  /// Create a boxed value (Fortran descriptor) to be passed to the runtime.
+  /// \p exv is an extended value holding a memory reference to the object that
+  /// must be boxed. This function will crash if provided something that is not
+  /// a memory reference type.
+  /// Array entities are boxed with a shape and character with their length.
+  mlir::Value createBox(mlir::Location loc, const fir::ExtendedValue &exv);
+
 private:
   const fir::KindMapping &kindMap;
 };

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -1,0 +1,27 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test that IO item list
+
+! FIXME: embox does not like getting a length when it gets
+! a !fir.ref<!fir.char<kind>> buffer. Either the verifier
+! should be relaxed, or we should finish up ensuring character
+! type for such buffer are !fir.ref<fir.array<?x!fir.char<kind>>>
+!
+!subroutine pass_assumed_len_char(c)
+!  character(*) :: c
+!  write(1, rec=1) c
+!end
+
+! CHECK-LABEL: func @_QPpass_assumed_len_char_array 
+subroutine pass_assumed_len_char_array(carray)
+  character(*) :: carray(2, 3)
+  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
+  ! CHECK-DAG: %[[buffer:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.array<?x2x3x!fir.char<1>>>
+  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
+  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape %[[c2]], %[[c3]] : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) typeparams %[[unboxed]]#1 : (!fir.ref<!fir.array<?x2x3x!fir.char<1>>>, !fir.shape<2>, index) -> !fir.box<!fir.array<?x2x3x!fir.char<1>>>
+  ! CHECK: %[[descriptor:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?x2x3x!fir.char<1>>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[descriptor]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+  print *, carray
+end


### PR DESCRIPTION
Note that descriptor for scalar character with dynamic length is still sometimes failing (see FIXME in test) since lowering of arguments still creates `!fir.ref<!fir.char<kind>>` instead of `!fir.ref<?x!fir.char<kind>>` for scalar dummy arguments.
I fix this in a different patch.