### PR TITLE
Array expression lowering. Part 2.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -47,6 +47,7 @@ struct Variable;
 using SomeExpr = Fortran::evaluate::Expr<Fortran::evaluate::SomeType>;
 using SymbolRef = Fortran::common::Reference<const Fortran::semantics::Symbol>;
 class FirOpBuilder;
+class StatementContext;
 
 //===----------------------------------------------------------------------===//
 // AbstractConverter interface
@@ -68,27 +69,30 @@ public:
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;
 
   /// Get the code defined by a label
-  virtual Fortran::lower::pft::Evaluation *lookupLabel(pft::Label label) = 0;
+  virtual pft::Evaluation *lookupLabel(pft::Label label) = 0;
 
   //===--------------------------------------------------------------------===//
   // Expressions
   //===--------------------------------------------------------------------===//
 
   /// Generate the address of the location holding the expression, someExpr
-  virtual fir::ExtendedValue genExprAddr(const SomeExpr &,
+  virtual fir::ExtendedValue genExprAddr(const SomeExpr &, StatementContext &,
                                          mlir::Location *loc = nullptr) = 0;
   /// Generate the address of the location holding the expression, someExpr
-  fir::ExtendedValue genExprAddr(const SomeExpr *someExpr, mlir::Location loc) {
-    return genExprAddr(*someExpr, &loc);
+  fir::ExtendedValue genExprAddr(const SomeExpr *someExpr,
+                                 StatementContext &stmtCtx,
+                                 mlir::Location loc) {
+    return genExprAddr(*someExpr, stmtCtx, &loc);
   }
 
   /// Generate the computations of the expression to produce a value
-  virtual fir::ExtendedValue genExprValue(const SomeExpr &,
+  virtual fir::ExtendedValue genExprValue(const SomeExpr &, StatementContext &,
                                           mlir::Location *loc = nullptr) = 0;
   /// Generate the computations of the expression, someExpr, to produce a value
   fir::ExtendedValue genExprValue(const SomeExpr *someExpr,
+                                  StatementContext &stmtCtx,
                                   mlir::Location loc) {
-    return genExprValue(*someExpr, &loc);
+    return genExprValue(*someExpr, stmtCtx, &loc);
   }
 
   /// Get FoldingContext that is required for some expression
@@ -133,7 +137,7 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Get the OpBuilder
-  virtual Fortran::lower::FirOpBuilder &getFirOpBuilder() = 0;
+  virtual FirOpBuilder &getFirOpBuilder() = 0;
   /// Get the ModuleOp
   virtual mlir::ModuleOp &getModuleOp() = 0;
   /// Get the MLIRContext

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -25,8 +25,10 @@ class Value;
 } // namespace mlir
 
 namespace fir {
+class AllocMemOp;
+class ArrayLoadOp;
 class ShapeOp;
-}
+} // namespace fir
 
 namespace Fortran {
 namespace evaluate {
@@ -38,70 +40,26 @@ struct SomeType;
 namespace lower {
 
 class AbstractConverter;
+class StatementContext;
 class SymMap;
-
-/// The evaluation of some expressions implies a surrounding context. This
-/// context is abstracted by this class.
-class ExpressionContext {
-public:
-  ExpressionContext() = default;
-
-  //===--------------------------------------------------------------------===//
-  // Expression is in an array context.
-  //===--------------------------------------------------------------------===//
-
-  ExpressionContext(mlir::Value shape) : shape{shape}, preludePhase{true} {}
-
-  bool inArrayContext() const { return shape ? true : false; }
-  bool inPreludePhase() const { return preludePhase; }
-  fir::ShapeOp getShape() const;
-  llvm::ArrayRef<mlir::Value> getLoopCounters() const { return loopCounters; }
-  llvm::ArrayRef<mlir::Value> getArrayBlockArgs() const {
-    return arrayBlockArgs;
-  }
-  llvm::ArrayRef<mlir::Value> getLoopReturnVals() const {
-    return loopReturnVals;
-  }
-
-  ExpressionContext &setLoopPhase(bool inPrelude = false) {
-    preludePhase = inPrelude;
-    return *this;
-  }
-
-  void addLoop(mlir::Value counter, mlir::Value blockArg, mlir::Value result);
-  void finalizeLoopNest();
-
-  //===--------------------------------------------------------------------===//
-  // Expression is in an initializer context.
-  //===--------------------------------------------------------------------===//
-
-  bool inInitializer() const { return isInitializer; }
-  ExpressionContext &setInInitializer(bool val = true) {
-    isInitializer = val;
-    return *this;
-  }
-
-private:
-  mlir::Value shape; // shape op
-  std::vector<mlir::Value> loopCounters;
-  std::vector<mlir::Value> arrayBlockArgs;
-  std::vector<mlir::Value> loopReturnVals;
-  bool preludePhase{false};
-
-  bool isInitializer{false};
-};
 
 /// Create an extended expression value.
 fir::ExtendedValue
 createSomeExtendedExpression(mlir::Location loc, AbstractConverter &converter,
                              const evaluate::Expr<evaluate::SomeType> &expr,
-                             SymMap &symMap, const ExpressionContext &context);
+                             SymMap &symMap, StatementContext &stmtCtx);
+
+fir::ExtendedValue
+createSomeInitializerExpression(mlir::Location loc,
+                                AbstractConverter &converter,
+                                const evaluate::Expr<evaluate::SomeType> &expr,
+                                SymMap &symMap, StatementContext &stmtCtx);
 
 /// Create an extended expression address.
 fir::ExtendedValue
 createSomeExtendedAddress(mlir::Location loc, AbstractConverter &converter,
                           const evaluate::Expr<evaluate::SomeType> &expr,
-                          SymMap &symMap, const ExpressionContext &context);
+                          SymMap &symMap, StatementContext &stmtCtx);
 
 /// Create a string literal. Lowers `str` to the MLIR representation of a
 /// literal CHARACTER value. (KIND is assumed to be 1.)
@@ -109,10 +67,25 @@ fir::ExtendedValue createStringLiteral(mlir::Location loc,
                                        AbstractConverter &converter,
                                        llvm::StringRef str, std::uint64_t len);
 
-/// Create a shape op from an extended value, exv.
-/// TODO: Do we want to keep a shape op in the extended value?
-mlir::Value createShape(mlir::Location loc, AbstractConverter &converter,
-                        const fir::ExtendedValue &exv);
+/// Create and return an projection of a subspace of an array value. This is the
+/// lhs onto which a newly constructed array value can be merged.
+fir::ArrayLoadOp
+createSomeArraySubspace(AbstractConverter &converter,
+                        const evaluate::Expr<evaluate::SomeType> &expr,
+                        SymMap &symMap, StatementContext &stmtCtx);
+
+/// Create an array temporary.
+fir::AllocMemOp
+createSomeArrayTemp(AbstractConverter &converter,
+                    const evaluate::Expr<evaluate::SomeType> &expr,
+                    SymMap &symMap, StatementContext &stmtCtx);
+
+/// Lower an array expression with "parallel" semantics. Such a rhs expression
+/// is fully evaluated prior to being assigned back to the destination array.
+fir::ExtendedValue
+createSomeNewArrayValue(AbstractConverter &converter, fir::ArrayLoadOp dst,
+                        const evaluate::Expr<evaluate::SomeType> &expr,
+                        SymMap &symMap, StatementContext &stmtCtx);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -67,7 +67,7 @@ fir::ExtendedValue createStringLiteral(mlir::Location loc,
                                        AbstractConverter &converter,
                                        llvm::StringRef str, std::uint64_t len);
 
-/// Create and return an projection of a subspace of an array value. This is the
+/// Create and return a projection of a subspace of an array value. This is the
 /// lhs onto which a newly constructed array value can be merged.
 fir::ArrayLoadOp
 createSomeArraySubspace(AbstractConverter &converter,

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -26,11 +26,11 @@
 #include "llvm/ADT/Optional.h"
 
 namespace fir {
+class AbstractArrayBox;
 class ExtendedValue;
-}
+} // namespace fir
 
 namespace Fortran::lower {
-
 class AbstractConverter;
 
 //===----------------------------------------------------------------------===//
@@ -84,10 +84,18 @@ public:
   mlir::Value createIntegerConstant(mlir::Location loc, mlir::Type integerType,
                                     std::int64_t i);
 
+  /// Create a real constant from an integer value.
+  mlir::Value createRealConstant(mlir::Location loc, mlir::Type realType,
+                                 llvm::APFloat::integerPart val);
+
+  /// Create a real constant from an APFloat value.
   mlir::Value createRealConstant(mlir::Location loc, mlir::Type realType,
                                  const llvm::APFloat &val);
+
   /// Create a real constant of type \p realType with a value zero.
-  mlir::Value createRealZeroConstant(mlir::Location loc, mlir::Type realType);
+  mlir::Value createRealZeroConstant(mlir::Location loc, mlir::Type realType) {
+    return createRealConstant(loc, realType, 0u);
+  }
 
   /// Create a slot for a local on the stack. Besides the variable's type and
   /// shape, it may be given name or target attributes.
@@ -206,6 +214,9 @@ public:
   mlir::Value convertToIndexType(mlir::Location loc, mlir::Value val) {
     return createConvert(loc, getIndexType(), val);
   }
+
+  /// Construct one of the two forms of shape op from an array box.
+  mlir::Value consShape(mlir::Location loc, const fir::AbstractArrayBox &arr);
 
   /// Create one of the shape ops given an extended value.
   mlir::Value createShape(mlir::Location loc, const fir::ExtendedValue &exv);

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1668,6 +1668,10 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
 
     return mlir::success();
   }];
+
+  let extraClassDeclaration = [{
+    std::vector<mlir::Value> getExtents();
+  }];
 }
 
 def fir_ArrayFetchOp : fir_Op<"array_fetch", [NoSideEffect]> {
@@ -2136,6 +2140,12 @@ def fir_ShapeOp : fir_Op<"shape", [NoSideEffect]> {
       return emitOpError("shape type rank mismatch");
     return mlir::success();
   }];
