### PR TITLE
Simplify type lowering and reflect constant length in more cases

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -25,7 +25,6 @@ class Reference;
 }
 
 namespace evaluate {
-struct DataRef;
 template <typename>
 class Expr;
 class FoldingContext;
@@ -99,8 +98,6 @@ public:
   // Types
   //===--------------------------------------------------------------------===//
 
-  /// Generate the type of a DataRef
-  virtual mlir::Type genType(const Fortran::evaluate::DataRef &) = 0;
   /// Generate the type of an Expr
   virtual mlir::Type genType(const SomeExpr &) = 0;
   /// Generate the type of a Symbol

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -32,23 +32,14 @@ class Type;
 
 namespace Fortran {
 namespace common {
-class IntrinsicTypeDefaultKinds;
 template <typename>
 class Reference;
 } // namespace common
 
 namespace evaluate {
-class DataRef;
-template <typename>
-class Designator;
 template <typename>
 class Expr;
-template <common::TypeCategory>
-struct SomeKind;
 struct SomeType;
-template <common::TypeCategory, int>
-class Type;
-class FoldingContext;
 } // namespace evaluate
 
 namespace semantics {
@@ -56,6 +47,7 @@ class Symbol;
 } // namespace semantics
 
 namespace lower {
+class AbstractConverter;
 namespace pft {
 struct Variable;
 }
@@ -64,61 +56,23 @@ using SomeExpr = evaluate::Expr<evaluate::SomeType>;
 using SymbolRef = common::Reference<const semantics::Symbol>;
 
 /// Get a FIR type based on a category and kind.
-mlir::Type getFIRType(mlir::MLIRContext *ctxt,
-                      common::IntrinsicTypeDefaultKinds const &defaults,
-                      common::TypeCategory tc, int kind);
-
-/// Get a FIR type based on a category.
-mlir::Type getFIRType(mlir::MLIRContext *ctxt,
-                      common::IntrinsicTypeDefaultKinds const &defaults,
-                      common::TypeCategory tc);
-
-/// Translate a Fortran::evaluate::DataRef to an mlir::Type.
-mlir::Type
-translateDataRefToFIRType(mlir::MLIRContext *ctxt,
-                          common::IntrinsicTypeDefaultKinds const &defaults,
-                          const evaluate::DataRef &dataRef);
-
-/// Translate a Fortran::evaluate::Designator<> to an mlir::Type.
-template <common::TypeCategory TC, int KIND>
-inline mlir::Type translateDesignatorToFIRType(
-    mlir::MLIRContext *ctxt, common::IntrinsicTypeDefaultKinds const &defaults,
-    const evaluate::Designator<evaluate::Type<TC, KIND>> &) {
-  return getFIRType(ctxt, defaults, TC, KIND);
-}
-
-/// Translate a Fortran::evaluate::Designator<> to an mlir::Type.
-template <common::TypeCategory TC>
-inline mlir::Type translateDesignatorToFIRType(
-    mlir::MLIRContext *ctxt, common::IntrinsicTypeDefaultKinds const &defaults,
-    const evaluate::Designator<evaluate::SomeKind<TC>> &) {
-  return getFIRType(ctxt, defaults, TC);
-}
+mlir::Type getFIRType(mlir::MLIRContext *ctxt, common::TypeCategory tc,
+                      int kind);
 
 /// Translate a SomeExpr to an mlir::Type.
-mlir::Type translateSomeExprToFIRType(mlir::MLIRContext *ctxt,
-                                      evaluate::FoldingContext &,
-                                      const SomeExpr *expr);
+mlir::Type translateSomeExprToFIRType(Fortran::lower::AbstractConverter &,
+                                      const SomeExpr &expr);
 
 /// Translate a Fortran::semantics::Symbol to an mlir::Type.
-mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
-                                    Fortran::evaluate::FoldingContext &,
+mlir::Type translateSymbolToFIRType(Fortran::lower::AbstractConverter &,
                                     const SymbolRef symbol);
 
 /// Translate a Fortran::lower::pft::Variable to an mlir::Type.
-mlir::Type translateVariableToFIRType(mlir::MLIRContext *ctxt,
-                                      Fortran::evaluate::FoldingContext &,
+mlir::Type translateVariableToFIRType(Fortran::lower::AbstractConverter &,
                                       const pft::Variable &variable);
 
 /// Translate a REAL of KIND to the mlir::Type.
 mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
-
-// Given a ReferenceType of a base type, returns the ReferenceType to
-// the SequenceType of this base type.
-// The created SequenceType has one dimension of unknown extent.
-// This is useful to do pointer arithmetic using fir::CoordinateOp that requires
-// a memory reference to a sequence type.
-mlir::Type getSequenceRefType(mlir::Type referenceType);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -38,7 +38,7 @@ class Reference;
 } // namespace common
 
 namespace evaluate {
-struct DataRef;
+class DataRef;
 template <typename>
 class Designator;
 template <typename>
@@ -101,16 +101,14 @@ mlir::Type translateSomeExprToFIRType(mlir::MLIRContext *ctxt,
                                       const SomeExpr *expr);
 
 /// Translate a Fortran::semantics::Symbol to an mlir::Type.
-mlir::Type
-translateSymbolToFIRType(mlir::MLIRContext *ctxt,
-                         common::IntrinsicTypeDefaultKinds const &defaults,
-                         const SymbolRef symbol);
+mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
+                                    Fortran::evaluate::FoldingContext &,
+                                    const SymbolRef symbol);
 
 /// Translate a Fortran::lower::pft::Variable to an mlir::Type.
-mlir::Type
-translateVariableToFIRType(mlir::MLIRContext *ctxt,
-                           common::IntrinsicTypeDefaultKinds const &defaults,
-                           const pft::Variable &variable);
+mlir::Type translateVariableToFIRType(mlir::MLIRContext *ctxt,
+                                      Fortran::evaluate::FoldingContext &,
+                                      const pft::Variable &variable);
 
 /// Translate a REAL of KIND to the mlir::Type.
 mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -265,30 +265,22 @@ public:
     return foldingContext;
   }
 
-  mlir::Type genType(const Fortran::evaluate::DataRef &data) override final {
-    return Fortran::lower::translateDataRefToFIRType(
-        &getMLIRContext(), bridge.getDefaultKinds(), data);
-  }
   mlir::Type genType(const Fortran::lower::SomeExpr &expr) override final {
-    return Fortran::lower::translateSomeExprToFIRType(&getMLIRContext(),
-                                                      foldingContext, &expr);
+    return Fortran::lower::translateSomeExprToFIRType(*this, expr);
   }
   mlir::Type genType(const Fortran::lower::pft::Variable &var) override final {
-    return Fortran::lower::translateVariableToFIRType(&getMLIRContext(),
-                                                      foldingContext, var);
+    return Fortran::lower::translateVariableToFIRType(*this, var);
   }
   mlir::Type genType(Fortran::lower::SymbolRef sym) override final {
-    return Fortran::lower::translateSymbolToFIRType(&getMLIRContext(),
-                                                    foldingContext, sym);
+    return Fortran::lower::translateSymbolToFIRType(*this, sym);
   }
   mlir::Type genType(Fortran::common::TypeCategory tc,
                      int kind) override final {
-    return Fortran::lower::getFIRType(&getMLIRContext(),
-                                      bridge.getDefaultKinds(), tc, kind);
+    return Fortran::lower::getFIRType(&getMLIRContext(), tc, kind);
   }
   mlir::Type genType(Fortran::common::TypeCategory tc) override final {
-    return Fortran::lower::getFIRType(&getMLIRContext(),
-                                      bridge.getDefaultKinds(), tc);
+    return Fortran::lower::getFIRType(
+        &getMLIRContext(), tc, bridge.getDefaultKinds().GetDefaultKind(tc));
   }
 
   mlir::Location getCurrentLocation() override final { return toLocation(); }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -274,12 +274,12 @@ public:
                                                       foldingContext, &expr);
   }
   mlir::Type genType(const Fortran::lower::pft::Variable &var) override final {
-    return Fortran::lower::translateVariableToFIRType(
-        &getMLIRContext(), bridge.getDefaultKinds(), var);
+    return Fortran::lower::translateVariableToFIRType(&getMLIRContext(),
+                                                      foldingContext, var);
   }
   mlir::Type genType(Fortran::lower::SymbolRef sym) override final {
-    return Fortran::lower::translateSymbolToFIRType(
-        &getMLIRContext(), bridge.getDefaultKinds(), sym);
+    return Fortran::lower::translateSymbolToFIRType(&getMLIRContext(),
+                                                    foldingContext, sym);
   }
   mlir::Type genType(Fortran::common::TypeCategory tc,
                      int kind) override final {

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -9,6 +9,8 @@
 #include "flang/Lower/ConvertType.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/shape.h"
+#include "flang/Lower/AbstractConverter.h"
+#include "flang/Lower/CallInterface.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Lower/Utils.h"
@@ -18,501 +20,129 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/StandardTypes.h"
 
-template <typename A>
-bool isConstant(const Fortran::evaluate::Expr<A> &e) {
-  return Fortran::evaluate::IsConstantExpr(Fortran::lower::SomeExpr{e});
-}
+//===--------------------------------------------------------------------===//
+// Intrinsic type translation helpers
+//===--------------------------------------------------------------------===//
 
-template <typename A>
-int64_t toConstant(const Fortran::evaluate::Expr<A> &e) {
-  auto opt = Fortran::evaluate::ToInt64(e);
-  assert(opt.has_value() && "expression didn't resolve to a constant");
-  return opt.value();
-}
-
-// one argument template, must be specialized
-template <Fortran::common::TypeCategory TC>
-mlir::Type genFIRType(mlir::MLIRContext *, int) {
-  return {};
-}
-
-// two argument template
-template <Fortran::common::TypeCategory TC, int KIND>
-mlir::Type genFIRType(mlir::MLIRContext *context) {
-  if constexpr (TC == Fortran::common::TypeCategory::Integer) {
-    auto bits{Fortran::evaluate::Type<Fortran::common::TypeCategory::Integer,
-                                      KIND>::Scalar::bits};
-    return mlir::IntegerType::get(bits, context);
-  } else if constexpr (TC == Fortran::common::TypeCategory::Logical ||
-                       TC == Fortran::common::TypeCategory::Character ||
-                       TC == Fortran::common::TypeCategory::Complex) {
-    return genFIRType<TC>(context, KIND);
-  } else {
-    return {};
-  }
-}
-
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Real, 2>(mlir::MLIRContext *context) {
-  return mlir::FloatType::getF16(context);
-}
-
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Real, 3>(mlir::MLIRContext *context) {
-  return mlir::FloatType::getBF16(context);
-}
-
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Real, 4>(mlir::MLIRContext *context) {
-  return mlir::FloatType::getF32(context);
-}
-
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Real, 8>(mlir::MLIRContext *context) {
-  return mlir::FloatType::getF64(context);
-}
-
-template <>
-mlir::Type genFIRType<Fortran::common::TypeCategory::Real, 10>(
-    mlir::MLIRContext *context) {
-  return fir::RealType::get(context, 10);
-}
-
-template <>
-mlir::Type genFIRType<Fortran::common::TypeCategory::Real, 16>(
-    mlir::MLIRContext *context) {
-  return fir::RealType::get(context, 16);
-}
-
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Real>(mlir::MLIRContext *context,
-                                                int kind) {
+static mlir::Type genRealType(mlir::MLIRContext *context, int kind) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Real, kind)) {
     switch (kind) {
     case 2:
-      return genFIRType<Fortran::common::TypeCategory::Real, 2>(context);
+      return mlir::FloatType::getF16(context);
     case 3:
-      return genFIRType<Fortran::common::TypeCategory::Real, 3>(context);
+      return mlir::FloatType::getBF16(context);
     case 4:
-      return genFIRType<Fortran::common::TypeCategory::Real, 4>(context);
+      return mlir::FloatType::getF32(context);
     case 8:
-      return genFIRType<Fortran::common::TypeCategory::Real, 8>(context);
+      return mlir::FloatType::getF64(context);
     case 10:
-      return genFIRType<Fortran::common::TypeCategory::Real, 10>(context);
+      return fir::RealType::get(context, 10);
     case 16:
-      return genFIRType<Fortran::common::TypeCategory::Real, 16>(context);
+      return fir::RealType::get(context, 16);
     }
   }
   llvm_unreachable("REAL type translation not implemented");
 }
 
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Integer>(mlir::MLIRContext *context,
-                                                   int kind) {
+template <int KIND>
+int getIntegerBits() {
+  return Fortran::evaluate::Type<Fortran::common::TypeCategory::Integer,
+                                 KIND>::Scalar::bits;
+}
+static mlir::Type genIntegerType(mlir::MLIRContext *context, int kind) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Integer, kind)) {
     switch (kind) {
     case 1:
-      return genFIRType<Fortran::common::TypeCategory::Integer, 1>(context);
+      return mlir::IntegerType::get(getIntegerBits<1>(), context);
     case 2:
-      return genFIRType<Fortran::common::TypeCategory::Integer, 2>(context);
+      return mlir::IntegerType::get(getIntegerBits<2>(), context);
     case 4:
-      return genFIRType<Fortran::common::TypeCategory::Integer, 4>(context);
+      return mlir::IntegerType::get(getIntegerBits<4>(), context);
     case 8:
-      return genFIRType<Fortran::common::TypeCategory::Integer, 8>(context);
+      return mlir::IntegerType::get(getIntegerBits<8>(), context);
     case 16:
-      return genFIRType<Fortran::common::TypeCategory::Integer, 16>(context);
+      return mlir::IntegerType::get(getIntegerBits<16>(), context);
     }
   }
   llvm_unreachable("INTEGER type translation not implemented");
 }
 
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Logical>(mlir::MLIRContext *context,
-                                                   int KIND) {
+static mlir::Type genLogicalType(mlir::MLIRContext *context, int KIND) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Logical, KIND))
     return fir::LogicalType::get(context, KIND);
   return {};
 }
 
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Character>(mlir::MLIRContext *context,
-                                                     int KIND) {
+static mlir::Type genCharacterType(mlir::MLIRContext *context, int KIND) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Character, KIND))
     return fir::CharacterType::get(context, KIND);
   return {};
 }
 
