### PR TITLE
Add OpenMP conversion patterns

### DIFF
--- a/flang/lib/Optimizer/CMakeLists.txt
+++ b/flang/lib/Optimizer/CMakeLists.txt
@@ -39,6 +39,7 @@ add_flang_library(FIROptimizer
 
   LINK_LIBS
   ${dialect_libs}
+  MLIROpenMPToLLVM
   MLIRTargetLLVMIR
   MLIRTargetLLVMIRModuleTranslation
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2630,7 +2630,7 @@ struct FIRToLLVMLoweringPass
     // The OpenMP dialect is legal for Operations without regions, for those
     // which contains regions it is legal if the region contains only the
     // LLVM dialect.
-    target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
+    target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp, omp::MasterOp>(
         [&](Operation *op) {
           return typeConverter.isLegal(&op->getRegion(0));
         });

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -23,6 +23,7 @@
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/KindMapping.h"
 #include "flang/Optimizer/Support/TypeCode.h"
+#include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -2623,8 +2624,16 @@ struct FIRToLLVMLoweringPass
         UnboxProcOpConversion, UndefOpConversion, UnreachableOpConversion,
         XArrayCoorOpConversion, XEmboxOpConversion>(context, typeConverter);
     mlir::populateStdToLLVMConversionPatterns(typeConverter, pattern);
+    mlir::populateOpenMPToLLVMConversionPatterns(typeConverter, pattern);
     mlir::ConversionTarget target{*context};
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+    // The OpenMP dialect is legal for Operations without regions, for those
+    // which contains regions it is legal if the region contains only the
+    // LLVM dialect.
+    target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
+        [&](Operation *op) {
+          return typeConverter.isLegal(&op->getRegion(0));
+        });
     target.addLegalDialect<mlir::omp::OpenMPDialect>();
 
     // required NOPs for applying a full conversion

--- a/flang/test/Lower/OpenMP/omp-parallel-with-loop.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-with-loop.f90
@@ -1,0 +1,39 @@
+! This test checks lowering of OpenMP parallel Directive with a loop inside.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp -emit-llvm %s -o - | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco | FileCheck %s --check-prefix=LLVMIR
+
+
+program main
+!$OMP PARALLEL
+      do i = 2, 5
+      end do
+!$OMP END PARALLEL
+end
+!FIRDialect: omp.parallel {
+!FIRDialect: omp.terminator
+!FIRDialect-NEXT: }
+
+!LLVMIRDialect: omp.parallel {
+!LLVMIRDialect:   ^[[BB1:.*]]({{.*}}):
+!LLVMIRDialect:     %[[COND:.*]] = llvm.icmp "sgt" {{.*}}
+!LLVMIRDialect:     llvm.cond_br %[[COND]], ^[[BB2:.*]], ^[[BB3:.*]]
+!LLVMIRDialect:   ^[[BB2]]:
+!LLVMIRDialect:     llvm.br ^[[BB1]]({{.*}})
+!LLVMIRDialect:   ^[[BB3]]:
+!LLVMIRDialect:   omp.terminator
+!LLVMIRDialect: }
+
+!LLVMIR: call {{.*}} @__kmpc_fork_call(%struct.ident_t* @{{.*}} @_QQmain..omp_par
+!LLVMIR: define internal void @_QQmain..omp_par{{.*}} {
+!LLVMIR: [[BB1:.*]]: ; preds = %{{.*}}, %{{.*}}
+!LLVMIR:   %[[COND:.*]] = icmp sgt i64 {{.*}}
+!LLVMIR-NEXT:   br i1 %[[COND]], label %[[BB2:.*]], label %[[BB3:.*]],
+!LLVMIR: [[BB3]]:
+!LLVMIR: [[BB2]]:
+!LLVMIR:   br label %[[BB1]]
+!LLVMIR: }


### PR DESCRIPTION
OpenMP Dialect operations with regions containing basicblock arguments
require conversion patterns to legalize. This patch populates those
patterns and modifies the legalization criteria. A test is also included.

Fixes #454