+
+  let extraClassDeclaration = [{
+    std::vector<mlir::Value> getExtents() {
+      return {extents().begin(), extents().end()};
+    }
+  }];
 }
 
 def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
@@ -2180,10 +2190,12 @@ def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
 
   let extraClassDeclaration = [{
     // Logically unzip the extents from the origin values.
-    void getExtents(llvm::SmallVectorImpl<mlir::Value> &result) {
+    std::vector<mlir::Value> getExtents() {
+      std::vector<mlir::Value> result;
       for (auto i : llvm::enumerate(pairs()))
         if (i.index() & 1)
           result.push_back(i.value());
+      return result;
     }
   }];
 }

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/OpenACC.h"
+#include "StatementContext.h"
 #include "flang/Common/idioms.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/FIRBuilder.h"
@@ -124,11 +125,12 @@ static Op createSimpleOp(Fortran::lower::FirOpBuilder &builder,
 
 static void genAsyncClause(Fortran::lower::AbstractConverter &converter,
                            const Fortran::parser::AccClause::Async *asyncClause,
-                           mlir::Value &async, bool &addAsyncAttr) {
+                           mlir::Value &async, bool &addAsyncAttr,
+                           Fortran::lower::StatementContext &stmtCtx) {
   const auto &asyncClauseValue = asyncClause->v;
   if (asyncClauseValue) { // async has a value.
     async = fir::getBase(converter.genExprValue(
-        *Fortran::semantics::GetExpr(*asyncClauseValue)));
+        *Fortran::semantics::GetExpr(*asyncClauseValue), stmtCtx));
   } else {
     addAsyncAttr = true;
   }
