### PR TITLE
Lowering modules

### DIFF
--- a/flang/lib/Lower/BoxAnalyzer.h
+++ b/flang/lib/Lower/BoxAnalyzer.h
@@ -135,12 +135,12 @@ struct DynamicBound {
   static constexpr bool staticSize() { return false; }
   static constexpr bool isArray() { return true; }
   bool lboundAllOnes() const {
-      return llvm::all_of(bounds, [](const Fortran::semantics::ShapeSpec *p) {
-        if (auto low = p->lbound().GetExplicit())
-          if (auto lb = Fortran::evaluate::ToInt64(*low))
-            return *lb == 1;
-        return false;
-      });
+    return llvm::all_of(bounds, [](const Fortran::semantics::ShapeSpec *p) {
+      if (auto low = p->lbound().GetExplicit())
+        if (auto lb = Fortran::evaluate::ToInt64(*low))
+          return *lb == 1;
+      return false;
+    });
   }
 
   llvm::SmallVector<const Fortran::semantics::ShapeSpec *, 8> bounds;
@@ -227,12 +227,14 @@ inline bool symIsChar(const Fortran::semantics::Symbol &sym) {
 }
 
 inline bool symIsArray(const Fortran::semantics::Symbol &sym) {
-  const auto *det = sym.detailsIf<Fortran::semantics::ObjectEntityDetails>();
+  const auto *det =
+      sym.GetUltimate().detailsIf<Fortran::semantics::ObjectEntityDetails>();
   return det && det->IsArray();
 }
 
 inline bool isExplicitShape(const Fortran::semantics::Symbol &sym) {
-  const auto *det = sym.detailsIf<Fortran::semantics::ObjectEntityDetails>();
+  const auto *det =
+      sym.GetUltimate().detailsIf<Fortran::semantics::ObjectEntityDetails>();
   return det && det->IsArray() && det->shape().IsExplicitShape();
 }
 
@@ -458,7 +460,9 @@ private:
   // Get the shape of a symbol.
   const Fortran::semantics::ArraySpec &
   getSymShape(const Fortran::semantics::Symbol &sym) {
-    return sym.get<Fortran::semantics::ObjectEntityDetails>().shape();
+    return sym.GetUltimate()
+        .get<Fortran::semantics::ObjectEntityDetails>()
+        .shape();
   }
 
   // Get the constant LEN of a CHARACTER, if it exists.

--- a/flang/test/Lower/common.f90
+++ b/flang/test/Lower/common.f90
@@ -3,6 +3,7 @@
 ! CHECK: @_QB = common global [8 x i8] zeroinitializer
 ! CHECK: @_QBx = global { float, float } { float 1.0{{.*}}, float 2.0{{.*}} }
 ! CHECK: @_QBy = common global [12 x i8] zeroinitializer
+! CHECK: @_QBz = global { i32, [4 x i8], float } { i32 42, [4 x i8] undef, float 3.000000e+00 }
 
 ! CHECK-LABEL: _QPs0
 subroutine s0
@@ -29,3 +30,17 @@ subroutine s2
   ! CHECK: call void @_QPs(float* bitcast ([12 x i8]* @_QBy to float*), float* bitcast (i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_QBy, i32 0, i64 4) to float*))
   call s(a2, b2)
 end subroutine s2
+
+! Test that common initialized through aliases of common members are getting
+! the correct initializer.
+! CHECK-LABEL: _QPs3
+subroutine s3
+ integer :: i = 42
+ real :: x
+ complex :: c
+ real :: glue(2)
+ real :: y = 3.
+ equivalence (i, x), (glue(1), c), (glue(2), y)
+ ! x and c are not directly initialized, but overlapping aliases are.
+ common /z/ x, c
+end

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -8,8 +8,8 @@ module m1
   real :: x
   integer :: y(100)
 end module
