### PR TITLE
fir.embox and fir.store codegen changes to support descriptor initialization

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -16,7 +16,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def CodeGenRewrite : FunctionPass<"cg-rewrite"> {
+def CodeGenRewrite : Pass<"cg-rewrite", "mlir::ModuleOp"> {
   let summary = "Rewrite some FIR ops into their code-gen forms.";
   let description = [{
     Fuse specific subgraphs into single Ops for code generation.

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -511,8 +511,8 @@ def fir_StoreOp : fir_Op<"store", []> {
   let verifier = [{
     if (value().getType() != fir::dyn_cast_ptrEleTy(memref().getType()))
       return emitOpError("store value type must match memory reference type");
-    if (fir::isa_box_type(value().getType()))
-      return emitOpError("!fir.box cannot be stored");
+    if (fir::isa_unknown_size_box(value().getType()))
+      return emitOpError("cannot store !fir.box of unknown rank or type");
     return mlir::success();
   }];
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -426,7 +426,8 @@ struct BoxEleSizeOpConversion : public FIROpConversion<fir::BoxEleSizeOp> {
     auto c0 = genConstantOffset(loc, rewriter, 0);
     auto c1 = genConstantOffset(loc, rewriter, 1);
     auto ty = convertType(boxelesz.getType());
-    auto p = genGEP(loc, unwrap(ty), rewriter, a, c0, c1);
+    auto pty = unwrap(ty).getPointerTo();
+    auto p = genGEP(loc, unwrap(pty), rewriter, a, c0, c1);
     rewriter.replaceOpWithNewOp<mlir::LLVM::LoadOp>(boxelesz, ty, p);
     return success();
   }
@@ -900,6 +901,13 @@ template <typename OP>
 struct EmboxCommonConversion : public FIROpConversion<OP> {
   using FIROpConversion<OP>::FIROpConversion;
 
+  /// Type of lambda helper to abstract whether the embox is lowered as StoreOps
+  /// or InsertOps.
+  using StoreOrInserter = std::function<mlir::Value(
+      mlir::ConversionPatternRewriter &, mlir::Value, llvm::ArrayRef<unsigned>,
+      mlir::Value,
+      const std::function<mlir::Value(mlir::LLVM::LLVMType, mlir::Value)> &)>;
+
   /// Generate an alloca of size `size` and cast it to type `toTy`
   mlir::LLVM::AllocaOp
   genAllocaWithType(mlir::Location loc, mlir::LLVM::LLVMType toTy,
@@ -915,18 +923,21 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
     return al;
   }
 
-  template <typename... FLDS>
-  mlir::LLVM::GEPOp genGEPToField(mlir::Location loc, mlir::LLVM::LLVMType ty,
-                                  mlir::ConversionPatternRewriter &rewriter,
-                                  mlir::Value base, mlir::Value zero,
-                                  FLDS... fields) const {
-    return this->genGEP(loc, ty.getPointerTo(), rewriter, base, zero,
-                        this->genConstantOffset(loc, rewriter, fields)...);
-  }
-
-  static mlir::LLVM::LLVMType getBoxEleTy(mlir::LLVM::LLVMType boxPtrTy,
-                                          unsigned i) {
-    return boxPtrTy.getPointerElementTy().getStructElementType(i);
+  // Get the element type given an LLVM type that is of the form
+  // [llvm.ptr](llvm.array|llvm.struct)+ and the provided indexes.
+  static mlir::LLVM::LLVMType getBoxEleTy(mlir::LLVM::LLVMType type,
+                                          llvm::ArrayRef<unsigned> indexes) {
+    if (type.isPointerTy())
+      type = type.getPointerElementTy();
+    for (auto i : indexes) {
+      if (type.isStructTy())
+        type = type.getStructElementType(i);
+      else if (type.isArrayTy())
+        type = type.getArrayElementType();
+      else if (type.isVectorTy())
+        type = type.getVectorElementType();
+    }
+    return type;
   }
 
   int getCFIAttr(fir::BoxType boxTy) const {
@@ -1034,27 +1045,71 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
     TODO("");
   }
 
+  /// Basic pattern to write a field in the descriptor
   template <typename BOX>
-  std::tuple<mlir::Value, mlir::Value>
+  std::tuple<mlir::Value, StoreOrInserter>
+  getStoreOrInsertField(BOX box, OperandTy operands,
+                        mlir::ConversionPatternRewriter &rewriter,
+                        unsigned rank) const {
+    auto loc = box.getLoc();
+    auto firBoxTy = box.getType().template dyn_cast<fir::BoxType>();
+    assert(firBoxTy && "embox must have box type");
+    auto boxPtrTy =
+        this->unwrap(this->lowerTy().convertBoxType(firBoxTy, rank));
+
+    auto *thisBlock = rewriter.getInsertionBlock();
+    if (thisBlock &&
+        mlir::isa<mlir::LLVM::GlobalOp>(thisBlock->getParentOp())) {
+      auto boxTy = boxPtrTy.getPointerElementTy();
+      auto un = rewriter.create<mlir::LLVM::UndefOp>(loc, boxTy);
+      auto *ctx = box.getContext();
+      auto insertField =
+          [=](mlir::ConversionPatternRewriter &rewriter, mlir::Value dest,
+              llvm::ArrayRef<unsigned> fldIndexes, mlir::Value value,
+              const std::function<mlir::Value(mlir::LLVM::LLVMType,
+                                              mlir::Value)> &applyCast)
+          -> mlir::Value {
+        auto fldTy = this->getBoxEleTy(boxTy, fldIndexes);
+        auto fld = applyCast(fldTy, value);
+        llvm::SmallVector<mlir::Attribute, 2> attrs;
+        for (auto i : fldIndexes)
+          attrs.push_back(rewriter.getI32IntegerAttr(i));
+        auto indexesAttr = mlir::ArrayAttr::get(attrs, ctx);
+        return rewriter.create<mlir::LLVM::InsertValueOp>(loc, boxTy, dest, fld,
+                                                          indexesAttr);
+      };
+      return {un, insertField};
+    }
+    // Create new descriptor in memory and store into its fields.
+    mlir::Value c0 = this->genConstantOffset(loc, rewriter, 0);
+    auto alloca = genAllocaWithType(loc, boxPtrTy, defaultAlign, rewriter);
+    auto storeField =
+        [=](mlir::ConversionPatternRewriter &rewriter, mlir::Value dest,
+            llvm::ArrayRef<unsigned> fldIndexes, mlir::Value value,
+            const std::function<mlir::Value(mlir::LLVM::LLVMType, mlir::Value)>
+                &applyCast) -> mlir::Value {
+      auto fldTy = getBoxEleTy(boxPtrTy, fldIndexes);
+      auto fld = applyCast(fldTy, value);
+      llvm::SmallVector<mlir::Value, 3> indexValues = {c0};
+      for (auto i : fldIndexes)
+        indexValues.push_back(this->genConstantOffset(loc, rewriter, i));
+      auto fldPtr = rewriter.create<mlir::LLVM::GEPOp>(
+          loc, fldTy.getPointerTo(), dest, indexValues);
+      rewriter.create<mlir::LLVM::StoreOp>(loc, fld, fldPtr);
+      return dest;
+    };
+    return {alloca, storeField};
+  }
+
+  template <typename BOX>
+  std::tuple<fir::BoxType, mlir::Value, mlir::Value, StoreOrInserter>
   consDescriptorPrefix(BOX box, OperandTy operands,
                        mlir::ConversionPatternRewriter &rewriter, unsigned rank,
                        unsigned dropFront) const {
+    auto [dest, storeField] =
+        getStoreOrInsertField(box, operands, rewriter, rank);
     auto loc = box.getLoc();
     auto boxTy = box.getType().template dyn_cast<fir::BoxType>();
-    assert(boxTy && "embox must have box type");
-    auto ty = this->unwrap(this->lowerTy().convertBoxType(boxTy, rank));
-    auto alloca = genAllocaWithType(loc, ty, defaultAlign, rewriter);
-    auto c0 = this->genConstantOffset(loc, rewriter, 0);
-
-    // Basic pattern to write a field in the descriptor
-    auto storeField = [&](unsigned fldIndex, mlir::Value value,
-                          const std::function<mlir::Value(
-                              mlir::LLVM::LLVMType, mlir::Value)> &applyCast) {
-      auto fldTy = getBoxEleTy(ty, fldIndex);
-      auto fldPtr = genGEPToField(loc, fldTy, rewriter, alloca, c0, fldIndex);
-      auto fld = applyCast(fldTy, value);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, fld, fldPtr);
-    };
     auto bitCast = [&](mlir::LLVM::LLVMType ty,
                        mlir::Value val) -> mlir::Value {
       return rewriter.create<mlir::LLVM::BitcastOp>(loc, ty, val);
@@ -1065,18 +1120,23 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
     };
 
     // Write each of the fields with the appropriate values
-    storeField(0, operands[0], bitCast);
+    dest = storeField(rewriter, dest, {0}, operands[0], bitCast);
     auto [eleSize, cfiTy] = getSizeAndTypeCode(loc, rewriter, boxTy.getEleTy(),
                                                operands.drop_front(dropFront));
-    storeField(1, eleSize, intCast);
-    storeField(2, this->genConstantOffset(loc, rewriter, CFI_VERSION), intCast);
-    storeField(3, this->genConstantOffset(loc, rewriter, rank), intCast);
-    storeField(4, cfiTy, intCast);
-    storeField(5, this->genConstantOffset(loc, rewriter, getCFIAttr(boxTy)),
-               intCast);
-    storeField(6, this->genConstantOffset(loc, rewriter, isDerivedType(boxTy)),
-               intCast);
-    return {alloca, eleSize};
+    dest = storeField(rewriter, dest, {1}, eleSize, intCast);
+    dest = storeField(rewriter, dest, {2},
+                      this->genConstantOffset(loc, rewriter, CFI_VERSION),
+                      intCast);
+    dest = storeField(rewriter, dest, {3},
+                      this->genConstantOffset(loc, rewriter, rank), intCast);
+    dest = storeField(rewriter, dest, {4}, cfiTy, intCast);
+    dest = storeField(rewriter, dest, {5},
+                      this->genConstantOffset(loc, rewriter, getCFIAttr(boxTy)),
+                      intCast);
+    dest = storeField(
+        rewriter, dest, {6},
+        this->genConstantOffset(loc, rewriter, isDerivedType(boxTy)), intCast);
+    return {boxTy, dest, eleSize, storeField};
   }
 };
 
@@ -1090,14 +1150,12 @@ struct EmboxOpConversion : public EmboxCommonConversion<fir::EmboxOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // There should be no dims on this embox op
     assert(!embox.getShape());
-    auto boxTy = embox.getType().dyn_cast<fir::BoxType>();
-    auto [alloca, eleSize] =
-        consDescriptorPrefix(embox, operands, rewriter, /*rank=*/0,
-                             /*dropFront=*/1);
+    auto [boxTy, dest, eleSize, storeOrInsert] = consDescriptorPrefix(
+        embox, operands, rewriter, /* rank */ 0, /* dropFront */ 1);
     if (isDerivedType(boxTy))
       TODO("derived type");
 
-    rewriter.replaceOp(embox, alloca);
+    rewriter.replaceOp(embox, dest);
     return success();
   }
 };
@@ -1110,11 +1168,10 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::XEmboxOp> {
   matchAndRewrite(fir::XEmboxOp xbox, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto rank = xbox.getRank();
-    auto [alloca, eleSize] = consDescriptorPrefix(
+    auto [boxTy, dest, eleSize, storeOrInsert] = consDescriptorPrefix(
         xbox, operands, rewriter, rank, xbox.lenParamOffset() + 1);
     // Generate the triples in the dims field of the descriptor
     auto i64Ty = mlir::LLVM::LLVMType::getInt64Ty(xbox.getContext());
-    auto i64PtrTy = i64Ty.getPointerTo();
     assert(xbox.shapeOperands().size() && "must have a shape");
     unsigned shapeOff = 1;
     bool hasShift = xbox.shiftOperands().size();
@@ -1122,26 +1179,27 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::XEmboxOp> {
     bool hasSlice = xbox.sliceOperands().size();
     unsigned sliceOff = shiftOff + xbox.shiftOperands().size();
     auto loc = xbox.getLoc();
+    auto intCast = [&](mlir::LLVM::LLVMType ty,
+                       mlir::Value val) -> mlir::Value {
+      return integerCast(loc, rewriter, ty, val);
+    };
     mlir::Value zero = genConstantIndex(loc, i64Ty, rewriter, 0);
     mlir::Value one = genConstantIndex(loc, i64Ty, rewriter, 1);
     mlir::Value prevDim = integerCast(loc, rewriter, i64Ty, eleSize);
-    auto c0 = genConstantOffset(loc, rewriter, 0);
-    auto boxTy = xbox.getType().dyn_cast<fir::BoxType>();
+    auto eleTy = boxTy.getEleTy();
     for (unsigned d = 0; d < rank; ++d) {
       // store lower bound (normally 0)
-      auto f70p = genGEPToField(loc, i64PtrTy, rewriter, alloca, c0, 7, d, 0);
-      if (boxTy.isa<fir::PointerType>() || boxTy.isa<fir::HeapType>() ||
+      mlir::Value lb = zero;
+      if (eleTy.isa<fir::PointerType>() || eleTy.isa<fir::HeapType>() ||
           hasSlice) {
-        mlir::Value lb = one;
+        lb = one;
         if (hasShift)
           lb = operands[shiftOff];
         if (hasSlice)
           lb = rewriter.create<mlir::LLVM::SubOp>(loc, i64Ty, lb,
                                                   operands[sliceOff]);
-        rewriter.create<mlir::LLVM::StoreOp>(loc, lb, f70p);
-      } else {
-        rewriter.create<mlir::LLVM::StoreOp>(loc, zero, f70p);
       }
+      dest = storeOrInsert(rewriter, dest, {7, d, 0}, lb, intCast);
 
       // store extent
       mlir::Value extent = operands[shapeOff];
@@ -1154,16 +1212,14 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::XEmboxOp> {
         extent = rewriter.create<mlir::LLVM::SDivOp>(loc, i64Ty, extent,
                                                      operands[sliceOff + 2]);
       }
-      auto f71p = genGEPToField(loc, i64PtrTy, rewriter, alloca, c0, 7, d, 1);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, extent, f71p);
+      dest = storeOrInsert(rewriter, dest, {7, d, 1}, extent, intCast);
 
       // store step (scaled by shaped extent)
       mlir::Value step = prevDim;
       if (hasSlice)
         step = rewriter.create<mlir::LLVM::MulOp>(loc, i64Ty, step,
                                                   operands[sliceOff + 2]);
-      auto f72p = genGEPToField(loc, i64PtrTy, rewriter, alloca, c0, 7, d, 2);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, step, f72p);
+      dest = storeOrInsert(rewriter, dest, {7, d, 2}, step, intCast);
       // compute the stride for the next natural dimension
       prevDim =
           rewriter.create<mlir::LLVM::MulOp>(loc, i64Ty, prevDim, outerExtent);
@@ -1177,10 +1233,8 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::XEmboxOp> {
     }
     if (isDerivedType(boxTy))
       TODO("derived type");
-    // Convert descriptor to the prefix type for strong typing.
-    auto desc = rewriter.create<mlir::LLVM::BitcastOp>(
-        loc, lowerTy().convertType(boxTy), alloca);
-    rewriter.replaceOp(xbox, desc.getResult());
+
+    rewriter.replaceOp(xbox, dest);
     return success();
   }
 };
@@ -1878,6 +1932,8 @@ struct GlobalOpConversion : public FIROpConversion<fir::GlobalOp> {
   matchAndRewrite(fir::GlobalOp global, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto tyAttr = unwrap(convertType(global.getType()));
+    if (global.getType().isa<fir::BoxType>())
+      tyAttr = tyAttr.getPointerElementTy();
     auto loc = global.getLoc();
     mlir::Attribute initAttr{};
     if (global.initVal())
@@ -2116,8 +2172,17 @@ struct StoreOpConversion : public FIROpConversion<fir::StoreOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::StoreOp store, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(store, operands[0],
-                                                     operands[1]);
+    if (store.value().getType().isa<fir::BoxType>()) {
+      // fir.box value is actually in memory, load it first before storing it.
+      auto loc = store.getLoc();
+      auto boxPtrTy = unwrap(operands[0].getType());
+      auto val = rewriter.create<mlir::LLVM::LoadOp>(
+          loc, boxPtrTy.getPointerElementTy(), operands[0]);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(store, val, operands[1]);
+    } else {
+      rewriter.replaceOpWithNewOp<mlir::LLVM::StoreOp>(store, operands[0],
+                                                       operands[1]);
+    }
     return success();
   }
 };

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -26,23 +26,18 @@ func private @ga(%b : !fir.box<!fir.array<?xf32>>)
 // CHECK-LABEL: define void @f
 // CHECK: (float* %[[ARG:.*]])
 func @f(%a : !fir.ref<f32>) {
-  // CHECK: %[[GEP0:.*]] = getelementptr {{.*}}, i32 0, i32 0
-  // CHECK: store float* %[[ARG]], float** %[[GEP0]]
-  // CHECK: %[[GEP1:.*]] = getelementptr {{.*}}, i32 0, i32 1
-  // CHECK: store i64 {{.*}}, i64* %[[GEP1]]
-  // CHECK: %[[GEP2:.*]] = getelementptr {{.*}}, i32 0, i32 2
-  // CHECK: store i32 {{.*}}, i32* %[[GEP2]]
-  // CHECK: %[[GEP3:.*]] = getelementptr {{.*}}, i32 0, i32 3
-  // CHECK: store i8 {{.*}}, i8* %[[GEP3]]
-  // CHECK: %[[GEP4:.*]] = getelementptr {{.*}}, i32 0, i32 4
-  // CHECK: store i8 {{.*}}, i8* %[[GEP4]]
-  // CHECK: %[[GEP5:.*]] = getelementptr {{.*}}, i32 0, i32 5
-  // CHECK: store i8 {{.*}}, i8* %[[GEP5]]
-  // CHECK: %[[GEP6:.*]] = getelementptr {{.*}}, i32 0, i32 6
-  // CHECK: store i8 {{.*}}, i8* %[[GEP6]]
+  // CHECK: %[[DESC:.*]] = alloca { float*, i64, i32, i8, i8, i8, i8 }
+  // CHECK: %[[INS0:.*]] = insertvalue {{.*}} undef, float* %[[ARG]], 0
+  // CHECK: %[[INS1:.*]] = insertvalue {{.*}} %[[INS0]], i64 4, 1
+  // CHECK: %[[INS2:.*]] = insertvalue {{.*}} %[[INS1]], i32 {{.*}}, 2
+  // CHECK: %[[INS3:.*]] = insertvalue {{.*}} %[[INS2]], i8 0, 3
+  // CHECK: %[[INS4:.*]] = insertvalue {{.*}} %[[INS3]], i8 25, 4
+  // CHECK: %[[INS5:.*]] = insertvalue {{.*}} %[[INS4]], i8 0, 5
+  // CHECK: %[[INS6:.*]] = insertvalue {{.*}} %[[INS5]], i8 0, 6
+  // CHECK: store {{.*}} %[[INS6]], {{.*}}* %[[DESC]]
   %b = fir.embox %a : (!fir.ref<f32>) -> !fir.box<f32>
 
-  // CHECK: call void @g(
+  // CHECK: call void @g({{.*}} %[[DESC]])
   fir.call @g(%b) : (!fir.box<f32>) -> ()
   // CHECK: ret void
   return
@@ -55,12 +50,9 @@ func @fa(%a : !fir.ref<!fir.array<100xf32>>) {
   %c1 = constant 1 : index
   %c100 = constant 100 : index
   %d = fir.shape %c100 : (index) -> !fir.shape<1>
-  // CHECK: %[[GEP70:.*]] = getelementptr {{.*}}, i32 0, i32 7, i32 0, i32 0
-  // CHECK: store i64 {{.*}}, i64* %[[GEP70]]
-  // CHECK: %[[GEP71:.*]] = getelementptr {{.*}}, i32 0, i32 7, i32 0, i32 1
-  // CHECK: store i64 {{.*}}, i64* %[[GEP71]]
-  // CHECK: %[[GEP72:.*]] = getelementptr {{.*}}, i32 0, i32 7, i32 0, i32 2
-  // CHECK: store i64 {{.*}}, i64* %[[GEP72]]
+  // CHECK: %[[INS70:.*]] = insertvalue {{.*}} %{{.*}}, i64 0, 7, 0, 0
+  // CHECK: %[[INS71:.*]] = insertvalue {{.*}} %[[INS70]], i64 100, 7, 0, 1
+  // CHECK: %[[INS72:.*]] = insertvalue {{.*}} %[[INS71]], i64 4, 7, 0, 2
   %b = fir.embox %c(%d) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
   // CHECK: call void @ga(
   fir.call @ga(%b) : (!fir.box<!fir.array<?xf32>>) -> ()
@@ -72,9 +64,9 @@ func @fa(%a : !fir.ref<!fir.array<100xf32>>) {
 // CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8 }* @b1(
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b1(%arg0 : !fir.ref<!fir.char<1,?>>, %arg1 : index) -> !fir.box<!fir.char<1,?>> {
-  // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  // CHECK: store i32 20180515, i32* %
+  // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 1
+  // CHECK: insertvalue {{.*}} i32 20180515, 2
   %x = fir.embox %arg0 typeparams %arg1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
   return %x : !fir.box<!fir.char<1,?>>
 }
@@ -84,11 +76,11 @@ func @b1(%arg0 : !fir.ref<!fir.char<1,?>>, %arg1 : index) -> !fir.box<!fir.char<
 // CHECK-SAME: [5 x i8]* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.box<!fir.array<?x!fir.char<1,5>>> {
   %1 = fir.shape %arg1 : (index) -> !fir.shape<1>
-  // CHECK: store [5 x i8]* %[[arg0]], [5 x i8]** %{{.*}}, align
-  // CHECK: store i64 5, i64* %{{.*}}, align
-  // CHECK: store i32 20180515, i32* %
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  // CHECK: store i64 5, i64* %{{.*}}, align
+  // CHECK: insertvalue {{.*}} [5 x i8]* %[[arg0]], 0
+  // CHECK: insertvalue {{.*}} i64 5, 1
+  // CHECK: insertvalue {{.*}} i32 20180515, 2
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 7, 0, 1
+  // CHECK: insertvalue {{.*}} i64 5, 7, 0, 2
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<?x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<?x!fir.char<1,5>>>
   return %2 : !fir.box<!fir.array<?x!fir.char<1,5>>>
 }
@@ -98,11 +90,11 @@ func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.
 // CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]], i64 %[[arg2:.*]])
 func @b3(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,?>>>, %arg1 : index, %arg2 : index) -> !fir.box<!fir.array<?x!fir.char<1,?>>> {
   %1 = fir.shape %arg2 : (index) -> !fir.shape<1>
-  // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  // CHECK: store i32 20180515, i32* %
-  // CHECK: store i64 %[[arg2]], i64* %{{.*}}, align
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
+  // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 1
+  // CHECK: insertvalue {{.*}} i32 20180515, 2
+  // CHECK: insertvalue {{.*}} i64 %[[arg2]], 7, 0, 1
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 7, 0, 2
   %2 = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
   return %2 : !fir.box<!fir.array<?x!fir.char<1,?>>>
 }
@@ -113,11 +105,11 @@ func @b3(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,?>>>, %arg1 : index, %arg2 : 
 func @b4(%arg0 : !fir.ref<!fir.array<7x!fir.char<1,?>>>, %arg1 : index) -> !fir.box<!fir.array<7x!fir.char<1,?>>> {
   %c_7 = constant 7 : index
   %1 = fir.shape %c_7 : (index) -> !fir.shape<1>
-  // CHECK: store i8* %[[arg0]], i8** %{{.*}}, align
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
-  // CHECK: store i32 20180515, i32* %
-  // CHECK: store i64 7, i64* %{{.*}}, align
-  // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
+  // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 1
+  // CHECK: insertvalue {{.*}} i32 20180515, 2
+  // CHECK: insertvalue {{.*}} i64 7, 7, 0, 1
+  // CHECK: insertvalue {{.*}} i64 %[[arg1]], 7, 0, 2
   %x = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<7x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<7x!fir.char<1,?>>>
   return %x : !fir.box<!fir.array<7x!fir.char<1,?>>>
 }

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -1,5 +1,23 @@
 // RUN: tco -o - %s | FileCheck %s
 
+// Global box initialization (test must come first because llvm globals are emitted first).
+// CHECK-LABEL: @globalx = internal global { i32*, i64, i32, i8, i8, i8, i8 } { i32* null, i64 4, i32 20180515, i8 0, i8 9, i8 2, i8 0 }
+fir.global internal @globalx : !fir.box<!fir.heap<i32>> {
+  %c0 = constant 0 : index
+  %0 = fir.convert %c0 : (index) -> !fir.heap<i32>
+  %1 = fir.embox %0 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+  fir.has_value %1 : !fir.box<!fir.heap<i32>>
+}
+
+// CHECK-LABEL: @globaly = internal global { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* null, i64 4, i32 20180515, i8 1, i8 25, i8 2, i8 0,{{.*}}[3 x i64] [i64 1, i64 0, i64 4]
+fir.global internal @globaly : !fir.box<!fir.heap<!fir.array<?xf32>>> {
+  %c0 = constant 0 : index
+  %0 = fir.convert %c0 : (index) -> !fir.heap<!fir.array<?xf32>>
+  %1 = fir.shape %c0 : (index) -> !fir.shape<1>
+  %2 = fir.embox %0(%1) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+  fir.has_value %2 : !fir.box<!fir.heap<!fir.array<?xf32>>>
+}
+
 // CHECK-LABEL: declare void @g({ float*, i64, i32, i8, i8, i8, i8 }*)
 func private @g(%b : !fir.box<f32>)
 // CHECK-LABEL: declare void @ga({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }*)
@@ -102,4 +120,14 @@ func @b4(%arg0 : !fir.ref<!fir.array<7x!fir.char<1,?>>>, %arg1 : index) -> !fir.
   // CHECK: store i64 %[[arg1]], i64* %{{.*}}, align
   %x = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<7x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<7x!fir.char<1,?>>>
   return %x : !fir.box<!fir.array<7x!fir.char<1,?>>>
+}
+
+// Storing a fir.box into a fir.ref<fir.box> (modifying descriptors).
+// CHECK-LABEL: define void @b5(
+// CHECK-SAME: { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[arg0:.*]], { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[arg1:.*]])
+func @b5(%arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>, %arg1 : !fir.box<!fir.heap<!fir.array<?x?xf32>>>) {
+  fir.store %arg1 to %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  // CHECK: %[[boxLoad:.*]] = load { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[arg1]]
+  // CHECK: store { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %[[boxLoad]], { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[arg0]]
+  return
 }

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -302,7 +302,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
 
   if (emitLLVM) {
     // Continue to lower from MLIR down to LLVM IR. Emit LLVM and MLIR.
-    pm.addNestedPass<mlir::FuncOp>(fir::createFirCodeGenRewritePass());
+    pm.addPass(fir::createFirCodeGenRewritePass());
     pm.addPass(fir::createFirTargetRewritePass());
     pm.addPass(fir::createFIRToLLVMPass(nameUniquer));
 

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -123,7 +123,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     pm.addNestedPass<mlir::FuncOp>(fir::createCSEPass());
 
     // pm.addPass(fir::createMemToRegPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createFirCodeGenRewritePass());
+    pm.addPass(fir::createFirCodeGenRewritePass());
     pm.addPass(fir::createFirTargetRewritePass());
     pm.addPass(fir::createFIRToLLVMPass(uniquer));
     pm.addPass(fir::createLLVMDialectToLLVMPass(out.os()));


### PR DESCRIPTION
Preliminary fir/codegen changes required to lower global allocatables variables:

- Allow `fir.store` on `fir.box` elements. This is implemented with an llvm memcpy. It is needed to initialize local descriptor (lowering not part of this PR).
- Allow `fir.embox` to be used in globalOp initializer. This required modifying embox codegen to either use AllocaOp + StoreOp (normal context) or UndefOp + InsertValueOp (global initializer context). This is needed to lower global allocatables (lowering not part of this PR).
- Modify `CodeGenRewrite` to run on both FuncOp and GlobalOp bodies (it only ran on FuncOp). This is needed so that array embox generated in global allocatable array initializer can be rewritten to XEmbox and the shapeOp deleted.

With this, it will be possible to lower global allocatables without requiring a call to initialize their descriptor.
[edit: last commit adds BoxEleSizeOp codegen fix that was stuck in my non contiguity support draft and is required to work with character allocatables]