### PR TITLE
Rewrite "if (cond) goto N" statements to eliminate the goto

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -47,9 +47,6 @@ struct Program;
 struct ModuleLikeUnit;
 struct FunctionLikeUnit;
 
-// TODO: A collection of Evaluations can obviously be any of the container
-// types; leaving this as a std::list _for now_ because we reserve the right to
-// insert PFT nodes in any order in O(1) time.
 using EvaluationList = std::list<Evaluation>;
 using LabelEvalMap = llvm::DenseMap<Fortran::parser::Label, Evaluation *>;
 
@@ -222,7 +219,7 @@ struct Evaluation : EvaluationVariant {
       : EvaluationVariant{a},
         parentVariant{parentVariant}, position{position}, label{label} {}
 
-  /// Construct ctor
+  /// Construct and Directive ctor
   template <typename A>
   Evaluation(const A &a, const ParentVariant &parentVariant)
       : EvaluationVariant{a}, parentVariant{parentVariant} {
@@ -354,7 +351,7 @@ struct Evaluation : EvaluationVariant {
   Evaluation *constructExit{nullptr};    // set for constructs
   bool isNewBlock{false};                // evaluation begins a new basic block
   bool isUnstructured{false};  // evaluation has unstructured control flow
-  bool skip{false};            // evaluation has been processed in advance
+  bool negateCondition{false}; // If[Then]Stmt condition must be negated
   mlir::Block *block{nullptr}; // isNewBlock block
   llvm::SmallVector<mlir::Block *, 1> localBlocks{}; // construct local blocks
   int printIndex{0}; // (ActionStmt, ConstructStmt) evaluation index for dumps

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -976,10 +976,10 @@ private:
         createFIRExpr(
             loc, Fortran::semantics::GetExpr(
                      std::get<Fortran::parser::ScalarLogicalExpr>(stmt->t))));
-    if (!negate)
-      return cond;
-    return builder->create<mlir::XOrOp>(
-        loc, cond, builder->createIntegerConstant(loc, cond.getType(), 1));
+    if (negate)
+      cond = builder->create<mlir::XOrOp>(
+          loc, cond, builder->createIntegerConstant(loc, cond.getType(), 1));
+    return cond;
   }
 
   /// Generate structured or unstructured FIR for an IF construct.
@@ -992,7 +992,7 @@ private:
       fir::IfOp topIfOp, currentIfOp;
       for (auto &e : eval.getNestedEvaluations()) {
         auto genIfOp = [&](mlir::Value cond) {
-          auto ifOp = builder->create<fir::IfOp>(loc, cond, /*withElse*/ true);
+          auto ifOp = builder->create<fir::IfOp>(loc, cond, /*withElse=*/true);
           builder->setInsertionPointToStart(&ifOp.thenRegion().front());
           return ifOp;
         };
@@ -1008,7 +1008,7 @@ private:
         } else if (e.isA<Fortran::parser::EndIfStmt>()) {
           builder->setInsertionPointAfter(topIfOp);
         } else {
-          genFIR(e, /*unstructuredContext*/ false);
+          genFIR(e, /*unstructuredContext=*/false);
         }
       }
       return;

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -450,6 +450,11 @@ private:
     builder->create<mlir::CondBranchOp>(loc, bcc, trueTarget, llvm::None,
                                         falseTarget, llvm::None);
   }
+  void genFIRConditionalBranch(mlir::Value cond,
+                               Fortran::lower::pft::Evaluation *trueTarget,
+                               Fortran::lower::pft::Evaluation *falseTarget) {
+    genFIRConditionalBranch(cond, trueTarget->block, falseTarget->block);
+  }
   void genFIRConditionalBranch(const Fortran::parser::ScalarLogicalExpr &expr,
                                mlir::Block *trueTarget,
                                mlir::Block *falseTarget) {
@@ -464,9 +469,9 @@ private:
     genFIRConditionalBranch(cond, trueTarget->block, falseTarget->block);
   }
 
-  //===----------------------------------------------------------------------===//
+  //===--------------------------------------------------------------------===//
   // Termination of symbolically referenced execution units