-! CHECK: fir.global @_QMm1Ex : f32
-! CHECK: fir.global @_QMm1Ey : !fir.array<100xi32>
+! CHECK: fir.global linkonce @_QMm1Ex : f32
+! CHECK: fir.global linkonce @_QMm1Ey : !fir.array<100xi32>
 
 ! Module modEq1 defines data that is equivalenced and not used in this
 ! file.
@@ -21,10 +21,10 @@ module modEq1
   real :: y2(10)
   equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
 end module
-! CHECK-LABEL: fir.global @_QMmodeq1Ex1 : tuple<!fir.array<36xi8>, !fir.array<40xi8>> {
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ex1 : tuple<!fir.array<36xi8>, !fir.array<40xi8>> {
   ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<36xi8>, !fir.array<40xi8>>
   ! CHECK: fir.has_value %[[undef]] : tuple<!fir.array<36xi8>, !fir.array<40xi8>>
-! CHECK-LABEL: fir.global @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
   ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
   ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
   ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], %c1{{.*}} : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32, index) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -1,0 +1,52 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test lowering of module that defines data that is otherwise not used
+! in this file.
+
+! Module m1 defines simple data
+module m1
+  real :: x
+  integer :: y(100)
+end module
+! CHECK: fir.global @_QMm1Ex : f32
+! CHECK: fir.global @_QMm1Ey : !fir.array<100xi32>
+
+! Module modEq1 defines data that is equivalenced and not used in this
+! file.
+module modEq1
+  ! Equivalence, no initialization
+  real :: x1(10), x2(10), x3(10) 
+  ! Equivalence with initialization
+  real :: y1 = 42.
+  real :: y2(10)
+  equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
+end module
+! CHECK-LABEL: fir.global @_QMmodeq1Ex1 : tuple<!fir.array<36xi8>, !fir.array<40xi8>> {
+  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<36xi8>, !fir.array<40xi8>>
+  ! CHECK: fir.has_value %[[undef]] : tuple<!fir.array<36xi8>, !fir.array<40xi8>>
+! CHECK-LABEL: fir.global @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
+  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
+  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
+  ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], %c1{{.*}} : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32, index) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
+  ! CHECK: fir.has_value %[[init]] : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
+
+! Module defines variable in common block without initializer
+module modCommonNoInit1
+  ! Module variable is in blank common
+  real :: x_blank
+  common // x_blank
+  ! Module variable is in named common, no init
+  real :: x_named1
+  common /named1/ x_named1
+end module
+! CHECK-LABEL: fir.global common @_QB(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+! CHECK-LABEL: fir.global common @_QBnamed1(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+
+! Module defines variable in common block with initialization
+module modCommonInit1
+  integer :: i_named2 = 42
+  common /named2/ i_named2
+end module
+! CHECK-LABEL: fir.global @_QBnamed2 : tuple<i32> {
+  ! CHECK: %[[init:.*]] = fir.insert_value %{{.*}}, %c42{{.*}}, %c0{{.*}} : (tuple<i32>, i32, index) -> tuple<i32>
+  ! CHECK: fir.has_value %[[init]] : tuple<i32>

--- a/flang/test/Lower/module_use.f90
+++ b/flang/test/Lower/module_use.f90
@@ -1,0 +1,42 @@
+! RUN: bbc -emit-fir %S/module_definition.f90
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test use of module data not defined in this file.
+! The modules are defined in module_definition.f90
+! The first runs ensures the module file is generated.
+
+! CHECK-LABEL: func @_QPm1use()
+real function m1use()
+  use m1
+  ! CHECK-DAG: fir.address_of(@_QMm1Ex) : !fir.ref<f32>
+  ! CHECK-DAG: fir.address_of(@_QMm1Ey) : !fir.ref<!fir.array<100xi32>>
+  m1use = x + y(1)
+end function
+
+! TODO: test equivalences once front-end fix in module file is pushed.
+!! CHECK-LABEL func @_QPmodeq1use()
+!real function modEq1use()
+!  use modEq1
+!  ! CHECK-DAG fir.address_of(@_QMmodeq1Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+!  ! CHECK-DAG fir.address_of(@_QMmodeq1Ey1) : !fir.ref<tuple<!fir.array<16xi8>, !fir.array<24xi8>>>
+!  modEq1use = x2(1) + y1
+!end function
+! CHECK-DAG fir.global @_QMmodeq1Ex1 : tuple<!fir.array<36xi8>, !fir.array<40xi8>>
+! CHECK-DAG fir.global @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, !fir.array<24xi8>>
+
+! CHECK-LABEL: func @_QPmodcommon1use()
+real function modCommon1Use()
+  use modCommonInit1
+  use modCommonNoInit1
+  ! CHECK-DAG: fir.address_of(@_QBnamed2) : !fir.ref<!fir.array<4xi8>>
+  ! CHECK-DAG: fir.address_of(@_QB) : !fir.ref<!fir.array<4xi8>>
+  ! CHECK-DAG: fir.address_of(@_QBnamed1) : !fir.ref<!fir.array<4xi8>>
+  modCommon1Use = x_blank + x_named1 + i_named2 
+end function
+
+
+! CHECK-DAG: fir.global @_QMm1Ex : f32
+! CHECK-DAG: fir.global @_QMm1Ey : !fir.array<100xi32>
+! CHECK-DAG: fir.global common @_QBnamed2(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+! CHECK-DAG: fir.global common @_QB(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+! CHECK-DAG: fir.global common @_QBnamed1(dense<0> : vector<4xi8>) : !fir.array<4xi8>

--- a/flang/test/Lower/module_use_in_same_file.f90
+++ b/flang/test/Lower/module_use_in_same_file.f90
@@ -1,0 +1,122 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test use of module data that is defined in this file.
+! TODO: similar tests for the functions that are using the modules, but without the
+! module being defined in this file. This require a front-end fix to be pushed first
+! so
+
+! Module m2 defines simple data
+module m2
+  real :: x
+  integer :: y(100)
+contains
+  ! CHECK-LABEL: func @_QMm2Pfoo()
+  real function foo()
+    ! CHECK-DAG: fir.address_of(@_QMm2Ex) : !fir.ref<f32>
+    ! CHECK-DAG: fir.address_of(@_QMm2Ey) : !fir.ref<!fir.array<100xi32>>
+    foo = x + y(1)
+  end function
+end module
+! CHECK-LABEL: func @_QPm2use()
+real function m2use()
+  use m2
+  ! CHECK-DAG: fir.address_of(@_QMm2Ex) : !fir.ref<f32>
+  ! CHECK-DAG: fir.address_of(@_QMm2Ey) : !fir.ref<!fir.array<100xi32>>
+  m2use = x + y(1)
+end function
+! Test renaming
+! CHECK-LABEL: func @_QPm2use_rename()
+real function m2use_rename()
+  use m2, only: renamedx => x
+  ! CHECK-DAG: fir.address_of(@_QMm2Ex) : !fir.ref<f32>
+  m2use_rename = renamedx
+end function
+
+! Module modEq2 defines data that is equivalenced
+module modEq2
+  ! Equivalence, no initialization
+  real :: x1(10), x2(10), x3(10) 
+  ! Equivalence with initialization
+  real :: y1 = 42.
+  real :: y2(10)
+  equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
+contains
+  ! CHECK-LABEL: func @_QMmodeq2Pfoo()
+  real function foo()
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+    foo = x2(1) + y1
+  end function
+end module
+! CHECK-LABEL: func @_QPmodeq2use()
+real function modEq2use()
+  use modEq2
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  modEq2use = x2(1) + y1
+end function
+! Test rename of used equivalence members
+! CHECK-LABEL: func @_QPmodeq2use_rename()
+real function modEq2use_rename()
+  use modEq2, only: renamedx => x2, renamedy => y1
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  modEq2use = renamedx(1) + renamedy
+end function
+
+
+! Module defines variable in common block
+module modCommon2
+  ! Module variable is in blank common
+  real :: x_blank
+  common // x_blank
+  ! Module variable is in named common, no init
+  real :: x_named1(10)
+  common /named1/ x_named1
+  ! Module variable is in named common, with init
+  integer :: i_named2 = 42
+  common /named2/ i_named2
+contains
+  ! CHECK-LABEL: func @_QMmodcommon2Pfoo()
+  real function foo()
+   ! CHECK-DAG: fir.address_of(@_QBnamed2) : !fir.ref<tuple<i32>>
+   ! CHECK-DAG: fir.address_of(@_QB) : !fir.ref<!fir.array<4xi8>>
+   ! CHECK-DAG: fir.address_of(@_QBnamed1) : !fir.ref<!fir.array<40xi8>>
+   foo = x_blank + x_named1(5) + i_named2
+  end function
+end module
+! CHECK-LABEL: func @_QPmodcommon2use()
+real function modCommon2use()
+ use modCommon2
+ ! CHECK-DAG: fir.address_of(@_QBnamed2) : !fir.ref<tuple<i32>>
+ ! CHECK-DAG: fir.address_of(@_QB) : !fir.ref<!fir.array<4xi8>>
+ ! CHECK-DAG: fir.address_of(@_QBnamed1) : !fir.ref<!fir.array<40xi8>>
+ modCommon2use = x_blank + x_named1(5) + i_named2
+end function
+! CHECK-LABEL: func @_QPmodcommon2use_rename()
+real function modCommon2use_rename()
+ use modCommon2, only : renamed0 => x_blank, renamed1 => x_named1, renamed2 => i_named2
+ ! CHECK-DAG: fir.address_of(@_QBnamed2) : !fir.ref<tuple<i32>>
+ ! CHECK-DAG: fir.address_of(@_QB) : !fir.ref<!fir.array<4xi8>>
+ ! CHECK-DAG: fir.address_of(@_QBnamed1) : !fir.ref<!fir.array<40xi8>>
+ modCommon2use_rename = renamed0 + renamed1(5) + renamed2
+end function
+
+
+! Test that there are no conflicts between equivalence use associated and the ones
+! from the scope
+real function test_no_equiv_conflicts()
+  use modEq2
+  ! Same equivalences as in modEq2. Test that lowering does not mixes
+  ! up the equivalence based on the similar offset inside the scope.
+  real :: x1l(10), x2l(10), x3l(10) 
+  real :: y1l = 42.
+  real :: y2l(10)
+  save :: x1l, x2l, x3l, y1l, y2l
+  equivalence (x1l(1), x2l(5), x3l(10)), (y1l, y2l(5))
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEx1l) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEy1l) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  test_no_equiv_conflicts = x2(1) + y1 + x2l(1) + y1l
+end function


### PR DESCRIPTION
All the work done in this patch is around module variables since module procedure were already mangled OK and have nothing special in lowering, apart that they can access module data.

In PFT variables:
- add isDeclaration() to indicate if the scope is using a variable that
it does not own (because it is in a module for instance).
- ramp-up the alias analysis to take into account equivalences imported
 from used modules.

In the bridge:
- split instantiateGlobal function into: declareGlobal, defineGlobal,
  instantiateGlobal.
- split instantiateAggregateStore functions into: declareGlobalAggregateStore,
  defineGlobalAggregateStore, and instantiateAggregateStore
- split instantiateCommon into: defineCommon, and, instantiateCommon.

"declareXX" is meant to be used to create global op for a variable that
is defined in another file (not owned by any of the scopes being lowered).
"defineXX" is meant to be used to create global op for a variable defined
in this file.
"instantiateXX" is meant to create a SymbolBox and add it into the
symbol map. It may call declareXX or defineXX if the globalOp needed
to build the symbol address does not exit yet.

Common blocks only have a defineXX method because one cannot say if they
don't belong to any scope. The common linkage ensure this is not an
issue.

I took the opportunity to organize all the code instantiating variables
to make upstream review easier.

Note: a front-end fix will be pushed in LLVM to make the use side of
equivalenced module data not defined in the file working.
Submodules need testing.