### PR TITLE
Lower allocatables (draft) and allocate/deallocate statement (nearly f95 complete)

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -120,6 +120,11 @@ public:
   /// Generate the location as converted from a CharBlock
   virtual mlir::Location genLocation(const Fortran::parser::CharBlock &) = 0;
 
+  /// Generate a string literal containing the file name and return its address
+  virtual mlir::Value locationToFilename(mlir::Location) = 0;
+  /// Generate a constant of the given type with the location line number
+  virtual mlir::Value locationToLineNo(mlir::Location, mlir::Type) = 0;
+
   //===--------------------------------------------------------------------===//
   // FIR/MLIR
   //===--------------------------------------------------------------------===//

--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -1,0 +1,45 @@
+//===-- Allocatable.h -- Allocatable statements lowering ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+class Value;
+class Location;
+} // namespace mlir
+
+namespace Fortran::parser {
+struct AllocateStmt;
+struct DeallocateStmt;
+} // namespace Fortran::parser
+
+namespace Fortran::lower {
+class AbstractConverter;
+namespace pft {
+class Variable;
+}
+
+/// Generate fir to initialize the box (descriptor) of an allocatable variable.
+/// Initialization of such box has to be done at the beginning of the variable
+/// lifetime.
+/// The memory address of the box to be initialized must be provided as an
+/// input.
+void genAllocatableInit(Fortran::lower::AbstractConverter &,
+                        const Fortran::lower::pft::Variable &,
+                        mlir::Value boxAddress);
+
+/// Lower an allocate statement to fir.
+void genAllocateStmt(Fortran::lower::AbstractConverter &,
+                     const Fortran::parser::AllocateStmt &, mlir::Location);
+
+/// Lower a deallocate statement to fir.
+void genDeallocateStmt(Fortran::lower::AbstractConverter &,
+                       const Fortran::parser::DeallocateStmt &, mlir::Location);
+} // namespace Fortran::lower

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -218,6 +218,11 @@ public:
   /// Array entities are boxed with a shape and character with their length.
   mlir::Value createBox(mlir::Location loc, const fir::ExtendedValue &exv);
 
+  /// Create constant i1 with value 1. if \p b is true or 0. otherwise
+  mlir::Value createBool(mlir::Location loc, bool b) {
+    return createIntegerConstant(loc, getIntegerType(1), b ? 1 : 0);
+  }
+
 private:
   const fir::KindMapping &kindMap;
 };

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -389,6 +389,8 @@ def fir_AllocaOp :
     mlir::Type outType = getType();
     if (!outType.isa<fir::ReferenceType>())
       return emitOpError("must be a !fir.ref type");
+    if (fir::isa_unknown_size_box(fir::dyn_cast_ptrEleTy(outType)))
+      return emitOpError("cannot allocate !fir.box of unknown rank or type");
     return mlir::success();
   }];
 
@@ -508,6 +510,8 @@ def fir_StoreOp : fir_Op<"store", []> {
   let verifier = [{
     if (value().getType() != fir::dyn_cast_ptrEleTy(memref().getType()))
       return emitOpError("store value type must match memory reference type");
+    if (fir::isa_box_type(value().getType()))
+      return emitOpError("!fir.box cannot be stored");
     return mlir::success();
   }];
 
@@ -562,6 +566,8 @@ def fir_AllocMemOp : fir_AllocatableOp<"allocmem", DefaultResource> {
     mlir::Type outType = getType();
     if (!outType.dyn_cast<fir::HeapType>())
       return emitOpError("must be a !fir.heap type");
+    if (fir::isa_unknown_size_box(fir::dyn_cast_ptrEleTy(outType)))
+      return emitOpError("cannot allocate !fir.box of unknown rank or type");
     return mlir::success();
   }];
 

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -462,6 +462,11 @@ inline bool isa_char_string(mlir::Type t) {
   return false;
 }
 
+/// Is `t` a box type for which it is not possible to deduce the box size.
+/// It is not possible to deduce the size of a box that describes an entity
+/// of unknown rank or type.
+bool isa_unknown_size_box(mlir::Type t);
+
 } // namespace fir
 
 #endif // OPTIMIZER_DIALECT_FIRTYPE_H

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -33,7 +33,7 @@ static void genAllocatableInitIntrinsic(Fortran::lower::FirOpBuilder &builder,
                                         mlir::Value kind, mlir::Value rank,
                                         mlir::Value corank) {
   auto callee =
-      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableInitIntrinsic)>(
+      Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableInitIntrinsic)>(
           loc, builder);
   llvm::SmallVector<mlir::Value, 5> args = {boxAddress, typeCategory, kind,
                                             rank, corank};
@@ -47,9 +47,8 @@ static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
                                     mlir::Location loc, mlir::Value boxAddress,
                                     mlir::Value dimIndex, mlir::Value lowerBoud,
                                     mlir::Value upperBound) {
-  auto callee =
-      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableSetBounds)>(
-          loc, builder);
+  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableSetBounds)>(
+      loc, builder);
   llvm::SmallVector<mlir::Value, 4> args{boxAddress, dimIndex, lowerBoud,
                                          upperBound};
   llvm::SmallVector<mlir::Value, 4> operands;
