### PR TITLE
Support top level directives in PFT

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -353,7 +353,7 @@ using ProgramVariant =
     ReferenceVariant<parser::MainProgram, parser::FunctionSubprogram,
                      parser::SubroutineSubprogram, parser::Module,
                      parser::Submodule, parser::SeparateModuleSubprogram,
-                     parser::BlockData>;
+                     parser::BlockData, parser::CompilerDirective>;
 /// A program is a list of program units.
 /// These units can be function like, module like, or block data.
 struct ProgramUnit : ProgramVariant {
@@ -672,9 +672,19 @@ struct BlockDataUnit : public ProgramUnit {
   const Fortran::semantics::Scope &symTab; // symbol table
 };
 
+// Top level compiler directives
+struct CompilerDirectiveUnit : public ProgramUnit {
+  CompilerDirectiveUnit(const parser::CompilerDirective &directive,
+                        const ParentVariant &parentVariant)
+      : ProgramUnit{directive, parentVariant} {};
+  CompilerDirectiveUnit(CompilerDirectiveUnit &&) = default;
+  CompilerDirectiveUnit(const CompilerDirectiveUnit &) = delete;
+};
+
 /// A Program is the top-level root of the PFT.
 struct Program {
-  using Units = std::variant<FunctionLikeUnit, ModuleLikeUnit, BlockDataUnit>;
+  using Units = std::variant<FunctionLikeUnit, ModuleLikeUnit, BlockDataUnit,
+                             CompilerDirectiveUnit>;
 
   Program() = default;
   Program(Program &&) = default;

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -169,6 +169,12 @@ public:
               [&](Fortran::lower::pft::FunctionLikeUnit &f) { lowerFunc(f); },
               [&](Fortran::lower::pft::ModuleLikeUnit &m) { lowerMod(m); },
               [&](Fortran::lower::pft::BlockDataUnit &b) { lowerBlockData(b); },
+              [&](Fortran::lower::pft::CompilerDirectiveUnit &d) {
+                setCurrentPosition(
+                    d.get<Fortran::parser::CompilerDirective>().source);
+                mlir::emitWarning(toLocation(),
+                                  "ignoring all compiler directives");
+              },
           },
           u);
     }
@@ -188,6 +194,9 @@ public:
                      },
                      [&](Fortran::lower::pft::BlockDataUnit &) {
                        // No functions defined in block data.
+                     },
+                     [&](Fortran::lower::pft::CompilerDirectiveUnit &) {
+                       // No functions defined.
                      },
                  },
                  u);

--- a/flang/test/Lower/pre-fir-tree01.f90
+++ b/flang/test/Lower/pre-fir-tree01.f90
@@ -119,6 +119,20 @@ function bar()
 end function
 ! CHECK: EndFunction bar
 
+! Test top level directives
+!DIR$ INTEGER=64
+! CHECK: CompilerDirective:
+! CHECK: EndCompilerDirective
+
+! Test nested directive
+! CHECK: Subroutine test_directive
+subroutine test_directive()
+  !DIR$ INTEGER=64
+  ! CHECK: <<CompilerDirective>>
+  ! CHECK: <<End CompilerDirective>>
+end subroutine
+! CHECK: EndSubroutine
+
 ! CHECK: Program <anonymous>
   ! check specification parts are not part of the PFT.
   ! CHECK-NOT: node


### PR DESCRIPTION
Compiler directives can be "Program unit" (i.e, directly nested under the root Program parser node) since https://reviews.llvm.org/D86555. Modify the PFT to represent this and ignore it in lowering for now with a warning.

Note: At first I wanted to add them in there own lists, but then I realized that the order where they appear relatively to other program units could be meaningful, so I just handled them as program units.

Fixes #508 