@@ -137,30 +139,31 @@ static void genAsyncClause(Fortran::lower::AbstractConverter &converter,
 static void genDeviceTypeClause(
     Fortran::lower::AbstractConverter &converter,
     const Fortran::parser::AccClause::DeviceType *deviceTypeClause,
-    SmallVectorImpl<mlir::Value> &operands) {
+    SmallVectorImpl<mlir::Value> &operands,
+    Fortran::lower::StatementContext &stmtCtx) {
   const auto &deviceTypeValue = deviceTypeClause->v;
   if (deviceTypeValue) {
     for (const auto &scalarIntExpr : *deviceTypeValue) {
-      mlir::Value expr = fir::getBase(
-          converter.genExprValue(*Fortran::semantics::GetExpr(scalarIntExpr)));
+      mlir::Value expr = fir::getBase(converter.genExprValue(
+          *Fortran::semantics::GetExpr(scalarIntExpr), stmtCtx));
       operands.push_back(expr);
     }
   } else {
     auto &firOpBuilder = converter.getFirOpBuilder();
     // * was passed as value and will be represented as a special constant.
     mlir::Value star = firOpBuilder.createIntegerConstant(
-        converter.getCurrentLocation(), firOpBuilder.getIndexType(),
-        starCst);
+        converter.getCurrentLocation(), firOpBuilder.getIndexType(), starCst);
     operands.push_back(star);
   }
 }
 
 static void genIfClause(Fortran::lower::AbstractConverter &converter,
                         const Fortran::parser::AccClause::If *ifClause,
-                        mlir::Value &ifCond) {
+                        mlir::Value &ifCond,
+                        Fortran::lower::StatementContext &stmtCtx) {
   auto &firOpBuilder = converter.getFirOpBuilder();
-  Value cond = fir::getBase(
-      converter.genExprValue(*Fortran::semantics::GetExpr(ifClause->v)));
+  Value cond = fir::getBase(converter.genExprValue(
+      *Fortran::semantics::GetExpr(ifClause->v), stmtCtx));
   ifCond = firOpBuilder.createConvert(converter.getCurrentLocation(),
                                       firOpBuilder.getI1Type(), cond);
 }
@@ -168,7 +171,8 @@ static void genIfClause(Fortran::lower::AbstractConverter &converter,
 static void genWaitClause(Fortran::lower::AbstractConverter &converter,
                           const Fortran::parser::AccClause::Wait *waitClause,
                           SmallVectorImpl<mlir::Value> &operands,
-                          mlir::Value &waitDevnum, bool &addWaitAttr) {
+                          mlir::Value &waitDevnum, bool &addWaitAttr,
+                          Fortran::lower::StatementContext &stmtCtx) {
   const auto &waitClauseValue = waitClause->v;
   if (waitClauseValue) { // wait has a value.
     const Fortran::parser::AccWaitArgument &waitArg = *waitClauseValue;
@@ -176,7 +180,7 @@ static void genWaitClause(Fortran::lower::AbstractConverter &converter,
         std::get<std::list<Fortran::parser::ScalarIntExpr>>(waitArg.t);
     for (const Fortran::parser::ScalarIntExpr &value : waitList) {
       mlir::Value v = fir::getBase(
-          converter.genExprValue(*Fortran::semantics::GetExpr(value)));
+          converter.genExprValue(*Fortran::semantics::GetExpr(value), stmtCtx));
       operands.push_back(v);
     }
 
@@ -184,7 +188,7 @@ static void genWaitClause(Fortran::lower::AbstractConverter &converter,
         std::get<std::optional<Fortran::parser::ScalarIntExpr>>(waitArg.t);
     if (waitDevnumValue)
       waitDevnum = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(*waitDevnumValue)));
+          *Fortran::semantics::GetExpr(*waitDevnumValue), stmtCtx));
   } else {
     addWaitAttr = true;
   }