-template <>
-mlir::Type
-genFIRType<Fortran::common::TypeCategory::Complex>(mlir::MLIRContext *context,
-                                                   int KIND) {
+static mlir::Type genComplexType(mlir::MLIRContext *context, int KIND) {
   if (Fortran::evaluate::IsValidKindOfIntrinsicType(
           Fortran::common::TypeCategory::Complex, KIND))
     return fir::ComplexType::get(context, KIND);
   return {};
 }
 
+static mlir::Type genFIRType(mlir::MLIRContext *context,
+                             Fortran::common::TypeCategory tc, int kind) {
+  switch (tc) {
+  case Fortran::common::TypeCategory::Real:
+    return genRealType(context, kind);
+  case Fortran::common::TypeCategory::Integer:
+    return genIntegerType(context, kind);
+  case Fortran::common::TypeCategory::Complex:
+    return genComplexType(context, kind);
+  case Fortran::common::TypeCategory::Logical:
+    return genLogicalType(context, kind);
+  case Fortran::common::TypeCategory::Character:
+    return genCharacterType(context, kind);
+  default:
+    break;
+  }
+  llvm_unreachable("unhandled type category");
+}
+
+//===--------------------------------------------------------------------===//
+// Symbol and expression type translation
+//===--------------------------------------------------------------------===//
+
+/// TypeBuilder translates expression and symbol type taking into account
+/// their shape and length parameters. For symbols, attributes such as
+/// ALLOCATABLE or POINTER are reflected in the fir type.
+/// It uses evaluate::DynamicType and evaluate::Shape when possible to
+/// avoid re-implementing type/shape analysis here.
+/// Do not use the FirOpBuilder from the AbstractConverter to get fir/mlir types
+/// since it is not guaranteed to exist yet when we lower types.
 namespace {
+struct TypeBuilder {
 
-/// Discover the type of an Fortran::evaluate::Expr<T> and convert it to an
-/// mlir::Type. The type returned may be an MLIR standard or FIR type.
-class TypeBuilder {
-public:
-  /// Constructor.
-  explicit TypeBuilder(
-      mlir::MLIRContext *context,
-      const Fortran::common::IntrinsicTypeDefaultKinds &defaults)
-      : context{context}, defaults{defaults} {}
-
-  //===--------------------------------------------------------------------===//
-  // Generate type entry points
-  //===--------------------------------------------------------------------===//
-
-  template <template <typename> typename A, Fortran::common::TypeCategory TC>
-  mlir::Type gen(const A<Fortran::evaluate::SomeKind<TC>> &) {
-    return genFIRType<TC>(context, defaultKind<TC>());
-  }
-
-  template <template <typename> typename A, Fortran::common::TypeCategory TC,
-            int KIND>
-  mlir::Type gen(const A<Fortran::evaluate::Type<TC, KIND>> &) {
-    return genFIRType<TC, KIND>(context);
-  }
-
-  // breaks the conflict between A<Type<TC,KIND>> and Expr<B> deduction
-  template <Fortran::common::TypeCategory TC, int KIND>
-  mlir::Type
-  gen(const Fortran::evaluate::Expr<Fortran::evaluate::Type<TC, KIND>> &) {
-    return genFIRType<TC, KIND>(context);
-  }
-
-  // breaks the conflict between A<SomeKind<TC>> and Expr<B> deduction
-  template <Fortran::common::TypeCategory TC>
-  mlir::Type
-  gen(const Fortran::evaluate::Expr<Fortran::evaluate::SomeKind<TC>> &expr) {
-    return genVariant(expr);
-  }
-
-  template <typename A>
-  mlir::Type gen(const Fortran::evaluate::Expr<A> &expr) {
-    return genVariant(expr);
-  }
-
-  mlir::Type gen(const Fortran::evaluate::DataRef &dref) {
-    return genVariant(dref);
-  }
-
-  mlir::Type gen(const Fortran::lower::pft::Variable &var) {
-    return genSymbolHelper(var.getSymbol(), var.isHeapAlloc(), var.isPointer());
-  }
-
-  /// Type consing from a symbol. A symbol's type must be created from the type
-  /// discovered by the front-end at runtime.
-  mlir::Type gen(Fortran::semantics::SymbolRef symbol) {
-    return genSymbolHelper(symbol);
-  }
-
-  // non-template, category is runtime values, kind is defaulted
-  mlir::Type genFIRTy(Fortran::common::TypeCategory tc) {
-    return genFIRTy(tc, defaultKind(tc));
-  }
-
-  // non-template, arguments are runtime values
-  mlir::Type genFIRTy(Fortran::common::TypeCategory tc, int kind) {
-    switch (tc) {
-    case Fortran::common::TypeCategory::Real:
-      return genFIRType<Fortran::common::TypeCategory::Real>(context, kind);
-    case Fortran::common::TypeCategory::Integer:
-      return genFIRType<Fortran::common::TypeCategory::Integer>(context, kind);
-    case Fortran::common::TypeCategory::Complex:
-      return genFIRType<Fortran::common::TypeCategory::Complex>(context, kind);
-    case Fortran::common::TypeCategory::Logical:
-      return genFIRType<Fortran::common::TypeCategory::Logical>(context, kind);
-    case Fortran::common::TypeCategory::Character:
-      return genFIRType<Fortran::common::TypeCategory::Character>(context,
-                                                                  kind);
-    default:
-      break;
-    }
-    llvm_unreachable("unhandled type category");
-  }
-
-private:
-  //===--------------------------------------------------------------------===//
-  // Generate type helpers
-  //===--------------------------------------------------------------------===//
-
-  mlir::Type gen(const Fortran::evaluate::ImpliedDoIndex &) {
-    return genFIRType<Fortran::evaluate::ImpliedDoIndex::Result::category>(
-        context, Fortran::evaluate::ImpliedDoIndex::Result::kind);
-  }
-
-  mlir::Type gen(const Fortran::evaluate::TypeParamInquiry &) {
-    return genFIRType<Fortran::evaluate::TypeParamInquiry::Result::category>(
-        context, Fortran::evaluate::TypeParamInquiry::Result::kind);
-  }
-
-  template <typename A>
-  mlir::Type gen(const Fortran::evaluate::Relational<A> &) {
-    return genFIRType<Fortran::common::TypeCategory::Logical, 1>(context);
-  }
-
-  // some sequence of `n` bytes
-  mlir::Type gen(const Fortran::evaluate::StaticDataObject::Pointer &ptr) {
-    mlir::Type byteTy{mlir::IntegerType::get(8, context)};
-    return fir::SequenceType::get(trivialShape(ptr->itemBytes()), byteTy);
-  }
-
-  mlir::Type gen(const Fortran::evaluate::Substring &ss) {
-    return genVariant(ss.GetBaseObject());
-  }
-
-  mlir::Type gen(const Fortran::evaluate::NullPointer &) {
-    return genTypelessPtr();
-  }
-  mlir::Type gen(const Fortran::evaluate::ProcedureRef &) {
-    return genTypelessPtr();
-  }
-  mlir::Type gen(const Fortran::evaluate::ProcedureDesignator &) {
-    return genTypelessPtr();
-  }
-  mlir::Type gen(const Fortran::evaluate::BOZLiteralConstant &) {
-    return genTypelessPtr();
-  }
-  mlir::Type gen(const Fortran::evaluate::ArrayRef &) { TODO("array ref"); }
-  mlir::Type gen(const Fortran::evaluate::CoarrayRef &) { TODO("coarray ref"); }
-  mlir::Type gen(const Fortran::evaluate::Component &) { TODO("component"); }
-  mlir::Type gen(const Fortran::evaluate::ComplexPart &) {
-    TODO("complex part");
-  }
-  mlir::Type gen(const Fortran::evaluate::DescriptorInquiry &) {
-    TODO("descriptor inquiry");
-  }
-  mlir::Type gen(const Fortran::evaluate::StructureConstructor &) {
-    TODO("structure constructor");
-  }
-
-  fir::SequenceType::Shape genSeqShape(Fortran::semantics::SymbolRef symbol) {
-    assert(symbol->IsObjectArray() && "unexpected symbol type");
-    fir::SequenceType::Shape bounds;
-    return seqShapeHelper(symbol, bounds);
-  }
-
-  fir::SequenceType::Shape genSeqShape(Fortran::semantics::SymbolRef symbol,
-                                       fir::SequenceType::Extent charLen) {
-    assert(symbol->IsObjectArray() && "unexpected symbol type");
-    fir::SequenceType::Shape bounds;
-    bounds.push_back(charLen);
-    return seqShapeHelper(symbol, bounds);
-  }
-
-  fir::SequenceType::Extent
-  getCharacterLength(const Fortran::semantics::Symbol &symbol) {
-    if (symbol.GetType()->category() !=
-        Fortran::semantics::DeclTypeSpec::Character)
-      llvm::report_fatal_error("not a character symbol");
-    const auto &lenParam = symbol.GetType()->characterTypeSpec().length();
-    if (auto expr = lenParam.GetExplicit()) {
-      auto len = Fortran::evaluate::AsGenericExpr(std::move(*expr));
-      if (auto asInt = Fortran::evaluate::ToInt64(len))
-        return *asInt;
-    }
-    return fir::SequenceType::getUnknownExtent();
-  }
-
-  mlir::Type genSymbolHelper(const Fortran::semantics::Symbol &symbol,
-                             bool isAlloc = false, bool isPtr = false) {
-    mlir::Type ty;
-    if (auto *type{symbol.GetType()}) {
-      if (auto *tySpec{type->AsIntrinsic()}) {
-        int kind = toConstant(tySpec->kind());
-        switch (tySpec->category()) {
-        case Fortran::common::TypeCategory::Integer:
-          ty =
-              genFIRType<Fortran::common::TypeCategory::Integer>(context, kind);
-          break;
-        case Fortran::common::TypeCategory::Real:
-          ty = genFIRType<Fortran::common::TypeCategory::Real>(context, kind);
-          break;
-        case Fortran::common::TypeCategory::Complex:
-          ty =
-              genFIRType<Fortran::common::TypeCategory::Complex>(context, kind);
-          break;
-        case Fortran::common::TypeCategory::Character:
-          ty = genFIRType<Fortran::common::TypeCategory::Character>(context,
-                                                                    kind);
-          break;
-        case Fortran::common::TypeCategory::Logical:
-          ty =
-              genFIRType<Fortran::common::TypeCategory::Logical>(context, kind);
-          break;
-        default:
-          emitError("symbol has unknown intrinsic type");
-          return {};
-        }
-      } else if (auto *tySpec = type->AsDerived()) {
-        std::vector<std::pair<std::string, mlir::Type>> ps;
-        std::vector<std::pair<std::string, mlir::Type>> cs;
-        auto &symbol = tySpec->typeSymbol();
-        // FIXME: don't want to recurse forever here, but this won't happen
-        // since we don't know the components at this time
-        auto rec = fir::RecordType::get(context, toStringRef(symbol.name()));
-        auto &details = symbol.get<Fortran::semantics::DerivedTypeDetails>();
-        for (auto &param : details.paramDecls()) {
-          auto &p{*param};
-          ps.push_back(std::pair{p.name().ToString(), gen(p)});
-        }
-        emitError("the front-end returns symbols of derived type that have "
-                  "components that are simple names and not symbols, so cannot "
-                  "construct the type '" +
-                  toStringRef(symbol.name()) + "'");
-        rec.finalize(ps, cs);
-        ty = rec;
-      } else {
-        emitError("symbol's type must have a type spec");
-        return {};
-      }
-    } else {
-      emitError("symbol must have a type");
-      return {};
-    }
-    if (symbol.IsObjectArray()) {
-      if (symbol.GetType()->category() ==
-          Fortran::semantics::DeclTypeSpec::Character) {
-        auto charLen = getCharacterLength(symbol);
-        ty = fir::SequenceType::get(genSeqShape(symbol, charLen), ty);
-      } else {
-        ty = fir::SequenceType::get(genSeqShape(symbol), ty);
-      }
-    }
-
-    if (ty.isa<fir::CharacterType>()) {
-      auto charLen = getCharacterLength(symbol);
-      fir::SequenceType::Shape shape = {charLen};
-      ty = fir::SequenceType::get(shape, ty);
-    }
-
-    if (isPtr || Fortran::semantics::IsPointer(symbol))
-      ty = fir::PointerType::get(ty);
-    else if (isAlloc || Fortran::semantics::IsAllocatable(symbol))
-      ty = fir::HeapType::get(ty);
-    return ty;
-  }
-
-  //===--------------------------------------------------------------------===//
-  // Other helper functions
-  //===--------------------------------------------------------------------===//
-
-  fir::SequenceType::Shape trivialShape(int size) {
-    fir::SequenceType::Shape bounds;
-    bounds.emplace_back(size);
-    return bounds;
-  }
-
-  mlir::Type mkVoid() { return mlir::TupleType::get(context); }
-  mlir::Type genTypelessPtr() { return fir::ReferenceType::get(mkVoid()); }
-
-  template <typename A>
-  mlir::Type genVariant(const A &variant) {
-    return std::visit([&](const auto &x) { return gen(x); }, variant.u);
-  }
-
-  template <Fortran::common::TypeCategory TC>
-  int defaultKind() {
-    return defaultKind(TC);
-  }
-  int defaultKind(Fortran::common::TypeCategory TC) {
-    return defaults.GetDefaultKind(TC);
-  }
-
-  fir::SequenceType::Shape seqShapeHelper(Fortran::semantics::SymbolRef symbol,
-                                          fir::SequenceType::Shape &bounds) {
-    auto &details = symbol->get<Fortran::semantics::ObjectEntityDetails>();
-    const auto size = details.shape().size();
-    for (auto &ss : details.shape()) {
-      auto lb = ss.lbound();
-      auto ub = ss.ubound();
-      if (lb.isAssumed() && ub.isAssumed() && size == 1)
-        return {};
-      if (lb.isExplicit() && ub.isExplicit()) {
-        auto &lbv = lb.GetExplicit();
-        auto &ubv = ub.GetExplicit();
-        if (lbv.has_value() && ubv.has_value() && isConstant(lbv.value()) &&
-            isConstant(ubv.value())) {
-          bounds.emplace_back(toConstant(ubv.value()) -
-                              toConstant(lbv.value()) + 1);
-        } else {
-          bounds.emplace_back(fir::SequenceType::getUnknownExtent());
-        }
-      } else {
-        bounds.emplace_back(fir::SequenceType::getUnknownExtent());
-      }
-    }
-    return bounds;
-  }
-
-  //===--------------------------------------------------------------------===//
-  // Emit errors and warnings.
-  //===--------------------------------------------------------------------===//
-
-  mlir::InFlightDiagnostic emitError(const llvm::Twine &message) {
-    return mlir::emitError(mlir::UnknownLoc::get(context), message);
-  }
-
-  mlir::InFlightDiagnostic emitWarning(const llvm::Twine &message) {
-    return mlir::emitWarning(mlir::UnknownLoc::get(context), message);
-  }
-
-  //===--------------------------------------------------------------------===//
-
-  mlir::MLIRContext *context;
-  const Fortran::common::IntrinsicTypeDefaultKinds &defaults;
-};
-
-/// NewTypeBuilder simplifies the expression type conversion by operating
-/// on evaluate::DynamicType and evaluate::Shape instead of going down the
-/// expression tree. It fixes the fact that genType("array") would
-/// return the scalar type and crash code using the result to dispatch between
-/// scalar and array handling.
-/// TODO: replace the previous expression type conversion with it or fix the
-/// current one (The old one is still used for DataRef and Designator).
-struct NewTypeBuilder {
+  TypeBuilder(Fortran::lower::AbstractConverter &converter)
+      : converter{converter}, context{&converter.getMLIRContext()} {}
 
   mlir::Type genExprType(const Fortran::lower::SomeExpr &expr) {
     auto dynamicType = expr.GetType();
     if (!dynamicType)
-      llvm::report_fatal_error("lowering typeless expression type");
+      return genTypelessExprType(expr);
     auto category = dynamicType->category();
     if (category == Fortran::common::TypeCategory::Derived)
       TODO("derived types lowering");
-    auto shapeExpr = Fortran::evaluate::GetShape(foldingContext, expr);
+    auto shapeExpr =
+        Fortran::evaluate::GetShape(converter.getFoldingContext(), expr);
     if (!shapeExpr)
       TODO("Assumed rank expression type lowering");
 
-    auto baseType = TypeBuilder{context, foldingContext.defaults()}.genFIRTy(
-        category, dynamicType->kind());
-    if (category == Fortran::common::TypeCategory::Character) {
-      auto len = fir::SequenceType::getUnknownExtent();
-      if (auto constantLen = toInt64(dynamicType->GetCharLength()))
-        len = *constantLen;
-      fir::SequenceType::Shape shape{len};
-      translateShape(shape, std::move(*shapeExpr));
-      return fir::SequenceType::get(shape, baseType);
-    }
-    // LOGICAL, INTEGER, REAL, COMPLEX
-    fir::SequenceType::Shape shape{};
+    // LOGICAL, INTEGER, REAL, COMPLEX, CHARACTER
+    auto baseType = genFIRType(context, category, dynamicType->kind());
+    fir::SequenceType::Shape shape;
+    if (category == Fortran::common::TypeCategory::Character)
+      shape.push_back(getCharacterLength(expr));
     translateShape(shape, std::move(*shapeExpr));
     if (!shape.empty())
       return fir::SequenceType::get(shape, baseType);
@@ -531,20 +161,45 @@ struct NewTypeBuilder {
 
   template <typename A>
   std::optional<std::int64_t> toInt64(A &&expr) {
-    return Fortran::evaluate::ToInt64(
-        Fortran::evaluate::Fold(foldingContext, std::move(expr)));
+    return Fortran::evaluate::ToInt64(Fortran::evaluate::Fold(
+        converter.getFoldingContext(), std::move(expr)));
+  }
+
+  mlir::Type genTypelessExprType(const Fortran::lower::SomeExpr &expr) {
+    return std::visit(
+        Fortran::common::visitors{
+            [&](const Fortran::evaluate::BOZLiteralConstant &) -> mlir::Type {
+              return mlir::NoneType::get(context);
+            },
+            [&](const Fortran::evaluate::NullPointer &) -> mlir::Type {
+              return fir::ReferenceType::get(mlir::NoneType::get(context));
+            },
+            [&](const Fortran::evaluate::ProcedureDesignator &proc)
+                -> mlir::Type {
+              return Fortran::lower::translateSignature(proc, converter);
+            },
+            [&](const Fortran::evaluate::ProcedureRef &) -> mlir::Type {
+              return mlir::NoneType::get(context);
+            },
+            [](const auto &x) -> mlir::Type {
+              using T = std::decay_t<decltype(x)>;
+              static_assert(!Fortran::common::HasMember<
+                                T, Fortran::evaluate::TypelessExpression>,
+                            "missing typeless expr handling in type lowering");
+              llvm::report_fatal_error("not a typeless expression");
+            },
+        },
+        expr.u);
   }
 
   mlir::Type genSymbolType(const Fortran::semantics::Symbol &symbol,
                            bool isAlloc = false, bool isPtr = false) {
-    // TODO: translate symbol location to mlir loc. Need converter
-    auto loc = mlir::UnknownLoc::get(context);
+    auto loc = converter.genLocation(symbol.name());
     mlir::Type ty;
     if (auto *type{symbol.GetType()}) {
       if (auto *tySpec{type->AsIntrinsic()}) {
         int kind = toInt64(Fortran::common::Clone(tySpec->kind())).value();
-        ty = TypeBuilder{context, foldingContext.defaults()}.genFIRTy(
-            tySpec->category(), kind);
+        ty = genFIRType(context, tySpec->category(), kind);
       } else if (auto *tySpec = type->AsDerived()) {
         std::vector<std::pair<std::string, mlir::Type>> ps;
         std::vector<std::pair<std::string, mlir::Type>> cs;
@@ -565,8 +220,8 @@ struct NewTypeBuilder {
       return {};
     }
     if (symbol.IsObjectArray()) {
-      auto shapeExpr =
-          Fortran::evaluate::GetShapeHelper{foldingContext}(symbol);
+      auto shapeExpr = Fortran::evaluate::GetShapeHelper{
+          converter.getFoldingContext()}(symbol);
       if (!shapeExpr)
         TODO("assumed rank symbol type lowering");
       fir::SequenceType::Shape shape;
@@ -599,7 +254,7 @@ struct NewTypeBuilder {
     using TC =
         Fortran::evaluate::Type<Fortran::common::TypeCategory::Character, Kind>;
     auto designator = Fortran::evaluate::Fold(
-        foldingContext,
+        converter.getFoldingContext(),
         Fortran::evaluate::Expr<TC>{Fortran::evaluate::Designator<TC>{symbol}});
     if (auto len = toInt64(std::move(designator.LEN())))
       return *len;
@@ -622,66 +277,52 @@ struct NewTypeBuilder {
     case 4:
       return getCharacterLengthHelper<4>(symbol);
     }
-    llvm::report_fatal_error("unknown character kind");
+    llvm_unreachable("unknown character kind");
+  }
+  fir::SequenceType::Extent
+  getCharacterLength(const Fortran::lower::SomeExpr &expr) {
+    // Do not use dynamic type length here. We would miss constant
+    // lengths opportunities because dynamic type only has the length
+    // if it comes from a declaration.
+    auto charExpr =
+        std::get<Fortran::evaluate::Expr<Fortran::evaluate::SomeCharacter>>(
+            expr.u);
+    if (auto constantLen = toInt64(charExpr.LEN()))
+      return *constantLen;
+    return fir::SequenceType::getUnknownExtent();
   }
 
   mlir::Type genVariableType(const Fortran::lower::pft::Variable &var) {
     return genSymbolType(var.getSymbol(), var.isHeapAlloc(), var.isPointer());
   }
 
+  Fortran::lower::AbstractConverter &converter;
   mlir::MLIRContext *context;
-  Fortran::evaluate::FoldingContext &foldingContext;
 };
-
 } // namespace
 
-mlir::Type Fortran::lower::getFIRType(
-    mlir::MLIRContext *context,
-    const Fortran::common::IntrinsicTypeDefaultKinds &defaults,
-    Fortran::common::TypeCategory tc, int kind) {
-  return TypeBuilder{context, defaults}.genFIRTy(tc, kind);
-}
-
-mlir::Type Fortran::lower::getFIRType(
-    mlir::MLIRContext *context,
-    const Fortran::common::IntrinsicTypeDefaultKinds &defaults,
-    Fortran::common::TypeCategory tc) {
-  return TypeBuilder{context, defaults}.genFIRTy(tc);
-}
-
-mlir::Type Fortran::lower::translateDataRefToFIRType(
-    mlir::MLIRContext *context,
-    const Fortran::common::IntrinsicTypeDefaultKinds &defaults,
-    const Fortran::evaluate::DataRef &dataRef) {
-  return TypeBuilder{context, defaults}.gen(dataRef);
+mlir::Type Fortran::lower::getFIRType(mlir::MLIRContext *context,
+                                      Fortran::common::TypeCategory tc,
+                                      int kind) {
+  return genFIRType(context, tc, kind);
 }
 
 mlir::Type Fortran::lower::translateSomeExprToFIRType(
-    mlir::MLIRContext *context, Fortran::evaluate::FoldingContext &foldingCtx,
-    const SomeExpr *expr) {
-  return NewTypeBuilder{context, foldingCtx}.genExprType(*expr);
+    Fortran::lower::AbstractConverter &converter, const SomeExpr &expr) {
+  return TypeBuilder{converter}.genExprType(expr);
 }
 
 mlir::Type Fortran::lower::translateSymbolToFIRType(
-    mlir::MLIRContext *context, Fortran::evaluate::FoldingContext &foldingCtx,
-    const SymbolRef symbol) {
-  return NewTypeBuilder{context, foldingCtx}.genSymbolType(symbol);
+    Fortran::lower::AbstractConverter &converter, const SymbolRef symbol) {
+  return TypeBuilder{converter}.genSymbolType(symbol);
 }
 
 mlir::Type Fortran::lower::translateVariableToFIRType(
-    mlir::MLIRContext *context, Fortran::evaluate::FoldingContext &foldingCtx,
+    Fortran::lower::AbstractConverter &converter,
     const Fortran::lower::pft::Variable &var) {
-  return NewTypeBuilder{context, foldingCtx}.genVariableType(var);
+  return TypeBuilder{converter}.genVariableType(var);
 }
 
 mlir::Type Fortran::lower::convertReal(mlir::MLIRContext *context, int kind) {
-  return genFIRType<Fortran::common::TypeCategory::Real>(context, kind);
-}
-
-mlir::Type Fortran::lower::getSequenceRefType(mlir::Type refType) {
-  auto type{refType.dyn_cast<fir::ReferenceType>()};
-  assert(type && "expected a reference type");
-  auto elementType{type.getEleTy()};
-  fir::SequenceType::Shape shape{fir::SequenceType::getUnknownExtent()};
-  return fir::ReferenceType::get(fir::SequenceType::get(shape, elementType));
+  return genRealType(context, kind);
 }


### PR DESCRIPTION
- Refactor type conversions.
    - remove unused/untested entry points
    - replace `TypeBuilder` by a version that do not visit expressions (use front-end tools to get shape/dynamic type instead)
- Get length of assumed length named constant in mlir type (we cannot get it directly from the symbol). This fixes #539 
- Use `expr.LEN()` for expression instead of dynamic type length info that does not always hold an explicit length in cases where it can be deduced from the expression but is not a length coming from a declaration (like `a // b` where `a` and `b` have compiled time constant length). 