### PR TITLE
Lowering assumed shape arrays

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1965,61 +1965,79 @@ private:
     Fortran::lower::BoxAnalyzer sba;
     sba.analyze(sym);
 
+    // compute extent from lower and upper bound.
+    auto computeExtent = [&](mlir::Value lb, mlir::Value ub) -> mlir::Value {
+      // let the folder deal with the common `ub - <const> + 1` case
+      auto diff = builder->create<mlir::SubIOp>(loc, idxTy, ub, lb);
+      auto one = builder->createIntegerConstant(loc, idxTy, 1);
+      return builder->create<mlir::AddIOp>(loc, idxTy, diff, one);
+    };
+
     // The origin must be \vec{1}.
-    auto populateShape = [&](auto &shapes, const auto &bounds) {
-      for (auto *spec : bounds) {
-        if (auto low = spec->lbound().GetExplicit()) {
-          if (auto high = spec->ubound().GetExplicit()) {
-            Fortran::semantics::SomeExpr highEx{*high};
-            auto ub = createFIRExpr(loc, &highEx);
-            shapes.emplace_back(builder->createConvert(loc, idxTy, ub));
-          } else if (spec->ubound().isAssumed()) {
-            shapes.emplace_back(mlir::Value{});
-          } else {
-            TODO("upper bound");
-          }
+    auto populateShape = [&](auto &shapes, const auto &bounds,
+                             mlir::Value box) {
+      for (auto iter : llvm::enumerate(bounds)) {
+        auto *spec = iter.value();
+        assert(spec->lbound().GetExplicit() &&
+               "lbound must be explicit with constant value 1");
+        if (auto high = spec->ubound().GetExplicit()) {
+          Fortran::semantics::SomeExpr highEx{*high};
+          auto ub = createFIRExpr(loc, &highEx);
+          shapes.emplace_back(builder->createConvert(loc, idxTy, ub));
+        } else if (spec->ubound().isDeferred()) {
+          assert(box && "deferred bounds require a descriptor");
+          auto dim = builder->createIntegerConstant(loc, idxTy, iter.index());
+          auto dimInfo = builder->create<fir::BoxDimsOp>(loc, idxTy, idxTy,
+                                                         idxTy, box, dim);
+          shapes.emplace_back(dimInfo.getResult(2));
+        } else if (spec->ubound().isAssumed()) {
+          shapes.emplace_back(mlir::Value{});
         } else {
-          TODO("lower bound");
+          llvm::report_fatal_error("unknown bound category");
         }
       }
     };
 
-    auto genLBoundsAndExtents =
-        [&](const Fortran::semantics::SomeExpr &lowEx,
-            const Fortran::semantics::SomeExpr &highEx) {
-          auto lb = createFIRExpr(loc, &lowEx);
-          auto ub = createFIRExpr(loc, &highEx);
-          auto ty = ub.getType();
-          auto diff = builder->create<mlir::SubIOp>(loc, ty, ub, lb);
-          auto one = builder->createIntegerConstant(loc, ty, 1);
-          auto sz = builder->create<mlir::AddIOp>(loc, ty, diff, one);
-          auto idx = builder->createConvert(loc, idxTy, sz);
-          return std::pair<mlir::Value, mlir::Value>{lb, idx};
-        };
-
     // The origin is not \vec{1}.
     auto populateLBoundsExtents = [&](auto &lbounds, auto &extents,
-                                      const auto &bounds) {
-      for (auto *spec : bounds) {
-        if (auto low = spec->lbound().GetExplicit()) {
-          if (auto high = spec->ubound().GetExplicit()) {
-            // let the folder deal with the common `ub - <const> + 1` case
-            auto [lb, idx] =
-                genLBoundsAndExtents(Fortran::semantics::SomeExpr{*low},
-                                     Fortran::semantics::SomeExpr{*high});
+                                      const auto &bounds, mlir::Value box) {
+      for (auto iter : llvm::enumerate(bounds)) {
+        auto *spec = iter.value();
+        fir::BoxDimsOp dimInfo;
+        mlir::Value ub, lb;
+        if (spec->lbound().isDeferred() || spec->ubound().isDeferred()) {
+          assert(box && "deferred bounds require a descriptor");
+          auto dim = builder->createIntegerConstant(loc, idxTy, iter.index());
+          dimInfo = builder->create<fir::BoxDimsOp>(loc, idxTy, idxTy, idxTy,
+                                                    box, dim);
+          extents.emplace_back(dimInfo.getResult(2));
+          if (auto low = spec->lbound().GetExplicit()) {
+            auto expr = Fortran::semantics::SomeExpr{*low};
+            auto lb =
+                builder->createConvert(loc, idxTy, createFIRExpr(loc, &expr));
             lbounds.emplace_back(lb);
-            extents.emplace_back(idx);
-            continue;
-          } else if (spec->ubound().isAssumed()) {
-            // An assumed size array. The extent is not computed.
-            Fortran::semantics::SomeExpr lowEx{*low};
-            lbounds.emplace_back(createFIRExpr(loc, &lowEx));
-            extents.emplace_back(mlir::Value{});
           } else {
-            TODO("upper bound");
+            lbounds.emplace_back(dimInfo.getResult(1));
           }
         } else {
-          TODO("lower bound");
+          if (auto low = spec->lbound().GetExplicit()) {
+            auto expr = Fortran::semantics::SomeExpr{*low};
+            lb = builder->createConvert(loc, idxTy, createFIRExpr(loc, &expr));
+          } else {
+            TODO("assumed rank lowering");
+          }
+
+          if (auto high = spec->ubound().GetExplicit()) {
+            auto expr = Fortran::semantics::SomeExpr{*high};
+            ub = builder->createConvert(loc, idxTy, createFIRExpr(loc, &expr));
+            lbounds.emplace_back(lb);
+            extents.emplace_back(computeExtent(lb, ub));
+          } else {
+            // An assumed size array. The extent is not computed.
+            assert(spec->ubound().isAssumed() && "expected assumed size");
+            lbounds.emplace_back(lb);
+            extents.emplace_back(mlir::Value{});
+          }
         }
       }
     };
@@ -2152,12 +2170,19 @@ private:
           // cast to the known constant parts from the declaration
           auto castTy = builder->getRefType(genType(var));
           mlir::Value addr = lookupSymbol(sym).getAddr();
-          if (addr)
+          mlir::Value argBox;
+          if (addr) {
+            if (auto boxTy = addr.getType().dyn_cast<fir::BoxType>()) {
+              argBox = addr;
+              auto refTy = builder->getRefType(boxTy.getEleTy());
+              addr = builder->create<fir::BoxAddrOp>(loc, refTy, argBox);
+            }
             addr = builder->createConvert(loc, castTy, addr);
+          }
           if (x.lboundAllOnes()) {
             // if lower bounds are all ones, build simple shaped object
             llvm::SmallVector<mlir::Value, 8> shapes;
-            populateShape(shapes, x.bounds);
+            populateShape(shapes, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addSymbolWithShape(sym, addr, shapes, true);
               return;
@@ -2172,7 +2197,7 @@ private:
           // if object is an array process the lower bound and extent values
           llvm::SmallVector<mlir::Value, 8> extents;
           llvm::SmallVector<mlir::Value, 8> lbounds;
-          populateLBoundsExtents(lbounds, extents, x.bounds);
+          populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addSymbolWithBounds(sym, addr, extents, lbounds, true);
             return;
@@ -2326,12 +2351,18 @@ private:
         [&](const Fortran::lower::details::DynamicArrayStaticChar &x) {
           mlir::Value addr;
           mlir::Value len;
+          mlir::Value argBox;
           auto charLen = x.charLen();
           // if element type is a CHARACTER, determine the LEN value
           if (isDummy || isResult) {
-            auto symBox = lookupSymbol(sym);
-            auto unboxchar = charHelp.createUnboxChar(symBox.getAddr());
-            addr = unboxchar.first;
+            auto actualArg = lookupSymbol(sym).getAddr();
+            if (auto boxTy = actualArg.getType().dyn_cast<fir::BoxType>()) {
+              argBox = actualArg;
+              auto refTy = builder->getRefType(boxTy.getEleTy());
+              addr = builder->create<fir::BoxAddrOp>(loc, refTy, argBox);
+            } else {
+              addr = charHelp.createUnboxChar(actualArg).first;
+            }
             // Set/override LEN with a constant
             len = builder->createIntegerConstant(loc, idxTy, charLen);
           } else {
@@ -2346,7 +2377,7 @@ private:
           if (x.lboundAllOnes()) {
             // if lower bounds are all ones, build simple shaped object
             llvm::SmallVector<mlir::Value, 8> shape;
-            populateShape(shape, x.bounds);
+            populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
               return;
@@ -2359,7 +2390,7 @@ private:
           // if object is an array process the lower bound and extent values
           llvm::SmallVector<mlir::Value, 8> extents;
           llvm::SmallVector<mlir::Value, 8> lbounds;
-          populateLBoundsExtents(lbounds, extents, x.bounds);
+          populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
                                                  lbounds, true);
@@ -2381,17 +2412,32 @@ private:
         [&](const Fortran::lower::details::DynamicArrayDynamicChar &x) {
           mlir::Value addr;
           mlir::Value len;
+          mlir::Value argBox;
           auto charLen = x.charLen();
           // if element type is a CHARACTER, determine the LEN value
           if (isDummy || isResult) {
-            auto symBox = lookupSymbol(sym);
-            auto unboxchar = charHelp.createUnboxChar(symBox.getAddr());
-            addr = unboxchar.first;
-            if (charLen) {
-              // Set/override LEN with an expression
-              len = createFIRExpr(loc, &*charLen);
+            auto actualArg = lookupSymbol(sym).getAddr();
+            if (auto boxTy = actualArg.getType().dyn_cast<fir::BoxType>()) {
+              argBox = actualArg;
+              auto refTy = builder->getRefType(boxTy.getEleTy());
+              addr = builder->create<fir::BoxAddrOp>(loc, refTy, argBox);
+              if (charLen) {
+                // Set/override LEN with an expression
+                len = createFIRExpr(loc, &*charLen);
+              } else {
+                // FIXME: that is not correct with kind > 1 character, we need
+                // to divide by the character width.
+                len = builder->create<fir::BoxEleSizeOp>(loc, idxTy, argBox);
+              }
             } else {
-              len = unboxchar.second;
+              auto unboxchar = charHelp.createUnboxChar(actualArg);
+              addr = unboxchar.first;
+              if (charLen) {
+                // Set/override LEN with an expression
+                len = createFIRExpr(loc, &*charLen);
+              } else {
+                len = unboxchar.second;
+              }
             }
           } else {
             // local CHARACTER variable
@@ -2408,7 +2454,7 @@ private:
           if (x.lboundAllOnes()) {
             // if lower bounds are all ones, build simple shaped object
             llvm::SmallVector<mlir::Value, 8> shape;
-            populateShape(shape, x.bounds);
+            populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
               return;
@@ -2421,7 +2467,7 @@ private:
           // Process the lower bound and extent values.
           llvm::SmallVector<mlir::Value, 8> extents;
           llvm::SmallVector<mlir::Value, 8> lbounds;
-          populateLBoundsExtents(lbounds, extents, x.bounds);
+          populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
                                                  lbounds, true);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1490,7 +1490,7 @@ private:
             });
         caller.placeInput(arg, boxChar);
       } else if (arg.passBy == PassBy::Box) {
-        TODO("passing descriptor in call"); // generate emboxing if need.
+        caller.placeInput(arg, builder.createBox(getLoc(), argRef));
       } else if (arg.passBy == PassBy::AddressAndLength) {
         caller.placeAddressAndLengthInput(arg, fir::getBase(argRef),
                                           fir::getLen(argRef));

--- a/flang/test/Lower/assumed-shaped-callee.f90
+++ b/flang/test/Lower/assumed-shaped-callee.f90
@@ -1,0 +1,91 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test assumed shape dummy argument on callee side
+
+! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>>) 
+subroutine test_assumed_shape_1(x)
+  integer :: x(:)
+  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
+  ! CHECK: %[[c0:.*]] = constant 0 : index
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %[[c0]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+
+  print *, x
+  ! Test extent/lower bound use in the IO statement
+  ! CHECK: %[[cookie:.*]] = fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[newbox:.*]] = fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<?xi32>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[newbox]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioOutputDescriptor(%[[cookie]], %[[castedBox]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+end subroutine
+
+! lower bounds all ones
+! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>>)
+subroutine test_assumed_shape_2(x)
+  real :: x(1:, 1:)
+  ! CHECK: fir.box_addr
+  ! CHECK: %[[dims1:.*]]:3 = fir.box_dims
+  ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
+  print *, x
+  ! CHECK: fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK: fir.shape %[[dims1]]#2, %[[dims2]]#2
+end subroutine
+
+! explicit lower bounds different from 1
+! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>>)
+subroutine test_assumed_shape_3(x)
+  integer :: x(2:, 3:, 42:)
+  ! CHECK: fir.box_addr
+  ! CHECK: fir.box_dim
+  ! CHECK: %[[c2_i64:.*]] = constant 2 : i64
+  ! CHECK: %[[c2:.*]] = fir.convert %[[c2_i64]] : (i64) -> index
+  ! CHECK: fir.box_dim
+  ! CHECK: %[[c3_i64:.*]] = constant 3 : i64
+  ! CHECK: %[[c3:.*]] = fir.convert %[[c3_i64]] : (i64) -> index
+  ! CHECK: fir.box_dim
+  ! CHECK: %[[c42_i64:.*]] = constant 42 : i64
+  ! CHECK: %[[c42:.*]] = fir.convert %[[c42_i64]] : (i64) -> index
+
+  print *, x
+  ! CHECK: fir.shape_shift %[[c2]], %{{.*}}, %[[c3]], %{{.*}}, %[[c42]], %{{.*}} :
+end subroutine
+
+! Constant length
+! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<10x?x!fir.char<1>>>)
+subroutine test_assumed_shape_char(c)
+  character(10) :: c(:)
+  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>) -> !fir.ref<!fir.array<10x?x!fir.char<1>>>
+
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>, index) -> (index, index, index)
+
+  print *, c
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<10x?x!fir.char<1>>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<10x?x!fir.char<1>>>
+end subroutine
+
+! Assumed length
+! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x?x!fir.char<1>>>)
+subroutine test_assumed_shape_char_2(c)
+  character(*) :: c(:)
+  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x?x!fir.char<1>>>
+  ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>) -> index
+
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>, index) -> (index, index, index)
+
+  print *, c
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: fir.embox %[[addr]](%[[shape]]) typeparams %[[len]] : (!fir.ref<!fir.array<?x?x!fir.char<1>>>, !fir.shapeshift<1>, index) -> !fir.box<!fir.array<?x?x!fir.char<1>>>
+end subroutine
+
+
+! lower bounds all 1.
+! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x?x!fir.char<1>>>)
+subroutine test_assumed_shape_char_3(c)
+  character(*) :: c(1:, 1:)
+  ! CHECK: fir.box_addr
+  ! CHECK: fir.box_elesize
+  ! CHECK: %[[dims1:.*]]:3 = fir.box_dims
+  ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
+  print *, c
+  ! CHECK: fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK: fir.shape %[[dims1]]#2, %[[dims2]]#2
+end subroutine

--- a/flang/test/Lower/assumed-shaped-caller.f90
+++ b/flang/test/Lower/assumed-shaped-caller.f90
@@ -1,0 +1,53 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test passing arrays to assumed shape dummy arguments
+
+! CHECK-LABEL: func @_QPfoo()
+subroutine foo()
+  interface
+    subroutine bar(x)
+      ! lbounds are meaningless on caller side, some are added
+      ! here to check they are ignored.
+      real :: x(1:, 10:, :)
+    end subroutine
+  end interface
+  real :: x(42, 55, 12)
+  ! CHECK-DAG: %[[c42:.*]] = constant 42 : index
+  ! CHECK-DAG: %[[c55:.*]] = constant 55 : index
+  ! CHECK-DAG: %[[c12:.*]] = constant 12 : index
+  ! CHECK-DAG: %[[addr:.*]] = fir.alloca !fir.array<42x55x12xf32> {name = "_QFfooEx"}
+
+  call bar(x)
+  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<42x55x12xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<42x55x12xf32>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<42x55x12xf32>>) -> !fir.box<!fir.array<?x?x?xf32>>
+  ! CHECK: fir.call @_QPbar(%[[castedBox]]) : (!fir.box<!fir.array<?x?x?xf32>>) -> ()
+end subroutine
+
+
+! Test passing character array as assumed shape.
+! CHECK-LABEL: func @_QPfoo_char(%arg0: !fir.boxchar<1>)
+subroutine foo_char(x)
+  interface
+    subroutine bar_char(x)
+      character(*) :: x(1:, 10:, :)
+    end subroutine
+  end interface
+  character(*) :: x(42, 55, 12)
+  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
+  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>
+  ! CHECK-DAG: %[[c42:.*]] = constant 42 : index
+  ! CHECK-DAG: %[[c55:.*]] = constant 55 : index
+  ! CHECK-DAG: %[[c12:.*]] = constant 12 : index
+
+  call bar_char(x)
+  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) typeparams %[[x]]#1 : (!fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>, !fir.shape<3>, index) -> !fir.box<!fir.array<?x42x55x12x!fir.char<1>>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<?x42x55x12x!fir.char<1>>>) -> !fir.box<!fir.array<?x?x?x?x!fir.char<1>>>
+  ! CHECK: fir.call @_QPbar_char(%[[castedBox]]) : (!fir.box<!fir.array<?x?x?x?x!fir.char<1>>>) -> ()
+end subroutine
+
+! Test external function declarations
+
+! CHECK: func @_QPbar(!fir.box<!fir.array<?x?x?xf32>>)
+! CHECK: func @_QPbar_char(!fir.box<!fir.array<?x?x?x?x!fir.char<1>>>)


### PR DESCRIPTION
Handle assumed shape array both on callee/caller sides:

- Modify the call interface lowering utility to handle explicit interface,
  add TODOs for anything but intrinsic type assumed shape arrays.

- On caller side, simply add a call to createBox in case the interface needs
  a box.

- On callee side, the lowering of bounds is done using `fir.box_dims`, the
  address is obtained with `fir.box_addr` and for character the length is
  done using `fir.box_elesize`.

Note that fir generation works as expected, but lowering to LLVM on the callee
side fails due to a bad GEP generated for fir.box_dims.

Assumed shape array do not require any change in the symbol map used in lowering
because their shape and base address cannot change in the program unit (as
opposed to allocatable/pointers that are deferred shape arrays).