-  //===----------------------------------------------------------------------===//
+  //===--------------------------------------------------------------------===//
 
   /// END of program
   ///
@@ -539,27 +544,6 @@ private:
   //
   // Statements that have control-flow semantics
   //
-
-  template <typename A>
-  std::pair<mlir::OpBuilder::InsertPoint, fir::IfOp>
-  genIfCondition(const A *stmt, bool withElse = true) {
-    auto cond = createFIRExpr(
-        toLocation(),
-        Fortran::semantics::GetExpr(
-            std::get<Fortran::parser::ScalarLogicalExpr>(stmt->t)));
-    auto bcc = builder->createConvert(toLocation(), builder->getI1Type(), cond);
-    auto ifOp = builder->create<fir::IfOp>(toLocation(), bcc, withElse);
-    auto insPt = builder->saveInsertionPoint();
-    builder->setInsertionPointToStart(&ifOp.thenRegion().front());
-    return {insPt, ifOp};
-  }
-
-  mlir::Value genFIRLoopIndex(const Fortran::parser::ScalarExpr &x,
-                              mlir::Type t) {
-    auto loc = toLocation();
-    mlir::Value v = createFIRExpr(loc, Fortran::semantics::GetExpr(x));
-    return builder->createConvert(loc, t, v);
-  }
 
   mlir::FuncOp getFunc(llvm::StringRef name, mlir::FunctionType ty) {
     if (auto func = builder->getNamedFunction(name)) {
@@ -983,45 +967,48 @@ private:
     }
   }
 