@@ -195,6 +199,7 @@ createLoopOp(Fortran::lower::AbstractConverter &converter,
              const Fortran::parser::AccClauseList &accClauseList) {
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   mlir::Value workerNum;
   mlir::Value vectorNum;
@@ -211,7 +216,7 @@ createLoopOp(Fortran::lower::AbstractConverter &converter,
         if (const auto &gangNumValue =
                 std::get<std::optional<Fortran::parser::ScalarIntExpr>>(x.t)) {
           gangNum = fir::getBase(converter.genExprValue(
-              *Fortran::semantics::GetExpr(gangNumValue.value())));
+              *Fortran::semantics::GetExpr(gangNumValue.value()), stmtCtx));
         }
         if (const auto &gangStaticValue =
                 std::get<std::optional<Fortran::parser::AccSizeExpr>>(x.t)) {
@@ -219,8 +224,8 @@ createLoopOp(Fortran::lower::AbstractConverter &converter,
               std::get<std::optional<Fortran::parser::ScalarIntExpr>>(
                   gangStaticValue.value().t);
           if (expr) {
-            gangStatic = fir::getBase(
-                converter.genExprValue(*Fortran::semantics::GetExpr(*expr)));
+            gangStatic = fir::getBase(converter.genExprValue(
+                *Fortran::semantics::GetExpr(*expr), stmtCtx));
           } else {
             // * was passed as value and will be represented as a special
             // constant.
@@ -234,14 +239,14 @@ createLoopOp(Fortran::lower::AbstractConverter &converter,
                    std::get_if<Fortran::parser::AccClause::Worker>(&clause.u)) {
       if (workerClause->v) {
         workerNum = fir::getBase(converter.genExprValue(
-            *Fortran::semantics::GetExpr(*workerClause->v)));
+            *Fortran::semantics::GetExpr(*workerClause->v), stmtCtx));
       }
       executionMapping |= mlir::acc::OpenACCExecMapping::WORKER;
     } else if (const auto *vectorClause =
                    std::get_if<Fortran::parser::AccClause::Vector>(&clause.u)) {
       if (vectorClause->v) {
         vectorNum = fir::getBase(converter.genExprValue(
-            *Fortran::semantics::GetExpr(*vectorClause->v)));
+            *Fortran::semantics::GetExpr(*vectorClause->v), stmtCtx));
       }
       executionMapping |= mlir::acc::OpenACCExecMapping::VECTOR;
     } else if (const auto *tileClause =
@@ -252,8 +257,8 @@ createLoopOp(Fortran::lower::AbstractConverter &converter,
             std::get<std::optional<Fortran::parser::ScalarIntConstantExpr>>(
                 accTileExpr.t);
         if (expr) {
-          tileOperands.push_back(fir::getBase(
-              converter.genExprValue(*Fortran::semantics::GetExpr(*expr))));
+          tileOperands.push_back(fir::getBase(converter.genExprValue(
+              *Fortran::semantics::GetExpr(*expr), stmtCtx)));
         } else {
           // * was passed as value and will be represented as a -1 constant
           // integer.
@@ -357,6 +362,7 @@ createParallelOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -364,34 +370,34 @@ createParallelOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *asyncClause =
             std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
-      genAsyncClause(converter, asyncClause, async, addAsyncAttr);
+      genAsyncClause(converter, asyncClause, async, addAsyncAttr, stmtCtx);
     } else if (const auto *waitClause =
                    std::get_if<Fortran::parser::AccClause::Wait>(&clause.u)) {
       genWaitClause(converter, waitClause, waitOperands, waitDevnum,
-                    addWaitAttr);
+                    addWaitAttr, stmtCtx);
     } else if (const auto *numGangsClause =
                    std::get_if<Fortran::parser::AccClause::NumGangs>(
                        &clause.u)) {
       numGangs = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(numGangsClause->v)));
+          *Fortran::semantics::GetExpr(numGangsClause->v), stmtCtx));
     } else if (const auto *numWorkersClause =
                    std::get_if<Fortran::parser::AccClause::NumWorkers>(
                        &clause.u)) {
       numWorkers = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(numWorkersClause->v)));
+          *Fortran::semantics::GetExpr(numWorkersClause->v), stmtCtx));
     } else if (const auto *vectorLengthClause =
                    std::get_if<Fortran::parser::AccClause::VectorLength>(
                        &clause.u)) {
       vectorLength = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(vectorLengthClause->v)));
+          *Fortran::semantics::GetExpr(vectorLengthClause->v), stmtCtx));
     } else if (const auto *ifClause =
                    std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *selfClause =
                    std::get_if<Fortran::parser::AccClause::Self>(&clause.u)) {
       if (selfClause->v) {
         Value cond = fir::getBase(converter.genExprValue(
-            *Fortran::semantics::GetExpr(*(selfClause->v))));
+            *Fortran::semantics::GetExpr(*(selfClause->v)), stmtCtx));
         selfCond = firOpBuilder.createConvert(currentLocation,
                                               firOpBuilder.getI1Type(), cond);
       } else {
@@ -502,6 +508,7 @@ static void genACCDataOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -509,7 +516,7 @@ static void genACCDataOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *copyClause =
                    std::get_if<Fortran::parser::AccClause::Copy>(&clause.u)) {
       genObjectList(copyClause->v, converter, copyOperands);
@@ -633,6 +640,7 @@ genACCEnterDataOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -640,14 +648,14 @@ genACCEnterDataOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *asyncClause =
                    std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
-      genAsyncClause(converter, asyncClause, async, addAsyncAttr);
+      genAsyncClause(converter, asyncClause, async, addAsyncAttr, stmtCtx);
     } else if (const auto *waitClause =
                    std::get_if<Fortran::parser::AccClause::Wait>(&clause.u)) {
       genWaitClause(converter, waitClause, waitOperands, waitDevnum,
-                    addWaitAttr);
+                    addWaitAttr, stmtCtx);
     } else if (const auto *copyinClause =
                    std::get_if<Fortran::parser::AccClause::Copyin>(&clause.u)) {
       const Fortran::parser::AccObjectListWithModifier &listWithModifier =
@@ -707,6 +715,7 @@ genACCExitDataOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -714,14 +723,14 @@ genACCExitDataOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *asyncClause =
                    std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
-      genAsyncClause(converter, asyncClause, async, addAsyncAttr);
+      genAsyncClause(converter, asyncClause, async, addAsyncAttr, stmtCtx);
     } else if (const auto *waitClause =
                    std::get_if<Fortran::parser::AccClause::Wait>(&clause.u)) {
       genWaitClause(converter, waitClause, waitOperands, waitDevnum,
-                    addWaitAttr);
+                    addWaitAttr, stmtCtx);
     } else if (const auto *copyoutClause =
                    std::get_if<Fortran::parser::AccClause::Copyout>(
                        &clause.u)) {
@@ -772,6 +781,7 @@ genACCInitShutdownOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -779,16 +789,17 @@ genACCInitShutdownOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *deviceNumClause =
                    std::get_if<Fortran::parser::AccClause::DeviceNum>(
                        &clause.u)) {
       deviceNum = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(deviceNumClause->v)));