@@ -63,9 +62,8 @@ genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
                        mlir::Location loc, mlir::Value boxAddress,
                        mlir::Value hasStat, mlir::Value errMsgBox,
                        mlir::Value sourceFile, mlir::Value sourceLine) {
-  auto callee =
-      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableAllocate)>(loc,
-                                                                       builder);
+  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableAllocate)>(
+      loc, builder);
   llvm::SmallVector<mlir::Value, 5> args{boxAddress, hasStat, errMsgBox,
                                          sourceFile, sourceLine};
   llvm::SmallVector<mlir::Value, 5> operands;
@@ -79,9 +77,8 @@ genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
                          mlir::Location loc, mlir::Value boxAddress,
                          mlir::Value hasStat, mlir::Value errMsgBox,
                          mlir::Value sourceFile, mlir::Value sourceLine) {
-  auto callee =
-      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableDeallocate)>(
-          loc, builder);
+  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableDeallocate)>(
+      loc, builder);
   llvm::SmallVector<mlir::Value, 5> args{boxAddress, hasStat, errMsgBox,
                                          sourceFile, sourceLine};
   llvm::SmallVector<mlir::Value, 5> operands;

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -1,0 +1,391 @@
+//===-- Allocatable.cpp -- Allocatable statements lowering ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/Allocatable.h"
+#include "../runtime/allocatable.h"
+#include "RTBuilder.h"
+#include "flang/Evaluate/tools.h"
+#include "flang/Lower/AbstractConverter.h"
+#include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/PFTBuilder.h"
+#include "flang/Lower/Runtime.h"
+#include "flang/Lower/Todo.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Parser/parse-tree.h"
+#include "flang/Semantics/tools.h"
+#include "flang/Semantics/type.h"
+
+/// Runtime call generators
+using namespace Fortran::runtime;
+static void genAllocatableInitIntrinsic(Fortran::lower::FirOpBuilder &builder,
+                                        mlir::Location loc,
+                                        mlir::Value boxAddress,
+                                        mlir::Value typeCategory,
+                                        mlir::Value kind, mlir::Value rank,
+                                        mlir::Value corank) {
+  auto callee =
+      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableInitIntrinsic)>(
+          loc, builder);
+  llvm::SmallVector<mlir::Value, 5> args = {boxAddress, typeCategory, kind,
+                                            rank, corank};
+  llvm::SmallVector<mlir::Value, 5> operands;
+  for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
+    operands.emplace_back(builder.createConvert(loc, snd, fst));
+  builder.create<fir::CallOp>(loc, callee, operands);
+}
+
+static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
+                                    mlir::Location loc, mlir::Value boxAddress,
+                                    mlir::Value dimIndex, mlir::Value lowerBoud,
+                                    mlir::Value upperBound) {
+  auto callee =
+      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableSetBounds)>(
+          loc, builder);
+  llvm::SmallVector<mlir::Value, 4> args{boxAddress, dimIndex, lowerBoud,
+                                         upperBound};
+  llvm::SmallVector<mlir::Value, 4> operands;
+  for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
+    operands.emplace_back(builder.createConvert(loc, snd, fst));
+  builder.create<fir::CallOp>(loc, callee, operands);
+}
+
+static mlir::Value
+genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
+                       mlir::Location loc, mlir::Value boxAddress,
+                       mlir::Value hasStat, mlir::Value errMsgBox,
+                       mlir::Value sourceFile, mlir::Value sourceLine) {
+  auto callee =
+      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableAllocate)>(loc,
+                                                                       builder);
+  llvm::SmallVector<mlir::Value, 5> args{boxAddress, hasStat, errMsgBox,
+                                         sourceFile, sourceLine};
+  llvm::SmallVector<mlir::Value, 5> operands;
+  for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
+    operands.emplace_back(builder.createConvert(loc, snd, fst));
+  return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
+}
+
+static mlir::Value
+genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
+                         mlir::Location loc, mlir::Value boxAddress,
+                         mlir::Value hasStat, mlir::Value errMsgBox,
+                         mlir::Value sourceFile, mlir::Value sourceLine) {
+  auto callee =
+      Fortran::lower::genRuntimeFunction<mkRTKey(AllocatableDeallocate)>(
+          loc, builder);
+  llvm::SmallVector<mlir::Value, 5> args{boxAddress, hasStat, errMsgBox,
+                                         sourceFile, sourceLine};
+  llvm::SmallVector<mlir::Value, 5> operands;
+  for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
+    operands.emplace_back(builder.createConvert(loc, snd, fst));
+  return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
+}
+
+/// Helper to get symbol from AllocateObject.
+static const Fortran::semantics::Symbol &
+unwrapSymbol(const Fortran::parser::AllocateObject &allocObj) {
+  const auto &lastName = Fortran::parser::GetLastName(allocObj);
+  assert(lastName.symbol);
+  return lastName.symbol->GetUltimate();
+}
+
+namespace {
+// Lower ALLOCATE/DEALLOCATE stmt ERROR and STAT variable as well as the source
+// file location to be passed to the runtime.
+struct ErrorManagementValues {
+  void lower(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+             const Fortran::lower::SomeExpr *statExpr,
+             const ::Fortran::lower::SomeExpr *errMsgExpr) {
+    auto builder = converter.getFirOpBuilder();
+    if (statExpr) {
+      TODO("lower stat expr in allocate and deallocate");
+      hasStat = builder.createBool(loc, true);
+    } else {
+      hasStat = builder.createBool(loc, false);
+    }
+
+    if (errMsgExpr)
+      TODO("errmsg in allocate and deallocate");
+    else
+      errMsgBoxAddr = builder.createNullConstant(loc);
+    sourceFile = converter.locationToFilename(loc);
+    sourceLine = converter.locationToLineNo(loc, builder.getIntegerType(32));
+  }
+  bool hasErrorRecovery() const { return static_cast<bool>(statAddr); }
+  // Values always initialized before lowering individual allocations
+  mlir::Value sourceLine;
+  mlir::Value sourceFile;
+  mlir::Value hasStat;
+  mlir::Value errMsgBoxAddr;
+  // Value created only in certain cases before lowering individual allocations
+  mlir::Value statAddr;
+};
+
+class AllocateStmtHelper {
+public:
+  AllocateStmtHelper(Fortran::lower::AbstractConverter &converter,
+                     const Fortran::parser::AllocateStmt &stmt,
+                     mlir::Location loc)
+      : converter{converter}, builder{converter.getFirOpBuilder()}, stmt{stmt},
+        loc{loc} {}
+
+  void lower() {
+    visitAllocateOptions();
+    errorManagement.lower(converter, loc, statExpr, errMsgExpr);
+    // Create a landing block after all allocations so that
+    // we can jump there in case of error.
+    if (errorManagement.hasErrorRecovery())
+      TODO("error recovery");
+
+    // TODO lower source and mold.
+    if (sourceExpr || moldExpr)
+      TODO("lower MOLD/SOURCE expr in allocate");
+
+    for (const auto &allocation :
+         std::get<std::list<Fortran::parser::Allocation>>(stmt.t))
+      lowerAllocation(unwrapAllocation(allocation));
+  }
+
+private:
+  struct Allocation {
+    const Fortran::parser::Allocation &alloc;
+    const Fortran::semantics::Symbol &symbol;
+    const Fortran::semantics::DeclTypeSpec &type;
+    bool hasCoarraySpec() const {
+      return std::get<std::optional<Fortran::parser::AllocateCoarraySpec>>(
+                 alloc.t)
+          .has_value();
+    }
+    const auto &getShapeSpecs() const {
+      return std::get<std::list<Fortran::parser::AllocateShapeSpec>>(alloc.t);
+    }
+  };
+
+  Allocation unwrapAllocation(const Fortran::parser::Allocation &alloc) {
+    const auto &allocObj = std::get<Fortran::parser::AllocateObject>(alloc.t);
+    const auto &symbol = unwrapSymbol(allocObj);
+    assert(symbol.GetType());
+    return Allocation{alloc, symbol, *symbol.GetType()};
+  }
+
+  void visitAllocateOptions() {
+    for (const auto &allocOption :
+         std::get<std::list<Fortran::parser::AllocOpt>>(stmt.t))
+      std::visit(
+          Fortran::common::visitors{
+              [&](const Fortran::parser::StatOrErrmsg &statOrErr) {
+                std::visit(
+                    Fortran::common::visitors{
+                        [&](const Fortran::parser::StatVariable &statVar) {
+                          statExpr = Fortran::semantics::GetExpr(statVar);
+                        },
+                        [&](const Fortran::parser::MsgVariable &errMsgVar) {
+                          errMsgExpr = Fortran::semantics::GetExpr(errMsgVar);
+                        },
+                    },
+                    statOrErr.u);
+              },
+              [&](const Fortran::parser::AllocOpt::Source &source) {
+                sourceExpr = Fortran::semantics::GetExpr(source.v.value());
+              },
+              [&](const Fortran::parser::AllocOpt::Mold &mold) {
+                moldExpr = Fortran::semantics::GetExpr(mold.v.value());
+              },
+          },
+          allocOption.u);
+  }
+
+  void lowerAllocation(const Allocation &alloc) {
+    auto boxAddr = converter.getSymbolAddress(alloc.symbol);
+    if (!boxAddr)
+      TODO("Allocatable type not lowered yet");
+    mlir::Value backupBox;
+    if (errorManagement.hasErrorRecovery())
+      backupBox = genDescriptorBackup(boxAddr);
+
+    if (sourceExpr) {
+      genSourceAllocation(alloc, boxAddr);
+    } else if (moldExpr) {
+      genMoldAllocation(alloc, boxAddr);
+    } else {
+      genSimpleAllocation(alloc, boxAddr);
+    }
+
+    if (errorManagement.hasErrorRecovery())
+      genDescriptorRollBack(boxAddr, backupBox);
+  }
+
+  mlir::Value genDescriptorBackup(mlir::Value boxAddr) {
+    // back-up descriptors in case something goes wrong. This is to fullfill
+    // Fortran 2018 9.7.4 point 6 requirements that the original descriptor is
+    // unaltered in case of error when stat is present. Instead of overthinking
+    // what individual fields we need to backup, which in case of polymorphism
+    // can be quite a lot, just save the whole descriptor before modifying it.
+    TODO("descriptor backup in allocate with stat");
+  }
+
+  void genDescriptorRollBack(mlir::Value boxAddr, mlir::Value backupBox) {
+    // copy back backed-up descriptors in case something went wrong.
+    TODO("descriptor rollback in allocate with stat");
+  }
+
+  void genSimpleAllocation(const Allocation &alloc, mlir::Value boxAddr) {
+    if (alloc.hasCoarraySpec())
+      TODO("coarray allocation");
+    if (alloc.type.IsPolymorphic())
+      genSetType(alloc, boxAddr);
+    genSetDeferredLengthParameters(alloc, boxAddr);
+    // Set bounds for arrays
+    auto idxTy = builder.getIndexType();
+    auto i32Ty = builder.getIntegerType(32);
+    for (const auto &iter : llvm::enumerate(alloc.getShapeSpecs())) {
+      mlir::Value lb;
+      const auto &bounds = iter.value().t;
+      if (const auto &lbExpr = std::get<0>(bounds))
+        lb = fir::getBase(
+            converter.genExprValue(Fortran::semantics::GetExpr(*lbExpr), loc));
+      else
+        lb = builder.createIntegerConstant(loc, idxTy, 1);
+      auto ub = fir::getBase(converter.genExprValue(
+          Fortran::semantics::GetExpr(std::get<1>(bounds)), loc));
+      auto dimIndex = builder.createIntegerConstant(loc, i32Ty, iter.index());
+      // Runtime call
+      genAllocatableSetBounds(builder, loc, boxAddr, dimIndex, lb, ub);
+    }
+    // Runtime call
+    auto stat = genAllocatableAllocate(builder, loc, boxAddr, getHasStat(),
+                                       getErrMsgBoxAddr(), getSourceFile(),
+                                       getSourceLine());
+    if (auto statAddr = getStatAddr()) {
+      auto castStat = builder.createConvert(
+          loc, fir::dyn_cast_ptrEleTy(statAddr.getType()), stat);
+      builder.create<fir::StoreOp>(loc, castStat, statAddr);
+    }
+  }
+
+  void genSetDeferredLengthParameters(const Allocation &alloc,
+                                      mlir::Value boxAddr) {
+    // TODO: go through type parameters and set the ones that are deferred
+    // according to the allocation typespec.
+  }
+
+  void genSourceAllocation(const Allocation &alloc, mlir::Value boxAddr) {
+    TODO("SOURCE allocation lowering");
+  }
+  void genMoldAllocation(const Allocation &alloc, mlir::Value boxAddr) {
+    TODO("MOLD allocation lowering");
+  }
+  void genSetType(const Allocation &alloc, mlir::Value boxAddr) {
+    TODO("Polymorphic entity allocation lowering");
+  }
+
+  mlir::Value getSourceLine() const {
+    assert(errorManagement.sourceLine && "always needs to be lowered");
+    return errorManagement.sourceLine;
+  }
+  mlir::Value getSourceFile() const {
+    assert(errorManagement.sourceFile && "always needs to be lowered");
+    return errorManagement.sourceFile;
+  }
+  mlir::Value getHasStat() {
+    assert(errorManagement.sourceFile && "always needs to be lowered");
+    return errorManagement.hasStat;
+  }
+  mlir::Value getErrMsgBoxAddr() {
+    assert(errorManagement.sourceFile && "always needs to be lowered");
+    return errorManagement.errMsgBoxAddr;
+  }
+  mlir::Value getStatAddr() const { return errorManagement.statAddr; }
+
+  Fortran::lower::AbstractConverter &converter;
+  Fortran::lower::FirOpBuilder &builder;
+  const Fortran::parser::AllocateStmt &stmt;
+  const Fortran::lower::SomeExpr *sourceExpr{nullptr};
+  const Fortran::lower::SomeExpr *moldExpr{nullptr};
+  const Fortran::lower::SomeExpr *statExpr{nullptr};
+  const Fortran::lower::SomeExpr *errMsgExpr{nullptr};
+  ErrorManagementValues errorManagement;
+
+  mlir::Location loc;
+};
+} // namespace
+
+void Fortran::lower::genAllocateStmt(
+    Fortran::lower::AbstractConverter &converter,
+    const Fortran::parser::AllocateStmt &stmt, mlir::Location loc) {
+  AllocateStmtHelper{converter, stmt, loc}.lower();
+  return;
+}
+
+void Fortran::lower::genDeallocateStmt(
+    Fortran::lower::AbstractConverter &converter,
+    const Fortran::parser::DeallocateStmt &stmt, mlir::Location loc) {
+  const Fortran::lower::SomeExpr *statExpr{nullptr};
+  const Fortran::lower::SomeExpr *errMsgExpr{nullptr};
+  for (const auto &statOrErr :
+       std::get<std::list<Fortran::parser::StatOrErrmsg>>(stmt.t))
+    std::visit(Fortran::common::visitors{
+                   [&](const Fortran::parser::StatVariable &statVar) {
+                     statExpr = Fortran::semantics::GetExpr(statVar);
+                   },
+                   [&](const Fortran::parser::MsgVariable &errMsgVar) {
+                     errMsgExpr = Fortran::semantics::GetExpr(errMsgVar);
+                   },
+               },
+               statOrErr.u);
+  if (statExpr || errMsgExpr)
+    TODO("error recovery in deallocate");
+  ErrorManagementValues errorManagement;
+  auto &builder = converter.getFirOpBuilder();
+  errorManagement.lower(converter, loc, statExpr, errMsgExpr);
+  for (const auto &allocateObject :
+       std::get<std::list<Fortran::parser::AllocateObject>>(stmt.t)) {
+    const auto &symbol = unwrapSymbol(allocateObject);
+    auto boxAddr = converter.getSymbolAddress(symbol);
+    if (!boxAddr)
+      TODO("Allocatable type not lowered yet");
+    // TODO use return stat for error recovery
+    genAllocatableDeallocate(builder, loc, boxAddr, errorManagement.hasStat,
+                             errorManagement.errMsgBoxAddr,
+                             errorManagement.sourceFile,
+                             errorManagement.sourceLine);
+  }
+}
+
+void Fortran::lower::genAllocatableInit(
+    Fortran::lower::AbstractConverter &converter,
+    const Fortran::lower::pft::Variable &var, mlir::Value boxAddress) {
+  auto loc = converter.genLocation(var.getSymbol().name());
+  auto &builder = converter.getFirOpBuilder();
+  auto declType = var.getSymbol().GetType();
+  if (!declType)
+    TODO("Is this possible ?");
+  if (auto intrinsic = declType->AsIntrinsic()) {
+    if (intrinsic->category() == Fortran::common::TypeCategory::Character) {
+      TODO("character alloctable init");
+    } else {
+      auto i32ty = builder.getIntegerType(32);
+      int catCode = static_cast<int>(intrinsic->category());
+      auto cat = builder.createIntegerConstant(loc, i32ty, catCode);
+      auto kindExpr = Fortran::evaluate::AsGenericExpr(
+          Fortran::common::Clone(intrinsic->kind()));
+      auto kind = fir::getBase(converter.genExprValue(kindExpr));
+      auto rank =
+          builder.createIntegerConstant(loc, i32ty, var.getSymbol().Rank());
+      auto corank = builder.createIntegerConstant(loc, i32ty, 0);
+      genAllocatableInitIntrinsic(builder, loc, boxAddress, cat, kind, rank,
+                                  corank);
+    }
+  } else {
+    TODO("derived type allocatable init");
+  }
+}

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -2,6 +2,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_flang_library(FortranLower
+  Allocatable.cpp
   Bridge.cpp
   CallInterface.cpp
   CharacterExpr.cpp

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -18,54 +18,8 @@
 
 using namespace Fortran::runtime;
 
-#define NAMIFY_HELPER(X) #X
-#define NAMIFY(X) NAMIFY_HELPER(IONAME(X))
-#define mkRTKey(X) mkKey(RTNAME(X))
-
-namespace Fortran::lower {
-/// Static table of CHARACTER runtime calls
-///
-/// This logical map contains the name and type builder function for each
-/// runtime function listed in the tuple. This table is fully constructed at
-/// compile-time. Use the `mkRTKey` macro to access the table.
-static constexpr std::tuple<
-    mkRTKey(CharacterCompareScalar), mkRTKey(CharacterCompareScalar1),
-    mkRTKey(CharacterCompareScalar2), mkRTKey(CharacterCompareScalar4),
-    mkRTKey(CharacterCompare)>
-    newCharRTTable;
-} // namespace Fortran::lower
-
-using namespace Fortran::lower;
-
-/// Helper function to retrieve the name of the IO function given the key `A`
-template <typename A>
-static constexpr const char *getName() {
-  return std::get<A>(newCharRTTable).name;
-}
-
-/// Helper function to retrieve the type model signature builder of the IO
-/// function as defined by the key `A`
-template <typename A>
-static constexpr FuncTypeBuilderFunc getTypeModel() {
-  return std::get<A>(newCharRTTable).getTypeModel();
-}
-
-inline int64_t getLength(mlir::Type argTy) {
+static inline int64_t getLength(mlir::Type argTy) {
   return argTy.cast<fir::SequenceType>().getShape()[0];
-}
-
-/// Get (or generate) the MLIR FuncOp for a given runtime function.
-template <typename E>
-static mlir::FuncOp getRuntimeFunc(mlir::Location loc,
-                                   Fortran::lower::FirOpBuilder &builder) {
-  auto name = getName<E>();
-  auto func = builder.getNamedFunction(name);
-  if (func)
-    return func;
-  auto funTy = getTypeModel<E>()(builder.getContext());
-  func = builder.createFunction(loc, name, funTy);
-  func.setAttr("fir.runtime", builder.getUnitAttr());
-  return func;
 }
 
 /// Helper function to recover the KIND from the FIR type.
@@ -96,13 +50,16 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
   mlir::FuncOp beginFunc;
   switch (discoverKind(lhsBuff.getType())) {
   case 1:
-    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar1)>(loc, builder);
+    beginFunc =
+        genRuntimeFunction<mkRTKey(CharacterCompareScalar1)>(loc, builder);
     break;
   case 2:
-    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar2)>(loc, builder);
+    beginFunc =
+        genRuntimeFunction<mkRTKey(CharacterCompareScalar2)>(loc, builder);
     break;
   case 4:
-    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar4)>(loc, builder);
+    beginFunc =
+        genRuntimeFunction<mkRTKey(CharacterCompareScalar4)>(loc, builder);
     break;
   default:
     llvm_unreachable("runtime does not support CHARACTER KIND");

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -50,16 +50,13 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
   mlir::FuncOp beginFunc;
   switch (discoverKind(lhsBuff.getType())) {
   case 1:
-    beginFunc =
-        genRuntimeFunction<mkRTKey(CharacterCompareScalar1)>(loc, builder);
+    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar1)>(loc, builder);
     break;
   case 2:
