### PR TITLE
Rebase fix: align with LLVM unitttests/Decimal/CMakeLists.txt

### DIFF
--- a/flang/unittests/Decimal/CMakeLists.txt
+++ b/flang/unittests/Decimal/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_executable(quick-sanity-test
-  quick-sanity-test.cpp
-)
-
-target_link_libraries(quick-sanity-test
+add_flang_nongtest_unittest(quick-sanity-test
   FortranDecimal
 )
 
@@ -12,5 +8,3 @@ add_flang_nongtest_unittest(thorough-test
   SLOW_TEST
   FortranDecimal
 )
-
-add_test(NAME Sanity COMMAND quick-sanity-test)


### PR DESCRIPTION
Fresh builds after the rebase failed at link-time for me (There were changes in many CMakeLists.txt in LLVM recently regrading LLVMSupport linking).
I only took the part needed to fix the build for me, but in general, we may want to just take LLVM CMakeLists.txt (There may be a change or two that we want to upstream from fir-dev CMakeLists.txt) to make the LLVM merge easier.