### PR TITLE
Add END statements to the PFT - Fix #503 and #524

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -137,6 +137,10 @@ using ConstructStmts = std::tuple<
     parser::MaskedElsewhereStmt, parser::ElsewhereStmt, parser::EndWhereStmt,
     parser::ForallConstructStmt, parser::EndForallStmt>;
 
+using EndStmts =
+    std::tuple<parser::EndProgramStmt, parser::EndFunctionStmt,
+               parser::EndSubroutineStmt, parser::EndMpSubprogramStmt>;
+
 using Constructs =
     std::tuple<parser::AssociateConstruct, parser::BlockConstruct,
                parser::CaseConstruct, parser::ChangeTeamConstruct,
@@ -157,6 +161,9 @@ static constexpr bool isOtherStmt{common::HasMember<A, OtherStmts>};
 
 template <typename A>
 static constexpr bool isConstructStmt{common::HasMember<A, ConstructStmts>};
+
+template <typename A>
+static constexpr bool isEndStmt{common::HasMember<A, EndStmts>};
 
 template <typename A>
 static constexpr bool isConstruct{common::HasMember<A, Constructs>};
@@ -196,8 +203,8 @@ template <typename A>
 using MakeReferenceVariant = typename MakeReferenceVariantHelper<A>::type;
 
 using EvaluationTuple =
-    common::CombineTuples<ActionStmts, OtherStmts, ConstructStmts, Constructs,
-                          Directives>;
+    common::CombineTuples<ActionStmts, OtherStmts, ConstructStmts, EndStmts,
+                          Constructs, Directives>;
 /// Hide non-nullable pointers to the parse-tree node.
 /// Build type std::variant<const A* const, const B* const, ...>
 /// from EvaluationTuple type (std::tuple<A, B, ...>).
@@ -236,6 +243,10 @@ struct Evaluation : EvaluationVariant {
     return visit(common::visitors{[](auto &r) {
       return pft::isConstructStmt<std::decay_t<decltype(r)>>;
     }});
+  }
+  constexpr bool isEndStmt() const {
+    return visit(common::visitors{
+        [](auto &r) { return pft::isEndStmt<std::decay_t<decltype(r)>>; }});
   }
   constexpr bool isConstruct() const {
     return visit(common::visitors{

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1214,20 +1214,23 @@ private:
                                        valueList, blockList);
   }
 
-  // Nop statements - Code is generated elsewhere, often at the construct level.
+  // Nop statements - No code, or code is generated elsewhere.
   void genFIR(const Fortran::parser::CaseStmt &) {}              // nop
-  void genFIR(const Fortran::parser::EndSelectStmt &) {}         // nop
   void genFIR(const Fortran::parser::ContinueStmt &) {}          // nop
-  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}        // nop
-  void genFIR(const Fortran::parser::EndDoStmt &) {}             // nop
-  void genFIR(const Fortran::parser::EntryStmt &) {}             // nop
-  void genFIR(const Fortran::parser::IfThenStmt &) {}            // nop
   void genFIR(const Fortran::parser::ElseIfStmt &) {}            // nop
   void genFIR(const Fortran::parser::ElseStmt &) {}              // nop
-  void genFIR(const Fortran::parser::EndIfStmt &) {}             // nop
-  void genFIR(const Fortran::parser::ForallConstructStmt &) {}   // nop
-  void genFIR(const Fortran::parser::ForallAssignmentStmt &s) {} // nop
+  void genFIR(const Fortran::parser::EndDoStmt &) {}             // nop
   void genFIR(const Fortran::parser::EndForallStmt &) {}         // nop
+  void genFIR(const Fortran::parser::EndFunctionStmt &) {}       // nop
+  void genFIR(const Fortran::parser::EndIfStmt &) {}             // nop
+  void genFIR(const Fortran::parser::EndMpSubprogramStmt &) {}   // nop
+  void genFIR(const Fortran::parser::EndSelectStmt &) {}         // nop
+  void genFIR(const Fortran::parser::EndSubroutineStmt &) {}     // nop
+  void genFIR(const Fortran::parser::EntryStmt &) {}             // nop
+  void genFIR(const Fortran::parser::ForallAssignmentStmt &s) {} // nop
+  void genFIR(const Fortran::parser::ForallConstructStmt &) {}   // nop
+  void genFIR(const Fortran::parser::IfThenStmt &) {}            // nop
+  void genFIR(const Fortran::parser::NonLabelDoStmt &) {}        // nop
 
   void genFIR(const Fortran::parser::AssociateConstruct &) { TODO(""); }
   void genFIR(const Fortran::parser::AssociateStmt &) { TODO(""); }

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -191,16 +191,35 @@ private:
     resetFunctionState();
   }
 