-  /// Generate structured or unstructured FIR for an IF statement.
-  void genFIR(const Fortran::parser::IfStmt &stmt) {
-    auto &eval = getEval();
-    if (eval.lowerAsUnstructured()) {
-      genFIRConditionalBranch(
-          std::get<Fortran::parser::ScalarLogicalExpr>(stmt.t),
-          eval.lexicalSuccessor, eval.controlSuccessor);
-      return;
-    }
-
-    // Generate fir.if.
-    auto pair = genIfCondition(&stmt, /*withElse=*/false);
-    genFIR(*eval.lexicalSuccessor, /*unstructuredContext=*/false);
-    eval.lexicalSuccessor->skip = true;
-    builder->restoreInsertionPoint(pair.first);
+  /// Generate an If[Then]Stmt condition or its negation.
+  template <typename A>
+  mlir::Value genIfCondition(const A *stmt, bool negate = false) {
+    auto loc = toLocation();
+    auto cond = builder->createConvert(
+        loc, builder->getI1Type(),
+        createFIRExpr(
+            loc, Fortran::semantics::GetExpr(
+                     std::get<Fortran::parser::ScalarLogicalExpr>(stmt->t))));
+    if (!negate)
+      return cond;
+    return builder->create<mlir::XOrOp>(
+        loc, cond, builder->createIntegerConstant(loc, cond.getType(), 1));
   }
 
   /// Generate structured or unstructured FIR for an IF construct.
+  /// The initial statement may be either an IfStmt or an IfThenStmt.
   void genFIR(const Fortran::parser::IfConstruct &) {
+    auto loc = toLocation();
     auto &eval = getEval();
     if (eval.lowerAsStructured()) {
       // Structured fir.if nest.
-      fir::IfOp nestedIf;
-      mlir::OpBuilder::InsertPoint insPt;
+      fir::IfOp topIfOp, currentIfOp;
       for (auto &e : eval.getNestedEvaluations()) {
+        auto genIfOp = [&](mlir::Value cond) {
+          auto ifOp = builder->create<fir::IfOp>(loc, cond, /*withElse*/ true);
+          builder->setInsertionPointToStart(&ifOp.thenRegion().front());
+          return ifOp;
+        };
         if (auto *s = e.getIf<Fortran::parser::IfThenStmt>()) {
-          // fir.if op
-          std::tie(insPt, nestedIf) = genIfCondition(s);
+          topIfOp = currentIfOp = genIfOp(genIfCondition(s, e.negateCondition));
+        } else if (auto *s = e.getIf<Fortran::parser::IfStmt>()) {
+          topIfOp = currentIfOp = genIfOp(genIfCondition(s, e.negateCondition));
         } else if (auto *s = e.getIf<Fortran::parser::ElseIfStmt>()) {
-          // otherwise block, then nested fir.if
-          builder->setInsertionPointToStart(&nestedIf.elseRegion().front());
-          std::tie(std::ignore, nestedIf) = genIfCondition(s);
+          builder->setInsertionPointToStart(&currentIfOp.elseRegion().front());
+          currentIfOp = genIfOp(genIfCondition(s));
         } else if (e.isA<Fortran::parser::ElseStmt>()) {
-          // otherwise block
-          builder->setInsertionPointToStart(&nestedIf.elseRegion().front());
+          builder->setInsertionPointToStart(&currentIfOp.elseRegion().front());
         } else if (e.isA<Fortran::parser::EndIfStmt>()) {
-          builder->restoreInsertionPoint(insPt);
+          builder->setInsertionPointAfter(topIfOp);
         } else {
-          genFIR(e, /*unstructuredContext=*/false);
+          genFIR(e, /*unstructuredContext*/ false);
         }
       }
       return;
@@ -1029,21 +1016,22 @@ private:
 
     // Unstructured branch sequence.
     for (auto &e : eval.getNestedEvaluations()) {
-      const Fortran::parser::ScalarLogicalExpr *cond = nullptr;
+      auto genIfBranch = [&](mlir::Value cond) {
+        if (e.lexicalSuccessor == e.controlSuccessor) // empty block -> exit
+          genFIRConditionalBranch(cond, e.parentConstruct->constructExit,
+                                  e.controlSuccessor);
+        else // non-empty block
+          genFIRConditionalBranch(cond, e.lexicalSuccessor, e.controlSuccessor);
+      };
       if (auto *s = e.getIf<Fortran::parser::IfThenStmt>()) {
         maybeStartBlock(e.block);
-        cond = &std::get<Fortran::parser::ScalarLogicalExpr>(s->t);
+        genIfBranch(genIfCondition(s, e.negateCondition));
+      } else if (auto *s = e.getIf<Fortran::parser::IfStmt>()) {
+        maybeStartBlock(e.block);
+        genIfBranch(genIfCondition(s, e.negateCondition));
       } else if (auto *s = e.getIf<Fortran::parser::ElseIfStmt>()) {
         startBlock(e.block);
-        cond = &std::get<Fortran::parser::ScalarLogicalExpr>(s->t);
-      }
-      if (cond) {
-        genFIRConditionalBranch(
-            *cond,
-            e.lexicalSuccessor == e.controlSuccessor
-                ? e.parentConstruct->constructExit // empty block --> exit
-                : e.lexicalSuccessor,              // nonempty block
-            e.controlSuccessor);
+        genIfBranch(genIfCondition(s));
       } else {
         genFIR(e);
       }
@@ -1221,6 +1209,7 @@ private:
   void genFIR(const Fortran::parser::EntryStmt &) {}             // nop
   void genFIR(const Fortran::parser::ForallAssignmentStmt &s) {} // nop
   void genFIR(const Fortran::parser::ForallConstructStmt &) {}   // nop
+  void genFIR(const Fortran::parser::IfStmt &stmt) {}            // nop
   void genFIR(const Fortran::parser::IfThenStmt &) {}            // nop
   void genFIR(const Fortran::parser::NonLabelDoStmt &) {}        // nop
 
@@ -1715,9 +1704,6 @@ private:
   /// Generate the FIR for the Evaluation `eval`.
   void genFIR(Fortran::lower::pft::Evaluation &eval,
               bool unstructuredContext = true) {
-    if (eval.skip)
-      return; // rhs of IfStmt has already been processed
-
     if (unstructuredContext) {
       // When transitioning from unstructured to structured code,
       // the structured code could be a target that starts a new block.

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -104,12 +104,51 @@ public:
                                              stmt.position, stmt.label});
         return false;
       } else if constexpr (std::is_same_v<T, parser::ActionStmt>) {
-        addEvaluation(
-            makeEvaluationAction(stmt.unwrapped, stmt.position, stmt.label));
-        return true;
+        return std::visit(
+            common::visitors{
+                [&](const common::Indirection<parser::IfStmt> &x) {
+                  convertIfStmt(x.value(), stmt.position, stmt.label);
+                  return false;
+                },
+                [&](const auto &x) {
+                  addEvaluation(lower::pft::Evaluation{
+                      removeIndirection(x), parentVariantStack.back(),
+                      stmt.position, stmt.label});
+                  return true;
+                },
+            },
+            stmt.unwrapped.u);
       }
     }
     return true;
+  }
+
+  /// Convert an IfStmt into an IfConstruct, retaining the IfStmt as the
+  /// first statement of the construct.
+  void convertIfStmt(const parser::IfStmt &ifStmt, parser::CharBlock position,
+                     std::optional<parser::Label> label) {
+    // Generate a skeleton IfConstruct parse node.  Its components are never
+    // referenced.  The actual components are available via the IfConstruct
+    // evaluation's nested evaluationList, with the ifStmt in the position of
+    // the otherwise normal IfThenStmt.
+    enterConstructOrDirective(parser::IfConstruct{
+        parser::Statement<parser::IfThenStmt>{
+            std::nullopt,
+            parser::IfThenStmt{
+                std::optional<parser::Name>{},
+                parser::ScalarLogicalExpr{parser::LogicalExpr{parser::Expr{
+                    parser::LiteralConstant{parser::LogicalLiteralConstant{
+                        false, std::optional<parser::KindParam>{}}}}}}}},
+        parser::Block{}, std::list<parser::IfConstruct::ElseIfBlock>{},
+        std::optional<parser::IfConstruct::ElseBlock>{},
+        parser::Statement<parser::EndIfStmt>{std::nullopt,
+                                             parser::EndIfStmt{std::nullopt}}});
+    addEvaluation(lower::pft::Evaluation{ifStmt, parentVariantStack.back(),
+                                         position, label});
+    Pre(std::get<parser::UnlabeledStatement<parser::ActionStmt>>(ifStmt.t));
+    addEvaluation(lower::pft::Evaluation{
+        parser::EndIfStmt{std::nullopt}, parentVariantStack.back(), {}, {}});
+    exitConstructOrDirective();
   }
 
   template <typename A>
@@ -243,6 +282,7 @@ private:
   }
 
   void exitFunction() {
+    rewriteIfGotos();
     endFunctionBody();
     analyzeBranches(nullptr, *evaluationListStack.back()); // add branch links
     processEntryPoints();
@@ -266,6 +306,7 @@ private:
   }
 
   void exitConstructOrDirective() {
+    rewriteIfGotos();
     popEvaluationList();
     parentVariantStack.pop_back();
     constructAndDirectiveStack.pop_back();
@@ -369,6 +410,89 @@ private:
     evaluationListStack.pop_back();
   }
 
