### PR TITLE
Use fir.array<?xfir.char<kind>> for the type of the fir.boxchar address

### DIFF
--- a/flang/test/Lower/assumed-shaped-caller.f90
+++ b/flang/test/Lower/assumed-shaped-caller.f90
@@ -34,8 +34,8 @@ subroutine foo_char(x)
     end subroutine
   end interface
   character(*) :: x(42, 55, 12)
-  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
-  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>
+  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
+  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>
   ! CHECK-DAG: %[[c42:.*]] = constant 42 : index
   ! CHECK-DAG: %[[c55:.*]] = constant 55 : index
   ! CHECK-DAG: %[[c12:.*]] = constant 12 : index

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -16,8 +16,7 @@ subroutine assign1(lhs, rhs)
 
   ! Copy of rhs into temp
   ! CHECK: fir.do_loop %[[i:.*]] =
-    ! CHECK: %[[rhs_addr2:.*]] = fir.convert %{{[0-9]+}}#0
-    ! CHECK-DAG: %[[rhs_addr:.*]] = fir.coordinate_of %[[rhs_addr2]], %[[i]]
+    ! CHECK-DAG: %[[rhs_addr:.*]] = fir.coordinate_of %[[rhs]]#0, %[[i]]
     ! CHECK-DAG: %[[rhs_elt:.*]] = fir.load %[[rhs_addr]]
     ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[i]]
     ! CHECK: fir.store %[[rhs_elt]] to %[[tmp_addr]]
@@ -27,8 +26,7 @@ subroutine assign1(lhs, rhs)
   ! CHECK: fir.do_loop %[[ii:.*]] =
     ! CHECK-DAG: %[[tmp_addr:.*]] = fir.coordinate_of %[[tmp]], %[[ii]]
     ! CHECK-DAG: %[[tmp_elt:.*]] = fir.load %[[tmp_addr]]
-    ! CHECK-DAG: %[[lhs_addr2:.*]] = fir.convert %[[lhs]]#0
-    ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs_addr2]], %[[ii]]
+    ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[ii]]
     ! CHECK: fir.store %[[tmp_elt]] to %[[lhs_addr]]
   ! CHECK-NEXT: }
 
@@ -36,8 +34,7 @@ subroutine assign1(lhs, rhs)
   ! CHECK-DAG: %[[c32:.*]] = constant 32 : i8
   ! CHECK-DAG: %[[blank:.*]] = fir.convert %[[c32]] : (i8) -> !fir.char<1>
   ! CHECK: fir.do_loop %[[ij:.*]] =
-    ! CHECK: %[[lhs_addr2:.*]] = fir.convert %[[lhs]]#0
-    ! CHECK: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs_addr2]], %[[ij]]
+    ! CHECK: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[ij]]
     ! CHECK: fir.store %[[blank]] to %[[lhs_addr]]
   ! CHECK-NEXT: }
 end subroutine
@@ -56,8 +53,7 @@ subroutine assign_substring1(str, rhs, lb, ub)
   ! CHECK-DAG: %[[lbi:.*]] = fir.convert %[[lb]] : (i64) -> index
   ! CHECK-DAG: %[[c1:.*]] = constant 1
   ! CHECK-DAG: %[[offset:.*]] = subi %[[lbi]], %[[c1]]
-  ! CHECK-DAG: %[[lhs_addr2:.*]] = fir.convert %[[str]]#0
-  ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs_addr2]], %[[offset]]
+  ! CHECK-DAG: %[[lhs_addr:.*]] = fir.coordinate_of %[[str]]#0, %[[offset]]
 
   ! Compute substring length
   ! CHECK-DAG: %[[ubi:.*]] = fir.convert %[[ub]] : (i64) -> index
@@ -96,8 +92,7 @@ subroutine assign_constant(lhs)
   ! CHECK-DAG: %[[c32:.*]] = constant 32 : i8
   ! CHECK-DAG: %[[blank:.*]] = fir.convert %[[c32]] : (i8) -> !fir.char<1>
   ! CHECK: fir.do_loop %[[j:.*]] = %{{.*}} to %{{.*}} {
-    ! CHECK: %[[jhs_addr2:.*]] = fir.convert %[[lhs]]#0
-    ! CHECK: %[[jhs_addr:.*]] = fir.coordinate_of %[[jhs_addr2]], %[[j]]
+    ! CHECK: %[[jhs_addr:.*]] = fir.coordinate_of %[[lhs]]#0, %[[j]]
     ! CHECK: fir.store %[[blank]] to %[[jhs_addr]]
   ! CHECK: }
 end subroutine

--- a/flang/test/Lower/concat.f90
+++ b/flang/test/Lower/concat.f90
@@ -19,8 +19,7 @@ subroutine concat_1(a, b)
   ! CHECK-DAG: %[[c1:.*]] = constant 1
   ! CHECK-DAG: %[[count:.*]] = subi %[[a]]#1, %[[c1]]
   ! CHECK: fir.do_loop %[[index:.*]] = %[[c0]] to %[[count]] step %[[c1]] {
-    ! CHECK: %[[a_addr2:.*]] = fir.convert %[[a]]#0
-    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a_addr2]], %[[index]]
+    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a]]#0, %[[index]]
     ! CHECK-DAG: %[[a_elt:.*]] = fir.load %[[a_addr]]
     ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp]], %[[index]]
     ! CHECK: fir.store %[[a_elt]] to %[[temp_addr]]
