### PR TITLE
Get assumed shape working end-to-end

### DIFF
--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: declare void @g({ float*, i64, i32, i8, i8, i8, i8 }*)
 func @g(%b : !fir.box<f32>)
-// CHECK-LABEL: declare void @ga({ float*, i64, i32, i8, i8, i8, i8 }*)
+// CHECK-LABEL: declare void @ga({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }*)
 func @ga(%b : !fir.box<!fir.array<?xf32>>)
 
 // CHECK-LABEL: define void @f
@@ -62,7 +62,7 @@ func @b1(%arg0 : !fir.ref<!fir.array<?x!fir.char<1>>>, %arg1 : index) -> !fir.bo
 }
 
 // Boxing of a dynamic array of character with static length (5)
-// CHECK-LABEL: define { [5 x i8]*, i64, i32, i8, i8, i8, i8 }* @b2(
+// CHECK-LABEL: define { [5 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b2(
 // CHECK-SAME: [5 x i8]* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b2(%arg0 : !fir.ref<!fir.array<5x?x!fir.char<1>>>, %arg1 : index) -> !fir.box<!fir.array<5x?x!fir.char<1>>> {
   %1 = fir.shape %arg1 : (index) -> !fir.shape<1>
@@ -76,7 +76,7 @@ func @b2(%arg0 : !fir.ref<!fir.array<5x?x!fir.char<1>>>, %arg1 : index) -> !fir.
 }
 
 // Boxing of a dynamic array of character of dynamic length
-// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8 }* @b3(
+// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b3(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]], i64 %[[arg2:.*]])
 func @b3(%arg0 : !fir.ref<!fir.array<?x?x!fir.char<1>>>, %arg1 : index, %arg2 : index) -> !fir.box<!fir.array<?x?x!fir.char<1>>> {
   %1 = fir.shape %arg2 : (index) -> !fir.shape<1>
@@ -90,7 +90,7 @@ func @b3(%arg0 : !fir.ref<!fir.array<?x?x!fir.char<1>>>, %arg1 : index, %arg2 : 
 }
 
 // Boxing of a static array of character of dynamic length
-// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8 }* @b4(
+// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b4(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b4(%arg0 : !fir.ref<!fir.array<?x7x!fir.char<1>>>, %arg1 : index) -> !fir.box<!fir.array<?x7x!fir.char<1>>> {
   %c_7 = constant 7 : index

--- a/flang/test/Lower/assumed-shaped-callee.f90
+++ b/flang/test/Lower/assumed-shaped-callee.f90
@@ -8,11 +8,12 @@ subroutine test_assumed_shape_1(x)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %[[c0]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+  ! CHECK: %[[c1:.*]] = constant 1 : index
 
   print *, x
   ! Test extent/lower bound use in the IO statement
   ! CHECK: %[[cookie:.*]] = fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[c1]], %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
   ! CHECK: %[[newbox:.*]] = fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<?xi32>>
   ! CHECK: %[[castedBox:.*]] = fir.convert %[[newbox]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%[[cookie]], %[[castedBox]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
@@ -27,7 +28,7 @@ subroutine test_assumed_shape_2(x)
   ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
   print *, x
   ! CHECK: fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK: fir.shape %[[dims1]]#2, %[[dims2]]#2
+  ! CHECK: fir.shape %[[dims1]]#1, %[[dims2]]#1
 end subroutine
 
 ! explicit lower bounds different from 1
@@ -56,9 +57,10 @@ subroutine test_assumed_shape_char(c)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>) -> !fir.ref<!fir.array<10x?x!fir.char<1>>>
 
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>, index) -> (index, index, index)
+  ! CHECK: %[[c1:.*]] = constant 1 : index
 
   print *, c
-  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[c1]], %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
   ! CHECK: fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<10x?x!fir.char<1>>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<10x?x!fir.char<1>>>
 end subroutine
 
@@ -70,9 +72,10 @@ subroutine test_assumed_shape_char_2(c)
   ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>) -> index
 
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>, index) -> (index, index, index)
+  ! CHECK: %[[c1:.*]] = constant 1 : index
 
   print *, c
-  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[dims]]#1, %[[dims]]#2 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %[[c1]], %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
   ! CHECK: fir.embox %[[addr]](%[[shape]]) typeparams %[[len]] : (!fir.ref<!fir.array<?x?x!fir.char<1>>>, !fir.shapeshift<1>, index) -> !fir.box<!fir.array<?x?x!fir.char<1>>>
 end subroutine
 
@@ -87,5 +90,5 @@ subroutine test_assumed_shape_char_3(c)
   ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
   print *, c
   ! CHECK: fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK: fir.shape %[[dims1]]#2, %[[dims2]]#2
+  ! CHECK: fir.shape %[[dims1]]#1, %[[dims2]]#1
 end subroutine


### PR DESCRIPTION
- Always reflect rank when lowering fir.box type to its llvm
type (make the dimension array explicit). This is needed to
use the LLVM GEP when lowering fir.box_dims on callee side.

- Fix my own incompetence of getting bad indexes for lower_bound
and extent (1 and 2 instead of 0 and 1).

- The front-end is not making implicit assumed shape lower bounds
explicit (to 1) but is labeling as deferred. Due to this, the
code was taking the lower bound of the descriptor instead of
of 1. Workaround this for now, when we lower allocatable and
pointer, we will want either to update the front-end to make assumed
shape lower bound explicit or to handle this better in lowering.

- Align lit tests

With this patch, assumed shape associated with contiguous intrinsic
variable are compiling OK end to end.