### PR TITLE
Allocatable lowering part 2: globals, dummies, and character

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -95,6 +95,12 @@ public:
     return genExprValue(*someExpr, stmtCtx, &loc);
   }
 
+  /// Generate the address of the box describing the variable designated
+  /// by the expression. The expression must be an allocatable or pointer
+  /// designator.
+  virtual fir::MutableBoxValue genExprMutableBox(mlir::Location loc,
+                                                 const SomeExpr &) = 0;
+
   /// Get FoldingContext that is required for some expression
   /// analysis.
   virtual Fortran::evaluate::FoldingContext &getFoldingContext() = 0;

--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -17,14 +17,23 @@ class Type;
 class Location;
 } // namespace mlir
 
+namespace fir {
+class MutableBoxValue;
+}
+
 namespace Fortran::parser {
 struct AllocateStmt;
 struct DeallocateStmt;
 } // namespace Fortran::parser
 
 namespace Fortran::lower {
+struct SymbolBox;
 class AbstractConverter;
 class FirOpBuilder;
+
+namespace pft {
+struct Variable;
+}
 
 /// Create a fir.box of type \p boxType that can be used to initialize an
 /// allocatable variable. Initialization of such variable has to be done at the
@@ -44,4 +53,35 @@ void genAllocateStmt(Fortran::lower::AbstractConverter &,
 /// Lower a deallocate statement to fir.
 void genDeallocateStmt(Fortran::lower::AbstractConverter &,
                        const Fortran::parser::DeallocateStmt &, mlir::Location);
+
+/// Create a MutableBoxValue for an allocatable or pointer entity.
+/// If the variables is a local variable that is not a dummy, it will be
+/// initialized to unallocated/diassociated status.
+fir::MutableBoxValue createMutableBox(Fortran::lower::AbstractConverter &,
+                                      mlir::Location,
+                                      const Fortran::lower::pft::Variable &var,
+                                      mlir::Value boxAddr,
+                                      mlir::ValueRange nonDeferredParams);
+
+/// Read all mutable properties into a normal symbol box.
+/// It is OK to call this on unassociated/unallocated boxes but any use of the
+/// resulting values will be undefined (only the base address will be guaranteed
+/// to be null).
+Fortran::lower::SymbolBox genMutableBoxRead(Fortran::lower::FirOpBuilder &,
+                                            mlir::Location,
+                                            const fir::MutableBoxValue &);
+
+/// Returns the fir.ref<fir.box<T>> of a MutableBoxValue filled with the current
+/// association / allocation properties. If the fir.ref<fir.box> already exists
+/// and is-up to date, this is a no-op, otherwise, code will be generated to
+/// fill the it.
+mlir::Value getMutableIRBox(Fortran::lower::FirOpBuilder &, mlir::Location,
+                            const fir::MutableBoxValue &);
+
+/// When the MutableBoxValue was passed as a fir.ref<fir.box> to a call that may
+/// have modified it, update the MutableBoxValue according to the
+/// fir.ref<fir.box> value.
+void syncMutableBoxFromIRBox(Fortran::lower::FirOpBuilder &, mlir::Location,
+                             const fir::MutableBoxValue &);
+
 } // namespace Fortran::lower

--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -12,6 +12,8 @@
 
 namespace mlir {
 class Value;
+class ValueRange;
+class Type;
 class Location;
 } // namespace mlir
 
@@ -22,18 +24,18 @@ struct DeallocateStmt;
 
 namespace Fortran::lower {
 class AbstractConverter;
-namespace pft {
-struct Variable;
-}
+class FirOpBuilder;
 
-/// Generate fir to initialize the box (descriptor) of an allocatable variable.
-/// Initialization of such box has to be done at the beginning of the variable
-/// lifetime.
-/// The memory address of the box to be initialized must be provided as an
-/// input.
-void genAllocatableInit(Fortran::lower::AbstractConverter &,
-                        const Fortran::lower::pft::Variable &,
-                        mlir::Value boxAddress);
+/// Create a fir.box of type \p boxType that can be used to initialize an
+/// allocatable variable. Initialization of such variable has to be done at the
+/// beginning of the variable lifetime by storing the created box in the memory
+/// for the variable box.
+/// \p nonDeferredParams must provide the non deferred length parameters so that
+/// they can already be placed in the unallocated box (inquiries about these
+/// parameters are legal even in unallocated state).
+mlir::Value createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
+                                 mlir::Location loc, mlir::Type boxType,
+                                 mlir::ValueRange nonDeferredParams);
 
 /// Lower an allocate statement to fir.
 void genAllocateStmt(Fortran::lower::AbstractConverter &,

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -99,7 +99,10 @@ public:
   enum class PassEntityBy {
     BaseAddress,
     BoxChar,
+    // passing a read-only descriptor
     Box,
+    // passing a writable descriptor
+    MutableBox,
     AddressAndLength,
     /// Value means passed by value at the mlir level, it is not necessarily
     /// implied by Fortran Value attribute.
@@ -114,6 +117,7 @@ public:
     CharAddress,
     CharLength,
     Box,
+    MutableBox,
     Value
   };
 

--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -76,7 +76,7 @@ public:
   /// length. Will fail if call on non reference like base.
   fir::CharBoxValue toScalarCharacter(const fir::CharArrayBoxValue &);
 
-  /// Unbox \p boxchar into (fir.ref<fir.char<kind>>, getLengthType()).
+  /// Unbox \p boxchar into (fir.ref<fir.char<kind>>, character length type).
   std::pair<mlir::Value, mlir::Value> createUnboxChar(mlir::Value boxChar);
 
   /// Allocate a temp of fir::CharacterType type and length len.
@@ -111,10 +111,6 @@ public:
   static fir::CharacterType getCharacterType(mlir::Type type);
   static fir::CharacterType getCharacterType(const fir::CharBoxValue &box);
   static fir::CharacterType getCharacterType(mlir::Value str);
-
-  /// Return the integer type that must be used to manipulate
-  /// Character lengths. TODO: move this to FirOpBuilder?
-  mlir::Type getLengthType() { return builder.getIndexType(); }
 
   /// Create an extended value from a value of type:
   /// - fir.boxchar<kind>
@@ -156,6 +152,11 @@ public:
   mlir::Value createSingletonFromCode(mlir::Value code, int kind);
   /// Returns integer value held in a character singleton.
   mlir::Value extractCodeFromSingleton(mlir::Value singleton);
+
+  /// Compute length given a fir.box describing a character entity.
+  /// It adjusts the length from the number of bytes per the descriptor
+  /// to the number of characters per the Fortran KIND.
+  mlir::Value readLengthFromBox(mlir::Value box);
 
 private:
   /// FIXME: the implementation also needs a clean-up now that

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -61,6 +61,13 @@ createSomeExtendedAddress(mlir::Location loc, AbstractConverter &converter,
                           const evaluate::Expr<evaluate::SomeType> &expr,
                           SymMap &symMap, StatementContext &stmtCtx);
 
+/// Create the address of the box.
+/// \p expr must be the designator of an allocatable/pointer entity.
+fir::MutableBoxValue
+createSomeMutableBox(mlir::Location loc, AbstractConverter &converter,
+                     const evaluate::Expr<evaluate::SomeType> &expr,
+                     SymMap &symMap);
+
 /// Create a string literal. Lowers `str` to the MLIR representation of a
 /// literal CHARACTER value. (KIND is assumed to be 1.)
 fir::ExtendedValue createStringLiteral(mlir::Location loc,

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -76,9 +76,12 @@ public:
   /// Create a 1-dimensional sequence of `eleTy` of unknown size.
   mlir::Type getVarLenSeqTy(mlir::Type eleTy);
 
-  /// Create a null constant of type RefType and value 0. Need to pass in the
-  /// Location information.
-  mlir::Value createNullConstant(mlir::Location loc);
+  /// Get character length type
+  mlir::Type getCharacterLengthType() { return getIndexType(); }
+
+  /// Create a null constant memory reference of type \p ptrType.
+  /// If \p ptrType is not provided, !fir.ref<none> type will be used.
+  mlir::Value createNullConstant(mlir::Location loc, mlir::Type ptrType = {});
 
   /// Create an integer constant of type \p type and value \p i.
   mlir::Value createIntegerConstant(mlir::Location loc, mlir::Type integerType,

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -16,6 +16,7 @@
 #include "StatementContext.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Lower/AbstractConverter.h"
+#include "flang/Lower/CharacterExpr.h"
 #include "flang/Lower/FIRBuilder.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Runtime.h"
@@ -25,16 +26,36 @@
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Semantics/type.h"
+#include "llvm/Support/CommandLine.h"
 
-/// Runtime call generators
+/// By default fir memory operation fir::AllocMemOp/fir::FreeMemOp are used.
+/// This switch allow forcing the use of runtime and descriptors for everything.
+/// This is mainly intended as a debug switch.
+static llvm::cl::opt<bool> useAllocateRuntime(
+    "use-alloc-runtime",
+    llvm::cl::desc("Lower allocations to fortran runtime calls"),
+    llvm::cl::init(false));
+/// Switch to force lowering of allocatable and pointers to descriptors in all
+/// cases for debug purposes.
+static llvm::cl::opt<bool> useDescForMutableBox(
+    "use-desc-for-alloc",
+    llvm::cl::desc("Always use descriptors for POINTER and ALLOCATABLE"),
+    llvm::cl::init(false));
+
+//===----------------------------------------------------------------------===//
+// Allocatables runtime call generators
+//===----------------------------------------------------------------------===//
+
 using namespace Fortran::runtime;
+/// Generate runtime call to set the bounds of an allocatable descriptors.
 static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
                                     mlir::Location loc, mlir::Value boxAddress,
-                                    mlir::Value dimIndex, mlir::Value lowerBoud,
+                                    mlir::Value dimIndex,
+                                    mlir::Value lowerBound,
                                     mlir::Value upperBound) {
   auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableSetBounds)>(
       loc, builder);
-  llvm::SmallVector<mlir::Value, 4> args{boxAddress, dimIndex, lowerBoud,
+  llvm::SmallVector<mlir::Value, 4> args{boxAddress, dimIndex, lowerBound,
                                          upperBound};
   llvm::SmallVector<mlir::Value, 4> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
@@ -42,9 +63,11 @@ static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
   builder.create<fir::CallOp>(loc, callee, operands);
 }
 
+/// Generate runtime call to set the lengths of a character allocatable
+/// descriptor.
 static void genAllocatableInitCharRtCall(Fortran::lower::FirOpBuilder &builder,
                                          mlir::Location loc,
-                                         fir::MutableBoxValue boxAddress,
+                                         const fir::MutableBoxValue &box,
                                          mlir::Value len) {
   auto callee =
       Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableInitCharacter)>(
@@ -56,12 +79,11 @@ static void genAllocatableInitCharRtCall(Fortran::lower::FirOpBuilder &builder,
     return;
   }
   llvm::SmallVector<mlir::Value, 5> args;
-  args.push_back(
-      builder.createConvert(loc, inputTypes[0], boxAddress.getAddr()));
+  args.push_back(builder.createConvert(loc, inputTypes[0], box.getAddr()));
   args.push_back(builder.createConvert(loc, inputTypes[1], len));
-  auto kind = boxAddress.getEleTy().cast<fir::CharacterType>().getFKind();
+  auto kind = box.getEleTy().cast<fir::CharacterType>().getFKind();
   args.push_back(builder.createIntegerConstant(loc, inputTypes[2], kind));
-  auto rank = boxAddress.rank();
+  auto rank = box.rank();
   args.push_back(builder.createIntegerConstant(loc, inputTypes[3], rank));
   // TODO: coarrays
   auto corank = 0;
@@ -69,6 +91,7 @@ static void genAllocatableInitCharRtCall(Fortran::lower::FirOpBuilder &builder,
   builder.create<fir::CallOp>(loc, callee, args);
 }
 
+/// Generate runtime call to allocate the memory
 static mlir::Value
 genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
                        mlir::Location loc, mlir::Value boxAddress,
@@ -83,7 +106,7 @@ genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
 }
-
+/// Generate runtime call to deallocate the memory
 static mlir::Value
 genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
                          mlir::Location loc, mlir::Value boxAddress,
@@ -98,6 +121,233 @@ genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
 }
+
+//===----------------------------------------------------------------------===//
+// MutableBoxValue writer and reader
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// MutablePropertyWriter and MutablePropertyReader implementations are the only
+/// places that depend on how the properties of MutableBoxValue (pointers and
+/// allocatables) that can be modified in the lifetime of the entity (address,
+/// extents, lower bounds, length parameters) are represented.
+/// That is, the properties may be only stored in a fir.box in memory if we
+/// need to enforce a single point of truth for the properties across calls.
+/// Or, they can be tracked as independent local variables when it is safe to
+/// do so. Using bare variables benefits from all optimization passes, even
+/// when they are not aware of what a fir.box is and fir.box have not been
+/// optimized out yet.
+
+/// MutablePropertyWriter allows reading the properties of a MutableBoxValue.
+class MutablePropertyReader {
+public:
+  MutablePropertyReader(Fortran::lower::FirOpBuilder &builder,
+                        mlir::Location loc, const fir::MutableBoxValue &box,
+                        bool forceIRBoxRead = false)
+      : builder{builder}, loc{loc}, box{box} {
+    if (forceIRBoxRead || !box.isDescribedByVariables())
+      irBox = builder.create<fir::LoadOp>(loc, box.getAddr());
+  }
+  /// Get base address of allocated/associated entity.
+  mlir::Value readBaseAddress() {
+    if (irBox) {
+      auto heapOrPtrTy = box.getBoxTy().getEleTy();
+      return builder.create<fir::BoxAddrOp>(loc, heapOrPtrTy, irBox);
+    }
+    auto addrVar = box.getMutableProperties().addr;
+    return builder.create<fir::LoadOp>(loc, addrVar);
+  }
+  /// Return {lbound, extent} values read from the MutableBoxValue given
+  /// the dimension.
+  std::pair<mlir::Value, mlir::Value> readShape(unsigned dim) {
+    auto idxTy = builder.getIndexType();
+    if (irBox) {
+      auto dimVal = builder.createIntegerConstant(loc, idxTy, dim);
+      auto dimInfo = builder.create<fir::BoxDimsOp>(loc, idxTy, idxTy, idxTy,
+                                                    irBox, dimVal);
+      return {dimInfo.getResult(0), dimInfo.getResult(1)};
+    }
+    const auto &mutableProperties = box.getMutableProperties();
+    auto lb = builder.create<fir::LoadOp>(loc, mutableProperties.lbounds[dim]);
+    auto ext = builder.create<fir::LoadOp>(loc, mutableProperties.extents[dim]);
+    return {lb, ext};
+  }
+
+  /// Return the character length. If the length was not deferred, the value
+  /// that was specified is returned (The mutable fields is not read).
+  mlir::Value readCharacterLength() {
+    if (box.hasNonDeferredLenParams())
+      return box.nonDeferredLenParams()[0];
+    if (irBox)
+      return Fortran::lower::CharacterExprHelper{builder, loc}
+          .readLengthFromBox(irBox);
+    const auto &deferred = box.getMutableProperties().deferredParams;
+    if (deferred.empty())
+      fir::emitFatalError(loc, "allocatable entity has no length property");
+    return builder.create<fir::LoadOp>(loc, deferred[0]);
+  }
+  /// Read all mutable properties. Return the base address.
+  mlir::Value read(llvm::SmallVectorImpl<mlir::Value> &lbounds,
+                   llvm::SmallVectorImpl<mlir::Value> &extents,
+                   llvm::SmallVectorImpl<mlir::Value> &lengths) {
+    auto rank = box.rank();
+    for (decltype(rank) dim = 0; dim < rank; ++dim) {
+      auto [lb, extent] = readShape(dim);
+      lbounds.push_back(lb);
+      extents.push_back(extent);
+    }
+    if (box.isCharacter())
+      lengths.emplace_back(readCharacterLength());
+    else if (box.isDerived())
+      mlir::emitError(
+          loc, "TODO: read allocatable or pointer derived type LEN parameters");
+    return readBaseAddress();
+  }
+
+private:
+  Fortran::lower::FirOpBuilder &builder;
+  mlir::Location loc;
+  fir::MutableBoxValue box;
+  mlir::Value irBox;
+};
+
+/// MutablePropertyWriter allows modifying the properties of a MutableBoxValue.
+class MutablePropertyWriter {
+public:
+  MutablePropertyWriter(Fortran::lower::FirOpBuilder &builder,
+                        mlir::Location loc, const fir::MutableBoxValue &box)
+      : builder{builder}, loc{loc}, box{box} {}
+  /// Update MutableBoxValue with new address, shape and length parameters.
+  /// Extents and lbounds must all have index type.
+  /// lbounds can be empty in which case all ones is assumed.
+  /// Length parameters must be provided for the length parameters that are
+  /// deferred.
+  void updateMutableBox(mlir::Value addr, mlir::ValueRange lbounds,
+                        mlir::ValueRange extents, mlir::ValueRange lengths) {
+    if (box.isDescribedByVariables())
+      updateMutableProperties(addr, lbounds, extents, lengths);
+    else
+      updateIRBox(addr, lbounds, extents, lengths);
+  }
+  /// Set unallocated/disassociated status for the entity described by
+  /// MutableBoxValue. Deallocation is not performed by this helper.
+  void setUnallocatedSatus() {
+    if (box.isDescribedByVariables()) {
+      auto addrVar = box.getMutableProperties().addr;
+      auto nullTy = fir::dyn_cast_ptrEleTy(addrVar.getType());
+      builder.create<fir::StoreOp>(loc, builder.createNullConstant(loc, nullTy),
+                                   addrVar);
+    } else {
+      auto deallocatedBox = createUnallocatedBox(builder, loc, box.getBoxTy(),
+                                                 box.nonDeferredLenParams());
+      builder.create<fir::StoreOp>(loc, deallocatedBox, box.getAddr());
+    }
+  }
+
+  /// Copy Values from the fir.box into the property variables if any.
+  void syncMutablePropertiesFromIRBox() {
+    if (!box.isDescribedByVariables())
+      return;
+    llvm::SmallVector<mlir::Value, 2> lbounds;
+    llvm::SmallVector<mlir::Value, 2> extents;
+    llvm::SmallVector<mlir::Value, 2> lengths;
+    auto addr =
+        MutablePropertyReader{builder, loc, box, /*forceIRBoxRead=*/true}.read(
+            lbounds, extents, lengths);
+    updateMutableProperties(addr, lbounds, extents, lengths);
+  }
+
+  /// Copy Values from property variables, if any, into the fir.box.
+  void syncIRBoxFromMutableProperties() {
+    if (!box.isDescribedByVariables())
+      return;
+    llvm::SmallVector<mlir::Value, 2> lbounds;
+    llvm::SmallVector<mlir::Value, 2> extents;
+    llvm::SmallVector<mlir::Value, 2> lengths;
+    auto addr = MutablePropertyReader{builder, loc, box}.read(lbounds, extents,
+                                                              lengths);
+    updateIRBox(addr, lbounds, extents, lengths);
+  }
+
+private:
+  /// Update the IR box (fir.ref<fir.box<T>>) of the MutableBoxValue.
+  void updateIRBox(mlir::Value addr, mlir::ValueRange lbounds,
+                   mlir::ValueRange extents, mlir::ValueRange lengths) {
+    mlir::Value shape;
+    if (!extents.empty()) {
+      if (lbounds.empty()) {
+        auto shapeType =
+            fir::ShapeType::get(builder.getContext(), extents.size());
+        shape = builder.create<fir::ShapeOp>(loc, shapeType, extents);
+      } else {
+        llvm::SmallVector<mlir::Value, 2> shapeShiftBounds;
+        for (auto [lb, extent] : llvm::zip(lbounds, extents)) {
+          shapeShiftBounds.emplace_back(lb);
+          shapeShiftBounds.emplace_back(extent);
+        }
+        auto shapeShiftType =
+            fir::ShapeShiftType::get(builder.getContext(), extents.size());
+        shape = builder.create<fir::ShapeShiftOp>(loc, shapeShiftType,
+                                                  shapeShiftBounds);
+      }
+    }
+    mlir::Value emptySlice;
+    // Ignore lengths if already constant in the box type (this would trigger an
+    // error in the embox).
+    llvm::SmallVector<mlir::Value, 2> cleanedLengths;
+    if (auto charTy = box.getEleTy().dyn_cast<fir::CharacterType>()) {
+      if (charTy.getLen() == fir::CharacterType::unknownLen())
+        cleanedLengths.append(lengths.begin(), lengths.end());
+    } else if (box.isDerived()) {
+      // TODO: derived type lengths clean-up
+      cleanedLengths = lengths;
+    }
+    auto irBox = builder.create<fir::EmboxOp>(loc, box.getBoxTy(), addr, shape,
+                                              emptySlice, cleanedLengths);
+    builder.create<fir::StoreOp>(loc, irBox, box.getAddr());
+  }
+  /// Update the set of property variables of the MutableBoxValue.
+  void updateMutableProperties(mlir::Value addr, mlir::ValueRange lbounds,
+                               mlir::ValueRange extents,
+                               mlir::ValueRange lengths) {
+    const auto &mutableProperties = box.getMutableProperties();
+    builder.create<fir::StoreOp>(loc, addr, mutableProperties.addr);
+    for (auto [extent, extentVar] :
+         llvm::zip(extents, mutableProperties.extents))
+      builder.create<fir::StoreOp>(loc, extent, extentVar);
+    if (!mutableProperties.lbounds.empty()) {
+      if (lbounds.empty()) {
+        auto one =
+            builder.createIntegerConstant(loc, builder.getIndexType(), 1);
+        for (auto lboundVar : mutableProperties.lbounds)
+          builder.create<fir::StoreOp>(loc, one, lboundVar);
+      } else {
+        for (auto [lbound, lboundVar] :
+             llvm::zip(lbounds, mutableProperties.lbounds))
+          builder.create<fir::StoreOp>(loc, lbound, lboundVar);
+      }
+    }
+    if (box.isCharacter())
+      // llvm::zip account for the fact that the length only needs to be stored
+      // when it is specified in the allocation and deferred in the
+      // MutableBoxValue.
+      for (auto [len, lenVar] :
+           llvm::zip(lengths, mutableProperties.deferredParams))
+        builder.create<fir::StoreOp>(loc, len, lenVar);
+    else if (box.isDerived())
+      mlir::emitError(
+          loc, "TODO: update allocatable derived type length parameters");
+  }
+  Fortran::lower::FirOpBuilder &builder;
+  mlir::Location loc;
+  fir::MutableBoxValue box;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Allocate statement implementation
+//===----------------------------------------------------------------------===//
 
 /// Helper to get symbol from AllocateObject.
 static const Fortran::semantics::Symbol &
@@ -124,7 +374,7 @@ genMutableBoxValue(Fortran::lower::AbstractConverter &converter,
             Fortran::evaluate::TypedWrapper<Fortran::evaluate::Designator,
                                             Fortran::evaluate::DataRef>(
                 *dyType, std::move(ref)))
-      return converter.genExprMutableBox(*maybeExpr, &loc);
+      return converter.genExprMutableBox(loc, *maybeExpr);
   fir::emitFatalError(
       loc, "could not build expression from symbol in allocate statement");
 }
@@ -161,6 +411,7 @@ struct ErrorManagementValues {
   mlir::Value statAddr;
 };
 
+/// Implement Allocate statement lowering.
 class AllocateStmtHelper {
 public:
   AllocateStmtHelper(Fortran::lower::AbstractConverter &converter,
@@ -278,59 +529,44 @@ private:
   /// Generate allocation without runtime calls.
   /// Only for intrinsic types. No coarrays, no polymorphism. No error recovery.
   void genInlinedAllocation(const Allocation &alloc,
-                            fir::MutableBoxValue &boxAddr) {
-    mlir::SmallVector<mlir::Value, 2> lBounds;
-    mlir::SmallVector<mlir::Value, 2> uBounds;
+                            const fir::MutableBoxValue &box) {
+    llvm::SmallVector<mlir::Value, 2> lbounds;
+    llvm::SmallVector<mlir::Value, 2> extents;
     Fortran::lower::StatementContext stmtCtx;
     auto idxTy = builder.getIndexType();
     auto lBoundsAreOnes = lowerBoundsAreOnes(alloc);
+    auto one = builder.createIntegerConstant(loc, idxTy, 1);
     for (const auto &shapeSpec : alloc.getShapeSpecs()) {
+      mlir::Value lb;
       if (!lBoundsAreOnes) {
         if (const auto &lbExpr = std::get<0>(shapeSpec.t)) {
-          auto lb = fir::getBase(converter.genExprValue(
+          lb = fir::getBase(converter.genExprValue(
               Fortran::semantics::GetExpr(*lbExpr), stmtCtx, loc));
-          lBounds.emplace_back(builder.createConvert(loc, idxTy, lb));
+          lb = builder.createConvert(loc, idxTy, lb);
         } else {
-          lBounds.emplace_back(builder.createIntegerConstant(loc, idxTy, 1));
+          lb = one;
         }
+        lbounds.emplace_back(lb);
       }
       auto ub = fir::getBase(converter.genExprValue(
           Fortran::semantics::GetExpr(std::get<1>(shapeSpec.t)), stmtCtx, loc));
-      uBounds.emplace_back(builder.createConvert(loc, idxTy, ub));
-    }
-
-    mlir::Value shape;
-    mlir::SmallVector<mlir::Value, 2> extents;
-    if (!uBounds.empty()) {
-      if (lBoundsAreOnes) {
-        auto shapeType =
-            fir::ShapeType::get(builder.getContext(), uBounds.size());
-        shape = builder.create<fir::ShapeOp>(loc, shapeType, uBounds);
-        extents = uBounds;
+      ub = builder.createConvert(loc, idxTy, ub);
+      if (lb) {
+        auto diff = builder.create<mlir::SubIOp>(loc, ub, lb);
+        extents.emplace_back(builder.create<mlir::AddIOp>(loc, diff, one));
       } else {
-        auto one = builder.createIntegerConstant(loc, idxTy, 1);
-        mlir::SmallVector<mlir::Value, 2> shapeShiftBounds;
-        for (auto [lb, ub] : llvm::zip(lBounds, uBounds)) {
-          auto diff = builder.create<mlir::SubIOp>(loc, ub, lb);
-          auto extent = builder.create<mlir::AddIOp>(loc, diff, one);
-          extents.emplace_back(extent);
-          shapeShiftBounds.emplace_back(lb);
-          shapeShiftBounds.emplace_back(extent);
-        }
-        auto shapeShiftType =
-            fir::ShapeShiftType::get(builder.getContext(), uBounds.size());
-        shape = builder.create<fir::ShapeShiftOp>(loc, shapeShiftType,
-                                                  shapeShiftBounds);
+        extents.emplace_back(ub);
       }
     }
-    mlir::SmallVector<mlir::Value, 2> lengths;
-    if (auto charTy = boxAddr.getEleTy().dyn_cast<fir::CharacterType>()) {
+
+    llvm::SmallVector<mlir::Value, 2> lengths;
+    if (auto charTy = box.getEleTy().dyn_cast<fir::CharacterType>()) {
       if (charTy.getLen() == fir::CharacterType::unknownLen()) {
-        if (!lenParams.empty())
+        if (box.hasNonDeferredLenParams())
+          lengths.emplace_back(
+              builder.createConvert(loc, idxTy, box.nonDeferredLenParams()[0]));
+        else if (!lenParams.empty())
           lengths.emplace_back(builder.createConvert(loc, idxTy, lenParams[0]));
-        else if (boxAddr.hasNonDeferredLenParams())
-          lengths.emplace_back(builder.createConvert(
-              loc, idxTy, boxAddr.nonDeferredLenParams()[0]));
         else
           mlir::emitError(
               loc,
@@ -338,34 +574,36 @@ private:
       }
     }
 
-    // FIXME AllocMemOp is ignoring its length arguments. Squeezed in into the
+    // FIXME: AllocMemOp is ignoring its length arguments. Squeezed in into the
     // extents for now.
-    extents.append(lengths.begin(), lengths.end());
+    llvm::SmallVector<mlir::Value, 2> sizes = extents;
+    sizes.append(lengths.begin(), lengths.end());
     mlir::Value heap = builder.create<fir::AllocMemOp>(
-        loc, boxAddr.getBaseTy(), mangleAlloc(alloc), llvm::None, extents);
-    mlir::Value emptySlice;
-    auto box = builder.create<fir::EmboxOp>(loc, boxAddr.getBoxTy(), heap,
-                                            shape, emptySlice, lengths);
-    builder.create<fir::StoreOp>(loc, box, boxAddr.getAddr());
+        loc, box.getBaseTy(), mangleAlloc(alloc), llvm::None, sizes);
+    MutablePropertyWriter{builder, loc, box}.updateMutableBox(heap, lbounds,
+                                                              extents, lengths);
   }
 
   void genSimpleAllocation(const Allocation &alloc,
-                           fir::MutableBoxValue boxAddr) {
-    if (!boxAddr.isDerived() && !errorManagement.hasErrorRecovery() &&
-        !alloc.type.IsPolymorphic() && !alloc.hasCoarraySpec()) {
-      genInlinedAllocation(alloc, boxAddr);
+                           const fir::MutableBoxValue &box) {
+    if (!box.isDerived() && !errorManagement.hasErrorRecovery() &&
+        !alloc.type.IsPolymorphic() && !alloc.hasCoarraySpec() &&
+        !useAllocateRuntime) {
+      genInlinedAllocation(alloc, box);
       return;
     }
+    // Use runtime. sync MutableBoxValue and descriptor before and after calls.
+    Fortran::lower::getMutableIRBox(builder, loc, box);
     if (alloc.hasCoarraySpec())
       TODO("coarray allocation");
     if (alloc.type.IsPolymorphic())
-      genSetType(alloc, boxAddr);
-    genSetDeferredLengthParameters(alloc, boxAddr);
+      genSetType(alloc, box);
+    genSetDeferredLengthParameters(alloc, box);
     // Set bounds for arrays
     auto idxTy = builder.getIndexType();
     auto i32Ty = builder.getIntegerType(32);
     Fortran::lower::StatementContext stmtCtx;
-    auto addr = boxAddr.getAddr();
+    auto addr = box.getAddr();
     for (const auto &iter : llvm::enumerate(alloc.getShapeSpecs())) {
       mlir::Value lb;
       const auto &bounds = iter.value().t;
@@ -384,6 +622,7 @@ private:
     auto stat = genAllocatableAllocate(builder, loc, addr, getHasStat(),
                                        getErrMsgBoxAddr(), getSourceFile(),
                                        getSourceLine());
+    Fortran::lower::syncMutableBoxFromIRBox(builder, loc, box);
     if (auto statAddr = getStatAddr()) {
       auto castStat = builder.createConvert(
           loc, fir::dyn_cast_ptrEleTy(statAddr.getType()), stat);
@@ -394,7 +633,7 @@ private:
   /// Lower the length parameters that may be specified in the optional
   /// type specification.
   void lowerAllocateLengthParameters() {
-    const auto *typeSpec = getAllocateStmtTypeSpec();
+    const auto *typeSpec = getIfAllocateStmtTypeSpec();
     if (!typeSpec)
       return;
     if (typeSpec->AsDerived()) {
@@ -417,26 +656,26 @@ private:
   // This must be called before setting the bounds because it may use
   // Init runtime calls that may set the bounds to zero.
   void genSetDeferredLengthParameters(const Allocation &alloc,
-                                      fir::MutableBoxValue boxAddr) {
+                                      const fir::MutableBoxValue &box) {
     if (lenParams.empty())
       return;
     // TODO: in case a length parameter was not deferred, insert a runtime check
     // that the length is the same (AllocatableCheckLengthParameter runtime
     // call).
-    if (boxAddr.isCharacter())
-      genAllocatableInitCharRtCall(builder, loc, boxAddr, lenParams[0]);
-    // TODO: derived type
+    if (box.isCharacter())
+      genAllocatableInitCharRtCall(builder, loc, box, lenParams[0]);
+
+    if (box.isDerived())
+      TODO("derived type length parameters in allocate");
   }
 
-  void genSourceAllocation(const Allocation &alloc,
-                           fir::MutableBoxValue boxAddr) {
+  void genSourceAllocation(const Allocation &, const fir::MutableBoxValue &) {
     TODO("SOURCE allocation lowering");
   }
-  void genMoldAllocation(const Allocation &alloc,
-                         fir::MutableBoxValue boxAddr) {
+  void genMoldAllocation(const Allocation &, const fir::MutableBoxValue &) {
     TODO("MOLD allocation lowering");
   }
-  void genSetType(const Allocation &alloc, fir::MutableBoxValue boxAddr) {
+  void genSetType(const Allocation &, const fir::MutableBoxValue &) {
     TODO("Polymorphic entity allocation lowering");
   }
 
@@ -458,7 +697,9 @@ private:
   }
   mlir::Value getStatAddr() const { return errorManagement.statAddr; }
 
-  const Fortran::semantics::DeclTypeSpec *getAllocateStmtTypeSpec() const {
+  /// Returns a pointer to the DeclTypeSpec if a type-spec is provided in the
+  /// allocate statement. Returns a null pointer otherwise.
+  const Fortran::semantics::DeclTypeSpec *getIfAllocateStmtTypeSpec() const {
     if (const auto &typeSpec =
             std::get<std::optional<Fortran::parser::TypeSpec>>(stmt.t))
       return typeSpec->declTypeSpec;
@@ -488,28 +729,32 @@ void Fortran::lower::genAllocateStmt(
   return;
 }
 
+//===----------------------------------------------------------------------===//
+// Deallocate statement implementation
+//===----------------------------------------------------------------------===//
+
 // Generate deallocation of a pointer/allocatable.
 static void genDeallocate(Fortran::lower::FirOpBuilder &builder,
-                          mlir::Location loc, fir::MutableBoxValue box,
+                          mlir::Location loc, const fir::MutableBoxValue &box,
                           ErrorManagementValues &errorManagement) {
   // For derived and when error recovery is present, use runtime.
-  if (box.isDerived() || errorManagement.hasErrorRecovery()) {
-    // TODO use return stat for error recovery
-    genAllocatableDeallocate(
-        builder, loc, box.getAddr(), errorManagement.hasStat,
-        errorManagement.errMsgBoxAddr, errorManagement.sourceFile,
-        errorManagement.sourceLine);
+  if (box.isDerived() || errorManagement.hasErrorRecovery() ||
+      useAllocateRuntime) {
+    // Use runtime with descriptors. Sync MutableBoxValue with its descriptor
+    // before and after calls if needed.
+    auto irBox = Fortran::lower::getMutableIRBox(builder, loc, box);
+    // TODO use return stat for error recovery.
+    genAllocatableDeallocate(builder, loc, irBox, errorManagement.hasStat,
+                             errorManagement.errMsgBoxAddr,
+                             errorManagement.sourceFile,
+                             errorManagement.sourceLine);
+    Fortran::lower::syncMutableBoxFromIRBox(builder, loc, box);
     return;
   }
   // Inlined deallocate.
-  auto boxValue = builder.create<fir::LoadOp>(loc, box.getAddr());
-  auto boxTy = box.getBoxTy();
-  auto heapOrPtrTy = boxTy.getEleTy();
-  auto addr = builder.create<fir::BoxAddrOp>(loc, heapOrPtrTy, boxValue);
+  auto addr = MutablePropertyReader(builder, loc, box).readBaseAddress();
   builder.create<fir::FreeMemOp>(loc, addr);
-  auto deallocatedBox =
-      createUnallocatedBox(builder, loc, boxTy, box.nonDeferredLenParams());
-  builder.create<fir::StoreOp>(loc, deallocatedBox, box.getAddr());
+  MutablePropertyWriter{builder, loc, box}.setUnallocatedSatus();
 }
 
 void Fortran::lower::genDeallocateStmt(
@@ -540,6 +785,10 @@ void Fortran::lower::genDeallocateStmt(
   }
 }
 
+//===----------------------------------------------------------------------===//
+// MutableBoxValue creation implementation
+//===----------------------------------------------------------------------===//
+
 mlir::Value
 Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
                                      mlir::Location loc, mlir::Type boxType,
@@ -556,9 +805,8 @@ Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
   if (auto seqTy = type.dyn_cast<fir::SequenceType>()) {
     auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
     llvm::SmallVector<mlir::Value, 2> extents(seqTy.getDimension(), zero);
-    llvm::ArrayRef<mlir::Value> lbounds = llvm::None;
-    shape = builder.createShape(loc,
-                                fir::ArrayBoxValue{nullAddr, extents, lbounds});
+    shape = builder.createShape(
+        loc, fir::ArrayBoxValue{nullAddr, extents, /*lbounds=*/llvm::None});
   }
   // Provide dummy length parameters if they are dynamic. If a length parameter
   // is deferred. it is set to zero here and will be set on allocation.
@@ -568,8 +816,8 @@ Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
       if (!nonDeferredParams.empty()) {
         lenParams.push_back(nonDeferredParams[0]);
       } else {
-        auto zero =
-            builder.createIntegerConstant(loc, builder.getIndexType(), 0);
+        auto zero = builder.createIntegerConstant(
+            loc, builder.getCharacterLengthType(), 0);
         lenParams.push_back(zero);
       }
     }
@@ -577,4 +825,132 @@ Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
   mlir::Value emptySlice;
   return builder.create<fir::EmboxOp>(loc, boxType, nullAddr, shape, emptySlice,
                                       lenParams);
+}
+
+/// In case it is safe to track the properties in variables outside a
+/// descriptor, create the variables to hold the mutable properties of the
+/// entity var. The variables are not initialized here.
+static fir::MutableProperties
+createMutableProperties(Fortran::lower::AbstractConverter &converter,
+                        mlir::Location loc,
+                        const Fortran::lower::pft::Variable &var,
+                        mlir::ValueRange nonDeferredParams) {
+  auto &builder = converter.getFirOpBuilder();
+  const auto &sym = var.getSymbol();
+  // Globals and dummies may be associated, creating local variables would
+  // require keeping the values and descriptor before and after every single
+  // impure calls in the current scope (not only the ones taking the variable as
+  // arguments. All.) Volatile means the variable may change in ways not defined
+  // per Fortran, so lowering can most likely not keep the descriptor and values
+  // in sync as needed.
+  if (var.isGlobal() || Fortran::semantics::IsDummy(sym) ||
+      sym.attrs().test(Fortran::semantics::Attr::VOLATILE) ||
+      useAllocateRuntime || useDescForMutableBox)
+    return {};
+  fir::MutableProperties mutableProperties;
+  auto name = converter.mangleName(sym);
+  auto baseAddrTy = converter.genType(sym);
+  if (auto boxType = baseAddrTy.dyn_cast<fir::BoxType>())
+    baseAddrTy = boxType.getEleTy();
+  // Allocate variable to hold the address and set it will be set to null in
+  // setUnallocatedSatus.
+  mutableProperties.addr =
+      builder.allocateLocal(loc, baseAddrTy, name + ".addr",
+                            /*shape=*/llvm::None, /*lenParams=*/llvm::None);
+  // Allocate variables to hold lower bounds and extents.
+  auto rank = sym.Rank();
+  auto idxTy = builder.getIndexType();
+  for (decltype(rank) i = 0; i < rank; ++i) {
+    auto lboundVar =
+        builder.allocateLocal(loc, idxTy, name + ".lb" + std::to_string(i),
+                              /*shape=*/llvm::None, /*lenParams=*/llvm::None);
+    auto extentVar =
+        builder.allocateLocal(loc, idxTy, name + ".ext" + std::to_string(i),
+                              /*shape=*/llvm::None, /*lenParams=*/llvm::None);
+    mutableProperties.lbounds.emplace_back(lboundVar);
+    mutableProperties.extents.emplace_back(extentVar);
+  }
+
+  // Allocate variable to hold deferred length parameters.
+  auto eleTy = baseAddrTy;
+  if (auto newTy = fir::dyn_cast_ptrEleTy(eleTy))
+    eleTy = newTy;
+  if (auto seqTy = eleTy.dyn_cast<fir::SequenceType>())
+    eleTy = seqTy.getEleTy();
+  if (eleTy.isa<fir::RecordType>()) {
+    mlir::emitError(loc, "TODO: deferred length type parameters.");
+  }
+  if (eleTy.isa<fir::CharacterType>() && nonDeferredParams.empty()) {
+    auto lenVar = builder.allocateLocal(loc, builder.getCharacterLengthType(),
+                                        name + ".len", /*shape=*/llvm::None,
+                                        /*lenParams=*/llvm::None);
+    mutableProperties.deferredParams.emplace_back(lenVar);
+  }
+  return mutableProperties;
+}
+
+fir::MutableBoxValue Fortran::lower::createMutableBox(
+    Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+    const Fortran::lower::pft::Variable &var, mlir::Value boxAddr,
+    mlir::ValueRange nonDeferredParams) {
+
+  auto mutableProperties =
+      createMutableProperties(converter, loc, var, nonDeferredParams);
+  auto box =
+      fir::MutableBoxValue(boxAddr, nonDeferredParams, mutableProperties);
+  auto &builder = converter.getFirOpBuilder();
+  if (!var.isGlobal() && !Fortran::semantics::IsDummy(var.getSymbol()))
+    MutablePropertyWriter{builder, loc, box}.setUnallocatedSatus();
+  return box;
+}
+
+//===----------------------------------------------------------------------===//
+// MutableBoxValue reading interface implementation
+//===----------------------------------------------------------------------===//
+
+Fortran::lower::SymbolBox
+Fortran::lower::genMutableBoxRead(Fortran::lower::FirOpBuilder &builder,
+                                  mlir::Location loc,
+                                  const fir::MutableBoxValue &box) {
+  if (box.hasAssumedRank())
+    TODO("Assumed rank allocatables or pointers");
+  if (box.isPointer())
+    TODO("pointer"); // deal with non contiguity;
+  llvm::SmallVector<mlir::Value, 2> lbounds;
+  llvm::SmallVector<mlir::Value, 2> extents;
+  llvm::SmallVector<mlir::Value, 2> lengths;
+  auto addr =
+      MutablePropertyReader(builder, loc, box).read(lbounds, extents, lengths);
+  auto rank = box.rank();
+  if (box.isCharacter()) {
+    auto len = lengths.empty() ? mlir::Value{} : lengths[0];
+    if (rank)
+      return fir::CharArrayBoxValue{addr, len, extents, lbounds};
+    return fir::CharBoxValue{addr, len};
+  }
+  if (box.isDerived())
+    TODO("derived type MutableBoxValue opening");
+  if (rank)
+    return fir::ArrayBoxValue{addr, extents, lbounds};
+  return fir::AbstractBox{addr};
+}
+
+//===----------------------------------------------------------------------===//
+// MutableBoxValue syncing implementation
+//===----------------------------------------------------------------------===//
+
+/// Depending on the implementation, allocatable descriptor and the
+/// MutableBoxValue need to be synced before and after calls passing the
+/// descriptor. These calls will generate the syncing if needed and be no-op
+mlir::Value
+Fortran::lower::getMutableIRBox(Fortran::lower::FirOpBuilder &builder,
+                                mlir::Location loc,
+                                const fir::MutableBoxValue &box) {
+  MutablePropertyWriter{builder, loc, box}.syncIRBoxFromMutableProperties();
+  return box.getAddr();
+}
+void Fortran::lower::syncMutableBoxFromIRBox(
+    Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+    const fir::MutableBoxValue &box) {
+  MutablePropertyWriter{builder, loc, box}.syncMutablePropertiesFromIRBox();
 }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -285,6 +285,12 @@ public:
     return createSomeExtendedExpression(loc ? *loc : toLocation(), *this, expr,
                                         localSymbols, context);
   }
+  fir::MutableBoxValue
+  genExprMutableBox(mlir::Location loc,
+                    const Fortran::lower::SomeExpr &expr) override final {
+    return createSomeMutableBox(loc, *this, expr, localSymbols);
+  }
+
   Fortran::evaluate::FoldingContext &getFoldingContext() override final {
     return foldingContext;
   }
@@ -1765,8 +1771,20 @@ private:
     auto loc = genLocation(sym.name());
     bool isConst = sym.attrs().test(Fortran::semantics::Attr::PARAMETER);
     fir::GlobalOp global;
-    if (const auto *details =
-            sym.detailsIf<Fortran::semantics::ObjectEntityDetails>()) {
+    if (Fortran::semantics::IsAllocatableOrPointer(sym)) {
+      auto symTy = genType(var);
+      // Pointers may have an initial target
+      if (Fortran::semantics::IsPointer(sym))
+        mlir::emitError(loc, "TODO: global pointer initialization");
+      auto init = [&](Fortran::lower::FirOpBuilder &b) {
+        auto box =
+            Fortran::lower::createUnallocatedBox(b, loc, symTy, llvm::None);
+        b.create<fir::HasValueOp>(loc, box);
+      };
+      global =
+          builder->createGlobal(loc, symTy, globalName, isConst, init, linkage);
+    } else if (const auto *details =
+                   sym.detailsIf<Fortran::semantics::ObjectEntityDetails>()) {
       if (details->init()) {
         if (!sym.GetType()->AsIntrinsic()) {
           TODO(""); // Derived type / polymorphic
@@ -2266,17 +2284,17 @@ private:
     mapSymbolAttributes(var, stmtCtx, local);
   }
 
-  void createLocalAllocatable(mlir::Location loc,
-                              const Fortran::lower::pft::Variable &var,
-                              mlir::Type varType) {
-    auto boxTy = fir::BoxType::get(varType);
+  mlir::Value createLocalAllocatable(mlir::Location loc,
+                                     const Fortran::lower::pft::Variable &var,
+                                     mlir::Type boxTy,
+                                     mlir::ValueRange nonDeferredParams) {
     auto boxAlloc =
         builder->allocateLocal(loc, boxTy, mangleName(var.getSymbol()),
                                llvm::None, llvm::None, var.isTarget());
-    localSymbols.addSymbol(var.getSymbol(), boxAlloc);
-    // TODO Note: for globals, we want to init desc only once, so ideally we
-    // probably want to avoid a runtime call to do this.
-    Fortran::lower::genAllocatableInit(*this, var, boxAlloc);
+    auto box = Fortran::lower::createUnallocatedBox(*builder, loc, boxTy,
+                                                    nonDeferredParams);
+    builder->create<fir::StoreOp>(loc, box, boxAlloc);
+    return boxAlloc;
   }
 
   //===--------------------------------------------------------------===//
@@ -2303,6 +2321,35 @@ private:
     Fortran::lower::CharacterExprHelper charHelp{*builder, loc};
     Fortran::lower::BoxAnalyzer sba;
     sba.analyze(sym);
+
+    // First deal with pointers an allocatables, because their handling here
+    // is the same regardless of their rank.
+    if (Fortran::semantics::IsAllocatableOrPointer(sym)) {
+      llvm::SmallVector<mlir::Value, 1> nonDeferredLenParams;
+      auto lenTy = builder->getCharacterLengthType();
+      if (sba.isChar()) {
+        if (auto len = sba.getCharLenConst())
+          nonDeferredLenParams.push_back(
+              builder->createIntegerConstant(loc, lenTy, *len));
+        else if (auto lenExpr = sba.getCharLenExpr())
+          nonDeferredLenParams.push_back(
+              createFIRExpr(loc, &*lenExpr, stmtCtx));
+      }
+      // TODO: derived type length parameters
+      // global
+      auto boxAlloc = preAlloc;
+      // dummy or passed result
+      if (!boxAlloc)
+        if (auto symbox = lookupSymbol(sym))
+          boxAlloc = symbox.getAddr();
+      // local
+      if (!boxAlloc)
+        boxAlloc = createLocalAllocatable(loc, var, genType(var),
+                                          nonDeferredLenParams);
+      localSymbols.addAllocatableOrPointer(var.getSymbol(), boxAlloc,
+                                           nonDeferredLenParams, replace);
+      return;
+    }
 
     // compute extent from lower and upper bound.
     auto computeExtent = [&](mlir::Value lb, mlir::Value ub) -> mlir::Value {
@@ -2345,6 +2392,8 @@ private:
         fir::BoxDimsOp dimInfo;
         mlir::Value ub, lb;
         if (spec->lbound().isDeferred() || spec->ubound().isDeferred()) {
+          // This is an assumed shape because allocatables and pointers extents
+          // are not constant in the scope and are not read here.
           assert(box && "deferred bounds require a descriptor");
           auto dim = builder->createIntegerConstant(loc, idxTy, iter.index());
           dimInfo = builder->create<fir::BoxDimsOp>(loc, idxTy, idxTy, idxTy,
@@ -2356,10 +2405,7 @@ private:
                 loc, idxTy, createFIRExpr(loc, &expr, stmtCtx));
             lbounds.emplace_back(lb);
           } else {
-            // FIXME: The front-end is not setting up the implicit lower
-            // bounds to 1 for assumed shape array. Do this here for now,
-            // but that is absolutely wrong for allocatable and pointers.
-            // lbounds.emplace_back(dimInfo.getResult(0));
+            // Implict lower bound is 1 (Fortan 2018 section 8.5.8.3 point 3.)
             lbounds.emplace_back(builder->createIntegerConstant(loc, idxTy, 1));
           }
         } else {
@@ -2395,14 +2441,6 @@ private:
         // Trivial case.
         //===--------------------------------------------------------------===//
         [&](const Fortran::lower::details::ScalarSym &) {
-          if (Fortran::semantics::IsAllocatable(sym)) {
-            if (lookupSymbol(sym))
-              TODO("allocatable dummy or result");
-            if (var.isGlobal())
-              TODO("global allocatable");
-            createLocalAllocatable(loc, var, genType(var));
-            return;
-          }
           if (isDummy) {
             // This is an argument.
             if (!lookupSymbol(sym))
@@ -2465,9 +2503,8 @@ private:
               // since we are lowering all function unit statements regardless
               // of whether the execution will reach them or not, we need to
               // fill a value for the length here.
-              auto helper = Fortran::lower::CharacterExprHelper{*builder, loc};
-              len = builder->createIntegerConstant(loc, helper.getLengthType(),
-                                                   1);
+              len = builder->createIntegerConstant(
+                  loc, builder->getCharacterLengthType(), 1);
             }
             // Override LEN with an expression
             if (charLen)
@@ -2533,14 +2570,6 @@ private:
           auto varType = genType(var);
           mlir::Value addr = lookupSymbol(sym).getAddr();
           mlir::Value argBox;
-          if (Fortran::semantics::IsAllocatable(sym)) {
-            if (addr)
-              TODO("allocatable dummy or result");
-            if (var.isGlobal())
-              TODO("global allocatable");
-            createLocalAllocatable(loc, var, varType);
-            return;
-          }
           auto castTy = builder->getRefType(varType);
           if (addr) {
             if (auto boxTy = addr.getType().dyn_cast<fir::BoxType>()) {
@@ -2787,14 +2816,12 @@ private:
               argBox = actualArg;
               auto refTy = builder->getRefType(boxTy.getEleTy());
               addr = builder->create<fir::BoxAddrOp>(loc, refTy, argBox);
-              if (charLen) {
-                // Set/override LEN with an expression
+              if (charLen)
+                // Set/override LEN with an expression.
                 len = createFIRExpr(loc, &*charLen, stmtCtx);
-              } else {
-                // FIXME: that is not correct with kind > 1 character, we need
-                // to divide by the character width.
-                len = builder->create<fir::BoxEleSizeOp>(loc, idxTy, argBox);
-              }
+              else
+                // Get the length from the actual arguments.
+                len = charHelp.readLengthFromBox(argBox);
             } else {
               auto unboxchar = charHelp.createUnboxChar(actualArg);
               addr = unboxchar.first;
@@ -2802,6 +2829,7 @@ private:
                 // Set/override LEN with an expression
                 len = createFIRExpr(loc, &*charLen, stmtCtx);
               } else {
+                // Get the length from the actual arguments.
                 len = unboxchar.second;
               }
             }

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -245,10 +245,17 @@ struct TypeBuilder {
       ty = fir::SequenceType::get(shape, ty);
     }
 
-    if (isPtr || Fortran::semantics::IsPointer(ultimate))
-      ty = fir::PointerType::get(ty);
-    else if (isAlloc || Fortran::semantics::IsAllocatable(ultimate))
-      ty = fir::HeapType::get(ty);
+    if (Fortran::semantics::IsPointer(symbol))
+      return fir::BoxType::get(fir::PointerType::get(ty));
+    if (Fortran::semantics::IsAllocatable(symbol))
+      return fir::BoxType::get(fir::HeapType::get(ty));
+    // isPtr and isAlloc are variable that were promoted to be on the
+    // heap or to be pointers, but they do not have Fortran allocatable
+    // or pointer semantics, so do not use box for them.
+    if (isPtr)
+      return fir::PointerType::get(ty);
+    if (isAlloc)
+      return fir::HeapType::get(ty);
     return ty;
   }
 

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -48,11 +48,13 @@ mlir::Type Fortran::lower::FirOpBuilder::getVarLenSeqTy(mlir::Type eleTy) {
 }
 
 mlir::Value
-Fortran::lower::FirOpBuilder::createNullConstant(mlir::Location loc) {
+Fortran::lower::FirOpBuilder::createNullConstant(mlir::Location loc,
+                                                 mlir::Type ptrType) {
   auto indexType = getIndexType();
   auto zero = createIntegerConstant(loc, indexType, 0);
-  auto noneRefType = getRefType(getNoneType());
-  return createConvert(loc, noneRefType, zero);
+  if (!ptrType)
+    ptrType = getRefType(getNoneType());
+  return createConvert(loc, ptrType, zero);
 }
 
 mlir::Value Fortran::lower::FirOpBuilder::createIntegerConstant(

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1104,7 +1104,8 @@ IntrinsicLibrary::genChar(mlir::Type type,
   Fortran::lower::CharacterExprHelper helper{builder, loc};
   auto kind = helper.getCharacterType(type).getFKind();
   auto cast = helper.createSingletonFromCode(*arg, kind);
-  auto len = builder.createIntegerConstant(loc, helper.getLengthType(), 1);
+  auto len =
+      builder.createIntegerConstant(loc, builder.getCharacterLengthType(), 1);
   return fir::CharBoxValue{cast, len};
 }
 

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -106,6 +106,17 @@ llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
+                                   const fir::MutableBoxValue &box) {
+  os << "boxaddress: { box: " << box.getAddr();
+  if (!box.lenParams.empty()) {
+    os << ", type params: [";
+    llvm::interleaveComma(box.lenParams, os);
+    os << "]";
+  }
+  return os << "}";
+}
+
+llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
                                    const fir::ExtendedValue &exv) {
   exv.match([&](const auto &value) { os << value; });
   return os;
@@ -167,4 +178,29 @@ Fortran::lower::operator<<(llvm::raw_ostream &os,
     os << " }>\n";
   }
   return os;
+}
+
+/// Debug verifier for MutableBox ctor. There is no guarantee that this will
+/// always be called, so it should not have any functional side effects,
+/// the const is here to enforce that.
+bool fir::MutableBoxValue::verify() const {
+  auto type = fir::dyn_cast_ptrEleTy(getAddr().getType());
+  if (!type)
+    return false;
+  auto box = type.dyn_cast<fir::BoxType>();
+  if (!box)
+    return false;
+  auto eleTy = box.getEleTy();
+  if (!eleTy.isa<fir::PointerType>() && !eleTy.isa<fir::HeapType>())
+    return false;
+
+  auto nParams = lenParams.size();
+  if (isCharacter()) {
+    if (nParams > 1)
+      return false;
+  } else if (!isDerived()) {
+    if (nParams != 0)
+      return false;
+  }
+  return true;
 }

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -107,11 +107,31 @@ llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
 
 llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
                                    const fir::MutableBoxValue &box) {
-  os << "boxaddress: { box: " << box.getAddr();
+  os << "mutablebox: { box: " << box.getAddr();
   if (!box.lenParams.empty()) {
-    os << ", type params: [";
+    os << ", non deferred type params: [";
     llvm::interleaveComma(box.lenParams, os);
     os << "]";
+  }
+  const auto &properties = box.mutableProperties;
+  if (!properties.isEmpty()) {
+    os << ", mutableProperties: { addr: " << properties.addr;
+    if (!properties.lbounds.empty()) {
+      os << ", lbounds: [";
+      llvm::interleaveComma(properties.lbounds, os);
+      os << "]";
+    }
+    if (!properties.extents.empty()) {
+      os << ", shape: [";
+      llvm::interleaveComma(properties.extents, os);
+      os << "]";
+    }
+    if (!properties.deferredParams.empty()) {
+      os << ", deferred type params: [";
+      llvm::interleaveComma(properties.deferredParams, os);
+      os << "]";
+    }
+    os << "}";
   }
   return os << "}";
 }

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -267,10 +267,9 @@ public:
             force);
   }
 
-  void addAllocatableOrPointer(semantics::SymbolRef sym, mlir::Value boxAddress,
-                               llvm::ArrayRef<mlir::Value> params,
-                               bool force = false) {
-    makeSym(sym, SymbolBox::PointerOrAllocatable(boxAddress, params), force);
+  void addAllocatableOrPointer(semantics::SymbolRef sym,
+                               fir::MutableBoxValue box, bool force = false) {
+    makeSym(sym, box, force);
   }
 
   /// Find `symbol` and return its value if it appears in the current mappings.

--- a/flang/test/Lower/allocatable-callee.f90
+++ b/flang/test/Lower/allocatable-callee.f90
@@ -1,0 +1,138 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test allocatable dummy argument on callee side
+
+! CHECK-LABEL: func @_QPtest_scalar(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>)
+subroutine test_scalar(x)
+  real, allocatable :: x
+
+  print *, x
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: %[[val:.*]] = fir.load %[[addr]] : !fir.heap<f32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>)
+subroutine test_array(x)
+  integer, allocatable :: x(:,:)
+
+  print *, x(1,2)
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
+  ! CHECK-DAG: fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>) -> !fir.heap<!fir.array<?x?xi32>>
+  ! CHECK-DAG: fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: fir.box_dims %[[box]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>, index) -> (index, index, index)
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_scalar_deferred(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>)
+subroutine test_char_scalar_deferred(c)
+  character(:), allocatable :: c
+  external foo1
+  call foo1(c)
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+  ! CHECK-DAG: %[[addr_cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr_cast]], %[[len]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_scalar_explicit_cst(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>)
+subroutine test_char_scalar_explicit_cst(c)
+  character(10), allocatable :: c
+  external foo1
+  call foo1(c)
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK-DAG: %[[addr_cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr_cast]], %c10{{.*}} : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_scalar_explicit_dynamic(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>, %[[arg1:.*]]: !fir.ref<i32>)
+subroutine test_char_scalar_explicit_dynamic(c, n)
+  integer :: n
+  character(n), allocatable :: c
+  external foo1
+  ! Check that the length expr was evaluated before the execution parts.
+  ! CHECK: %[[len:.*]] = fir.load %arg1 : !fir.ref<i32>
+  n = n + 1
+  ! CHECK: fir.store {{.*}} to %arg1 : !fir.ref<i32>
+  call foo1(c)
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[addr_cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK-DAG: %[[len_cast:.*]] = fir.convert %[[len]] : (i32) -> index
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr_cast]], %[[len_cast]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_array_deferred(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>)
+subroutine test_char_array_deferred(c)
+  character(:), allocatable :: c(:)
+  external foo1
+  call foo1(c(10))
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
+  ! [...] address computation
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %[[len]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_array_explicit_cst(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>)
+subroutine test_char_array_explicit_cst(c)
+  character(10), allocatable :: c(:)
+  external foo1
+  call foo1(c(3))
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! [...] address computation
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %c10{{.*}} : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_array_explicit_dynamic(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>, %[[arg1:.*]]: !fir.ref<i32>)
+subroutine test_char_array_explicit_dynamic(c, n)
+  integer :: n
+  character(n), allocatable :: c(:)
+  external foo1
+  ! Check that the length expr was evaluated before the execution parts.
+  ! CHECK: %[[len:.*]] = fir.load %arg1 : !fir.ref<i32>
+  n = n + 1
+  ! CHECK: fir.store {{.*}} to %arg1 : !fir.ref<i32>
+  call foo1(c(1))
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! [...] address computation
+  ! CHECK: fir.coordinate_of
+  ! CHECK-DAG: %[[len_cast:.*]] = fir.convert %[[len]] : (i32) -> index
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %[[len_cast]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! Check that when reading allocatable length from descriptor, the width is taking
+! into account when the kind is not 1.
+
+! CHECK-LABEL: func @_QPtest_char_scalar_deferred_k2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>)
+subroutine test_char_scalar_deferred_k2(c)
+  character(kind=2, len=:), allocatable :: c
+  external foo2
+  call foo2(c)
+  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<2,?>>>) -> !fir.heap<!fir.char<2,?>>
+  ! CHECK-DAG: %[[size:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.char<2,?>>>) -> index
+  ! CHECK-DAG: %[[len:.*]] = divi_signed %[[size]], %c2{{.*}} : index
+  ! CHECK-DAG: %[[addr_cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.char<2,?>>) -> !fir.ref<!fir.char<2,?>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr_cast]], %[[len]] : (!fir.ref<!fir.char<2,?>>, index) -> !fir.boxchar<2>
+  ! CHECK: fir.call @_QPfoo2(%[[boxchar]]) : (!fir.boxchar<2>) -> ()
+end subroutine

--- a/flang/test/Lower/allocatable-caller.f90
+++ b/flang/test/Lower/allocatable-caller.f90
@@ -1,0 +1,103 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test passing allocatables on caller side
+
+! CHECK-LABEL: func @_QPtest_scalar_call(
+subroutine test_scalar_call()
+  interface
+  subroutine test_scalar(x)
+    real, allocatable :: x
+  end subroutine
+  end interface
+  real, allocatable :: x
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFtest_scalar_callEx"}
+  call test_scalar(x)
+  ! CHECK: fir.call @_QPtest_scalar(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array_call(
+subroutine test_array_call()
+  interface
+  subroutine test_array(x)
+    integer, allocatable :: x(:)
+  end subroutine
+  end interface
+  integer, allocatable :: x(:)
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {name = "_QFtest_array_callEx"}
+  call test_array(x)
+  ! CHECK: fir.call @_QPtest_array(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> ()
+end subroutine
+
+
+! CHECK-LABEL: func @_QPtest_char_scalar_deferred_call(
+subroutine test_char_scalar_deferred_call()
+  interface
+  subroutine test_char_scalar_deferred(x)
+    character(:), allocatable :: x
+  end subroutine
+  end interface
+  character(:), allocatable :: x
+  character(10), allocatable :: x2
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFtest_char_scalar_deferred_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFtest_char_scalar_deferred_callEx2"}
+  call test_char_scalar_deferred(x)
+  ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
+  call test_char_scalar_deferred(x2)
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_scalar_explicit_call(
+subroutine test_char_scalar_explicit_call()
+  interface
+  subroutine test_char_scalar_explicit(x)
+    character(10), allocatable :: x
+  end subroutine
+  end interface
+  character(10), allocatable :: x
+  character(:), allocatable :: x2
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFtest_char_scalar_explicit_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFtest_char_scalar_explicit_callEx2"}
+  call test_char_scalar_explicit(x)
+  ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
+  call test_char_scalar_explicit(x2)
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
+end subroutine
+
+
+! CHECK-LABEL: func @_QPtest_char_array_deferred_call(
+subroutine test_char_array_deferred_call()
+  interface
+  subroutine test_char_array_deferred(x)
+    character(:), allocatable :: x(:)
+  end subroutine
+  end interface
+  character(:), allocatable :: x(:)
+  character(10), allocatable :: x2(:)
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFtest_char_array_deferred_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFtest_char_array_deferred_callEx2"}
+  call test_char_array_deferred(x)
+  ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
+  call test_char_array_deferred(x2)
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_char_array_explicit_call(
+subroutine test_char_array_explicit_call()
+  interface
+  subroutine test_char_array_explicit(x)
+    character(10), allocatable :: x(:)
+  end subroutine
+  end interface
+  character(10), allocatable :: x(:)
+  character(:), allocatable :: x2(:)
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFtest_char_array_explicit_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFtest_char_array_explicit_callEx2"}
+  call test_char_array_explicit(x)
+  ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
+  call test_char_array_explicit(x2)
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
+end subroutine

--- a/flang/test/Lower/allocatable-globals.f90
+++ b/flang/test/Lower/allocatable-globals.f90
@@ -1,0 +1,72 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir -use-alloc-runtime %s -o - | FileCheck %s
+
+! Test global allocatable definition lowering
+
+module mod_allocatables
+  character(10), allocatable :: c(:)
+end module
+
+! CHECK-LABEL: func @_QPtest_mod_allocatables()
+subroutine test_mod_allocatables()
+  use mod_allocatables, only: c
+  ! CHECK: fir.address_of(@_QMmod_allocatablesEc) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  call bar(c(1))
+end subroutine
+
+
+! CHECK-LABEL: func @_QPtest_globals()
+subroutine test_globals()
+  integer, allocatable :: gx, gy(:, :)
+  save :: gx, gy
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgx) : !fir.ref<!fir.box<!fir.heap<i32>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgy) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
+  character(:), allocatable :: gc1, gc2(:, :)
+  character(10), allocatable :: gc3, gc4(:, :)
+  save :: gc1, gc2, gc3, gc4
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc1) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc2) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc3) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc4) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>>
+  allocate(gx, gy(20, 30), gc3, gc4(40, 50))
+  allocate(character(15):: gc1, gc2(60, 70))
+end subroutine
+
+! CHECK-LABEL: fir.global linkonce @_QMmod_allocatablesEc : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {
+  ! CHECK-DAG: %[[modcNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[modcShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[modcInitBox:.*]] = fir.embox %[[modcNullAddr]](%[[modcShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK: fir.has_value %[[modcInitBox]] : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc1 : !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK: %[[gc1InitBox:.*]] = fir.embox %[[gc1NullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK: fir.has_value %[[gc1InitBox]] : !fir.box<!fir.heap<!fir.char<1,?>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc2 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+  ! CHECK-DAG: %[[gc2NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[gc2NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gc2InitBox:.*]] = fir.embox %[[gc2NullAddr]](%[[gc2NullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, index) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+  ! CHECK: fir.has_value %[[gc2InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc3 : !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK-DAG: %[[gc3NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK: %[[gc3InitBox:.*]] = fir.embox %[[gc3NullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK: fir.has_value %[[gc3InitBox]] : !fir.box<!fir.heap<!fir.char<1,10>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc4 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+  ! CHECK-DAG: %[[gc4NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[gc4NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gc4InitBox:.*]] = fir.embox %[[gc4NullAddr]](%[[gc4NullShape]]) : (!fir.heap<!fir.array<?x?x!fir.char<1,10>>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+  ! CHECK: fir.has_value %[[gc4InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgx : !fir.box<!fir.heap<i32>>
+  ! CHECK: %[[gxNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<i32>
+  ! CHECK: %[[gxInitBox:.*]] = fir.embox %0 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+  ! CHECK: fir.has_value %[[gxInitBox]] : !fir.box<!fir.heap<i32>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgy : !fir.box<!fir.heap<!fir.array<?x?xi32>>> {
+  ! CHECK-DAG: %[[gyNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xi32>>
+  ! CHECK-DAG: %[[gyShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gyInitBox:.*]] = fir.embox %[[gyNullAddr]](%[[gyShape]]) : (!fir.heap<!fir.array<?x?xi32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xi32>>>
+  ! CHECK: fir.has_value %[[gyInitBox]] : !fir.box<!fir.heap<!fir.array<?x?xi32>>>

--- a/flang/test/Lower/allocatable-runtime.f90
+++ b/flang/test/Lower/allocatable-runtime.f90
@@ -1,0 +1,160 @@
+! RUN: bbc -emit-fir -use-alloc-runtime %s -o - | FileCheck %s
+
+! Test lowering of allocatables using runtime for allocate/deallcoate statements.
+! CHECK-LABEL: _QPfoo
+subroutine foo()
+  real, allocatable :: x(:), y(:, :), z
+  ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
+  ! CHECK-DAG: %[[xNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[xNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[xInitEmbox:.*]] = fir.embox %[[xNullAddr]](%[[xNullShape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[xInitEmbox]] to %[[xBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+
+  ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
+  ! CHECK-DAG: %[[yNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK-DAG: %[[yNullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[yInitEmbox:.*]] = fir.embox %[[yNullAddr]](%[[yNullShape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK: fir.store %[[yInitEmbox]] to %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+
+  ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
+  ! CHECK: %[[zNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
+  ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+  ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+
+
+  allocate(x(42:100), y(43:50, 51), z)
+  ! CHECK-DAG: %[[xlb:.*]] = constant 42 : i32
+  ! CHECK-DAG: %[[xub:.*]] = constant 100 : i32
+  ! CHECK-DAG: %[[xBoxCast2:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[xlbCast:.*]] = fir.convert %[[xlb]] : (i32) -> i64
+  ! CHECK-DAG: %[[xubCast:.*]] = fir.convert %[[xub]] : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[xBoxCast2]], %c0{{.*}}, %[[xlbCast]], %[[xubCast]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
+  ! CHECK-DAG: %[[xBoxCast3:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[errMsg:.*]] = fir.convert %{{.*}} : (!fir.ref<none>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[sourceFile:.*]] = fir.convert %{{.*}} -> !fir.ref<i8>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[xBoxCast3]], %false{{.*}}, %[[errMsg]], %[[sourceFile]], %{{.*}}) : (!fir.ref<!fir.box<none>>, i1, !fir.ref<!fir.box<none>>, !fir.ref<i8>, i32) -> i32
+
+  ! Simply check that we are emitting the right numebr of set bound for y and z. Otherwise, this is just like x.
+  ! CHECK: fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate
+  ! CHECK: %[[zBoxCast:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-NOT: fir.call @{{.*}}AllocatableSetBounds
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate
+
+  ! Check that y descriptor is read when referencing it.
+  ! CHECK: %[[yBoxLoad:.*]] = fir.load %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: %[[yBounds1:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[yBounds2:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[yAddr:.*]] = fir.box_addr %[[yBoxLoad]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.heap<!fir.array<?x?xf32>>
+  print *, x, y(45, 46), z
+
+  deallocate(x, y, z)
+  ! CHECK: %[[xBoxCast4:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[xBoxCast4]], {{.*}})
+  ! CHECK: %[[yBoxCast4:.*]] = fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[yBoxCast4]], {{.*}})
+  ! CHECK: %[[zBoxCast4:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[zBoxCast4]], {{.*}})
+end subroutine
+
+! test lowering of character allocatables
+! CHECK-LABEL: _QPchar_deferred(
+subroutine char_deferred(n)
+  integer :: n
+  character(:), allocatable :: scalar, array(:)
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_deferredEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_deferredEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+
+  allocate(character(10):: scalar, array(30))
+  ! CHECK-DAG: %[[sBoxCast1:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten1:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast1]], %[[ten1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-NOT: AllocatableSetBounds
+  ! CHECK: %[[sBoxCast2:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[sBoxCast2]]
+
+  ! CHECK-DAG: %[[aBoxCast1:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten2:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast1]], %[[ten2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+  ! CHECK: %[[aBoxCast2:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[aBoxCast2]]
+  ! CHECK: %[[aBoxCast3:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[aBoxCast3]]
+
+  deallocate(scalar, array)
+  ! CHECK: %[[sBoxCast3:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[sBoxCast3]]
+  ! CHECK: %[[aBoxCast4:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[aBoxCast4]]
+
+  ! only testing that the correct length is set in the descriptor.
+  allocate(character(n):: scalar, array(40))
+  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[ncast1:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[sBoxCast4:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast4]], %[[ncast1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-DAG: %[[ncast2:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[aBoxCast5:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast5]], %[[ncast2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+end subroutine
+
+! CHECK-LABEL: _QPchar_explicit_cst(
+subroutine char_explicit_cst(n)
+  integer :: n
+  character(10), allocatable :: scalar, array(:)
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFchar_explicit_cstEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFchar_explicit_cstEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  allocate(scalar, array(20))
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  deallocate(scalar, array)
+  ! CHECK: AllocatableDeallocate
+  ! CHECK: AllocatableDeallocate
+end subroutine
+
+! CHECK-LABEL: _QPchar_explicit_dyn(
+subroutine char_explicit_dyn(n, l1, l2)
+  integer :: n, l1, l2
+  character(l1), allocatable :: scalar
+  ! CHECK-DAG: %[[l1:.*]] = fir.load %arg1 : !fir.ref<i32>
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_explicit_dynEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %[[l1]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+
+  character(l2), allocatable :: array(:)
+  ! CHECK-DAG: %[[l2:.*]] = fir.load %arg2 : !fir.ref<i32>
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_explicit_dynEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %[[l2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, i32) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  allocate(scalar, array(20))
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  deallocate(scalar, array)
+  ! CHECK: AllocatableDeallocate
+  ! CHECK: AllocatableDeallocate
+end subroutine

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -5,31 +5,22 @@
 subroutine foo()
   real, allocatable :: x(:), y(:, :), z
   ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
-  ! CHECK-DAG: %[[xTypeCat:.*]] = constant 1 : i32
-  ! CHECK-DAG: %[[xKind:.*]] = constant 4 : i64
-  ! CHECK-DAG: %[[xRank:.*]] = constant 1 : i32
-  ! CHECK-DAG: %[[xCorank:.*]] = constant 0 : i32
-  ! CHECK-DAG: %[[xBoxCast:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[xKindCast:.*]] = fir.convert %[[xKind]] : (i64) -> i32
-  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[xBoxCast]], %[[xTypeCat]], %[[xKindCast]], %[[xRank]], %[[xCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+  ! CHECK-DAG: %[[xNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[xNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[xInitEmbox:.*]] = fir.embox %[[xNullAddr]](%[[xNullShape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[xInitEmbox]] to %[[xBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 
   ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
-  ! CHECK-DAG: %[[yTypeCat:.*]] = constant 1 : i32
-  ! CHECK-DAG: %[[yKind:.*]] = constant 4 : i64
-  ! CHECK-DAG: %[[yRank:.*]] = constant 2 : i32
-  ! CHECK-DAG: %[[yCorank:.*]] = constant 0 : i32
-  ! CHECK-DAG: %[[yBoxCast:.*]] = fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[yKindCast:.*]] = fir.convert %[[yKind]] : (i64) -> i32
-  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[yBoxCast]], %[[yTypeCat]], %[[yKindCast]], %[[yRank]], %[[yCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+  ! CHECK-DAG: %[[yNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK-DAG: %[[yNullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[yInitEmbox:.*]] = fir.embox %[[yNullAddr]](%[[yNullShape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK: fir.store %[[yInitEmbox]] to %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 
   ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
-  ! CHECK-DAG: %[[zTypeCat:.*]] = constant 1 : i32
-  ! CHECK-DAG: %[[zKind:.*]] = constant 4 : i64
-  ! CHECK-DAG: %[[zRank:.*]] = constant 0 : i32
-  ! CHECK-DAG: %[[zCorank:.*]] = constant 0 : i32
-  ! CHECK-DAG: %[[zBoxCast:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[zKindCast:.*]] = fir.convert %[[zKind]] : (i64) -> i32
-  ! CHECK: fir.call @{{.*}}AllocatableInitIntrinsic(%[[zBoxCast]], %[[zTypeCat]], %[[zKindCast]], %[[zRank]], %[[zCorank]]) : (!fir.ref<!fir.box<none>>, i32, i32, i32, i32) -> none
+  ! CHECK: %[[zNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
+  ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+  ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+
 
   allocate(x(42:100), y(43:50, 51), z)
   ! CHECK-DAG: %[[xlb:.*]] = constant 42 : i32
@@ -67,3 +58,156 @@ subroutine foo()
   ! CHECK: %[[zBoxCast4:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[zBoxCast4]], {{.*}})
 end subroutine
+
+! test lowering of character allocatables
+! CHECK-LABEL: _QPchar_deferred(
+subroutine char_deferred(n)
+  integer :: n
+  character(:), allocatable :: scalar, array(:)
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_deferredEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_deferredEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+
+  allocate(character(10):: scalar, array(30))
+  ! CHECK-DAG: %[[sBoxCast1:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten1:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast1]], %[[ten1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-NOT: AllocatableSetBounds
+  ! CHECK: %[[sBoxCast2:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[sBoxCast2]]
+
+  ! CHECK-DAG: %[[aBoxCast1:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten2:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast1]], %[[ten2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+  ! CHECK: %[[aBoxCast2:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[aBoxCast2]]
+  ! CHECK: %[[aBoxCast3:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[aBoxCast3]]
+
+  deallocate(scalar, array)
+  ! CHECK: %[[sBoxCast3:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[sBoxCast3]]
+  ! CHECK: %[[aBoxCast4:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[aBoxCast4]]
+
+  ! only testing that the correct length is set in the descriptor.
+  allocate(character(n):: scalar, array(40))
+  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[ncast1:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[sBoxCast4:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast4]], %[[ncast1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-DAG: %[[ncast2:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[aBoxCast5:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast5]], %[[ncast2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+end subroutine
+
+! CHECK-LABEL: _QPchar_explicit_cst(
+subroutine char_explicit_cst(n)
+  integer :: n
+  character(10), allocatable :: scalar, array(:)
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFchar_explicit_cstEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFchar_explicit_cstEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  allocate(scalar, array(20))
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  deallocate(scalar, array)
+  ! CHECK: AllocatableDeallocate
+  ! CHECK: AllocatableDeallocate
+end subroutine
+
+! CHECK-LABEL: _QPchar_explicit_dyn(
+subroutine char_explicit_dyn(n, l1, l2)
+  integer :: n, l1, l2
+  character(l1), allocatable :: scalar
+  ! CHECK-DAG: %[[l1:.*]] = fir.load %arg1 : !fir.ref<i32>
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_explicit_dynEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %[[l1]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+
+  character(l2), allocatable :: array(:)
+  ! CHECK-DAG: %[[l2:.*]] = fir.load %arg2 : !fir.ref<i32>
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_explicit_dynEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %[[l2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, i32) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  allocate(scalar, array(20))
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  ! CHECK-NOT: AllocatableInitCharacter
+  ! CHECK: AllocatableAllocate
+  deallocate(scalar, array)
+  ! CHECK: AllocatableDeallocate
+  ! CHECK: AllocatableDeallocate
+end subroutine
+
+!  Test global allocatables lowering 
+
+! CHECK-LABEL: func @_QPtest_globals()
+subroutine test_globals()
+  integer, allocatable :: gx, gy(:, :)
+  save :: gx, gy
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgx) : !fir.ref<!fir.box<!fir.heap<i32>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgy) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
+  character(:), allocatable :: gc1, gc2(:, :)
+  character(10), allocatable :: gc3, gc4(:, :)
+  save :: gc1, gc2, gc3, gc4
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc1) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc2) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc3) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc4) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>>
+  allocate(gx, gy(20, 30), gc3, gc4(40, 50))
+  allocate(character(15):: gc1, gc2(60, 70))
+end subroutine
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc1 : !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK: %[[gc1InitBox:.*]] = fir.embox %[[gc1NullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK: fir.has_value %[[gc1InitBox]] : !fir.box<!fir.heap<!fir.char<1,?>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc2 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+  ! CHECK-DAG: %[[gc2NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[gc2NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gc2InitBox:.*]] = fir.embox %[[gc2NullAddr]](%[[gc2NullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, index) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+  ! CHECK: fir.has_value %[[gc2InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc3 : !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK-DAG: %[[gc3NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK: %[[gc3InitBox:.*]] = fir.embox %[[gc3NullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK: fir.has_value %[[gc3InitBox]] : !fir.box<!fir.heap<!fir.char<1,10>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc4 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+  ! CHECK-DAG: %[[gc4NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[gc4NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gc4InitBox:.*]] = fir.embox %[[gc4NullAddr]](%[[gc4NullShape]]) : (!fir.heap<!fir.array<?x?x!fir.char<1,10>>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+  ! CHECK: fir.has_value %[[gc4InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgx : !fir.box<!fir.heap<i32>>
+  ! CHECK: %[[gxNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<i32>
+  ! CHECK: %[[gxInitBox:.*]] = fir.embox %0 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+  ! CHECK: fir.has_value %[[gxInitBox]] : !fir.box<!fir.heap<i32>>
+
+! CHECK-LABEL: fir.global internal @_QFtest_globalsEgy : !fir.box<!fir.heap<!fir.array<?x?xi32>>> {
+  ! CHECK-DAG: %[[gyNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xi32>>
+  ! CHECK-DAG: %[[gyShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK: %[[gyInitBox:.*]] = fir.embox %[[gyNullAddr]](%[[gyShape]]) : (!fir.heap<!fir.array<?x?xi32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xi32>>>
+  ! CHECK: fir.has_value %[[gyInitBox]] : !fir.box<!fir.heap<!fir.array<?x?xi32>>>
+

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -1,213 +1,149 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! Test lowering of allocatables
-! CHECK-LABEL: _QPfoo
-subroutine foo()
-  real, allocatable :: x(:), y(:, :), z
-  ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
-  ! CHECK-DAG: %[[xNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
-  ! CHECK-DAG: %[[xNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK: %[[xInitEmbox:.*]] = fir.embox %[[xNullAddr]](%[[xNullShape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
-  ! CHECK: fir.store %[[xInitEmbox]] to %[[xBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! Test lowering of allocatables using runtime for allocate/deallcoate statements.
+! CHECK-LABEL: _QPfooscalar
+subroutine fooscalar()
+  ! Test lowering of local allocatable specification
+  real, allocatable :: x
+  ! CHECK: %[[xAddrVar:.*]] = fir.alloca !fir.heap<f32> {name = "_QFfooscalarEx.addr"}
+  ! CHECK: %[[nullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
+  ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 
-  ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
-  ! CHECK-DAG: %[[yNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xf32>>
-  ! CHECK-DAG: %[[yNullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
-  ! CHECK: %[[yInitEmbox:.*]] = fir.embox %[[yNullAddr]](%[[yNullShape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
-  ! CHECK: fir.store %[[yInitEmbox]] to %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! Test allocation of local allocatables
+  allocate(x)
+  ! CHECK: %[[alloc:.*]] = fir.allocmem f32 {name = "_QFfooscalarEx.alloc"}
+  ! CHECK: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 
-  ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
-  ! CHECK: %[[zNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
-  ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
-  ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! Test reading allocatable bounds and extents
+  print *, x
+  ! CHECK: %[[xAddr1:.*]] = fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
+  ! CHECK: = fir.load %[[xAddr1]] : !fir.heap<f32>
 
-
-  allocate(x(42:100), y(43:50, 51), z)
-  ! CHECK-DAG: %[[xlb:.*]] = constant 42 : i32
-  ! CHECK-DAG: %[[xub:.*]] = constant 100 : i32
-  ! CHECK-DAG: %[[xBoxCast2:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[xlbCast:.*]] = fir.convert %[[xlb]] : (i32) -> i64
-  ! CHECK-DAG: %[[xubCast:.*]] = fir.convert %[[xub]] : (i32) -> i64
-  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[xBoxCast2]], %c0{{.*}}, %[[xlbCast]], %[[xubCast]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
-  ! CHECK-DAG: %[[xBoxCast3:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[errMsg:.*]] = fir.convert %{{.*}} : (!fir.ref<none>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[sourceFile:.*]] = fir.convert %{{.*}} -> !fir.ref<i8>
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[xBoxCast3]], %false{{.*}}, %[[errMsg]], %[[sourceFile]], %{{.*}}) : (!fir.ref<!fir.box<none>>, i1, !fir.ref<!fir.box<none>>, !fir.ref<i8>, i32) -> i32
-
-  ! Simply check that we are emitting the right numebr of set bound for y and z. Otherwise, this is just like x.
-  ! CHECK: fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
-  ! CHECK: fir.call @{{.*}}AllocatableSetBounds
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate
-  ! CHECK: %[[zBoxCast:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-NOT: fir.call @{{.*}}AllocatableSetBounds
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate
-
-  ! Check that y descriptor is read when referencing it.
-  ! CHECK: %[[yBoxLoad:.*]] = fir.load %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
-  ! CHECK: %[[yAddr:.*]] = fir.box_addr %[[yBoxLoad]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.heap<!fir.array<?x?xf32>>
-  ! CHECK: %[[yBounds1:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
-  ! CHECK: %[[yBounds2:.*]]:3 = fir.box_dims %[[yBoxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
-  print *, x, y(45, 46), z
-
-  deallocate(x, y, z)
-  ! CHECK: %[[xBoxCast4:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[xBoxCast4]], {{.*}})
-  ! CHECK: %[[yBoxCast4:.*]] = fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[yBoxCast4]], {{.*}})
-  ! CHECK: %[[zBoxCast4:.*]] = fir.convert %[[zBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[zBoxCast4]], {{.*}})
+  ! Test deallocation
+  deallocate(x)
+  ! CHECK: %[[xAddr2:.*]] = fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
+  ! CHECK: fir.freemem %[[xAddr2]] : !fir.heap<f32>
+  ! CHECK: %[[nullAddr1:.*]] = fir.convert %c0_0 : (index) -> !fir.heap<f32>
+  ! fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 end subroutine
 
-! test lowering of character allocatables
+! CHECK-LABEL: _QPfoodim1
+subroutine foodim1()
+  ! Test lowering of local allocatable specification
+  real, allocatable :: x(:)
+  ! CHECK-DAG: %[[xAddrVar:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {name = "_QFfoodim1Ex.addr"}
+  ! CHECK-DAG: %[[xLbVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.lb0"}
+  ! CHECK-DAG: %[[xExtVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.ext0"}
+  ! CHECK: %[[nullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+
+  ! Test allocation of local allocatables
+  allocate(x(42:100))
+  ! CHECK-DAG: %[[c42:.*]] = fir.convert %c42{{.*}} : (i32) -> index
+  ! CHECK-DAG: %[[c100:.*]] = fir.convert %c100_i32 : (i32) -> index
+  ! CHECK-DAG: %[[diff:.*]] = subi %[[c100]], %[[c42]] : index
+  ! CHECK: %[[extent:.*]] = addi %[[diff]], %c1{{.*}} : index
+  ! CHECK: %[[alloc:.*]] = fir.allocmem !fir.array<?xf32>, %[[extent]] {name = "_QFfoodim1Ex.alloc"}
+  ! CHECK-DAG: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK-DAG: fir.store %[[extent]] to %[[xExtVar]] : !fir.ref<index>
+  ! CHECK-DAG: fir.store %[[c42]] to %[[xLbVar]] : !fir.ref<index>
+
+  ! Test reading allocatable bounds and extents
+  print *, x(42)
+  ! CHECK-DAG: fir.load %[[xExtVar]] : !fir.ref<index>
+  ! CHECK-DAG: fir.load %[[xLbVar]] : !fir.ref<index>
+  ! CHECK-DAG: fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+
+  deallocate(x)
+  ! CHECK: %[[xAddr1:.*]] = fir.load %1 : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK: fir.freemem %[[xAddr1]] : !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[nullAddr1:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+end subroutine
+
+! CHECK-LABEL: _QPfoodim2
+subroutine foodim2()
+  ! Test lowering of local allocatable specification
+  real, allocatable :: x(:, :)
+  ! CHECK-DAG: fir.alloca !fir.heap<!fir.array<?x?xf32>> {name = "_QFfoodim2Ex.addr"}
+  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.lb0"}
+  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.ext0"}
+  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.lb1"}
+  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.ext1"}
+end subroutine
+
+! test lowering of character allocatables. Focus is placed on the length handling
 ! CHECK-LABEL: _QPchar_deferred(
 subroutine char_deferred(n)
   integer :: n
-  character(:), allocatable :: scalar, array(:)
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_deferredEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
-  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
-  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
-
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_deferredEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
-  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
-  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-
-  allocate(character(10):: scalar, array(30))
-  ! CHECK-DAG: %[[sBoxCast1:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[ten1:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
-  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast1]], %[[ten1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
-  ! CHECK-NOT: AllocatableSetBounds
-  ! CHECK: %[[sBoxCast2:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[sBoxCast2]]
-
-  ! CHECK-DAG: %[[aBoxCast1:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[ten2:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
-  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast1]], %[[ten2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
-  ! CHECK: %[[aBoxCast2:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[aBoxCast2]]
-  ! CHECK: %[[aBoxCast3:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[aBoxCast3]]
-
-  deallocate(scalar, array)
-  ! CHECK: %[[sBoxCast3:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[sBoxCast3]]
-  ! CHECK: %[[aBoxCast4:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableDeallocate(%[[aBoxCast4]]
-
-  ! only testing that the correct length is set in the descriptor.
-  allocate(character(n):: scalar, array(40))
+  character(:), allocatable :: c
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {name = "_QFchar_deferredEc.addr"}
+  ! CHECK-DAG: %[[cLenVar:.*]] = fir.alloca index {name = "_QFchar_deferredEc.len"}
+  allocate(character(10):: c)
+  ! CHECK: %[[c10:.]] = fir.convert %c10_i32 : (i32) -> index
+  ! CHECK: fir.allocmem !fir.char<1,?>, %[[c10]] {name = "_QFchar_deferredEc.alloc"}
+  ! CHECK: fir.store %[[c10]] to %[[cLenVar]] : !fir.ref<index>
+  deallocate(c)
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
+  allocate(character(n):: c)
   ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK-DAG: %[[ncast1:.*]] = fir.convert %[[n]] : (i32) -> i64
-  ! CHECK-DAG: %[[sBoxCast4:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[sBoxCast4]], %[[ncast1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
-  ! CHECK-DAG: %[[ncast2:.*]] = fir.convert %[[n]] : (i32) -> i64
-  ! CHECK-DAG: %[[aBoxCast5:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK: fir.call @{{.*}}AllocatableInitCharacter(%[[aBoxCast5]], %[[ncast2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+  ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK: fir.allocmem !fir.char<1,?>, %[[ni]] {name = "_QFchar_deferredEc.alloc"}
+  ! CHECK: fir.store %[[ni]] to %[[cLenVar]] : !fir.ref<index>
+
+  call bar(c)
+  ! CHECK-DAG: %[[cLen:.*]] = fir.load %[[cLenVar]] : !fir.ref<index>
+  ! CHECK-DAG: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: %[[cAddrcast:.*]] = fir.convert %[[cAddr]] : (!fir.heap<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: fir.emboxchar %[[cAddrcast]], %[[cLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 end subroutine
 
 ! CHECK-LABEL: _QPchar_explicit_cst(
 subroutine char_explicit_cst(n)
   integer :: n
-  character(10), allocatable :: scalar, array(:)
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFchar_explicit_cstEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
-  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
-  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
-
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFchar_explicit_cstEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
-  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
-  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
-  allocate(scalar, array(20))
-  ! CHECK-NOT: AllocatableInitCharacter
-  ! CHECK: AllocatableAllocate
-  ! CHECK-NOT: AllocatableInitCharacter
-  ! CHECK: AllocatableAllocate
-  deallocate(scalar, array)
-  ! CHECK: AllocatableDeallocate
-  ! CHECK: AllocatableDeallocate
+  character(10), allocatable :: c
+  ! CHECK-DAG: %[[cLen:.*]] = constant 10 : index
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,10>> {name = "_QFchar_explicit_cstEc.addr"}
+  ! CHECK-NOT: "_QFchar_explicit_cstEc.len"
+  allocate(c)
+  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  deallocate(c)
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,10>>
+  allocate(character(n):: c)
+  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  deallocate(c)
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,10>>
+  allocate(character(10):: c)
+  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  call bar(c)
+  ! CHECK: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+  ! CHECK: %[[cAddrcast:.*]] = fir.convert %[[cAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: fir.emboxchar %[[cAddrcast]], %[[cLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 end subroutine
 
 ! CHECK-LABEL: _QPchar_explicit_dyn(
-subroutine char_explicit_dyn(n, l1, l2)
-  integer :: n, l1, l2
-  character(l1), allocatable :: scalar
-  ! CHECK-DAG: %[[l1:.*]] = fir.load %arg1 : !fir.ref<i32>
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_explicit_dynEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
-  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %[[l1]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
-  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
-
-  character(l2), allocatable :: array(:)
-  ! CHECK-DAG: %[[l2:.*]] = fir.load %arg2 : !fir.ref<i32>
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_explicit_dynEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
-  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %[[l2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, i32) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
-  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-  allocate(scalar, array(20))
-  ! CHECK-NOT: AllocatableInitCharacter
-  ! CHECK: AllocatableAllocate
-  ! CHECK-NOT: AllocatableInitCharacter
-  ! CHECK: AllocatableAllocate
-  deallocate(scalar, array)
-  ! CHECK: AllocatableDeallocate
-  ! CHECK: AllocatableDeallocate
+subroutine char_explicit_dyn(l1, l2)
+  integer :: l1, l2
+  character(l1), allocatable :: c
+  ! CHECK-DAG: %[[cLen:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {name = "_QFchar_explicit_dynEc.addr"}
+  ! CHECK-NOT: "_QFchar_explicit_dynEc.len"
+  allocate(c)
+  ! CHECK: %[[cLenCast1:.*]] = fir.convert %[[cLen]] : (i32) -> index
+  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast1]] {name = "_QFchar_explicit_dynEc.alloc"}
+  deallocate(c)
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
+  allocate(character(l2):: c)
+  ! CHECK: %[[cLenCast2:.*]] = fir.convert %[[cLen]] : (i32) -> index
+  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast2]] {name = "_QFchar_explicit_dynEc.alloc"}
+  deallocate(c)
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
+  allocate(character(10):: c)
+  ! CHECK: %[[cLenCast3:.*]] = fir.convert %[[cLen]] : (i32) -> index
+  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast3]] {name = "_QFchar_explicit_dynEc.alloc"}
+  call bar(c)
+  ! CHECK-DAG: %[[cLenCast4:.*]] = fir.convert %[[cLen]] : (i32) -> index
+  ! CHECK-DAG: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: %[[cAddrcast:.*]] = fir.convert %[[cAddr]] : (!fir.heap<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: fir.emboxchar %[[cAddrcast]], %[[cLenCast4]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 end subroutine
-
-!  Test global allocatables lowering 
-
-! CHECK-LABEL: func @_QPtest_globals()
-subroutine test_globals()
-  integer, allocatable :: gx, gy(:, :)
-  save :: gx, gy
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgx) : !fir.ref<!fir.box<!fir.heap<i32>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgy) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
-  character(:), allocatable :: gc1, gc2(:, :)
-  character(10), allocatable :: gc3, gc4(:, :)
-  save :: gc1, gc2, gc3, gc4
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc1) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc2) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc3) : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_globalsEgc4) : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>>
-  allocate(gx, gy(20, 30), gc3, gc4(40, 50))
-  allocate(character(15):: gc1, gc2(60, 70))
-end subroutine
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc1 : !fir.box<!fir.heap<!fir.char<1,?>>>
-  ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
-  ! CHECK: %[[gc1InitBox:.*]] = fir.embox %[[gc1NullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
-  ! CHECK: fir.has_value %[[gc1InitBox]] : !fir.box<!fir.heap<!fir.char<1,?>>>
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc2 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
-  ! CHECK-DAG: %[[gc2NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,?>>>
-  ! CHECK-DAG: %[[gc2NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
-  ! CHECK: %[[gc2InitBox:.*]] = fir.embox %[[gc2NullAddr]](%[[gc2NullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, index) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
-  ! CHECK: fir.has_value %[[gc2InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc3 : !fir.box<!fir.heap<!fir.char<1,10>>>
-  ! CHECK-DAG: %[[gc3NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
-  ! CHECK: %[[gc3InitBox:.*]] = fir.embox %[[gc3NullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
-  ! CHECK: fir.has_value %[[gc3InitBox]] : !fir.box<!fir.heap<!fir.char<1,10>>>
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc4 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
-  ! CHECK-DAG: %[[gc4NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,10>>>
-  ! CHECK-DAG: %[[gc4NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
-  ! CHECK: %[[gc4InitBox:.*]] = fir.embox %[[gc4NullAddr]](%[[gc4NullShape]]) : (!fir.heap<!fir.array<?x?x!fir.char<1,10>>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
-  ! CHECK: fir.has_value %[[gc4InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgx : !fir.box<!fir.heap<i32>>
-  ! CHECK: %[[gxNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<i32>
-  ! CHECK: %[[gxInitBox:.*]] = fir.embox %0 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-  ! CHECK: fir.has_value %[[gxInitBox]] : !fir.box<!fir.heap<i32>>
-
-! CHECK-LABEL: fir.global internal @_QFtest_globalsEgy : !fir.box<!fir.heap<!fir.array<?x?xi32>>> {
-  ! CHECK-DAG: %[[gyNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xi32>>
-  ! CHECK-DAG: %[[gyShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
-  ! CHECK: %[[gyInitBox:.*]] = fir.embox %[[gyNullAddr]](%[[gyShape]]) : (!fir.heap<!fir.array<?x?xi32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xi32>>>
-  ! CHECK: fir.has_value %[[gyInitBox]] : !fir.box<!fir.heap<!fir.array<?x?xi32>>>
-

--- a/flang/test/Lower/pointer.f90
+++ b/flang/test/Lower/pointer.f90
@@ -1,5 +1,10 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
+! TODO: Descriptor (fir.box) will most likely be used for pointers
+! (at least for the character case below). This code is hitting a
+! hard todo until pointers are handled correctly.
+! XFAIL: true
+
 ! CHECK-LABEL: func @_QPpointertests
 subroutine pointerTests
   ! CHECK: fir.global internal @_QFpointertestsEptr1 : !fir.ptr<i32>
@@ -38,4 +43,3 @@ subroutine pointerTests
   ! CHECK: fir.has_value [[reg2]] : !fir.ptr<!fir.logical<4>>
 
 end subroutine pointerTests
-

--- a/flang/test/Lower/variable.f90
+++ b/flang/test/Lower/variable.f90
@@ -4,7 +4,7 @@
 subroutine s
   ! CHECK-DAG: fir.alloca !fir.box<!fir.heap<i32>> {name = "{{.*}}Eally"}
   integer, allocatable :: ally
-  ! CHECK-DAG: fir.alloca !fir.ptr<i32> {name = "{{.*}}Epointy"} 
+  ! CHECK-DAG: fir.alloca !fir.box<!fir.ptr<i32>> {name = "{{.*}}Epointy"} 
   integer, pointer :: pointy
   ! CHECK-DAG: fir.alloca i32 {name = "{{.*}}Ebullseye", target}
   integer, target :: bullseye


### PR DESCRIPTION
This PR is composed of 4 commits. The first one is non functional. It adds `fir::BoxAddressValue` class to the `SymbolBox` variants to help propagating and interacting with allocatables and pointers in lowering. The other 3 parts enable lowering of more Fortran feature: global allocatable, dummi allocatables and character allocation.

- Commit 1: Preliminary changes
    - Add `fir::BoxAddressValue` (see BoxValue.h header for description).
    - Add `converter.genExprBoxAddr` that is similar to `converter.genExprAddr` and `converter.genExprValue`: it returns the address of the box that describes an allocatable/pointer entity designated in the ev::Expr provided as inputs. The motivation for this is that, while it is currently possible to get `fir::BoxAddressValue` through symbol map queries, this will most likely not be possible when derived types are lowered (we will have to compute the descriptor address based on the component reference).
   - Add `CharacterExprHelper::readLengthFromBox` to get the length from a fir.box.
   - Add `FirOpBuilder::getCharacterLengthType` to avoid building a `CharacterExprHelper` just to get this type.

- Commit 2: Lower global allocatables
   - Replace `genAllocatableInit` that was using runtime by `createUnallocatedBox` that produces an embox that can be used in global constant initializers.
   - Regroup allocatable/pointer related code in `mapSymbolAttributes` before all other code because it is independent of the shape and dynamic/constant length aspects, so duplicating it 10 times does not help.

- Commit 3: Passing allocatable dummies
   - In CallInterface, add a `BoxAddress` to the `PassEntityBy` to indicate that the address of the writable box of the entity needs to be passed. Enable pointers and allocatable passing according to this. Use `genExprBoxAddr` in ConvertExpr.cpp when lowering an argument that must be passed by  `BoxAddress`.

- Commit 4: Allocation of character allocatables 
  - Use `fir::BoxAddressValue` to simplify allocate statement lowering code.
  - Lower allocate type spec length if present, and set the length of the box being allocated accordingly.
  - Currently uses `AllocatableInitCharacter` to set the length (That could most likely be revisited soon by an `fir.embox` + `fir.store`. I want to deal with error management before going that path).

Note: Codegen PR #559 is required to compile Fortran program correctly with the PR.

Remaining TODOs around allocatables are:
- error recovery in allocate/deallocate statement (f95)
- allocatable assignments (f2003, but I think we want it to deal with this in f95).
- derived type allocatables f95 (tough features come after f95: length params and polymorphism will be non trivial). 
- source/mold allocation (f2003)
- coarray allocations/deallocation (f2008)