### PR TITLE
[flang][openacc] Fix self clause lowering for parallel and parallel loop

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -407,6 +407,21 @@ createParallelOp(Fortran::lower::AbstractConverter &converter,
         } else {
           addSelfAttr = true;
         }
+      } else if (const auto *accClauseList =
+                     std::get_if<Fortran::parser::AccObjectList>(
+                         &accSelfClause.u)) {
+        // TODO This would be nicer to be done in canonicalization step.
+        if (accClauseList->v.size() == 1) {
+          const auto &accObject = accClauseList->v.front();
+          if (const auto *designator = std::get_if<Fortran::parser::Designator>(
+                  &accObject.u)) {
+            if (const auto *name = getDesignatorNameIfDataRef(*designator)) {
+              auto cond = converter.getSymbolAddress(*name->symbol);
+              selfCond = firOpBuilder.createConvert(currentLocation,
+                                                firOpBuilder.getI1Type(), cond);
+            }
+          }
+        }
       }
     } else if (const auto *copyClause =
                    std::get_if<Fortran::parser::AccClause::Copy>(&clause.u)) {

--- a/flang/test/Lower/OpenACC/acc-parallel-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel-loop.f90
@@ -24,6 +24,7 @@ subroutine acc_parallel_loop
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[IFCONDITION:%.*]] = fir.address_of(@{{.*}}ifcondition) : !fir.ref<!fir.logical<4>>
 
   !$acc parallel loop
   DO i = 1, n
@@ -282,8 +283,7 @@ subroutine acc_parallel_loop
     a(i) = b(i)
   END DO
 
-!CHECK:      [[SELFCOND:%.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
-!CHECK:      [[SELF2:%.*]] = fir.convert [[SELFCOND]] : (!fir.logical<4>) -> i1
+!CHECK:      [[SELF2:%.*]] = fir.convert [[IFCONDITION]] : (!fir.ref<!fir.logical<4>>) -> i1
 !CHECK:      acc.parallel self([[SELF2]]) {
 !CHECK:        acc.loop {
 !CHECK:          fir.do_loop

--- a/flang/test/Lower/OpenACC/acc-parallel.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel.f90
@@ -17,6 +17,7 @@ subroutine acc_parallel
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[IFCONDITION:%.*]] = fir.address_of(@{{.*}}ifcondition) : !fir.ref<!fir.logical<4>>
 
   !$acc parallel
   !$acc end parallel
@@ -164,8 +165,7 @@ subroutine acc_parallel
   !$acc parallel self(ifCondition)
   !$acc end parallel
 
-!CHECK:      [[SELFCOND:%.*]] = fir.load %{{.*}} : !fir.ref<!fir.logical<4>>
-!CHECK:      [[SELF2:%.*]] = fir.convert [[SELFCOND]] : (!fir.logical<4>) -> i1
+!CHECK:      [[SELF2:%.*]] = fir.convert [[IFCONDITION]] : (!fir.ref<!fir.logical<4>>) -> i1
 !CHECK:      acc.parallel self([[SELF2]]) {
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}


### PR DESCRIPTION
This is a quick fix for the lowering of `self` clause on `parallel` and `parallel loop` directives after rebase. 