### PR TITLE
Handle characters as fir.char<k, len> instead of fir.array<len,fir.char<k>>

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -17,6 +17,7 @@
 #include "flang/Lower/Support/BoxValue.h"
 #include "flang/Lower/Utils.h"
 #include "mlir/IR/Module.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace Fortran {
 namespace common {
@@ -104,8 +105,10 @@ public:
   virtual mlir::Type genType(SymbolRef) = 0;
   /// Generate the type from a category
   virtual mlir::Type genType(Fortran::common::TypeCategory tc) = 0;
-  /// Generate the type from a category and kind
-  virtual mlir::Type genType(Fortran::common::TypeCategory tc, int kind) = 0;
+  /// Generate the type from a category and kind and length parameters.
+  virtual mlir::Type
+  genType(Fortran::common::TypeCategory tc, int kind,
+          llvm::ArrayRef<std::int64_t> lenParameters = llvm::None) = 0;
   /// Generate the type from a Variable
   virtual mlir::Type genType(const pft::Variable &) = 0;
 

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -23,6 +23,7 @@
 
 #include "flang/Common/Fortran.h"
 #include "mlir/IR/Types.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
 class Location;
@@ -55,9 +56,12 @@ struct Variable;
 using SomeExpr = evaluate::Expr<evaluate::SomeType>;
 using SymbolRef = common::Reference<const semantics::Symbol>;
 
+// Type for compile time constant length type parameters.
+using LenParameterTy = std::int64_t;
+
 /// Get a FIR type based on a category and kind.
 mlir::Type getFIRType(mlir::MLIRContext *ctxt, common::TypeCategory tc,
-                      int kind);
+                      int kind, llvm::ArrayRef<LenParameterTy>);
 
 /// Translate a SomeExpr to an mlir::Type.
 mlir::Type translateSomeExprToFIRType(Fortran::lower::AbstractConverter &,

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -64,7 +64,8 @@ def fir_SequenceType : Type<CPred<"$_self.isa<fir::SequenceType>()">,
 // Composable types
 def AnyCompositeLike : TypeConstraint<Or<[fir_RecordType.predicate,
     fir_SequenceType.predicate, fir_ComplexType.predicate,
-    fir_VectorType.predicate, IsTupleTypePred]>, "any composite">;
+    fir_VectorType.predicate, IsTupleTypePred, fir_CharacterType.predicate]>,
+      "any composite">;
 
 // Reference to an entity type
 def fir_ReferenceType : Type<CPred<"$_self.isa<fir::ReferenceType>()">,
@@ -1127,21 +1128,22 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
     auto eleTy = fir::dyn_cast_ptrEleTy(memref().getType());
     if (!eleTy)
       return emitOpError("must embox a memory reference type");
+    bool isArray = false;
+    if (auto seqTy = eleTy.dyn_cast<fir::SequenceType>()) {
+      eleTy = seqTy.getEleTy();
+      isArray = true;
+    }
     if (hasLenParams()) {
       auto lenPs = numLenParams();
       if (auto rt = eleTy.dyn_cast<fir::RecordType>()) {
         if (lenPs != rt.getNumLenParams())
           return emitOpError("number of LEN params does not correspond"
                              " to the !fir.type type");
+      } else if (auto strTy = eleTy.dyn_cast<fir::CharacterType>()) {
+        if (strTy.getLen() != fir::CharacterType::unknownLen())
+          return emitOpError("CHARACTER already has static LEN");
       } else {
-        if (auto strTy = eleTy.dyn_cast<fir::SequenceType>()) {
-          if (!strTy.getEleTy().isa<fir::CharacterType>())
-            return emitOpError("LEN parameters require CHARACTER type");
-          if (strTy.getShape()[0] != fir::SequenceType::getUnknownExtent())
-            return emitOpError("CHARACTER already has static LEN");
-        } else {
-          return emitOpError("LEN parameters require !fir.type type");
-        }
+          return emitOpError("LEN parameters require CHARACTER or derived type");
       }
       for (auto lp : lenParams())
         if (!fir::isa_integer(lp.getType()))
@@ -1151,11 +1153,15 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
       auto shapeTy = getShape().getType();
       if (!(shapeTy.isa<fir::ShapeType>() || shapeTy.isa<ShapeShiftType>()))
         return emitOpError("must be shape or shapeshift type");
+      if (!isArray)
+        return emitOpError("shape must not be provided for a scalar");
     }
     if (getSlice()) {
       auto sliceTy = getSlice().getType();
       if (!sliceTy.isa<fir::SliceType>())
         return emitOpError("must be a slice type");
+      if (!isArray)
+        return emitOpError("slice must not be provided for a scalar");
     }
     return mlir::success();
   }];