+          *Fortran::semantics::GetExpr(deviceNumClause->v), stmtCtx));
     } else if (const auto *deviceTypeClause =
                    std::get_if<Fortran::parser::AccClause::DeviceType>(
                        &clause.u)) {
-      genDeviceTypeClause(converter, deviceTypeClause, deviceTypeOperands);
+      genDeviceTypeClause(converter, deviceTypeClause, deviceTypeOperands,
+                          stmtCtx);
     }
   }
 
@@ -818,6 +829,7 @@ genACCUpdateOp(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   // Lower clauses values mapped to operands.
   // Keep track of each group of operands separatly as clauses can appear
@@ -825,18 +837,19 @@ genACCUpdateOp(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *asyncClause =
                    std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
-      genAsyncClause(converter, asyncClause, async, addAsyncAttr);
+      genAsyncClause(converter, asyncClause, async, addAsyncAttr, stmtCtx);
     } else if (const auto *waitClause =
                    std::get_if<Fortran::parser::AccClause::Wait>(&clause.u)) {
       genWaitClause(converter, waitClause, waitOperands, waitDevnum,
-                    addWaitAttr);
+                    addWaitAttr, stmtCtx);
     } else if (const auto *deviceTypeClause =
                    std::get_if<Fortran::parser::AccClause::DeviceType>(
                        &clause.u)) {
-      genDeviceTypeClause(converter, deviceTypeClause, deviceTypeOperands);
+      genDeviceTypeClause(converter, deviceTypeClause, deviceTypeOperands,
+                          stmtCtx);
     } else if (const auto *hostClause =
                    std::get_if<Fortran::parser::AccClause::Host>(&clause.u)) {
       genObjectList(hostClause->v, converter, hostOperands);
@@ -912,6 +925,7 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
 
   if (waitArgument) { // wait has a value.
     const Fortran::parser::AccWaitArgument &waitArg = *waitArgument;
@@ -919,7 +933,7 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
         std::get<std::list<Fortran::parser::ScalarIntExpr>>(waitArg.t);
     for (const Fortran::parser::ScalarIntExpr &value : waitList) {
       mlir::Value v = fir::getBase(
-          converter.genExprValue(*Fortran::semantics::GetExpr(value)));
+          converter.genExprValue(*Fortran::semantics::GetExpr(value), stmtCtx));
       waitOperands.push_back(v);
     }
 
@@ -927,7 +941,7 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
         std::get<std::optional<Fortran::parser::ScalarIntExpr>>(waitArg.t);
     if (waitDevnumValue)
       waitDevnum = fir::getBase(converter.genExprValue(
-          *Fortran::semantics::GetExpr(*waitDevnumValue)));
+          *Fortran::semantics::GetExpr(*waitDevnumValue), stmtCtx));
   }
 
   // Lower clauses values mapped to operands.
@@ -936,10 +950,10 @@ static void genACC(Fortran::lower::AbstractConverter &converter,
   for (const auto &clause : accClauseList.v) {
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, ifClause, ifCond);
+      genIfClause(converter, ifClause, ifCond, stmtCtx);
     } else if (const auto *asyncClause =
                    std::get_if<Fortran::parser::AccClause::Async>(&clause.u)) {
-      genAsyncClause(converter, asyncClause, async, addAsyncAttr);
+      genAsyncClause(converter, asyncClause, async, addAsyncAttr, stmtCtx);
     }
   }
 

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/OpenMP.h"
+#include "StatementContext.h"
 #include "flang/Common/idioms.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/FIRBuilder.h"