-  /// Ensure that a function ends with a valid branch target (and is nonempty).
+  /// Add the end statement Evaluation of a sub/program to the PFT.
+  /// There may be intervening internal subprogram definitions between
+  /// prior statements and this end statement.
   void endFunctionBody() {
     if (evaluationListStack.empty())
       return;
     auto evaluationList = evaluationListStack.back();
-    if (evaluationList->empty() ||
-        !evaluationList->back().isA<parser::ContinueStmt>()) {
-      static const parser::ContinueStmt endTarget{};
-      addEvaluation(
-          lower::pft::Evaluation{endTarget, parentVariantStack.back(), {}, {}});
+    if (evaluationList->empty() || !evaluationList->back().isEndStmt()) {
+      const auto &endStmt =
+          parentVariantStack.back().get<lower::pft::FunctionLikeUnit>().endStmt;
+      endStmt.visit(common::visitors{
+          [&](const parser::Statement<parser::EndProgramStmt> &s) {
+            addEvaluation(lower::pft::Evaluation{
+                s.statement, parentVariantStack.back(), s.source, s.label});
+          },
+          [&](const parser::Statement<parser::EndFunctionStmt> &s) {
+            addEvaluation(lower::pft::Evaluation{
+                s.statement, parentVariantStack.back(), s.source, s.label});
+          },
+          [&](const parser::Statement<parser::EndSubroutineStmt> &s) {
+            addEvaluation(lower::pft::Evaluation{
+                s.statement, parentVariantStack.back(), s.source, s.label});
+          },
+          [&](const parser::Statement<parser::EndMpSubprogramStmt> &s) {
+            addEvaluation(lower::pft::Evaluation{
+                s.statement, parentVariantStack.back(), s.source, s.label});
+          },
+          [&](auto &) {},
+      });
     }
     lastLexicalEvaluation = nullptr;
   }
@@ -307,7 +326,7 @@ private:
     auto &entryPointList = eval.getOwningProcedure()->entryPointList;
     evaluationListStack.back()->emplace_back(std::move(eval));
     lower::pft::Evaluation *p = &evaluationListStack.back()->back();
-    if (p->isActionStmt() || p->isConstructStmt()) {
+    if (p->isActionStmt() || p->isConstructStmt() || p->isEndStmt()) {
       if (lastLexicalEvaluation) {
         lastLexicalEvaluation->lexicalSuccessor = p;
         p->printIndex = lastLexicalEvaluation->printIndex + 1;
@@ -833,7 +852,7 @@ public:
                      [&](const lower::pft::BlockDataUnit &unit) {
                        outputStream << getNodeIndex(unit) << " ";
                        outputStream << "BlockData: ";
-                       outputStream << "\nEndBlockData\n\n";
+                       outputStream << "\nEnd BlockData\n\n";
                      },
                      [&](const lower::pft::FunctionLikeUnit &func) {
                        dumpFunctionLikeUnit(outputStream, func);
@@ -945,9 +964,9 @@ public:
       outputStream << "\nContains\n";
       for (auto &func : functionLikeUnit.nestedFunctions)
         dumpFunctionLikeUnit(outputStream, func);
-      outputStream << "EndContains\n";
+      outputStream << "End Contains\n";
     }
-    outputStream << "End" << unitKind << ' ' << name << "\n\n";
+    outputStream << "End " << unitKind << ' ' << name << "\n\n";
   }
 
   void dumpModuleLikeUnit(llvm::raw_ostream &outputStream,
@@ -957,7 +976,7 @@ public:
     outputStream << "\nContains\n";
     for (auto &func : moduleLikeUnit.nestedFunctions)
       dumpFunctionLikeUnit(outputStream, func);
-    outputStream << "EndContains\nEndModuleLike\n\n";
+    outputStream << "End Contains\nEnd ModuleLike\n\n";
   }
 
   // Top level directives
@@ -968,7 +987,7 @@ public:
     outputStream << "CompilerDirective: !";
     outputStream << directive.get<Fortran::parser::CompilerDirective>()
                         .source.ToString();
-    outputStream << "\nEndCompilerDirective\n\n";
+    outputStream << "\nEnd CompilerDirective\n\n";
   }
 
   template <typename T>

--- a/flang/test/Lower/pre-fir-tree01.f90
+++ b/flang/test/Lower/pre-fir-tree01.f90
@@ -20,8 +20,9 @@ subroutine foo()
   ! CHECK: EndDoStmt
   end do
   ! CHECK: <<End DoConstruct>>
+! CHECK: EndSubroutineStmt
 end subroutine
-! CHECK: EndSubroutine foo
+! CHECK: End Subroutine foo
 
 ! CHECK: BlockData
 block data
@@ -29,7 +30,7 @@ block data
   integer, dimension(n) :: a, b, c
   common /arrays/ a, b, c
 end
-! CHECK: EndBlockData
+! CHECK: End BlockData
 
 ! CHECK: ModuleLike
 module test_mod
@@ -44,49 +45,57 @@ end interface
 contains
   ! CHECK: Subroutine foo
   subroutine foo()
+  ! CHECK: EndSubroutineStmt
     contains
     ! CHECK: Subroutine subfoo
     subroutine subfoo()
-    end subroutine
-    ! CHECK: EndSubroutine subfoo
+    ! CHECK: EndSubroutineStmt
+  9 end subroutine
+    ! CHECK: End Subroutine subfoo
     ! CHECK: Function subfoo2
     function subfoo2()
-    end function
-    ! CHECK: EndFunction subfoo2
+    ! CHECK: EndFunctionStmt
+  9 end function
+    ! CHECK: End Function subfoo2
   end subroutine
-  ! CHECK: EndSubroutine foo
+  ! CHECK: End Subroutine foo
 
   ! CHECK: Function foo2
   function foo2(i, j)
     integer i, j, foo2
     ! CHECK: AssignmentStmt
     foo2 = i + j
+  ! CHECK: EndFunctionStmt
     contains
     ! CHECK: Subroutine subfoo
     subroutine subfoo()
+    ! CHECK: EndSubroutineStmt
     end subroutine
-    ! CHECK: EndSubroutine subfoo
+    ! CHECK: End Subroutine subfoo
   end function
-  ! CHECK: EndFunction foo2
+  ! CHECK: End Function foo2
 end module
-! CHECK: EndModuleLike
+! CHECK: End ModuleLike
 
 ! CHECK: ModuleLike
 submodule (test_mod) test_mod_impl
 contains
   ! CHECK: Subroutine foo
   subroutine foo()
+  ! CHECK: EndSubroutineStmt
     contains
     ! CHECK: Subroutine subfoo
     subroutine subfoo()
+    ! CHECK: EndSubroutineStmt
     end subroutine
-    ! CHECK: EndSubroutine subfoo
+    ! CHECK: End Subroutine subfoo
     ! CHECK: Function subfoo2
     function subfoo2()
+    ! CHECK: EndFunctionStmt
     end function
-    ! CHECK: EndFunction subfoo2
+    ! CHECK: End Function subfoo2
   end subroutine
-  ! CHECK: EndSubroutine foo
+  ! CHECK: End Subroutine foo
   ! CHECK: MpSubprogram dump
   module procedure dump
     ! CHECK: FormatStmt
@@ -105,24 +114,25 @@ contains
     ! CHECK: <<End IfConstruct>>
   end procedure
 end submodule
-! CHECK: EndModuleLike
+! CHECK: End ModuleLike
 
 ! CHECK: BlockData
 block data named_block
  integer i, j, k
  common /indexes/ i, j, k
 end
-! CHECK: EndBlockData
+! CHECK: End BlockData
 
 ! CHECK: Function bar
 function bar()
+! CHECK: EndFunctionStmt
 end function
-! CHECK: EndFunction bar
+! CHECK: End Function bar
 
 ! Test top level directives
 !DIR$ INTEGER=64
 ! CHECK: CompilerDirective:
-! CHECK: EndCompilerDirective
+! CHECK: End CompilerDirective
 
 ! Test nested directive
 ! CHECK: Subroutine test_directive
@@ -141,4 +151,4 @@ end subroutine
   ! CHECK: AllocateStmt
   allocate(x(foo2(10, 30)))
 end
-! CHECK: EndProgram
+! CHECK: End Program

--- a/flang/test/Lower/pre-fir-tree05.f90
+++ b/flang/test/Lower/pre-fir-tree05.f90
@@ -27,9 +27,9 @@ subroutine foo()
   !$acc end parallel
   ! CHECK-NEXT: <<End OpenACCConstruct>>
   ! CHECK-NEXT: <<End OpenACCConstruct>>
-  ! CHECK-NEXT: ContinueStmt
+  ! CHECK-NEXT: EndSubroutineStmt
 end subroutine
-! CHECK-NEXT: EndSubroutine foo
+! CHECK-NEXT: End Subroutine foo
 
 ! CHECK: Subroutine foo
 subroutine foo2()
@@ -43,7 +43,7 @@ subroutine foo2()
   end do
   !$acc end parallel loop
   ! CHECK-NEXT: <<End OpenACCConstruct>>
-  ! CHECK-NEXT: ContinueStmt
+  ! CHECK-NEXT: EndSubroutineStmt
 end subroutine
-! CHECK-NEXT: EndSubroutine foo2
+! CHECK-NEXT: End Subroutine foo2
 


### PR DESCRIPTION
Program unit end statements may have labels that may be branch targets.
Modify the PFT to include these statements.  Update the PFT dump to
insert a blank in PFT annotations, so 'EndSubroutineStmt', which is
an actual PFT node, is somewhat differentiated from 'End Subroutine',
which is not.

There is an additional front end bug that when addressed will fix
additional instances of #524.