-    beginFunc =
-        genRuntimeFunction<mkRTKey(CharacterCompareScalar2)>(loc, builder);
+    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar2)>(loc, builder);
     break;
   case 4:
-    beginFunc =
-        genRuntimeFunction<mkRTKey(CharacterCompareScalar4)>(loc, builder);
+    beginFunc = getRuntimeFunc<mkRTKey(CharacterCompareScalar4)>(loc, builder);
     break;
   default:
     llvm_unreachable("runtime does not support CHARACTER KIND");

--- a/flang/lib/Lower/RTBuilder.h
+++ b/flang/lib/Lower/RTBuilder.h
@@ -337,8 +337,8 @@ struct RuntimeTableEntry<RuntimeTableKey<KT>, RuntimeIdentifier<Cs...>> {
 /// Clients should add "using namespace Fortran::runtime"
 /// in order to use this function.
 template <typename RuntimeEntry>
-static mlir::FuncOp genRuntimeFunction(mlir::Location loc,
-                                       Fortran::lower::FirOpBuilder &builder) {
+static mlir::FuncOp getRuntimeFunc(mlir::Location loc,
+                                   Fortran::lower::FirOpBuilder &builder) {
   auto name = RuntimeEntry::name;
   auto func = builder.getNamedFunction(name);
   if (func)

--- a/flang/lib/Lower/RTBuilder.h
+++ b/flang/lib/Lower/RTBuilder.h
@@ -18,7 +18,9 @@
 #define FORTRAN_LOWER_RTBUILDER_H
 
 #include "flang/Lower/ConvertType.h"
+#include "flang/Lower/FIRBuilder.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
+#include "mlir/IR/Function.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/StandardTypes.h"
 #include "llvm/ADT/SmallVector.h"
@@ -42,6 +44,9 @@ using FuncTypeBuilderFunc = mlir::FunctionType (*)(mlir::MLIRContext *);
 //===----------------------------------------------------------------------===//
 // Type builder models
 //===----------------------------------------------------------------------===//
+
+// TODO: all usages of sizeof in this file assume build ==  host == target.
+// This will need to be re-visited for cross compilation.
 
 /// Return a function that returns the type signature model for the type `T`
 /// when provided an MLIRContext*. This allows one to translate C(++) function
@@ -209,6 +214,24 @@ constexpr TypeBuilderFunc getModel<const Fortran::runtime::Descriptor &>() {
   };
 }
 template <>
+constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor &>() {
+  return [](mlir::MLIRContext *context) -> mlir::Type {
+    return fir::ReferenceType::get(
+        fir::BoxType::get(mlir::NoneType::get(context)));
+  };
+}
+template <>
+constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor *>() {
+  return getModel<Fortran::runtime::Descriptor &>();
+}
+template <>
+constexpr TypeBuilderFunc getModel<Fortran::common::TypeCategory>() {
+  return [](mlir::MLIRContext *context) -> mlir::Type {
+    return mlir::IntegerType::get(sizeof(Fortran::common::TypeCategory) * 8,
+                                  context);
+  };
+}
+template <>
 constexpr TypeBuilderFunc getModel<const Fortran::runtime::NamelistGroup &>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
     // FIXME: a namelist group must be some well-defined data structure, use a
@@ -307,7 +330,24 @@ struct RuntimeTableEntry<RuntimeTableKey<KT>, RuntimeIdentifier<Cs...>> {
 #define mkKey(X)                                                               \
   Fortran::lower::RuntimeTableEntry<                                           \
       Fortran::lower::RuntimeTableKey<decltype(X)>, AsSequence(X)>
+#define mkRTKey(X) mkKey(RTNAME(X))
 
+/// Get (or generate) the MLIR FuncOp for a given runtime function. Its template
+/// argument is intended to be of the form: <mkRTKey(runtime function name)>
+/// Clients should add "using namespace Fortran::runtime"
+/// in order to use this function.
+template <typename RuntimeEntry>
+static mlir::FuncOp genRuntimeFunction(mlir::Location loc,
+                                       Fortran::lower::FirOpBuilder &builder) {
+  auto name = RuntimeEntry::name;
+  auto func = builder.getNamedFunction(name);
+  if (func)
+    return func;
+  auto funTy = RuntimeEntry::getTypeModel()(builder.getContext());
+  func = builder.createFunction(loc, name, funTy);
+  func.setAttr("fir.runtime", builder.getUnitAttr());
+  return func;
+}
 } // namespace Fortran::lower
 
 #endif // FORTRAN_LOWER_RTBUILDER_H

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -58,7 +58,7 @@ void Fortran::lower::genStopStatement(
                llvm::dbgs() << '\n');
     expr.match(
         [&](const fir::CharBoxValue &x) {
-          callee = genRuntimeFunction<mkRTKey(StopStatementText)>(loc, builder);
+          callee = getRuntimeFunc<mkRTKey(StopStatementText)>(loc, builder);
           calleeType = callee.getType();
           // Creates a pair of operands for the CHARACTER and its LEN.
           operands.push_back(
@@ -67,7 +67,7 @@ void Fortran::lower::genStopStatement(
               builder.createConvert(loc, calleeType.getInput(1), x.getLen()));
         },
         [&](fir::UnboxedValue x) {
-          callee = genRuntimeFunction<mkRTKey(StopStatement)>(loc, builder);
+          callee = getRuntimeFunc<mkRTKey(StopStatement)>(loc, builder);
           calleeType = callee.getType();
           auto cast = builder.createConvert(loc, calleeType.getInput(0), x);
           operands.push_back(cast);
@@ -77,7 +77,7 @@ void Fortran::lower::genStopStatement(
           std::exit(1);
         });
   } else {
-    callee = genRuntimeFunction<mkRTKey(StopStatement)>(loc, builder);
+    callee = getRuntimeFunc<mkRTKey(StopStatement)>(loc, builder);
     calleeType = callee.getType();
     operands.push_back(
         builder.createIntegerConstant(loc, calleeType.getInput(0), 0));
@@ -110,7 +110,7 @@ void Fortran::lower::genFailImageStatement(
     Fortran::lower::AbstractConverter &converter) {
   auto &builder = converter.getFirOpBuilder();
   auto loc = converter.getCurrentLocation();
-  auto callee = genRuntimeFunction<mkRTKey(FailImageStatement)>(loc, builder);
+  auto callee = getRuntimeFunc<mkRTKey(FailImageStatement)>(loc, builder);
   builder.create<fir::CallOp>(loc, callee, llvm::None);
   genUnreachable(builder, loc);
 }
@@ -176,7 +176,7 @@ void Fortran::lower::genPauseStatement(
     const Fortran::parser::PauseStmt &) {
   auto &builder = converter.getFirOpBuilder();
   auto loc = converter.getCurrentLocation();
-  auto callee = genRuntimeFunction<mkRTKey(PauseStatement)>(loc, builder);
+  auto callee = getRuntimeFunc<mkRTKey(PauseStatement)>(loc, builder);
   builder.create<fir::CallOp>(loc, callee, llvm::None);
 }
 
@@ -185,7 +185,7 @@ void Fortran::lower::genDateAndTime(Fortran::lower::FirOpBuilder &builder,
                                     llvm::Optional<fir::CharBoxValue> date,
                                     llvm::Optional<fir::CharBoxValue> time,
                                     llvm::Optional<fir::CharBoxValue> zone) {
-  auto callee = genRuntimeFunction<mkRTKey(DateAndTime)>(loc, builder);
+  auto callee = getRuntimeFunc<mkRTKey(DateAndTime)>(loc, builder);
   mlir::Type idxTy = builder.getIndexType();
   mlir::Value zero;
   auto splitArg = [&](llvm::Optional<fir::CharBoxValue> arg,

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -132,6 +132,9 @@ public:
     // (buffer*, ele-size, rank, type-descriptor, attribute, [dims])
     SmallVector<mlir::LLVM::LLVMType, 6> parts;
     mlir::Type ele = box.getEleTy();
+    // remove fir.heap/fir.ref/fir.ptr
+    if (auto removeIndirection = fir::dyn_cast_ptrEleTy(ele))
+      ele = removeIndirection;
     auto eleTy = unwrap(convertType(ele));
     // buffer*
     if (ele.isa<SequenceType>() && eleTy.isPointerTy())

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -240,6 +240,15 @@ public:
         eleTy = seqTy.getEleTy();
       }
     }
+    // fir.ref<fir.box> is a special case because fir.box type is already
+    // a pointer to a Fortran descriptor at the LLVM IR level. This implies
+    // that a fir.ref<fir.box>, that is the address of fir.box is actually
+    // the same as a fir.box at the LLVM level.
+    // The distinction is kept in fir to denote when a descriptor is expected
+    // to be mutable (fir.ref<fir.box>) and when it is not (fir.box).
+    if (eleTy.isa<fir::BoxType>())
+      return unwrap(convertType(eleTy));
+
     return unwrap(convertType(eleTy)).getPointerTo();
   }
 

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -1557,3 +1557,17 @@ void fir::printFirType(FIROpsDialect *, mlir::Type ty,
     return;
   }
 }
+
+bool fir::isa_unknown_size_box(mlir::Type t) {
+  if (auto boxTy = t.dyn_cast<fir::BoxType>()) {
+    auto eleTy = boxTy.getEleTy();
+    if (auto actualEleTy = fir::dyn_cast_ptrEleTy(eleTy))
+      eleTy = actualEleTy;
+    if (eleTy.isa<mlir::NoneType>())
+      return true;
+    if (auto seqTy = eleTy.dyn_cast<fir::SequenceType>())
+      if (seqTy.hasUnknownShape())
+        return true;
+  }
+  return false;
+}

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -1,0 +1,69 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test lowering of allocatables
+! CHECK-LABEL: _QPfoo
+subroutine foo()
+  real, allocatable :: x(:), y(:, :), z
+  ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
+  ! CHECK-DAG: %[[xTypeCat:.*]] = constant 1 : i32
+  ! CHECK-DAG: %[[xKind:.*]] = constant 4 : i64
+  ! CHECK-DAG: %[[xRank:.*]] = constant 1 : i32
+  ! CHECK-DAG: %[[xCorank:.*]] = constant 0 : i32
+  ! CHECK-DAG: %[[xBoxCast:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[xKindCast:.*]] = fir.convert %[[xKind]] : (i64) -> i32
+  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[xBoxCast]], %[[xTypeCat]], %[[xKindCast]], %[[xRank]], %[[xCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+
+  ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
+  ! CHECK-DAG: %[[yTypeCat:.*]] = constant 1 : i32
+  ! CHECK-DAG: %[[yKind:.*]] = constant 4 : i64
+  ! CHECK-DAG: %[[yRank:.*]] = constant 2 : i32
+  ! CHECK-DAG: %[[yCorank:.*]] = constant 0 : i32
+  ! CHECK-DAG: %[[yBoxCast:.*]] = fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[yKindCast:.*]] = fir.convert %[[yKind]] : (i64) -> i32
+  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[yBoxCast]], %[[yTypeCat]], %[[yKindCast]], %[[yRank]], %[[yCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+
+  ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
+  ! CHECK-DAG: %[[zTypeCat:.*]] = constant 1 : i32
+  ! CHECK-DAG: %[[zKind:.*]] = constant 4 : i64
+  ! CHECK-DAG: %[[zRank:.*]] = constant 0 : i32
+  ! CHECK-DAG: %[[zCorank:.*]] = constant 0 : i32
+  ! CHECK-DAG: %[[zBoxCast:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[zKindCast:.*]] = fir.convert %[[zKind]] : (i64) -> i32
+  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[zBoxCast]], %[[zTypeCat]], %[[zKindCast]], %[[zRank]], %[[zCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+
+  allocate(x(42:100), y(43:50, 51), z)
+  ! CHECK-DAG: %[[xlb:.*]] = constant 42 : i32
+  ! CHECK-DAG: %[[xub:.*]] = constant 100 : i32
+  ! CHECK-DAG: %[[xBoxCast2:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[xlbCast:.*]] = fir.convert %[[xlb]] : (i32) -> i64
+  ! CHECK-DAG: %[[xubCast:.*]] = fir.convert %[[xub]] : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[xBoxCast2]], %c0{{.*}}, %[[xlbCast]], %[[xubCast]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
+  ! CHECK-DAG: %[[xBoxCast3:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[errMsg:.*]] = fir.convert %{{.*}} : (!fir.ref<none>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[sourceFile:.*]] = fir.convert %{{.*}} -> !fir.ref<i8>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[xBoxCast3]], %false{{.*}}, %[[errMsg]], %[[sourceFile]], %{{.*}}) : (!fir.ref<!fir.box<none>>, i1, !fir.ref<!fir.box<none>>, !fir.ref<i8>, i32) -> i32
+
+  ! Simply check that we are emitting the right numebr of set bound for y and z. Otherwise, this is just like x.
+  ! CHECK: fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate
+  ! CHECK: %[[zBoxCast:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-NOT: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate
+
+  ! Check that y descriptor is read when referencing it.
+  ! CHECK: %[[yBoxLoad:.*]] = fir.load %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: %[[yAddr:.*]] = fir.box_addr %[[yBoxLoad]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK: %[[yBounds1:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[yBounds2:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  print *, x, y(45, 46), z
+
+  deallocate(x, y, z)
+  ! CHECK: %[[xBoxCast4:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[xBoxCast4]], {{.*}})
+  ! CHECK: %[[yBoxCast4:.*]] = fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[yBoxCast4]], {{.*}})
+  ! CHECK: %[[zBoxCast4:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[zBoxCast4]], {{.*}})
+end subroutine

--- a/flang/test/Lower/variable.f90
+++ b/flang/test/Lower/variable.f90
@@ -2,7 +2,7 @@
 
 ! CHECK-LABEL: func @_QPs() {
 subroutine s
-  ! CHECK-DAG: fir.alloca !fir.heap<i32> {name = "{{.*}}Eally"}
+  ! CHECK-DAG: fir.alloca !fir.box<!fir.heap<i32>> {name = "{{.*}}Eally"}
   integer, allocatable :: ally
   ! CHECK-DAG: fir.alloca !fir.ptr<i32> {name = "{{.*}}Epointy"} 
   integer, pointer :: pointy


### PR DESCRIPTION
Lower allocatables: only for locals non character intrinsic. Handle them as `fir.ref<fir.box<fir.heap<type>>>` in the symbol map. Load the box to an `ArrayBoxValue` (/...) in expression lowering in `genval(symbol)`.
This is very primitive and needs hardening.

Lower allocate-stmt/deallocate. The framework is complete (all cases should be planned with TODO("") here and there).
Done:
 - initialize allocatable descriptor when entering owning scope
   (only for local descriptors for now (notably, not main program allocatables)
 - lowering of allocate stmt allocating intrinsic array and scalars
   (other than characters) that do not have stat or errmsg.
 - Framework to handle all sorts of allocate stmt
 - Lower all cases of deallocate but for error recovery

TODO for F95:
 - character allocations (special runtime call to set the length)
 - errmsg/stat handling
 - initialize allocatable descriptor in global mem (either saved or
   belonging to modules/main programs...). We will probably want to
   do that without runtime if possible (Param derived types comes in
   mind as a case where that will require some work).
 - Pointers in alloc-stmt (different entry runtime point not yet defined,
   but otherwise really similar handling

The following kind of program compiles with this patch:
```
subroutine foo()
  real, allocatable :: x(:), y(:, :), z
  allocate(x(1:100), y(2:50, 3:42), z)
  print *, x, y(3, 10)
  deallocate(x, y, z)
end subroutine
 call foo()
end
```

I owe fir tests to this patch, but I'd rather take the time writing them when we agree how this is working.