+  /// Rewrite IfConstructs containing a GotoStmt to eliminate an unstructured
+  /// branch and a trivial basic block.  The pre-branch-analysis code:
+  ///
+  ///       <<IfConstruct>>
+  ///         1 If[Then]Stmt: if(cond) goto L
+  ///         2 GotoStmt: goto L
+  ///         3 EndIfStmt
+  ///       <<End IfConstruct>>
+  ///       4 AssignmentStmt: ...
+  ///       5 AssignmentStmt: L ...
+  ///
+  /// becomes:
+  ///
+  ///       <<IfConstruct>>
+  ///         1 If[Then]Stmt [negate]: if(cond) goto L
+  ///         4 AssignmentStmt: ...
+  ///         3 EndIfStmt
+  ///       <<End IfConstruct>>
+  ///       5 AssignmentStmt: L ...
+  ///
+  /// The If[Then]Stmt condition is implicitly negated.  It is not modified
+  /// in the PFT.  It must be negated when generating FIR.  The GotoStmt is
+  /// deleted.
+  ///
+  /// The transformation is only valid for forward branch targets at the same
+  /// construct nesting level as the IfConstruct.  The result must not violate
+  /// construct nesting requirements or contain an EntryStmt.  The result
+  /// is subject to normal un/structured code classification analysis.  The
+  /// result is allowed to violate the F18 Clause 11.1.2.1 prohibition on
+  /// transfer of control into the interior of a construct block, as that does
+  /// not compromise correct code generation.  When two transformation
+  /// candidates overlap, at least one must be disallowed.  In such cases,
+  /// the current heuristic favors simple code generation, which happens to
+  /// favor later candidates over earlier candidates.  That choice is probably
+  /// not significant, but could be changed.
+  ///
+  void rewriteIfGotos() {
+    using T = struct {
+      lower::pft::EvaluationList::iterator ifConstructIt;
+      parser::Label ifTargetLabel;
+    };
+    llvm::SmallVector<T, 8> ifExpansionStack;
+    auto &evaluationList = *evaluationListStack.back();
+    for (auto it = evaluationList.begin(), end = evaluationList.end();
+         it != end; ++it) {
+      auto &eval = *it;
+      if (eval.isA<parser::EntryStmt>()) {
+        ifExpansionStack.clear();
+        continue;
+      }
+      auto firstStmt = [](lower::pft::Evaluation *e) {
+        return e->isConstruct() ? &*e->evaluationList->begin() : e;
+      };
+      auto &targetEval = *firstStmt(&eval);
+      if (targetEval.label) {
+        while (!ifExpansionStack.empty() &&
+               ifExpansionStack.back().ifTargetLabel == *targetEval.label) {
+          auto ifConstructIt = ifExpansionStack.back().ifConstructIt;
+          auto successorIt = std::next(ifConstructIt);
+          if (successorIt != it) {
+            auto &ifBodyList = *ifConstructIt->evaluationList;
+            ifBodyList.erase(std::next(ifBodyList.begin())); // GotoStmt
+            auto &ifStmt = *ifBodyList.begin();              // If[Then]Stmt
+            ifStmt.negateCondition = true;
+            ifStmt.lexicalSuccessor = firstStmt(&*successorIt);
+            auto endIfStmtIt = std::prev(ifBodyList.end());
+            std::prev(it)->lexicalSuccessor = &*endIfStmtIt;
+            endIfStmtIt->lexicalSuccessor = firstStmt(&*it);
+            ifBodyList.splice(endIfStmtIt, evaluationList, successorIt, it);
+            for (; successorIt != endIfStmtIt; ++successorIt)
+              successorIt->parentConstruct = &*ifConstructIt;
+          }
+          ifExpansionStack.pop_back();
+        }
+      }
+      if (eval.isA<parser::IfConstruct>() && eval.evaluationList->size() == 3) {
+        if (auto *gotoStmt = std::next(eval.evaluationList->begin())
+                                 ->getIf<parser::GotoStmt>())
+          ifExpansionStack.push_back({it, gotoStmt->v});
+      }
+    }
+  }
+
   /// Mark I/O statement ERR, EOR, and END specifier branch targets.
   /// Mark an I/O statement with an assigned format as unstructured.
   template <typename A>