@@ -30,8 +29,7 @@ subroutine concat_1(a, b)
   ! CHECK: %[[count2:.*]] = subi %[[len]], %[[c1_0]]
   ! CHECK: fir.do_loop %[[index2:.*]] = %[[a]]#1 to %[[count2]] step %[[c1_0]] {
     ! CHECK: %[[b_index:.*]] = subi %[[index]], %[[a]]#1
-    ! CHECK: %[[b_addr2:.*]] = fir.convert %[[b]]#0
-    ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b_addr2]], %[[b_index]]
+    ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b]]#0, %[[b_index]]
     ! CHECK-DAG: %[[b_elt:.*]] = fir.load %[[b_addr]]
     ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp]], %[[index2]]
     ! CHECK: fir.store %[[b_elt]] to %[[temp_addr2]]

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -147,6 +147,6 @@ end subroutine
   !CHECK: return %[[imag]] : f32
 
 !CHECK-LABEL: func @fir.len.i32.bc1(%arg0: !fir.boxchar<1>)
-  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
+  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
   !CHECK: %[[len:.*]] = fir.convert %[[unboxed]]#1 : (index) -> i32
   !CHECK: return %[[len]] : i32

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -185,8 +185,9 @@ subroutine ichar_test(c)
   ! CHECK-DAG: %[[unbox:.*]]:2 = fir.unboxchar
   ! CHECK-DAG: %[[J:.*]] = fir.alloca i32 {name = "{{.*}}Ej"}
   ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {name = "{{.*}}Estr"}
-  ! CHECK: %[[BOX:.*]] = fir.load %[[unbox]]#0 : !fir.ref<!fir.char<1>>
-  ! CHECK: = fir.convert %[[BOX]] : (!fir.char<1>) -> i32
+  ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.char<1>> 
+  ! CHECK: %[[CHAR:.*]] = fir.load %[[BOX]] : !fir.ref<!fir.char<1>>
+  ! CHECK: = fir.convert %[[CHAR]] : (!fir.char<1>) -> i32
   print *, ichar(c)
   ! CHECK: fir.call @{{.*}}EndIoStatement
 

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -1,22 +1,22 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! Test that IO item list
+! Test that IO item list are lowered and passed correctly
 
-! FIXME: embox does not like getting a length when it gets
-! a !fir.ref<!fir.char<kind>> buffer. Either the verifier
-! should be relaxed, or we should finish up ensuring character
-! type for such buffer are !fir.ref<fir.array<?x!fir.char<kind>>>
-!
-!subroutine pass_assumed_len_char(c)
-!  character(*) :: c
-!  write(1, rec=1) c
-!end
+! CHECK-LABEL: func @_QPpass_assumed_len_char_unformatted_io
+subroutine pass_assumed_len_char_unformatted_io(c)
+  character(*) :: c
+  ! CHECK: %[[unbox:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
+  write(1, rec=1) c
+  ! CHECK: %[[box:.*]] = fir.embox %[[unbox]]#0 typeparams %[[unbox]]#1 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.box<!fir.array<?x!fir.char<1>>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[castedBox]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+end
 
 ! CHECK-LABEL: func @_QPpass_assumed_len_char_array 
 subroutine pass_assumed_len_char_array(carray)
   character(*) :: carray(2, 3)
-  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, index)
-  ! CHECK-DAG: %[[buffer:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.array<?x2x3x!fir.char<1>>>
+  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
+  ! CHECK-DAG: %[[buffer:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x2x3x!fir.char<1>>>
   ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
   ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
   ! CHECK-DAG: %[[shape:.*]] = fir.shape %[[c2]], %[[c3]] : (index, index) -> !fir.shape<2>

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -23,12 +23,12 @@ subroutine pointerTests
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.complex<4>>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.complex<4>>
 
-  ! CHECK: fir.global internal @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1>>
-  character, pointer :: ptr4 => NULL()
+  ! CHECK: fir.global internal @_QFpointertestsEptr4 : !fir.ptr<!fir.array<?x!fir.char<1>>>
+  character(:), pointer :: ptr4 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
-  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1>>
-  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1>>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.array<?x!fir.char<1>>>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.array<?x!fir.char<1>>>
 
   ! CHECK: fir.global internal @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
   logical, pointer :: ptr5 => NULL()

--- a/flang/test/Lower/stmt-function.f90
+++ b/flang/test/Lower/stmt-function.f90
@@ -92,7 +92,8 @@ integer function test_stmt_character(c, j)
    character(10) :: c, argc
    ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
    ! CHECK-DAG: %[[c10:.*]] = constant 10 :
-   ! CHECK: %[[c:.*]] = fir.emboxchar %[[unboxed]]#0, %[[c10]] 
+   ! CHECK: %[[addr:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
+   ! CHECK: %[[c:.*]] = fir.emboxchar %[[addr]], %[[c10]] 
 
    func(argc, argj) = len_trim(argc, 4) + argj
    ! CHECK: addi %{{.*}}, %{{.*}} : i


### PR DESCRIPTION
This was a left over TODO from character refactoring, scalar character base address type `fir.ref<fir.char>` should not be propagated anymore since character related utilities are expecting a sequence type with the length
as first dimension.
This prevented unformatted IO with scalar characters to lower.

Fixes #536.