@@ -1989,6 +1995,8 @@ def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [NoSideEffect]> {
     Extract a value from an entity with a type composed of tuples, arrays,
     and/or derived types. Returns the value from entity with the type of the
     specified component. Cannot be used on values of `!fir.box` type.
+    It can also be used to access complex parts and elements of a character
+    string.
 
     Note that the entity ssa-value must be of compile-time known size in order
     to use this operation.
@@ -2227,6 +2235,8 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]> {
     Insert a value into an entity with a type composed of tuples, arrays,
     and/or derived types. Returns a new ssa value with the same type as the
     original entity. Cannot be used on values of `!fir.box` type.
+    It can also be used to set complex parts and elements of a character
+    string.
 
     Note that the entity ssa-value must be of compile-time known size in order
     to use this operation.
@@ -2761,7 +2771,7 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     ```
   }];
 
-  let results = (outs fir_SequenceType);
+  let results = (outs fir_CharacterType);
 
   let parser = [{
     auto &builder = parser.getBuilder();
@@ -2783,10 +2793,11 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
         parser.parseRParen() ||
         parser.parseColonType(type))
       return mlir::failure();
-    if (!(type.isa<fir::CharacterType>() || type.isa<mlir::IntegerType>()))
+    auto charTy = type.dyn_cast<fir::CharacterType>();
+    if (!charTy)
       return parser.emitError(parser.getCurrentLocation(),
                               "must have character type");
-    type = fir::SequenceType::get({sz.getInt()}, type);
+    type = fir::CharacterType::get(builder.getContext(), charTy.getFKind(), sz.getInt());
     if (!type || parser.addTypesToList(type, result.types))
       return mlir::failure();
     return mlir::success();
@@ -2795,15 +2806,12 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
   let printer = [{
     p << getOperationName() << ' ' << getValue() << '(';
     p << getSize().cast<mlir::IntegerAttr>().getValue() << ") : ";
-    p.printType(getType().cast<fir::SequenceType>().getEleTy());
+    p.printType(getType());
   }];
 
   let verifier = [{
     if (getSize().cast<mlir::IntegerAttr>().getValue().isNegative())
       return emitOpError("size must be non-negative");
-    auto eleTy = getType().cast<fir::SequenceType>().getEleTy();
-    if (!eleTy.isa<fir::CharacterType>())
-      return emitOpError("must have !fir.char type");
     if (auto xl = getAttr(xlist())) {
       auto xList = xl.cast<mlir::ArrayAttr>();
       for (auto a : xList)

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -110,8 +110,15 @@ public:
   using Base::Base;
   using LenType = std::int64_t;
 
-  static CharacterType get(mlir::MLIRContext *ctxt, KindTy kind,
-                           LenType len = 1);
+  static CharacterType get(mlir::MLIRContext *ctxt, KindTy kind, LenType len);
+  /// Return unknown length CHARACTER type.
+  static CharacterType getUnknownLen(mlir::MLIRContext *ctxt, KindTy kind) {
+    return get(ctxt, kind, unknownLen());
+  }
+  /// Return length 1 CHARACTER type.
+  static CharacterType getSingleton(mlir::MLIRContext *ctxt, KindTy kind) {
+    return get(ctxt, kind, singleton());
+  }
   KindTy getFKind() const;
 
   /// CHARACTER is a singleton and has a LEN of 1.

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -275,13 +275,16 @@ public:
   mlir::Type genType(Fortran::lower::SymbolRef sym) override final {
     return Fortran::lower::translateSymbolToFIRType(*this, sym);
   }
-  mlir::Type genType(Fortran::common::TypeCategory tc,
-                     int kind) override final {
-    return Fortran::lower::getFIRType(&getMLIRContext(), tc, kind);
+  mlir::Type
+  genType(Fortran::common::TypeCategory tc, int kind,
+          llvm::ArrayRef<std::int64_t> lenParameters) override final {
+    return Fortran::lower::getFIRType(&getMLIRContext(), tc, kind,
+                                      lenParameters);
   }
   mlir::Type genType(Fortran::common::TypeCategory tc) override final {
     return Fortran::lower::getFIRType(
-        &getMLIRContext(), tc, bridge.getDefaultKinds().GetDefaultKind(tc));
+        &getMLIRContext(), tc, bridge.getDefaultKinds().GetDefaultKind(tc),
+        llvm::None);
   }
 
   mlir::Location getCurrentLocation() override final { return toLocation(); }
@@ -1773,9 +1776,6 @@ private:
         auto symTy = genType(var);
         if (symTy.isa<fir::CharacterType>()) {
           if (auto chLit = getCharacterLiteralCopy(details->init().value())) {
-            fir::SequenceType::Shape len;
-            len.push_back(std::get<std::size_t>(*chLit));
-            symTy = fir::SequenceType::get(len, symTy);
             auto init = builder->getStringAttr(std::get<std::string>(*chLit));
             global = builder->createGlobal(loc, symTy, globalName, linkage,
                                            init, isConst);

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -18,10 +18,6 @@
 
 using namespace Fortran::runtime;
 
-static inline int64_t getLength(mlir::Type argTy) {
-  return argTy.cast<fir::SequenceType>().getShape()[0];
-}
-
 /// Helper function to recover the KIND from the FIR type.
 static int discoverKind(mlir::Type ty) {
   if (auto charTy = ty.dyn_cast<fir::CharacterType>())

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -53,46 +53,46 @@ func @fa(%a : !fir.ref<!fir.array<100xf32>>) {
 // Boxing of a scalar character of dynamic length
 // CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8 }* @b1(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
-func @b1(%arg0 : !fir.ref<!fir.array<?x!fir.char<1>>>, %arg1 : index) -> !fir.box<!fir.array<?x!fir.char<1>>> {
+func @b1(%arg0 : !fir.ref<!fir.char<1,?>>, %arg1 : index) -> !fir.box<!fir.char<1,?>> {
   // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
   // CHECK: store i32 20180515, i32* %
-  %x = fir.embox %arg0 typeparams %arg1 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.box<!fir.array<?x!fir.char<1>>>
-  return %x : !fir.box<!fir.array<?x!fir.char<1>>>
+  %x = fir.embox %arg0 typeparams %arg1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+  return %x : !fir.box<!fir.char<1,?>>
 }
 
 // Boxing of a dynamic array of character with static length (5)
 // CHECK-LABEL: define { [5 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b2(
 // CHECK-SAME: [5 x i8]* %[[arg0:.*]], i64 %[[arg1:.*]])
-func @b2(%arg0 : !fir.ref<!fir.array<5x?x!fir.char<1>>>, %arg1 : index) -> !fir.box<!fir.array<5x?x!fir.char<1>>> {
+func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.box<!fir.array<?x!fir.char<1,5>>> {
   %1 = fir.shape %arg1 : (index) -> !fir.shape<1>
   // CHECK: store [5 x i8]* %[[arg0]], [5 x i8]** %{{.*}}, align
   // CHECK: store i64 5, i64* %{{.*}}, align
   // CHECK: store i32 20180515, i32* %
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
   // CHECK: store i64 5, i64* %{{.*}}, align
-  %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<5x?x!fir.char<1>>>, !fir.shape<1>) -> !fir.box<!fir.array<5x?x!fir.char<1>>>
-  return %2 : !fir.box<!fir.array<5x?x!fir.char<1>>>
+  %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<?x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<?x!fir.char<1,5>>>
+  return %2 : !fir.box<!fir.array<?x!fir.char<1,5>>>
 }
 
 // Boxing of a dynamic array of character of dynamic length
 // CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b3(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]], i64 %[[arg2:.*]])
-func @b3(%arg0 : !fir.ref<!fir.array<?x?x!fir.char<1>>>, %arg1 : index, %arg2 : index) -> !fir.box<!fir.array<?x?x!fir.char<1>>> {
+func @b3(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,?>>>, %arg1 : index, %arg2 : index) -> !fir.box<!fir.array<?x!fir.char<1,?>>> {
   %1 = fir.shape %arg2 : (index) -> !fir.shape<1>
   // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
   // CHECK: store i32 20180515, i32* %
   // CHECK: store i64 %[[arg2]], i64* %{{.*}}, align
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  %2 = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<?x?x!fir.char<1>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x?x!fir.char<1>>>
-  return %2 : !fir.box<!fir.array<?x?x!fir.char<1>>>
+  %2 = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  return %2 : !fir.box<!fir.array<?x!fir.char<1,?>>>
 }
 
 // Boxing of a static array of character of dynamic length
 // CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b4(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
-func @b4(%arg0 : !fir.ref<!fir.array<?x7x!fir.char<1>>>, %arg1 : index) -> !fir.box<!fir.array<?x7x!fir.char<1>>> {
+func @b4(%arg0 : !fir.ref<!fir.array<7x!fir.char<1,?>>>, %arg1 : index) -> !fir.box<!fir.array<7x!fir.char<1,?>>> {
   %c_7 = constant 7 : index
   %1 = fir.shape %c_7 : (index) -> !fir.shape<1>
   // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
@@ -100,6 +100,6 @@ func @b4(%arg0 : !fir.ref<!fir.array<?x7x!fir.char<1>>>, %arg1 : index) -> !fir.
   // CHECK: store i32 20180515, i32* %
   // CHECK: store i64 7, i64* %{{.*}}, align
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  %x = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<?x7x!fir.char<1>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x7x!fir.char<1>>>
-  return %x : !fir.box<!fir.array<?x7x!fir.char<1>>>
+  %x = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<7x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<7x!fir.char<1,?>>>
+  return %x : !fir.box<!fir.array<7x!fir.char<1,?>>>
 }

--- a/flang/test/Fir/boxchar.fir
+++ b/flang/test/Fir/boxchar.fir
@@ -6,17 +6,17 @@ func @callee(%x : !fir.boxchar<1>)
 
 // CHECK-LABEL: define void @get_name
 func @get_name() {
-  %1 = fir.address_of (@name) : !fir.ref<!fir.array<9x!fir.char<1>>>
+  %1 = fir.address_of (@name) : !fir.ref<!fir.char<1,9>>
   %2 = constant 9 : i64
-  %3 = fir.convert %1 : (!fir.ref<!fir.array<9x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
-  %4 = fir.emboxchar %3, %2 : (!fir.ref<!fir.char<1>>, i64) -> !fir.boxchar<1>
+  %3 = fir.convert %1 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<!fir.char<1,?>>
+  %4 = fir.emboxchar %3, %2 : (!fir.ref<!fir.char<1,?>>, i64) -> !fir.boxchar<1>
   // CHECK: call void @callee(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @name, i32 0, i32 0), i64 9)
   fir.call @callee(%4) : (!fir.boxchar<1>) -> ()
   return
 }
 
-fir.global @name constant : !fir.array<9x!fir.char<1>> {
-  %str = fir.string_lit "Your name"(9) : !fir.char<1>
+fir.global @name constant : !fir.char<1,9> {
+  %str = fir.string_lit "Your name"(9) : !fir.char<1,9>
   //constant 1
-  fir.has_value %str : !fir.array<9x!fir.char<1>>
+  fir.has_value %str : !fir.char<1,9>
 }

--- a/flang/test/Fir/char01.fir
+++ b/flang/test/Fir/char01.fir
@@ -1,13 +1,13 @@
 // RUN: tco -emit-fir %s | tco | FileCheck %s
 
 // CHECK-LABEL: @test
-func @test(%arg0 : !fir.ref<!fir.char<1>>, %arg1 : !fir.ref<!fir.char<1>>, %arg2 : i32) {
-  %0 = fir.convert %arg1 : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
-  // CHECK: getelementptr i8, i8*
+func @test(%arg0 : !fir.ref<!fir.char<1>>, %arg1 : !fir.ref<!fir.char<1,?>>, %arg2 : i32) {
+  %0 = fir.convert %arg1 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  // CHECK: getelementptr [1 x i8], [1 x i8]*
   %1 = fir.coordinate_of %0, %arg2 : (!fir.ref<!fir.array<?x!fir.char<1>>>, i32) -> !fir.ref<!fir.char<1>>
-  // CHECK: load i8, i8*
+  // CHECK: load [1 x i8], [1 x i8]*
   %2 = fir.load %1 : !fir.ref<!fir.char<1>>
-  // CHECK: store i8
+  // CHECK: store [1 x i8]
   fir.store %2 to %arg0 : !fir.ref<!fir.char<1>>
   // CHECK: ret void
   return

--- a/flang/test/Fir/constant.fir
+++ b/flang/test/Fir/constant.fir
@@ -1,10 +1,10 @@
 // RUN: tco -emit-fir %s | tco | FileCheck %s
 
 // CHECK-LABEL: define [3 x i8] @x
-func @x() -> !fir.array<3x!fir.char<1>> {
-  %1 = fir.string_lit "xyz"(3) : !fir.char<1>
+func @x() -> !fir.char<1,3> {
+  %1 = fir.string_lit "xyz"(3) : !fir.char<1,3>
  // CHECK: ret [3 x i8] c"xyz"
-  return %1 : !fir.array<3x!fir.char<1>>
+  return %1 : !fir.char<1,3>
 }
 
 // CHECK-LABEL: define x86_fp80 @y()

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -571,12 +571,12 @@ func @arith_complex(%a : !fir.complex<16>, %b : !fir.complex<16>) -> !fir.comple
   return %5 : !fir.complex<16>
 }
 
-// CHECK-LABEL: func @character_literal() -> !fir.array<13x!fir.char<1>> {
-func @character_literal() -> !fir.array<13 x !fir.char<1>> {
-// CHECK: [[VAL_185:%.*]] = fir.string_lit "Hello, World!"(13) : !fir.char<1>
+// CHECK-LABEL: func @character_literal() -> !fir.char<1,13> {
+func @character_literal() -> !fir.char<1,13> {
+// CHECK: [[VAL_185:%.*]] = fir.string_lit "Hello, World!"(13) : !fir.char<1,13>
   %0 = fir.string_lit "Hello, World!"(13) : !fir.char<1>
-// CHECK: return [[VAL_185]] : !fir.array<13x!fir.char<1>>
-  return %0 : !fir.array<13 x !fir.char<1>>
+// CHECK: return [[VAL_185]] : !fir.char<1,13>
+  return %0 : !fir.char<1,13>
 // CHECK: }
 }
 

--- a/flang/test/Fir/global.fir
+++ b/flang/test/Fir/global.fir
@@ -28,7 +28,7 @@ fir.global common @C_i511 (511:i32) : i32
 fir.global weak @w_i86 (86:i32) : i32
 
 // CHECK: @str1 = global [6 x i8] c"Hello!"
-fir.global @str1 : !fir.array<6 x !fir.char<1>> {
-  %1 = fir.string_lit "Hello!"(6) : !fir.char<1>
-  fir.has_value %1 : !fir.array<6 x !fir.char<1>>
+fir.global @str1 : !fir.char<1,6> {
+  %1 = fir.string_lit "Hello!"(6) : !fir.char<1,6>
+  fir.has_value %1 : !fir.char<1,6>
 }

--- a/flang/test/Fir/widechar.fir
+++ b/flang/test/Fir/widechar.fir
@@ -1,22 +1,22 @@
 // RUN: tco %s | FileCheck %s
 
 // CHECK-LABEL: @character_literal1
-func @character_literal1() -> !fir.array<13 x !fir.char<1>> {
-  %0 = fir.string_lit "Hello, World!"(13) : !fir.char<1>
+func @character_literal1() -> !fir.char<1,13> {
+  %0 = fir.string_lit "Hello, World!"(13) : !fir.char<1,13>
   // CHECK: ret [13 x i8] c"Hello, World!"
-  return %0 : !fir.array<13 x !fir.char<1>>
+  return %0 : !fir.char<1,13>
 }
 
 // CHECK-LABEL: @character_literal2
-func @character_literal2() -> !fir.array<2 x !fir.char<2>> {
-  %0 = fir.string_lit [234, 456](2) : !fir.char<2>
+func @character_literal2() -> !fir.char<2,2> {
+  %0 = fir.string_lit [234, 456](2) : !fir.char<2,2>
   // CHECK: ret [2 x i16] [i16 234, i16 456]
-  return %0 : !fir.array<2 x !fir.char<2>>
+  return %0 : !fir.char<2,2>
 }
 
 // CHECK-LABEL: @character_literal4
-func @character_literal4() -> !fir.array<3 x !fir.char<4>> {
-  %0 = fir.string_lit [89123, 999256, 4](3) : !fir.char<4>
+func @character_literal4() -> !fir.char<4,3> {
+  %0 = fir.string_lit [89123, 999256, 4](3) : !fir.char<4,3>
   // CHECK: ret [3 x i32] [i32 89123, i32 999256, i32 4]
-  return %0 : !fir.array<3 x !fir.char<4>>
+  return %0 : !fir.char<4,3>
 }

--- a/flang/test/Lower/assumed-shaped-callee.f90
+++ b/flang/test/Lower/assumed-shaped-callee.f90
@@ -51,37 +51,37 @@ subroutine test_assumed_shape_3(x)
 end subroutine
 
 ! Constant length
-! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<10x?x!fir.char<1>>>)
+! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>>)
 subroutine test_assumed_shape_char(c)
   character(10) :: c(:)
-  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>) -> !fir.ref<!fir.array<10x?x!fir.char<1>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>) -> !fir.ref<!fir.array<?x!fir.char<1,10>>>
 
-  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<10x?x!fir.char<1>>>, index) -> (index, index, index)
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>, index) -> (index, index, index)
   ! CHECK: %[[c1:.*]] = constant 1 : index
 
   print *, c
   ! CHECK: %[[shape:.*]] = fir.shape_shift %[[c1]], %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
-  ! CHECK: fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<10x?x!fir.char<1>>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<10x?x!fir.char<1>>>
+  ! CHECK: fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<?x!fir.char<1,10>>>, !fir.shapeshift<1>) -> !fir.box<!fir.array<?x!fir.char<1,10>>>
 end subroutine
 
 ! Assumed length
-! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x?x!fir.char<1>>>)
+! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>>)
 subroutine test_assumed_shape_char_2(c)
   character(*) :: c(:)
-  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x?x!fir.char<1>>>
-  ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>) -> index
+  ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
 
-  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x?x!fir.char<1>>>, index) -> (index, index, index)
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>, index) -> (index, index, index)
   ! CHECK: %[[c1:.*]] = constant 1 : index
 
   print *, c
   ! CHECK: %[[shape:.*]] = fir.shape_shift %[[c1]], %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
-  ! CHECK: fir.embox %[[addr]](%[[shape]]) typeparams %[[len]] : (!fir.ref<!fir.array<?x?x!fir.char<1>>>, !fir.shapeshift<1>, index) -> !fir.box<!fir.array<?x?x!fir.char<1>>>
+  ! CHECK: fir.embox %[[addr]](%[[shape]]) typeparams %[[len]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shapeshift<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
 end subroutine
 
 
 ! lower bounds all 1.
-! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x?x!fir.char<1>>>)
+! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>>)
 subroutine test_assumed_shape_char_3(c)
   character(*) :: c(1:, 1:)
   ! CHECK: fir.box_addr

--- a/flang/test/Lower/assumed-shaped-caller.f90
+++ b/flang/test/Lower/assumed-shaped-caller.f90
@@ -34,20 +34,20 @@ subroutine foo_char(x)
     end subroutine
   end interface
   character(*) :: x(42, 55, 12)
-  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
-  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>
+  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>
   ! CHECK-DAG: %[[c42:.*]] = constant 42 : index
   ! CHECK-DAG: %[[c55:.*]] = constant 55 : index
   ! CHECK-DAG: %[[c12:.*]] = constant 12 : index
 
   call bar_char(x)
   ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
-  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) typeparams %[[x]]#1 : (!fir.ref<!fir.array<?x42x55x12x!fir.char<1>>>, !fir.shape<3>, index) -> !fir.box<!fir.array<?x42x55x12x!fir.char<1>>>
-  ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<?x42x55x12x!fir.char<1>>>) -> !fir.box<!fir.array<?x?x?x?x!fir.char<1>>>
-  ! CHECK: fir.call @_QPbar_char(%[[castedBox]]) : (!fir.box<!fir.array<?x?x?x?x!fir.char<1>>>) -> ()
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) typeparams %[[x]]#1 : (!fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>, !fir.shape<3>, index) -> !fir.box<!fir.array<42x55x12x!fir.char<1,?>>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<42x55x12x!fir.char<1,?>>>) -> !fir.box<!fir.array<?x?x?x!fir.char<1,?>>>
+  ! CHECK: fir.call @_QPbar_char(%[[castedBox]]) : (!fir.box<!fir.array<?x?x?x!fir.char<1,?>>>) -> ()
 end subroutine
 
 ! Test external function declarations
 
 ! CHECK: func @_QPbar(!fir.box<!fir.array<?x?x?xf32>>)
-! CHECK: func @_QPbar_char(!fir.box<!fir.array<?x?x?x?x!fir.char<1>>>)
+! CHECK: func @_QPbar_char(!fir.box<!fir.array<?x?x?x!fir.char<1,?>>>)

--- a/flang/test/Lower/concat.f90
+++ b/flang/test/Lower/concat.f90
@@ -13,15 +13,17 @@ subroutine concat_1(a, b)
   ! Concatenation
 
   ! CHECK: %[[len:.*]] = addi %[[a]]#1, %[[b]]#1
-  ! CHECK: %[[temp:.*]] = fir.alloca !fir.array<?x!fir.char<1>>, %[[len]]
+  ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,?>, %[[len]]
 
   ! CHECK-DAG: %[[c0:.*]] = constant 0
   ! CHECK-DAG: %[[c1:.*]] = constant 1
   ! CHECK-DAG: %[[count:.*]] = subi %[[a]]#1, %[[c1]]
   ! CHECK: fir.do_loop %[[index:.*]] = %[[c0]] to %[[count]] step %[[c1]] {
-    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a]]#0, %[[index]]
+    ! CHECK: %[[a_cast:.*]] = fir.convert %[[a]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a_cast]], %[[index]]
     ! CHECK-DAG: %[[a_elt:.*]] = fir.load %[[a_addr]]
-    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp]], %[[index]]
+    ! CHECK: %[[temp_cast:.*]] = fir.convert %[[temp]]
+    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp_cast]], %[[index]]
     ! CHECK: fir.store %[[a_elt]] to %[[temp_addr]]
   ! CHECK: }
 
@@ -29,9 +31,11 @@ subroutine concat_1(a, b)
   ! CHECK: %[[count2:.*]] = subi %[[len]], %[[c1_0]]
   ! CHECK: fir.do_loop %[[index2:.*]] = %[[a]]#1 to %[[count2]] step %[[c1_0]] {
     ! CHECK: %[[b_index:.*]] = subi %[[index]], %[[a]]#1
-    ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b]]#0, %[[b_index]]
+    ! CHECK: %[[b_cast:.*]] = fir.convert %[[b]]#0
+    ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b_cast]], %[[b_index]]
     ! CHECK-DAG: %[[b_elt:.*]] = fir.load %[[b_addr]]
-    ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp]], %[[index2]]
+    ! CHECK: %[[temp_cast2:.*]] = fir.convert %[[temp]]
+    ! CHECK: %[[temp_addr2:.*]] = fir.coordinate_of %[[temp_cast2]], %[[index2]]
     ! CHECK: fir.store %[[b_elt]] to %[[temp_addr2]]
   ! CHECK: }
 

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -147,6 +147,6 @@ end subroutine
   !CHECK: return %[[imag]] : f32
 
 !CHECK-LABEL: func @fir.len.i32.bc1(%arg0: !fir.boxchar<1>)
-  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
+  !CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   !CHECK: %[[len:.*]] = fir.convert %[[unboxed]]#1 : (index) -> i32
   !CHECK: return %[[len]] : i32

--- a/flang/test/Lower/entry.f90
+++ b/flang/test/Lower/entry.f90
@@ -75,12 +75,12 @@ entry rr(n2)
   rr = rr + n2
 end
 
-! CHECK-LABEL: func @_QPhh(%arg0: !fir.ref<!fir.char<1>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPhh(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
 function hh(c1)
   character(10) c1, hh, qq
   hh = c1
   return
-! CHECK-LABEL: func @_QPqq(%arg0: !fir.ref<!fir.char<1>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPqq(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
 entry qq(c1)
   qq = c1
 end

--- a/flang/test/Lower/global-format-strings.f90
+++ b/flang/test/Lower/global-format-strings.f90
@@ -9,6 +9,6 @@ program other
 1008 format('ok')
 end
 ! CHECK-LABEL: fir.global linkonce @_QQcl.28276F6B2729 constant
-! CHECK: %[[lit:.*]] = fir.string_lit "('ok')"(6) : !fir.char<1>
-! CHECK: fir.has_value %[[lit]] : !fir.array<6x!fir.char<1>>
+! CHECK: %[[lit:.*]] = fir.string_lit "('ok')"(6) : !fir.char<1,6>
+! CHECK: fir.has_value %[[lit]] : !fir.char<1,6>
 ! CHECK: }

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
 function char_return_callee(i)
   character(10) :: char_return_callee
   integer :: i
@@ -9,7 +9,7 @@ end function
 ! CHECK-LABEL: @_QPtest_char_return_caller()
 subroutine test_char_return_caller
   character(10) :: char_return_caller
-  ! CHECK: fir.call @_QPchar_return_caller({{.*}}) : (!fir.ref<!fir.char<1>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPchar_return_caller({{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   print *, char_return_caller(5)
 end subroutine
 
@@ -17,10 +17,10 @@ end subroutine
 subroutine test_passing_char_array
   character(len=3) :: x(4)
   call sub_taking_a_char_array(x)
-  ! CHECK-DAG: %[[xarray:.*]] = fir.alloca !fir.array<3x4x!fir.char<1>>
+  ! CHECK-DAG: %[[xarray:.*]] = fir.alloca !fir.array<4x!fir.char<1,3>>
   ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
-  ! CHECK-DAG: %[[xbuff:.*]] = fir.convert %[[xarray]] : (!fir.ref<!fir.array<3x4x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[xbuff]], %[[c3]] : (!fir.ref<!fir.char<1>>, index) -> !fir.boxchar<1>
+  ! CHECK-DAG: %[[xbuff:.*]] = fir.convert %[[xarray]] : (!fir.ref<!fir.array<4x!fir.char<1,3>>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[xbuff]], %[[c3]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPsub_taking_a_char_array(%[[boxchar]]) : (!fir.boxchar<1>) -> () 
 end subroutine
 

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -185,16 +185,16 @@ subroutine ichar_test(c)
   ! CHECK-DAG: %[[unbox:.*]]:2 = fir.unboxchar
   ! CHECK-DAG: %[[J:.*]] = fir.alloca i32 {name = "{{.*}}Ej"}
   ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {name = "{{.*}}Estr"}
-  ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.char<1>> 
+  ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>> 
   ! CHECK: %[[CHAR:.*]] = fir.load %[[BOX]] : !fir.ref<!fir.char<1>>
-  ! CHECK: = fir.convert %[[CHAR]] : (!fir.char<1>) -> i32
+  ! CHECK: fir.extract_value %[[CHAR]], %c0{{.*}}
   print *, ichar(c)
   ! CHECK: fir.call @{{.*}}EndIoStatement
 
-  ! CHECK: %{{.*}} = fir.load %[[J]] : !fir.ref<i32>
+  ! CHECK-DAG: %{{.*}} = fir.load %[[J]] : !fir.ref<i32>
   ! CHECK: %[[ptr:.*]] = fir.coordinate_of %[[STR]], %
-  ! CHECK: %[[cast:.*]] = fir.convert %[[ptr]]
-  ! CHECK: fir.load %[[cast]] : !fir.ref<!fir.char<1>>
+  ! CHECK: %[[VAL:.*]] = fir.load %[[ptr]] : !fir.ref<!fir.char<1>>
+  ! CHECK: fir.extract_value %[[VAL]], %c0{{.*}}
   print *, ichar(str(J))
   ! CHECK: fir.call @{{.*}}EndIoStatement
 end subroutine

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -5,23 +5,23 @@
 ! CHECK-LABEL: func @_QPpass_assumed_len_char_unformatted_io
 subroutine pass_assumed_len_char_unformatted_io(c)
   character(*) :: c
-  ! CHECK: %[[unbox:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
+  ! CHECK: %[[unbox:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   write(1, rec=1) c
-  ! CHECK: %[[box:.*]] = fir.embox %[[unbox]]#0 typeparams %[[unbox]]#1 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.box<!fir.array<?x!fir.char<1>>>
-  ! CHECK: %[[castedBox:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.box<none>
+  ! CHECK: %[[box:.*]] = fir.embox %[[unbox]]#0 typeparams %[[unbox]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[box]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[castedBox]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
 end
 
 ! CHECK-LABEL: func @_QPpass_assumed_len_char_array 
 subroutine pass_assumed_len_char_array(carray)
   character(*) :: carray(2, 3)
-  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.array<?x!fir.char<1>>>, index)
-  ! CHECK-DAG: %[[buffer:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.array<?x2x3x!fir.char<1>>>
+  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK-DAG: %[[buffer:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<2x3x!fir.char<1,?>>>
   ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
   ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
   ! CHECK-DAG: %[[shape:.*]] = fir.shape %[[c2]], %[[c3]] : (index, index) -> !fir.shape<2>
-  ! CHECK: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) typeparams %[[unboxed]]#1 : (!fir.ref<!fir.array<?x2x3x!fir.char<1>>>, !fir.shape<2>, index) -> !fir.box<!fir.array<?x2x3x!fir.char<1>>>
-  ! CHECK: %[[descriptor:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?x2x3x!fir.char<1>>>) -> !fir.box<none>
+  ! CHECK: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) typeparams %[[unboxed]]#1 : (!fir.ref<!fir.array<2x3x!fir.char<1,?>>>, !fir.shape<2>, index) -> !fir.box<!fir.array<2x3x!fir.char<1,?>>>
+  ! CHECK: %[[descriptor:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<2x3x!fir.char<1,?>>>) -> !fir.box<none>
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[descriptor]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
   print *, carray
 end

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -23,12 +23,12 @@ subroutine pointerTests
   ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.complex<4>>
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.complex<4>>
 
-  ! CHECK: fir.global internal @_QFpointertestsEptr4 : !fir.ptr<!fir.array<?x!fir.char<1>>>
+  ! CHECK: fir.global internal @_QFpointertestsEptr4 : !fir.ptr<!fir.char<1,?>>
   character(:), pointer :: ptr4 => NULL()
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: [[reg1:%[0-9]+]] = fir.convert %[[c0:.*]] : (index) -> !fir.ref<none>
-  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.array<?x!fir.char<1>>>
-  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.array<?x!fir.char<1>>>
+  ! CHECK: [[reg2:%[0-9]+]] = fir.convert [[reg1]] : (!fir.ref<none>) -> !fir.ptr<!fir.char<1,?>>
+  ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.char<1,?>>
 
   ! CHECK: fir.global internal @_QFpointertestsEptr5 : !fir.ptr<!fir.logical<4>>
   logical, pointer :: ptr5 => NULL()

--- a/flang/test/Lower/read-write-buffer.f90
+++ b/flang/test/Lower/read-write-buffer.f90
@@ -6,13 +6,13 @@
 subroutine test_array_format
   ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
   ! CHECK-DAG: %[[c10:.*]] = constant 10 : index
-  ! CHECK-DAG: %[[mem:.*]] = fir.alloca !fir.array<10x2x!fir.char<1>>
+  ! CHECK-DAG: %[[mem:.*]] = fir.alloca !fir.array<2x!fir.char<1,10>>
   character(10) :: array(2)
   array(1) ="(15HThis i"
   array(2) ="s a test.)"
   ! CHECK-DAG: %[[fmtLen:.*]] = muli %[[c10]], %[[c2]] : index
-  ! CHECK-DAG: %[[scalarFmt:.*]] = fir.convert %[[mem]] : (!fir.ref<!fir.array<10x2x!fir.char<1>>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
-  ! CHECK-DAG: %[[fmtArg:.*]] = fir.convert %[[scalarFmt]] : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<i8>
+  ! CHECK-DAG: %[[scalarFmt:.*]] = fir.convert %[[mem]] : (!fir.ref<!fir.array<2x!fir.char<1,10>>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK-DAG: %[[fmtArg:.*]] = fir.convert %[[scalarFmt]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
   ! CHECK-DAG: %[[fmtLenArg:.*]] = fir.convert %[[fmtLen]] : (index) -> i64 
   ! CHECK: fir.call @_FortranAioBeginExternalFormattedOutput(%[[fmtArg]], %[[fmtLenArg]], {{.*}}) 
   write(*, array) 
@@ -29,7 +29,7 @@ subroutine some()
   read (buffer, 10) greeting
 end
 ! CHECK-LABEL: fir.global linkonce @_QQcl.636F6D70696C6572
-! CHECK: %[[lit:.*]] = fir.string_lit "compiler"(8) : !fir.char<1>
-! CHECK: fir.has_value %[[lit]] : !fir.array<8x!fir.char<1>>
+! CHECK: %[[lit:.*]] = fir.string_lit "compiler"(8) : !fir.char<1,8>
+! CHECK: fir.has_value %[[lit]] : !fir.char<1,8>
 ! CHECK: }
 

--- a/flang/test/Lower/stmt-function.f90
+++ b/flang/test/Lower/stmt-function.f90
@@ -92,8 +92,7 @@ integer function test_stmt_character(c, j)
    character(10) :: c, argc
    ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
    ! CHECK-DAG: %[[c10:.*]] = constant 10 :
-   ! CHECK: %[[addr:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.array<?x!fir.char<1>>>) -> !fir.ref<!fir.char<1>>
-   ! CHECK: %[[c:.*]] = fir.emboxchar %[[addr]], %[[c10]] 
+   ! CHECK: %[[c:.*]] = fir.emboxchar %[[unboxed]]#0, %[[c10]] 
 
    func(argc, argj) = len_trim(argc, 4) + argj
    ! CHECK: addi %{{.*}}, %{{.*}} : i

--- a/flang/test/Lower/stop.f90
+++ b/flang/test/Lower/stop.f90
@@ -57,8 +57,8 @@ end subroutine
 subroutine stop_char_lit
   ! CHECK-DAG: %[[false:.*]] = constant false
   ! CHECK-DAG: %[[five:.*]] = constant 5 : index
-  ! CHECK-DAG: %[[lit:.*]] = fir.address_of(@_QQ{{.*}}) : !fir.ref<!fir.array<5x!fir.char<1>>>
-  ! CHECK-DAG: %[[buff:.*]] = fir.convert %[[lit]] : (!fir.ref<!fir.array<5x!fir.char<1>>>) -> !fir.ref<i8>
+  ! CHECK-DAG: %[[lit:.*]] = fir.address_of(@_QQ{{.*}}) : !fir.ref<!fir.char<1,5>>
+  ! CHECK-DAG: %[[buff:.*]] = fir.convert %[[lit]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
   ! CHECK-DAG: %[[len:.*]] = fir.convert %[[five]] : (index) -> i64
   ! CHECK: fir.call @{{.*}}StopStatementText(%[[buff]], %[[len]], %[[false]], %[[false]]) :
   ! CHECK-NEXT: fir.unreachable


### PR DESCRIPTION
This change impacts both lowering an code gen. It moves the length in fir type representation from an array extent to a `fir::CharacterType` field. It passes both regression tests and FCVS (before the rebase).
 
Below is a summary of detailing and explaining the changes, but looking at the code might make more sense.

This change is motivated by the need to easily work with arrays after F77.
It was tricky to distinguish scalar from arrays because of the character
scalar usage of fir.array type.
It also made works with shape more error prone (drop first type extent if
characters...).
This change was facilitated by the fact that the CharacterType already had
a length field. It was simply not used (always defaulted to 1).

Changes:

Fir:
- Remove the default length in CharacterType builder
- Change StringLitOp to return a character and not a sequence
- Change BoxCharType underlying type to have unknow length.
- Add unwrap_char helper to get character type under fir.ref/ptr/heap/box/array
  decorations.
- Add fir.char to AnyCompositeLike so that insert_value/extrac_value can be used on
  it. This is needed because now that fir.char<k, len> is lower to llvm as [len x int]
  one cannot convert integer to singleton character anymore. And we need a way to create
  singleton character from integer (char/ichar...).
- Fix fir.char parsing that was not working ok with fir.char<kind, ?>.

Lowering:
- Specify the length in the places creating character types according to the
  need.
- Simplify all the places in CharacterExpr that are looking for the length in
  the type.
- Remove all the code adding sequence type around characters.
- Previous code was propagating fir.char type from operands to results (e.g when
  making substring, concatenation...). It is now wrong since the result length
  may differ from the operand length. So modify CharacterExprHelper to break
  type propagation (always extract the kind and create new CharacterType).
  Remove getReferenceType/getSeqTy and create getUnknownLenType instead.
- Use insert_value/extract_value instead of converts in char/ichar lowering
  and blank constant creation.
- Add createElementAddr to account for the fact that some casts now have to be
  added before accessing the address of a fic.char<k, l> with coordinate_of.
- Modify ArrayRef lowering using coordinate_of to add the length as a delta
  only for unknown length. When the length is known, the length will be taken
  into account by coordinate_of codegen. This part is tricky. But should
  disappear when array_coor becomes mainstream (array_coor takes dynamic
  lengths parameters in accounts).
- Change toRowMajor to avoid reversing past the provided index container. This
  is both a sanity change, and a needed change because the indexes provided
  by lowering are now 1 less than the LLVM type dimensions when indexing a
  fir.array<n x fir.char<kind>>.

CodeGen:
- Change fir.char<k, l> lowering from i8 to [len x i8].
- Change fir.ref<fir.array<n x fir.char<k, ?>>> and fir.array<n x fir.char<k, ?>>
  to make sure they still translate to int*, and not array of pointers.
  Add hasDynamicSize to this effect. One could also imagine using this
  if PDT end-up not being compile time constant size.
- Change embox rewrite to get the length from the CharacterType.
- Take into account the kind when computing the length.