### PR TITLE
Fix local character array lowering

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -102,6 +102,7 @@ public:
   mlir::Value allocateLocal(mlir::Location loc, mlir::Type ty,
                             llvm::StringRef nm,
                             llvm::ArrayRef<mlir::Value> shape,
+                            llvm::ArrayRef<mlir::Value> lenParams,
                             bool asTarget = false);
 
   /// Create a temporary. A temp is allocated using `fir.alloca` and can be read

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -332,7 +332,8 @@ Fortran::lower::CharacterExprHelper::createCharacterTemp(mlir::Type type,
   llvm::SmallVector<mlir::Value, 1> lenParams;
   if (typeLen == fir::CharacterType::unknownLen())
     lenParams.push_back(len);
-  auto ref = builder.allocateLocal(loc, charTy, llvm::StringRef{}, lenParams);
+  auto ref = builder.allocateLocal(loc, charTy, llvm::StringRef{}, llvm::None,
+                                   lenParams);
   return {ref, len};
 }
 

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -95,9 +95,15 @@ mlir::Value Fortran::lower::FirOpBuilder::createRealConstant(
 
 mlir::Value Fortran::lower::FirOpBuilder::allocateLocal(
     mlir::Location loc, mlir::Type ty, llvm::StringRef nm,
-    llvm::ArrayRef<mlir::Value> shape, bool asTarget) {
+    llvm::ArrayRef<mlir::Value> shape, llvm::ArrayRef<mlir::Value> lenParams,
+    bool asTarget) {
   llvm::SmallVector<mlir::Value, 8> indices;
   auto idxTy = getIndexType();
+  // FIXME: AllocaOp has a lenParams argument, but it is ignored, so add lengths
+  // into the index so far (for characters, that works OK).
+  llvm::for_each(lenParams, [&](mlir::Value sh) {
+    indices.push_back(createConvert(loc, idxTy, sh));
+  });
   llvm::for_each(shape, [&](mlir::Value sh) {
     indices.push_back(createConvert(loc, idxTy, sh));
   });

--- a/flang/test/Lower/character-local-variables.f90
+++ b/flang/test/Lower/character-local-variables.f90
@@ -1,0 +1,53 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! Test lowering of local character variables
+
+! CHECK-LABEL: func @_QPscalar_cst_len
+subroutine scalar_cst_len()
+  character(10) :: c
+  ! CHECK: fir.alloca !fir.char<1,10> {name = "_QFscalar_cst_lenEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPscalar_dyn_len
+subroutine scalar_dyn_len(l)
+  integer :: l
+  character(l) :: c
+  ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
+  ! CHECK: fir.alloca !fir.char<1,?>, %[[li]] {name = "_QFscalar_dyn_lenEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_array_cst_len
+subroutine cst_array_cst_len()
+  character(10) :: c(20)
+  ! CHECK: fir.alloca !fir.array<20x!fir.char<1,10>> {name = "_QFcst_array_cst_lenEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_array_dyn_len
+subroutine cst_array_dyn_len(l)
+  integer :: l
+  character(l) :: c
+  ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
+  ! CHECK: fir.alloca !fir.char<1,?>, %[[li]] {name = "_QFcst_array_dyn_lenEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPdyn_array_cst_len
+subroutine dyn_array_cst_len(n)
+  integer :: n
+  character(10) :: c(n)
+  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[ni]] {name = "_QFdyn_array_cst_lenEc"}
+end subroutine
+
+! CHECK: func @_QPdyn_array_dyn_len
+subroutine dyn_array_dyn_len(l, n)
+  integer :: l, n
+  character(l) :: c(n)
+  ! CHECK-DAG: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
+  ! CHECK-DAG: %[[n:.*]] = fir.load %arg1 : !fir.ref<i32>
+  ! CHECK-DAG: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>, %[[li]], %[[ni]] {name = "_QFdyn_array_dyn_lenEc"}
+end subroutine


### PR DESCRIPTION
`createNewLocal` was used to build character arrays without considering the dynamic lengths.
Upgarde `createNewLocal` and `FirOpBuilder::allocateLocal` to take an array of lengths
parameter.
For now, merge the lengths and the shape in allcoateLocal because fir::AllocaOp is ignoring it lengths arguments (fixme added).
Remove usage of createCharacterTemp in variable lowering (use createNewLocal instead) to make character processing similar in all cases and to have the variable name in the allocaOp.