@@ -440,7 +564,7 @@ private:
     // ancestors must be marked as unstructured.
     auto *sourceConstruct = sourceEvaluation.parentConstruct;
     auto *targetConstruct = targetEvaluation.parentConstruct;
-    if (targetEvaluation.isConstructStmt() &&
+    if (targetConstruct &&
         &targetConstruct->getFirstNestedEvaluation() == &targetEvaluation)
       // A branch to an initial constructStmt is a branch to the construct.
       targetConstruct = targetConstruct->parentConstruct;
@@ -518,7 +642,6 @@ private:
   void analyzeBranches(lower::pft::Evaluation *parentConstruct,
                        std::list<lower::pft::Evaluation> &evaluationList) {
     lower::pft::Evaluation *lastConstructStmtEvaluation{};
-    lower::pft::Evaluation *lastIfStmtEvaluation{};
     for (auto &eval : evaluationList) {
       eval.visit(common::visitors{
           // Action statements (except I/O statements)
@@ -550,7 +673,10 @@ private:
             markBranchTarget(eval, *construct->constructExit);
           },
           [&](const parser::GotoStmt &s) { markBranchTarget(eval, s.v); },
-          [&](const parser::IfStmt &) { lastIfStmtEvaluation = &eval; },
+          [&](const parser::IfStmt &) {
+            eval.lexicalSuccessor->isNewBlock = true;
+            lastConstructStmtEvaluation = &eval;
+          },
           [&](const parser::ReturnStmt &) {
             eval.isUnstructured = true;
             if (eval.lexicalSuccessor->lexicalSuccessor)
@@ -762,18 +888,6 @@ private:
       if (eval.evaluationList)
         analyzeBranches(&eval, *eval.evaluationList);
 
-      // Insert branch links for an unstructured IF statement.
-      if (lastIfStmtEvaluation && lastIfStmtEvaluation != &eval) {
-        // eval is the action substatement of an IfStmt.
-        if (eval.lowerAsUnstructured()) {
-          eval.isNewBlock = true;
-          markSuccessorAsNewBlock(eval);
-          lastIfStmtEvaluation->isUnstructured = true;
-        }
-        lastIfStmtEvaluation->controlSuccessor = &eval.nonNopSuccessor();
-        lastIfStmtEvaluation = nullptr;
-      }
-
       // Set the successor of the last statement in an IF or SELECT block.
       if (!eval.controlSuccessor && eval.lexicalSuccessor &&
           eval.lexicalSuccessor->isIntermediateConstructStmt()) {
@@ -900,6 +1014,8 @@ public:
       outputStream << '*';
     outputStream << name << bang;
     if (eval.isActionStmt() || eval.isConstructStmt()) {
+      if (eval.negateCondition)
+        outputStream << " [negate]";
       if (eval.controlSuccessor)
         outputStream << " -> " << eval.controlSuccessor->printIndex;
     } else if (eval.isA<parser::EntryStmt>() && eval.lexicalSuccessor) {

--- a/flang/test/Lower/loops.f90
+++ b/flang/test/Lower/loops.f90
@@ -24,9 +24,10 @@ subroutine loop_test
     a(i,j,k) = 0
   enddo
   ! CHECK: fir.call @_FortranAioBeginExternalListOutput
-  print*, i, j, k
+  print*, 'A:', i, j, k
 
   ! CHECK-COUNT-3: fir.do_loop {{.*}} unordered
+  ! CHECK: fir.if
   do concurrent (integer(1)::i=1:5, j=1:5, k=1:5, i.ne.j .and. k.ne.3) shared(a)
     ! CHECK-COUNT-2: fir.coordinate_of
     a(i,j,k) = a(i,j,k) + 1
@@ -43,21 +44,45 @@ subroutine loop_test
     enddo
   enddo
   ! CHECK: fir.call @_FortranAioBeginExternalListOutput
-  print*, i, j, k, '-', asum
+  print*, 'B:', i, j, k, '-', asum
+
+  ! CHECK: fir.do_loop {{.*}} unordered
+  ! CHECK-COUNT-2: fir.if
+  do concurrent (integer(2)::i=1:5, i.ne.3)
+    if (i.eq.2 .or. i.eq.4) goto 5 ! fir.if
+    ! CHECK: fir.call @_FortranAioBeginExternalListOutput
+    print*, 'C:', i
+  5 continue
+  enddo
+
+  ! CHECK: fir.do_loop {{.*}} unordered
+  ! CHECK-COUNT-2: fir.if
+  do concurrent (integer(2)::i=1:5, i.ne.3)
+    if (i.eq.2 .or. i.eq.4) then ! fir.if
+      goto 6
+    endif
+    ! CHECK: fir.call @_FortranAioBeginExternalListOutput
+    print*, 'D:', i
+  6 continue
+  enddo
 
   ! CHECK-NOT: fir.do_loop
+  ! CHECK-NOT: fir.if
   do concurrent (integer(2)::i=1:5, i.ne.3)
-    if (i.eq.2 .or. i.eq.4) goto 9
+    goto (7, 7) i+1
     ! CHECK: fir.call @_FortranAioBeginExternalListOutput
-    print*, i
-  9 continue
+    print*, 'E:', i
+  7 continue
   enddo
-  
+
   xsum = 0.0
   ! CHECK-NOT: fir.do_loop
   do x = 1.5, 3.5, 0.3
     xsum = xsum + 1
   enddo
   ! CHECK: fir.call @_FortranAioBeginExternalFormattedOutput
-  print '(X,F3.1,A,I2)', x, ' -', xsum
+  print '(" F:",X,F3.1,A,I2)', x, ' -', xsum
 end subroutine loop_test
+
+  call loop_test
+end


### PR DESCRIPTION
Rewrite:

```
    if (cond) goto L
    <statement1>
    <statement2>
  L <statement3>
```

or:

```
    if (cond) then
      goto L
    endif
    <statement1>
    <statement2>
  L <statement3>
```

as:

```
    if (.not. cond) then
      <statement1>
      <statement2>
    endif
  L <statement3>
```

This transformation eliminates a trivial basic block containing just
a goto, and allows implementation of the IF as a structured fir.if
(assuming that the statements that are moved into the IF construct
are themselves structured), enabling additional code optimization.

There are three places where this transformation could be done.
All three have problems.

1. In the front end, similar to canonicalization of DO statements.

Primary problem: This would transform some conformant programs into
nonconformant programs that branch into the body of the resulting
IF construct, complicating parse-unparse-reparse code sequences.
(Nonconformance does not itself compromise correct code generation.)

2. When building the PFT.

Primary problem: This would require changing the parse tree, which
is otherwise read-only.

3. When generating FIR from the PFT.

Primary problem:  This transformation invalidates some of the analysis
done when building the PFT.  That analysis would need to be redone
to avoid generation of incorrect code.

There are possible ways to mitigate each of these problems, such as
restricting the number of cases that are transformed, implementing
additional analyses, or copying code.  However, there are additional
problems in some cases, and more importantly, there is an alternative.

The alternative is to use a hybrid approach that splits the
implementation into two or three parts to avoid these problems.
The primary split is to make structural control flow changes when
building the PFT, but defer expression level changes to FIR generation.
The structural changes can be done without modifying the parse tree,
which avoids the option #2 problem.  When done at the right time,
these changes are sufficient to allow correct analysis of the
transformed IR, which avoids the option #3 problem.

Since at least some IF statements are rewritten as IF constructs,
there is a question as to whether it might be useful to rewrite all
IF statements.  This does not by itself change generated code.
However, it has several secondary benefits, including simple enabling
of the "if (cond) then; goto L; endif" case, so this PR does that
conversion for all cases.

That splits the implementation into three parts.  All IF statements
are converted to IF constructs when building the PFT.  After the
basic PFT is built, but before branches are analyzed, IF constructs
containing just a GOTO are visited, and viable candidates are
transformed to eliminate the GOTO.  This is effectively a new pass.
IfStmt's and IfThenStmt's that are transformed are tagged with a
"negateCondition" flag.  After branch analysis finalizes the PFT,
FIR generation looks at this flag to determine when to negate a
branch condition.

A key part of this implementation is the selection of candidates
to transform.  The transformation is only valid for forward branch
targets at the same construct nesting level as the IfConstruct.
The result must not violate construct nesting requirements or contain
an EntryStmt.  The result is allowed to violate the F18 Clause 11.1.2.1
prohibition on transfer of control into the interior of a construct
block, as that does not compromise correct code generation.  When two
transformation candidates overlap, at least one must be disallowed.
In such cases, the current heuristic favors simple code generation,
which happens to favor later candidates over earlier candidates.
That choice is probably not significant, but could be changed.