### PR TITLE
Removes an old bit of workaround code from the MLIR tree that appears…

### DIFF
--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -606,11 +606,8 @@ bool OperationEquivalence::isEquivalentTo(Operation *lhs, Operation *rhs,
   }
   // Compare operands.
   bool ignoreOperands = flags & Flags::IgnoreOperands;
-  if (ignoreOperands) {
-    // Ignore the operand values, but cannot ignore their types.
-    return std::equal(lhs->operand_type_begin(), lhs->operand_type_end(),
-                      rhs->operand_type_begin());
-  }
+  if (ignoreOperands)
+    return true;
   // TODO: Allow commutative operations to have different ordering.
   return std::equal(lhs->operand_begin(), lhs->operand_end(),
                     rhs->operand_begin());


### PR DESCRIPTION
… to be no longer needed.

This change makes this file harmonious with llvm-project.