@@ -135,6 +136,7 @@ genOMP(Fortran::lower::AbstractConverter &converter,
 
   auto &firOpBuilder = converter.getFirOpBuilder();
   auto currentLocation = converter.getCurrentLocation();
+  Fortran::lower::StatementContext stmtCtx;
   llvm::ArrayRef<mlir::Type> argTy;
   if (blockDirective.v == llvm::omp::OMPD_parallel) {
 
@@ -150,14 +152,14 @@ genOMP(Fortran::lower::AbstractConverter &converter,
       if (const auto &ifClause =
               std::get_if<Fortran::parser::OmpIfClause>(&clause.u)) {
         auto &expr = std::get<Fortran::parser::ScalarLogicalExpr>(ifClause->t);
-        ifClauseOperand = fir::getBase(
-            converter.genExprValue(*Fortran::semantics::GetExpr(expr)));
+        ifClauseOperand = fir::getBase(converter.genExprValue(
+            *Fortran::semantics::GetExpr(expr), stmtCtx));
       } else if (const auto &numThreadsClause =
                      std::get_if<Fortran::parser::OmpClause::NumThreads>(
                          &clause.u)) {
         // OMPIRBuilder expects `NUM_THREAD` clause as a `Value`.
         numThreadsClauseOperand = fir::getBase(converter.genExprValue(
-            *Fortran::semantics::GetExpr(numThreadsClause->v)));
+            *Fortran::semantics::GetExpr(numThreadsClause->v), stmtCtx));
       } else if (const auto &privateClause =
                      std::get_if<Fortran::parser::OmpClause::Private>(
                          &clause.u)) {
@@ -193,7 +195,7 @@ genOMP(Fortran::lower::AbstractConverter &converter,
             allocateClause->t);
         if (allocatorValue) {
           allocatorOperand = fir::getBase(converter.genExprValue(
-              *Fortran::semantics::GetExpr(allocatorValue->v)));
+              *Fortran::semantics::GetExpr(allocatorValue->v), stmtCtx));
           allocatorOperands.insert(allocatorOperands.end(),
                                    ompObjectList.v.size(), allocatorOperand);
         } else {

--- a/flang/lib/Lower/StatementContext.h
+++ b/flang/lib/Lower/StatementContext.h
@@ -1,0 +1,80 @@
+//===-- StatementContext.h --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_STATEMENTCONTEXT_H
+#define FORTRAN_LOWER_STATEMENTCONTEXT_H
+
+#include "SymbolMap.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <functional>
+
+namespace Fortran::lower {
+
+/// When lowering a statement, large temporaries may be allocated on the heap to
+/// buffer intermediate results. These temporaries must be deallocated at the
+/// end of the statement. These deallocations are threaded via a
+/// StatementContext back to the "end" of the statement.
+class StatementContext {
+public:
+  explicit StatementContext() {
+    cleanup = []() {};
+  }
+
+  /// Cleanups can be prohibited in some contexts. If prohibited, the compiler
+  /// will crash if and where it tries to unexpectedly add a cleanup.
+  explicit StatementContext(bool prohibited) : cleanupProhibited{prohibited} {
+    cleanup = []() {};
+  }
+
+  ~StatementContext() {
+    if (!finalized)
+      cleanup();
+  }
+
+  /// Append the cleanup function `cuf` to the list of cleanups.
+  void attachCleanup(std::function<void()> cuf) {
+    if (cleanupProhibited)
+      llvm::report_fatal_error("expression cleanups disallowed");
+    assert(!finalized);
+    auto oldCleanup = cleanup;
+    cleanup = [=]() {
+      cuf();
+      oldCleanup();
+    };
+    cleanupAdded = true;
+  }
+
+  /// Force finalization of cleanups. Normally, cleanups are applied by the
+  /// destructor, but some statements require the cleanups be added before an Op
+  /// that will change the control dependence.
+  void finalize() {
+    cleanup();
+    finalized = true;
+    cleanup = []() { llvm::report_fatal_error("already finalized"); };
+  }
+
+  bool hasCleanups() const { return cleanupAdded; }
+
+private:
+  StatementContext(const StatementContext &) = delete;
+  StatementContext &operator=(const StatementContext &) = delete;
+  StatementContext(StatementContext &&) = delete;
+
+  std::function<void()> cleanup;
+  bool finalized{};
+  bool cleanupAdded{};
+  bool cleanupProhibited{};
+};
+
+} // namespace Fortran::lower
+
+#endif // FORTRAN_LOWER_STATEMENTCONTEXT_H

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -5,6 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_LOWER_SYMBOLMAP_H
 #define FORTRAN_LOWER_SYMBOLMAP_H

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -124,6 +124,21 @@ mlir::Type fir::AllocMemOp::wrapResultType(mlir::Type intype) {
 }
 
 //===----------------------------------------------------------------------===//
+// ArrayLoadOp
+//===----------------------------------------------------------------------===//
+
+std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
+  std::vector<mlir::Value> result;
+  if (auto sh = shape())
+    if (auto *op = sh.getDefiningOp()) {
+      if (auto shOp = dyn_cast<fir::ShapeOp>(op))
+        return shOp.getExtents();
+      return cast<fir::ShapeShiftOp>(op).getExtents();
+    }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
 // BoxAddrOp
 //===----------------------------------------------------------------------===//
 
@@ -1072,8 +1087,8 @@ fir::DoLoopOp::moveOutOfLoop(llvm::ArrayRef<mlir::Operation *> ops) {
   return success();
 }
 
-/// Translate a value passed as an iter_arg to the corresponding block argument
-/// in the body of the loop.
+/// Translate a value passed as an iter_arg to the corresponding block
+/// argument in the body of the loop.
 mlir::BlockArgument fir::DoLoopOp::iterArgToBlockArg(mlir::Value iterArg) {
   for (auto i : llvm::enumerate(initArgs()))
     if (iterArg == i.value())
@@ -1081,8 +1096,8 @@ mlir::BlockArgument fir::DoLoopOp::iterArgToBlockArg(mlir::Value iterArg) {
   return {};
 }
 
-/// Translate the result vector (by index number) to the corresponding value to
-/// the `fir.result` Op.
+/// Translate the result vector (by index number) to the corresponding value
+/// to the `fir.result` Op.
 void fir::DoLoopOp::resultToSourceOps(
     llvm::SmallVectorImpl<mlir::Value> &results, unsigned resultNum) {
   auto oper = finalValue() ? resultNum : resultNum + 1;
@@ -1141,7 +1156,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&...additionalArgs) {
+                        AdditionalArgs &&... additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();

--- a/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
+++ b/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
@@ -464,12 +464,13 @@ public:
                          mlir::Operation *shapeOp) {
     assert(result.empty());
     if (auto s = mlir::dyn_cast<fir::ShapeOp>(shapeOp)) {
-      auto e = s.extents();
+      auto e = s.getExtents();
       result.insert(result.end(), e.begin(), e.end());
       return;
     }
     if (auto s = mlir::dyn_cast<fir::ShapeShiftOp>(shapeOp)) {
-      s.getExtents(result);
+      auto e = s.getExtents();
+      result.insert(result.end(), e.begin(), e.end());
       return;
     }
     llvm::report_fatal_error("not a shape op");
@@ -481,12 +482,9 @@ public:
     auto insPt = rewriter.saveInsertionPoint();
     llvm::SmallVector<mlir::Value, 8> shape;
     getExtents(shape, shapeOp.getDefiningOp());
-    llvm::SmallVector<mlir::Value, 8> revShape;
-    revShape.insert(revShape.end(), shape.begin(), shape.end());
-    std::reverse(revShape.begin(), revShape.end());
-    llvm::SmallVector<mlir::Value, 8> indices;
+   llvm::SmallVector<mlir::Value, 8> indices;
     // Build loop nest from column to row.
-    for (auto sh : revShape) {
+    for (auto sh : llvm::reverse(shape)) {
       auto idxTy = rewriter.getIndexType();
       auto ub = rewriter.create<fir::ConvertOp>(loc, idxTy, sh);
       auto one = rewriter.create<mlir::ConstantIndexOp>(loc, 1);

--- a/flang/test/Lower/arrexp.f90
+++ b/flang/test/Lower/arrexp.f90
@@ -1,0 +1,204 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LINE: func @_QPtest1
+subroutine test1(a,b,c,n)
+  integer :: n
+  real, intent(out) :: a(n)
+  real, intent(in) :: b(n), c(n)
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1(%
+  ! CHECK-DAG: %[[C:.*]] = fir.array_load %arg2(%
+  ! CHECK: %[[T:.*]] = fir.do_loop
+  ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[B]]
+  ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[C]]
+  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
+  a = b + c
+  ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
+end subroutine test1
+
+! CHECK-LINE: func @_QPtest2
+subroutine test2(a,b,c)
+  real, intent(out) :: a(:)
+  real, intent(in) :: b(:), c(:)
+!  a = b + c
+end subroutine test2
+
+! CHECK-LINE: func @_QPtest3
+subroutine test3(a,b,c,n)
+  integer :: n
+  real, intent(out) :: a(n)
+  real, intent(in) :: b(n), c
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1(%
+  ! CHECK-DAG: %[[C:.*]] = fir.load %arg2
+  ! CHECK: %[[T:.*]] = fir.do_loop
+  ! CHECK: %[[Bi:.*]] = fir.array_fetch %[[B]]
+  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[C]]
+  ! CHECK: %[[Ti:.*]] = fir.array_update %{{.*}}, %[[rv]], %
+  ! CHECK: fir.result %[[Ti]]
+  a = b + c
+  ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
+end subroutine test3
+
+! CHECK-LINE: func @_QPtest4
+subroutine test4(a,b,c)
+! TODO: this declaration fails in CallInterface lowering
+!  real, allocatable, intent(out) :: a(:)
+  real :: a(100) ! FIXME: fake it for now
+  real, intent(in) :: b(:), c
+  ! CHECK: %[[Ba:.*]] = fir.box_addr %arg1
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %[[Ba]](%
+  ! CHECK: fir.do_loop
+  ! CHECK: fir.array_fetch %[[B]], %
+  ! CHECK: fir.array_update
+  a = b + c
+  ! CHECK: fir.array_merge_store %[[A]], %{{.*}} to %arg0
+end subroutine test4
+
+! CHECK-LINE: func @_QPtest5
+subroutine test5(a,b,c)
+! TODO: this declaration fails in CallInterface lowering
+!  real, allocatable, intent(out) :: a(:)
+!  real, pointer, intent(in) :: b(:)
+  real :: a(100), b(100) ! FIXME: fake it for now
+  real, intent(in) :: c
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1(%
+  ! CHECK: fir.do_loop
+  ! CHECK: fir.array_fetch %[[B]], %
+  ! CHECK: fir.array_update
+  a = b + c
+  ! CHECK: fir.array_merge_store %[[A]], %{{.*}} to %arg0
+end subroutine test5
+
+! CHECK-LINE: func @_QPtest6
+subroutine test6(a,b,c,n,m)
+  integer :: n, m
+  real, intent(out) :: a(n)
+  real, intent(in) :: b(m), c
+!  a(3:n:4) = b + c
+end subroutine test6
+
+! This is NOT a conflict. `a` appears on both the lhs and rhs here, but there
+! are no loop-carried dependences and no copy is needed.
+! CHECK-LINE: func @_QPtest7
+subroutine test7(a,b,n)
+  integer :: n
+  real, intent(inout) :: a(n)
+  real, intent(in) :: b(n)
+  ! CHECK: %[[Aout:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[Ain:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1(%
+  ! CHECK: %[[T:.*]] = fir.do_loop
+  ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[Ain]]
+  ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[B]]
+  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
+  a = a + b
+  ! CHECK: fir.array_merge_store %[[Aout]], %[[T]] to %arg0
+end subroutine test7
+
+! CHECK-LINE: func @_QPtest8
+subroutine test8(a,b)
+  integer :: a(100), b(100)
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B1_addr:.*]] = fir.coordinate_of %arg1, %
+  ! CHECK: %[[B1:.*]] = fir.load %[[B1_addr]]
+  ! CHECK: %[[LOOP:.*]] = fir.do_loop
+  ! CHECK: fir.array_update %{{.*}}, %[[B1]], %
+  a = b(1)
+  ! CHECK: fir.array_merge_store %[[A]], %[[LOOP]] to %arg0
+end subroutine test8
+
+! This FORALL construct does present a potential loop-carried dependence if
+! implemented naively (and incorrectly). The final value of a(3) must be the
+! value of a(2) before alistair begins execution added to b(2).
+! CHECK-LINE: func @_QPtest9
+subroutine test9(a,b,n)
+  integer :: n
+  real, intent(inout) :: a(n)
+  real, intent(in) :: b(n)
+  ! CHECK: fir.do_loop
+  alistair: FORALL (i=1:n-1)
+     a(i+1) = a(i) + b(i)
+  END FORALL alistair
+end subroutine test9
+
+! CHECK-LINE: func @_QPtest10
+subroutine test10(a,b,c,d)
+  interface
+     function foo(a) result(res)
+       real :: a(:)  ! FIXME: must be before res or semantics fails
+                     ! as `size(a,1)` fails to resolve to the argument
+       real, dimension(size(a,1)) :: res
+     end function foo
+  end interface
+  interface
+     real function bar(a)
+       real :: a(:)
+     end function bar
+  end interface
+  real :: a(:), b(:), c(:), d(:)
+!  a = b + foo(c + foo(d + bar(a)))
+end subroutine test10
+
+! CHECK-LINE: func @_QPtest11
+subroutine test11(a,b,c,d)
+  real, external :: bar
+  real :: a(100), b(100), c(100), d(100)
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1
+  ! CHECK-DAG: %[[C:.*]] = fir.array_load %arg2
+  ! CHECK-DAG: %[[D:.*]] = fir.array_load %arg3
+  ! CHECK-DAG: %[[tmp:.*]] = fir.allocmem
+  ! CHECK-DAG: %[[T:.*]] = fir.array_load %[[tmp]]
+  
+  !    temporary <- c + d
+  ! CHECK: %[[bar_in:.*]] = fir.do_loop
+  !  CHECK-DAG: %[[c_i:.*]] = fir.array_fetch %[[C]]
+  !  CHECK-DAG: %[[d_i:.*]] = fir.array_fetch %[[D]]
+  !  CHECK: %[[sum:.*]] = fir.addf %[[c_i]], %[[d_i]]
+  !  CHECK: fir.array_update %{{.*}}, %[[sum]], %
+  ! CHECK: fir.array_merge_store %[[T]], %[[bar_in]] to %[[tmp]]
+  ! CHECK: %[[cast:.*]] = fir.convert %[[tmp]]
+  ! CHECK: %[[bar_out:.*]] = fir.call @_QPbar(%[[cast]]
+  
+  !    a <- b + bar(?)
+  ! CHECK: %[[S:.*]] = fir.do_loop
+  !  CHECK: %[[b_i:.*]] = fir.array_fetch %[[B]], %
+  !  CHECK: %[[sum2:.*]] = fir.addf %[[b_i]], %[[bar_out]]
+  !  CHECK: fir.array_update %{{.*}}, %[[sum2]], %
+  ! CHECK: fir.array_merge_store %[[A]], %[[S]] to %arg0
+  a = b + bar(c + d)
+end subroutine test11
+
+! CHECK-LINE: func @_QPtest12
+subroutine test12(a,b,c,d,n,m)
+  integer :: n, m
+  ! CHECK: %[[n:.*]] = fir.load %arg4
+  ! CHECK: %[[m:.*]] = fir.load %arg5
+  ! CHECK: %[[sha:.*]] = fir.shape %
+  ! CHECK: %[[A:.*]] = fir.array_load %arg0(%[[sha]])
+  ! CHECK: %[[shb:.*]] = fir.shape %
+  ! CHECK: %[[B:.*]] = fir.array_load %arg1(%[[shb]])
+  ! CHECK: %[[tmp:.*]] = fir.allocmem !fir.array<?xf32>, %{{.*}} {name = ".array.expr"}
+  ! CHECK: %[[T:.*]] = fir.array_load %[[tmp]](%
+  ! CHECK: %[[C:.*]] = fir.array_load %arg2(%
+  ! CHECK: %[[D:.*]] = fir.array_load %arg3(%
+  real, external :: bar
+  real :: a(n), b(n), c(m), d(m)
+  ! CHECK: %[[LOOP:.*]] = fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %[[T]])
+    ! CHECK-DAG: fir.array_fetch %[[C]]
+    ! CHECK-DAG: fir.array_fetch %[[D]]
+  ! CHECK: fir.array_merge_store %[[T]], %[[LOOP]]
+  ! CHECK: %[[CALL:.*]] = fir.call @_QPbar
+  ! CHECK: %[[LOOP2:.*]] = fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %[[A]])
+    ! CHECK: fir.array_fetch %[[B]]
+  ! CHECK: fir.array_merge_store %[[A]], %[[LOOP2]] to %arg0
+  a = b + bar(c + d)
+  ! CHECK: fir.freemem %[[tmp]] : !fir.heap<!fir.array<?xf32>>
+end subroutine test12
+
+! CHECK: func private @_QPbar(

--- a/flang/test/Lower/arrexp.f90
+++ b/flang/test/Lower/arrexp.f90
@@ -17,6 +17,26 @@ subroutine test1(a,b,c,n)
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
 end subroutine test1
 
+! CHECK-LINE: func @_QPtest1b
+subroutine test1b(a,b,c,d,n)
+  integer :: n
+  real, intent(out) :: a(n)
+  real, intent(in) :: b(n), c(n), d(n)
+  ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1(%
+  ! CHECK-DAG: %[[C:.*]] = fir.array_load %arg2(%
+  ! CHECK-DAG: %[[D:.*]] = fir.array_load %arg3(%
+  ! CHECK: %[[T:.*]] = fir.do_loop
+  ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[B]]
+  ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[C]]
+  ! CHECK: %[[rv1:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: %[[Di:.*]] = fir.array_fetch %[[D]]
+  ! CHECK: %[[rv:.*]] = fir.addf %[[rv1]], %[[Di]]
+  ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
+  a = b + c + d
+  ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
+end subroutine test1b
+
 ! CHECK-LINE: func @_QPtest2
 subroutine test2(a,b,c)
   real, intent(out) :: a(:)


### PR DESCRIPTION
Lowering of array assignments. This makes the old lowering of array expressions and assignments obsolete.

Expression lowering is bifurcated into the lowering of scalar expressions and array expressions (>= F90). This allows a natural nested scoping of sub-expression contexts as each sub-expression is lowered. The scalar expression code was mostly kept intact with some cleanup. The array expression lowering uses CPS (continuation passing style) to lower array expressions in parts: setup, loop nest and body, and cleanup.

While this is incomplete, it provides an interface and an initial implementation for some target cases.