### PR TITLE
Associate constructs

### DIFF
--- a/flang/test/Lower/associate.f90
+++ b/flang/test/Lower/associate.f90
@@ -1,0 +1,27 @@
+! RUN: bbc %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
+! RUN: %CC %t.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm -o %t.out
+! RUN: %t.out | FileCheck %s
+
+program p
+  integer :: n, foo
+  n = 0
+  associate (i => n, j => n + 10, k => foo(20))
+!   CHECK: 0 0 10 20
+    print*, n, i, j, k
+    n = n + 1
+!   CHECK: 1 1 10 20
+    print*, n, i, j, k
+    i = i + 1
+!   CHECK: 2 2 10 20
+    print*, n, i, j, k
+  end associate
+! CHECK: 2
+  print*, n
+end
+
+integer function foo(x)
+  integer x
+  integer, save :: i = 0
+  i = i + x
+  foo = i
+end function foo


### PR DESCRIPTION
Implement associate construct associations where the associating entity
is assigned the value of the selector expression, or is an alias of a
whole selector variable.  Associations where the associating entity is
an alias of a subobject of a selector variable are related to pointer
assignments, and are not yet implemented.  Generated code for
associations such as "associate (b => a, a => b)" will be incorrect
pending a front end fix.

See F18 Clause 19.5.1.6p3