### PR TITLE
Lower non contiguous dummies and CONTIGUOUS keyword

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -126,6 +126,10 @@ public:
   /// FirPlaceHolder are place holders for the mlir inputs and outputs that are
   /// created during the first pass before the mlir::FuncOp is created.
   struct FirPlaceHolder {
+    FirPlaceHolder(mlir::Type t, int passedPosition, Property p,
+                   llvm::ArrayRef<mlir::NamedAttribute> attrs)
+        : type{t}, passedEntityPosition{passedPosition}, property{p},
+          attributes{attrs.begin(), attrs.end()} {}
     /// Type for this input/output
     mlir::Type type;
     /// Position of related passedEntity in passedArguments.
@@ -135,6 +139,8 @@ public:
     /// Indicate property of the entity passedEntityPosition that must be passed
     /// through this argument.
     Property property;
+    /// MLIR attributes for this argument
+    llvm::SmallVector<mlir::NamedAttribute, 1> attributes;
   };
 
   /// PassedEntity is what is provided back to the CallInterface user.

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -115,7 +115,7 @@ public:
 
   /// If the entity is described by a box (e.g. it is a dummy, allocatable, or
   /// pointer) The information in the source box that is also present in other
-  /// fields (e.g the extents) is the same, except the lower bounds of the
+  /// fields (e.g. the extents) is the same, except the lower bounds of the
   /// sourceBox that should be ignored.
   mlir::Value getSourceBox() const { return sourceBox; }
 

--- a/flang/include/flang/Optimizer/CodeGen/CGOps.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGOps.td
@@ -101,6 +101,8 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
          the element of the array to be computed.
        - LEN type parameters: A vector of runtime LEN type parameters that
          describe an correspond to the elemental derived type.
+       - Source box: a box describing the memory layout if the underlying array
+         is not contiguous (e.g pointer or assumed shape dummy). 
 
     The memref, shape, and indices arguments are mandatory. The rest are
     optional.
@@ -113,13 +115,15 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
     Variadic<AnyIntegerType>:$slice,
     Variadic<AnyCoordinateType>:$subcomponent,
     Variadic<AnyCoordinateType>:$indices,
-    Variadic<AnyIntegerType>:$lenParams
+    Variadic<AnyIntegerType>:$lenParams,
+    Optional<fir_BoxType>:$sourceBox
   );
   let results = (outs fir_ReferenceType);
 
   let assemblyFormat = [{
     $memref (`(`$shape^`)`)? (`origin` $shift^)? (`[`$slice^`]`)?
       (`path` $subcomponent^)? `<`$indices`>` (`typeparams` $lenParams^)?
+      (`sourcebox` $sourceBox^)?
       attr-dict `:` functional-type(operands, results)
   }];
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1569,7 +1569,7 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins
-    Arg<AnyReferenceLike, "", [MemRead]>:$memref,
+    Arg<AnyRefOrBox, "", [MemRead]>:$memref,
     Optional<AnyShapeType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyIntegerType>:$lenParams
@@ -1699,10 +1699,10 @@ def fir_ArrayUpdateOp : fir_Op<"array_update", [NoSideEffect]> {
 def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
     TypesMatchWith<"type of 'original' matches element type of 'memref'",
                      "memref", "original",
-                     "fir::dyn_cast_ptrEleTy($_self)">,
+                     "fir::dyn_cast_ptrOrBoxEleTy($_self)">,
     TypesMatchWith<"type of 'sequence' matches element type of 'memref'",
                      "memref", "sequence",
-                     "fir::dyn_cast_ptrEleTy($_self)">]> {
+                     "fir::dyn_cast_ptrOrBoxEleTy($_self)">]> {
 
   let summary = "Store merged array value to memory.";
 
@@ -1731,7 +1731,7 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
   let arguments = (ins
     fir_SequenceType:$original,
     fir_SequenceType:$sequence,
-    Arg<AnyReferenceLike, "", [MemWrite]>:$memref
+    Arg<AnyRefOrBox, "", [MemWrite]>:$memref
   );
 
   let assemblyFormat = "$original `,` $sequence `to` $memref attr-dict `:` type($memref)";
@@ -1775,7 +1775,7 @@ def fir_ArrayCoorOp : fir_Op<"array_coor",
   }];
 
   let arguments = (ins
-    AnyReferenceLike:$memref,
+    AnyRefOrBox:$memref,
     Optional<AnyShapeType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyCoordinateType>:$indices,

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -59,6 +59,19 @@ fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
                              llvm::StringRef name, mlir::Type type,
                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
+/// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
+inline llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
+
+/// Tell if \p value is:
+///   - a function argument that has attribute \p attributeName
+///   - or, the result of fir.alloca/fir.allocamem op that has attribute \p
+///   attributeName.
+///   - or, the result of a fir.address_of of a fir.global that has attribute \p
+///   attributeName
+///   - or, a fir.box loaded from a fir.ref<fir.box> that matches on of the
+///   previous cases.
+bool valueHasFirAttribute(mlir::Value value, llvm::StringRef attributeName);
+
 } // namespace fir
 
 #endif // OPTIMIZER_DIALECT_FIROPSSUPPORT_H

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -68,7 +68,7 @@ inline llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
 ///   attributeName.
 ///   - or, the result of a fir.address_of of a fir.global that has attribute \p
 ///   attributeName
-///   - or, a fir.box loaded from a fir.ref<fir.box> that matches on of the
+///   - or, a fir.box loaded from a fir.ref<fir.box> that matches one of the
 ///   previous cases.
 bool valueHasFirAttribute(mlir::Value value, llvm::StringRef attributeName);
 

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -97,6 +97,10 @@ bool isa_aggregate(mlir::Type t);
 /// not a memory reference type, then returns a null `Type`.
 mlir::Type dyn_cast_ptrEleTy(mlir::Type t);
 
+/// Extract the `Type` pointed to from a FIR memory reference or box type. If
+/// `t` is not a memory reference or box type, then returns a null `Type`.
+mlir::Type dyn_cast_ptrOrBoxEleTy(mlir::Type t);
+
 // Intrinsic types
 
 /// Model of the Fortran CHARACTER intrinsic type, including the KIND type
@@ -185,13 +189,17 @@ class BoxType
     : public mlir::Type::TypeBase<BoxType, mlir::Type, detail::BoxTypeStorage> {
 public:
   using Base::Base;
-  static BoxType get(mlir::Type eleTy, mlir::AffineMapAttr map = {});
+  static BoxType get(mlir::Type eleTy, bool isContiguous = false,
+                     mlir::AffineMapAttr map = {});
   mlir::Type getEleTy() const;
+  /// Does this describe an entity that is known to be contiguous at compile
+  /// time ?
+  bool isContiguous() const;
   mlir::AffineMapAttr getLayoutMap() const;
 
   static mlir::LogicalResult
   verifyConstructionInvariants(mlir::Location, mlir::Type eleTy,
-                               mlir::AffineMapAttr map);
+                               bool isContiguous, mlir::AffineMapAttr map);
 };
 
 /// The type of a pair that describes a CHARACTER variable. Specifically, a

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2586,7 +2586,8 @@ private:
               shape.push_back(builder->createIntegerConstant(loc, idxTy, i));
             mlir::Value local =
                 replace ? addr : createNewLocal(loc, var, preAlloc);
-            localSymbols.addSymbolWithShape(sym, local, shape, replace);
+            localSymbols.addSymbolWithShape(
+                sym, local, shape, /*sourceBox*/ mlir::Value{}, replace);
             return;
           }
           // If object is an array process the lower bound and extent values by
@@ -2604,6 +2605,7 @@ private:
           assert(replace || Fortran::lower::isExplicitShape(sym) ||
                  Fortran::semantics::IsAllocatableOrPointer(sym));
           localSymbols.addSymbolWithBounds(sym, local, extents, lbounds,
+                                           /*sourceBox*/ mlir::Value{},
                                            replace);
         },
 
@@ -2628,7 +2630,8 @@ private:
             llvm::SmallVector<mlir::Value, 8> shapes;
             populateShape(shapes, x.bounds, argBox);
             if (isDummy || isResult) {
-              localSymbols.addSymbolWithShape(sym, addr, shapes, true);
+              localSymbols.addSymbolWithShape(sym, addr, shapes,
+                                              /*sourceBox*/ argBox, true);
               return;
             }
             // local array with computed bounds
@@ -2643,7 +2646,8 @@ private:
           llvm::SmallVector<mlir::Value, 8> lbounds;
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
-            localSymbols.addSymbolWithBounds(sym, addr, extents, lbounds, true);
+            localSymbols.addSymbolWithBounds(sym, addr, extents, lbounds,
+                                             /*sourceBox*/ argBox, true);
             return;
           }
           // local array with computed bounds
@@ -2683,8 +2687,8 @@ private:
               shape.push_back(builder->createIntegerConstant(loc, idxTy, i));
             mlir::Value local =
                 replace ? addr : createNewLocal(loc, var, preAlloc);
-            localSymbols.addCharSymbolWithShape(sym, local, len, shape,
-                                                replace);
+            localSymbols.addCharSymbolWithShape(
+                sym, local, len, shape, /*sourceBox*/ mlir::Value{}, replace);
             return;
           }
 
@@ -2700,8 +2704,9 @@ private:
           }
 
           if (isDummy || isResult) {
-            localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
-                                                 lbounds, true);
+            localSymbols.addCharSymbolWithBounds(
+                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                true);
             return;
           }
           // local CHARACTER array with computed bounds
@@ -2753,7 +2758,8 @@ private:
             for (auto i : x.shapes)
               shape.push_back(builder->createIntegerConstant(loc, idxTy, i));
             if (isDummy || isResult) {
-              localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
+              localSymbols.addCharSymbolWithShape(
+                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
               return;
             }
             // local CHARACTER array with constant size
@@ -2775,8 +2781,9 @@ private:
                 builder->createIntegerConstant(loc, idxTy, snd));
           }
           if (isDummy || isResult) {
-            localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
-                                                 lbounds, true);
+            localSymbols.addCharSymbolWithBounds(
+                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                true);
             return;
           }
           // local CHARACTER array with computed bounds
@@ -2821,7 +2828,8 @@ private:
             llvm::SmallVector<mlir::Value, 8> shape;
             populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
-              localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
+              localSymbols.addCharSymbolWithShape(
+                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
               return;
             }
             // local CHARACTER array
@@ -2834,8 +2842,9 @@ private:
           llvm::SmallVector<mlir::Value, 8> lbounds;
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
-            localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
-                                                 lbounds, true);
+            localSymbols.addCharSymbolWithBounds(
+                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                true);
             return;
           }
           // local CHARACTER array with computed bounds
@@ -2895,7 +2904,8 @@ private:
             llvm::SmallVector<mlir::Value, 8> shape;
             populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
-              localSymbols.addCharSymbolWithShape(sym, addr, len, shape, true);
+              localSymbols.addCharSymbolWithShape(
+                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
               return;
             }
             // local CHARACTER array
@@ -2908,8 +2918,9 @@ private:
           llvm::SmallVector<mlir::Value, 8> lbounds;
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
-            localSymbols.addCharSymbolWithBounds(sym, addr, len, extents,
-                                                 lbounds, true);
+            localSymbols.addCharSymbolWithBounds(
+                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                true);
             return;
           }
           // local CHARACTER array with computed bounds

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2587,7 +2587,7 @@ private:
             mlir::Value local =
                 replace ? addr : createNewLocal(loc, var, preAlloc);
             localSymbols.addSymbolWithShape(
-                sym, local, shape, /*sourceBox*/ mlir::Value{}, replace);
+                sym, local, shape, /*sourecBox=*/mlir::Value{}, replace);
             return;
           }
           // If object is an array process the lower bound and extent values by
@@ -2605,7 +2605,7 @@ private:
           assert(replace || Fortran::lower::isExplicitShape(sym) ||
                  Fortran::semantics::IsAllocatableOrPointer(sym));
           localSymbols.addSymbolWithBounds(sym, local, extents, lbounds,
-                                           /*sourceBox*/ mlir::Value{},
+                                           /*sourecBox=*/mlir::Value{},
                                            replace);
         },
 
@@ -2631,7 +2631,7 @@ private:
             populateShape(shapes, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addSymbolWithShape(sym, addr, shapes,
-                                              /*sourceBox*/ argBox, true);
+                                              /*sourecBox=*/argBox, true);
               return;
             }
             // local array with computed bounds
@@ -2647,7 +2647,7 @@ private:
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addSymbolWithBounds(sym, addr, extents, lbounds,
-                                             /*sourceBox*/ argBox, true);
+                                             /*sourecBox=*/argBox, true);
             return;
           }
           // local array with computed bounds
@@ -2688,7 +2688,7 @@ private:
             mlir::Value local =
                 replace ? addr : createNewLocal(loc, var, preAlloc);
             localSymbols.addCharSymbolWithShape(
-                sym, local, len, shape, /*sourceBox*/ mlir::Value{}, replace);
+                sym, local, len, shape, /*sourecBox=*/mlir::Value{}, replace);
             return;
           }
 
@@ -2705,7 +2705,7 @@ private:
 
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(
-                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                sym, addr, len, extents, lbounds, /*sourecBox=*/mlir::Value{},
                 true);
             return;
           }
@@ -2759,7 +2759,7 @@ private:
               shape.push_back(builder->createIntegerConstant(loc, idxTy, i));
             if (isDummy || isResult) {
               localSymbols.addCharSymbolWithShape(
-                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
+                  sym, addr, len, shape, /*sourecBox=*/mlir::Value{}, true);
               return;
             }
             // local CHARACTER array with constant size
@@ -2782,7 +2782,7 @@ private:
           }
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(
-                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                sym, addr, len, extents, lbounds, /*sourecBox=*/mlir::Value{},
                 true);
             return;
           }
@@ -2829,7 +2829,7 @@ private:
             populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addCharSymbolWithShape(
-                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
+                  sym, addr, len, shape, /*sourecBox=*/mlir::Value{}, true);
               return;
             }
             // local CHARACTER array
@@ -2843,7 +2843,7 @@ private:
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(
-                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                sym, addr, len, extents, lbounds, /*sourecBox=*/mlir::Value{},
                 true);
             return;
           }
@@ -2905,7 +2905,7 @@ private:
             populateShape(shape, x.bounds, argBox);
             if (isDummy || isResult) {
               localSymbols.addCharSymbolWithShape(
-                  sym, addr, len, shape, /*sourceBox*/ mlir::Value{}, true);
+                  sym, addr, len, shape, /*sourecBox=*/mlir::Value{}, true);
               return;
             }
             // local CHARACTER array
@@ -2919,7 +2919,7 @@ private:
           populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
           if (isDummy || isResult) {
             localSymbols.addCharSymbolWithBounds(
-                sym, addr, len, extents, lbounds, /*sourceBox*/ mlir::Value{},
+                sym, addr, len, extents, lbounds, /*sourecBox=*/mlir::Value{},
                 true);
             return;
           }

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -234,7 +234,6 @@ void Fortran::lower::CallInterface<T>::declare() {
       for (const auto &placeHolder : llvm::enumerate(inputs))
         if (!placeHolder.value().attributes.empty())
           func.setArgAttrs(placeHolder.index(), placeHolder.value().attributes);
-      // for (const auto &placeHolder : outputs)
     }
   }
 }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1218,7 +1218,7 @@ public:
             return genAllocatableOrPointerUnbox(x);
           },
           [](const auto &x) -> Fortran::lower::SymbolBox { return x; });
-      if (!si.hasConstantShape() && si.isContiugous())
+      if (!si.hasConstantShape() && si.isContiguous())
         return gen(si, aref);
       auto box = gen(symbol);
       auto memref = box.getMemRef();

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -129,6 +129,36 @@ convertOptExtentExpr(Fortran::lower::AbstractConverter &converter,
   return fir::getBase(converter.genExprValue(&e, stmtCtx, loc));
 }
 
+static mlir::Value getLBoundOrDefault(mlir::Location loc,
+                                      const fir::ExtendedValue &exv,
+                                      mlir::Value one, unsigned dim) {
+  auto getLBound = [&](const fir::AbstractArrayBox &v) -> mlir::Value {
+    auto &lbounds = v.getLBounds();
+    if (lbounds.empty())
+      return one;
+    return lbounds[dim];
+  };
+  return exv.match(
+      [&](const fir::ArrayBoxValue &v) { return getLBound(v); },
+      [&](const fir::CharArrayBoxValue &v) { return getLBound(v); },
+      [&](const fir::BoxValue &v) { return getLBound(v); },
+      [&](auto) -> mlir::Value { fir::emitFatalError(loc, "expected array"); });
+}
+static mlir::Value getExtent(mlir::Location loc, const fir::ExtendedValue &exv,
+                             unsigned dim) {
+  auto getExtentImpl = [&](const fir::AbstractArrayBox &v) -> mlir::Value {
+    if (v.getExtents().size() < dim + 1)
+      fir::emitFatalError(loc,
+                          "inquiring extent in dimension bigger than the rank");
+    return v.getExtents()[dim];
+  };
+  return exv.match(
+      [&](const fir::ArrayBoxValue &v) { return getExtentImpl(v); },
+      [&](const fir::CharArrayBoxValue &v) { return getExtentImpl(v); },
+      [&](const fir::BoxValue &v) { return getExtentImpl(v); },
+      [&](auto) -> mlir::Value { fir::emitFatalError(loc, "expected array"); });
+}
+
 namespace {
 
 /// Lowering of Fortran::evaluate::Expr<T> expressions
@@ -367,13 +397,38 @@ public:
   }
 
   fir::ExtendedValue genval(const Fortran::evaluate::DescriptorInquiry &desc) {
-    auto symBox = symMap.lookupSymbol(desc.base().GetLastSymbol());
-    assert(symBox && "no SymbolBox associated to Symbol");
+    // This gen(symbolref) call will read all properties from a descriptor into
+    // the ExtendedValue if they are not already kept in the symbol map (which
+    // is the case if they are not constant in the scope: e.g
+    // allocatables/pointers). So for allocatable/pointers, it will most likely
+    // generate reads of properties that are not inquired here, but that is OK
+    // because dead code elimination will remove these unused reads right after
+    // lowering.
+    auto exv = gen(desc.base().GetLastSymbol());
+    auto loc = getLoc();
     switch (desc.field()) {
     case Fortran::evaluate::DescriptorInquiry::Field::Len:
-      return symBox.getCharLen().getValue();
-    default:
-      TODO("descriptor inquiry other than length");
+      return exv.match(
+          [](const fir::CharBoxValue &x) { return x.getLen(); },
+          [](const fir::CharArrayBoxValue &x) { return x.getLen(); },
+          [loc](const auto &) -> mlir::Value {
+            fir::emitFatalError(
+                loc,
+                "len descriptor inquiry on an entity that is not a character");
+          });
+    case Fortran::evaluate::DescriptorInquiry::Field::LowerBound:
+      return getLBoundOrDefault(
+          loc, exv,
+          builder.createIntegerConstant(loc, builder.getIndexType(), 1),
+          desc.dimension());
+    case Fortran::evaluate::DescriptorInquiry::Field::Extent:
+      return getExtent(loc, exv, desc.dimension());
+    case Fortran::evaluate::DescriptorInquiry::Field::Rank:
+      fir::emitFatalError(getLoc(), "TODO: Rank DescriptorInquiry lowering");
+    case Fortran::evaluate::DescriptorInquiry::Field::Stride:
+      // Currently the front end is not generating this.
+      // Should it be removed from the front-end ?
+      fir::emitFatalError(getLoc(), "TODO: Stride DescriptorInquiry lowering");
     }
     llvm_unreachable("unknown descriptor inquiry");
   }
@@ -2093,24 +2148,6 @@ public:
   template <typename A>
   static const Fortran::semantics::Symbol *extractSubscriptSymbol(const A &x) {
     return nullptr;
-  }
-
-  static mlir::Value getLBoundOrDefault(mlir::Location loc,
-                                        const fir::ExtendedValue &exv,
-                                        mlir::Value one, unsigned dim) {
-    auto getLBound = [&](const fir::AbstractArrayBox &v) -> mlir::Value {
-      auto &lbounds = v.getLBounds();
-      if (lbounds.empty())
-        return one;
-      return lbounds[dim];
-    };
-    return exv.match(
-        [&](const fir::ArrayBoxValue &v) { return getLBound(v); },
-        [&](const fir::CharArrayBoxValue &v) { return getLBound(v); },
-        [&](const fir::BoxValue &v) { return getLBound(v); },
-        [&](auto) -> mlir::Value {
-          fir::emitFatalError(loc, "expected array");
-        });
   }
 
   /// Array reference with subscripts. Since this has rank > 0, this is a form

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -154,8 +154,8 @@ struct SymbolBox : public fir::details::matcher<SymbolBox> {
     return false;
   }
 
-  /// Does the boxed value have a contiguous memory layout
-  bool isContiugous() const {
+  /// Does the boxed value have a contiguous memory layout?
+  bool isContiguous() const {
     return match(
         [](const FullDim &box) { return box.isContiguous(); },
         [](const CharFullDim &box) { return box.isContiguous(); },

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -128,9 +128,9 @@ mlir::Type fir::AllocMemOp::wrapResultType(mlir::Type intype) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
   if (!eleTy)
-    return op.emitOpError("must be a reference type");
+    return op.emitOpError("must be a reference or box type");
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
@@ -174,9 +174,9 @@ std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
 }
 
 static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
   if (!eleTy)
-    return op.emitOpError("must be a reference type");
+    return op.emitOpError("must be a reference or box type");
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
@@ -1304,7 +1304,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&...additionalArgs) {
+                        AdditionalArgs &&... additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();
@@ -1902,6 +1902,47 @@ fir::GlobalOp fir::createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
   auto result = modBuilder.create<fir::GlobalOp>(loc, name, type, attrs);
   result.setVisibility(mlir::SymbolTable::Visibility::Private);
   return result;
+}
+
+bool fir::valueHasFirAttribute(mlir::Value value,
+                               llvm::StringRef attributeName) {
+  // If this is a fir.box that was loaded, the fir attributes will be on the
+  // related fir.ref<fir.box> creation.
+  if (value.getType().isa<fir::BoxType>())
+    if (auto definingOp = value.getDefiningOp())
+      if (auto loadOp = mlir::dyn_cast<fir::LoadOp>(definingOp))
+        value = loadOp.memref();
+  // If this is a function argument, look in the argument attributes.
+  if (auto blockArg = value.dyn_cast<mlir::BlockArgument>()) {
+    if (blockArg.getOwner() && blockArg.getOwner()->isEntryBlock())
+      if (auto funcOp =
+              mlir::dyn_cast<mlir::FuncOp>(blockArg.getOwner()->getParentOp()))
+        if (funcOp.getArgAttr(blockArg.getArgNumber(), attributeName))
+          return true;
+    return false;
+  }
+
+  if (auto definingOp = value.getDefiningOp()) {
+    // If this is an allocated value, look at the allocation attributes.
+    if (mlir::isa<fir::AllocMemOp>(definingOp) ||
+        mlir::isa<AllocaOp>(definingOp))
+      return definingOp->hasAttr(attributeName);
+    // If this is an imported global, look at AddOfOp and GlobalOp attributes.
+    // Both operations are looked at because use/host associated variable (the
+    // AddrOfOp) can have ASYNCHRONOUS/VOLATILE attributes even if the ultimate
+    // entity (the globalOp) does not have them.
+    if (auto addressOfOp = mlir::dyn_cast<fir::AddrOfOp>(definingOp)) {
+      if (addressOfOp->hasAttr(attributeName))
+        return true;
+      if (auto module = definingOp->getParentOfType<mlir::ModuleOp>())
+        if (auto globlaOp =
+                module.lookupSymbol<fir::GlobalOp>(addressOfOp.symbol()))
+          return globlaOp->hasAttr(attributeName);
+    }
+  }
+  // TODO: Construct associated entities attributes. Decide where the fir
+  // attributes must be placed/looked for in this case.
+  return false;
 }
 
 // Tablegen operators

--- a/flang/test/Fir/coordinateof.fir
+++ b/flang/test/Fir/coordinateof.fir
@@ -28,9 +28,15 @@ func @foo3(%box : !fir.box<!fir.array<?xi32>>, %i : i32) -> i32 {
   %ii = fir.convert %i : (i32) -> index
   // CHECK: %[[gep0:.*]] = getelementptr { i32*
   // CHECK: %[[boxptr:.*]] = load i32*, i32** %[[gep0]]
-  // CHECK: %[[gep1:.*]] = getelementptr i32, i32* %[[boxptr]], i64 %
+  // CHECK: %[[gep1:.*]] = getelementptr { i32*, i64, {{.*}} i32 7
+  // CHECK: %[[stride:.*]] = load i64, i64* %[[gep1]]
+  // CHECK: %[[dimoffset:.*]] = mul i64 %[[cvt]], %[[stride]]
+  // CHECK: %[[offset:.*]] = add i64 %[[dimoffset]], 0
+  // CHECK: %[[voidptr:.*]] = bitcast i32* %[[boxptr]] to i8*
+  // CHECK: %[[gep2:.*]] = getelementptr i8, i8* %[[voidptr]], i64 %[[offset]]
+  // CHECK: %[[i32ptr:.*]] = bitcast i8* %[[gep2]] to i32*
   %1 = fir.coordinate_of %box, %ii : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-  // CHECK: load i32, i32* %[[gep1]]
+  // CHECK: load i32, i32* %[[i32ptr]]
   %rv = fir.load %1 : !fir.ref<i32>
   return %rv : i32
 }

--- a/flang/test/Lower/arrexp.f90
+++ b/flang/test/Lower/arrexp.f90
@@ -66,7 +66,7 @@ subroutine test4(a,b,c)
 ! TODO: this declaration fails in CallInterface lowering
 !  real, allocatable, intent(out) :: a(:)
   real :: a(100) ! FIXME: fake it for now
-  real, intent(in) :: b(:), c
+  real, intent(in), contiguous :: b(:), c
   ! CHECK: %[[Ba:.*]] = fir.box_addr %arg1
   ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
   ! CHECK-DAG: %[[B:.*]] = fir.array_load %[[Ba]](%

--- a/flang/test/Lower/assumed-shaped-callee.f90
+++ b/flang/test/Lower/assumed-shaped-callee.f90
@@ -2,9 +2,16 @@
 
 ! Test assumed shape dummy argument on callee side
 
-! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>>) 
+! Currently only tests contiguous assumed shape.
+! TODO: find a better way to test lowering is getting the right address, shape
+! and extents. The current tests relies on looking at how a new descriptor is
+! created for a print statement involving the assumed shape. But lowering is
+! actually not guaranteed to created a new descriptor, it could also propagate the
+! input one.
+
+! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.contiguous}) 
 subroutine test_assumed_shape_1(x)
-  integer :: x(:)
+  integer, contiguous :: x(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %[[c0]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
@@ -20,9 +27,9 @@ subroutine test_assumed_shape_1(x)
 end subroutine
 
 ! lower bounds all ones
-! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>>)
+! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.contiguous})
 subroutine test_assumed_shape_2(x)
-  real :: x(1:, 1:)
+  real, contiguous :: x(1:, 1:)
   ! CHECK: fir.box_addr
   ! CHECK: %[[dims1:.*]]:3 = fir.box_dims
   ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
@@ -32,9 +39,9 @@ subroutine test_assumed_shape_2(x)
 end subroutine
 
 ! explicit lower bounds different from 1
-! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>>)
+! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>> {fir.contiguous})
 subroutine test_assumed_shape_3(x)
-  integer :: x(2:, 3:, 42:)
+  integer, contiguous :: x(2:, 3:, 42:)
   ! CHECK: fir.box_addr
   ! CHECK: fir.box_dim
   ! CHECK: %[[c2_i64:.*]] = constant 2 : i64
@@ -51,9 +58,9 @@ subroutine test_assumed_shape_3(x)
 end subroutine
 
 ! Constant length
-! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>>)
+! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>> {fir.contiguous})
 subroutine test_assumed_shape_char(c)
-  character(10) :: c(:)
+  character(10), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>) -> !fir.ref<!fir.array<?x!fir.char<1,10>>>
 
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>, index) -> (index, index, index)
@@ -65,9 +72,9 @@ subroutine test_assumed_shape_char(c)
 end subroutine
 
 ! Assumed length
-! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>>)
+! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.contiguous})
 subroutine test_assumed_shape_char_2(c)
-  character(*) :: c(:)
+  character(*), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
   ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
 
@@ -81,9 +88,9 @@ end subroutine
 
 
 ! lower bounds all 1.
-! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>>)
+! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>> {fir.contiguous})
 subroutine test_assumed_shape_char_3(c)
-  character(*) :: c(1:, 1:)
+  character(*), contiguous :: c(1:, 1:)
   ! CHECK: fir.box_addr
   ! CHECK: fir.box_elesize
   ! CHECK: %[[dims1:.*]]:3 = fir.box_dims

--- a/flang/test/Lower/dummy-arg-contiguity.f90
+++ b/flang/test/Lower/dummy-arg-contiguity.f90
@@ -1,0 +1,140 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir -gen-array-coor %s -o - | FileCheck %s --check-prefix=ArrayCoorCHECK
+
+! Test that non-contiguous assumed-shape memory layout is handled in lowering.
+! In practice, test that input fir.box is propagated to fir operations 
+
+! Also test that when the contiguous keyword is present, lowering adds the
+! attribute to the fir argument and that is takes the contiguity into account
+! In practice, test that the input fir.box is not propagated to fir operations.
+
+! CHECK-LABEL: func @_QPtest_element_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! ArrayCoorCHECK-LABEL: func @_QPtest_element_ref
+subroutine test_element_ref(x, y)
+  real, contiguous :: x(:)
+  ! CHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(4:)
+  ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
+
+  call bar(x(100))
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  call bar(y(100))
+  ! Test that for an entity that is not know to be contiguous, the fir.box is passed
+  ! to coordinate of and that the lower bounds is already applied by lowering.
+  ! CHECK: %[[c4_2:.*]] = fir.convert %[[c4]] : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c100{{.*}}, %[[c4_2]] : i64
+  ! CHECK: fir.coordinate_of %arg1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+
+
+  ! Repeat test when lowering is using fir.array_coor
+  ! ArrayCoorCHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  ! ArrayCoorCHECK: %[[xshape:.*]] = fir.shape_shift 
+  ! ArrayCoorCHECK: %[[c100:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %[[xaddr]](%[[xshape]]) %[[c100]] : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK: %[[yshape:.*]] = fir.shape_shift 
+  ! ArrayCoorCHECK: %[[c100_1:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %arg1(%[[yshape]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_element_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+!  ArrayCoorCHECK-LABEL: func @_QPtest_element_assign
+subroutine test_element_assign(x, y)
+  real, contiguous :: x(:)
+  ! CHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(4:)
+  ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
+  x(100) = 42.
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  y(100) = 42.
+  ! CHECK: %[[c4_2:.*]] = fir.convert %[[c4]] : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c100{{.*}}, %[[c4_2]] : i64
+  ! CHECK: fir.coordinate_of %arg1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  ! ArrayCoorCHECK: %[[xshape:.*]] = fir.shape_shift 
+  ! ArrayCoorCHECK: %[[c100:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %[[xaddr]](%[[xshape]]) %[[c100]] : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK: %[[yshape:.*]] = fir.shape_shift 
+  ! ArrayCoorCHECK: %[[c100_1:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %arg1(%[[yshape]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_ref_in_array_expr(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+subroutine test_ref_in_array_expr(x, y)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  call bar2(x+1.)
+  ! CHECK: fir.array_load %[[xaddr]](%{{.*}}) : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  call bar2(y+1.)
+  ! CHECK: fir.array_load %arg1(%{{.*}}) : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+end subroutine
+
+
+! CHECK-LABEL: func @_QPtest_assign_in_array_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+subroutine test_assign_in_array_ref(x, y)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  x = 42.
+  ! CHECK: %[[xload:.*]] = fir.array_load %0(%3) : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  ! CHECK: %[[xloop:.*]] = fir.do_loop {{.*}} iter_args(%arg3 = %[[xload]]) -> (!fir.array<?xf32>)
+  ! CHECK: fir.array_merge_store %[[xload]], %[[xloop]] to %[[xaddr]] : !fir.ref<!fir.array<?xf32>>
+  y = 42.
+  ! CHECK: %[[yload:.*]] = fir.array_load %arg1(%{{.*}}) : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  ! CHECK: %[[yloop:.*]] = fir.do_loop {{.*}} iter_args(%arg3 = %[[yload]]) -> (!fir.array<?xf32>) {
+  ! CHECK: fir.array_merge_store %[[yload]], %[[yloop]] to %arg1 : !fir.box<!fir.array<?xf32>>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_slice_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+subroutine test_slice_ref(x, y, z1, z2, i, j, k, n)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  integer :: i, j, k, n
+  real :: z1(n), z2(n)
+  z2 = x(i:j:k)
+  ! CHECK: %[[xslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %[[xaddr]]{{.*}}%[[xslice]]{{.*}}: (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+  z1 = y(i:j:k)
+  ! CHECK: %[[yslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %arg1{{.*}}%[[yslice]]{{.*}}: (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_slice_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+subroutine test_slice_assign(x, y, i, j, k)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  integer :: i, j, k
+  x(i:j:k) = 42.
+  ! CHECK: %[[xslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %[[xaddr]]{{.*}}%[[xslice]]{{.*}}: (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+  y(i:j:k) = 42.
+  ! CHECK: %[[yslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %arg1{{.*}}%[[yslice]]{{.*}}: (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+end subroutine
+
+! test that allocatable are considered contiguous.
+! CHECK-LABEL: func @_QPfoo
+subroutine foo(x)
+  real, allocatable :: x(:)
+  call bar(x(100))
+  ! CHECK: fir.coordinate_of {{.*}} (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+end subroutine
+
+! Test that non-contiguous dummy are propagated with their memory layout (we
+! mainly do not want to create a new box that would ignore the original layout).
+! CHECK: func @_QPpropagate(%arg0: !fir.box<!fir.array<?xf32>>)
+subroutine propagate(x)
+  interface
+    subroutine bar3(x)
+      real :: x(:)
+    end subroutine
+  end interface
+  real :: x(:)
+  call bar3(x)
+ ! CHECK: fir.call @_QPbar3(%arg0) : (!fir.box<!fir.array<?xf32>>) -> ()
+end subroutine


### PR DESCRIPTION
PR split in two parts/commits: first commit is codgen only and does not depend on the second which is lowering only (but needs the codegen update). 

Summary: update fir.array_coor, fir.array_load, fir.array_merge_store and fir.xarray_coor to accept fir.box argument. Update array BoxValues to keep track of input fir.box in the bridge and pass that to the fir operations. Read and applies byte strides from the fir.box (descriptor) in codegen.

**1: Update FIR dialect to handle non contiguous entities with fir.box**

- Update fir.array_coor, fir.array_load, fir.array_merge_store and fir.xarray_coor
  to accept a fir.box argument as a memref to support the case where an entity
  described by a fir.box is not known to be contiguous.

- Update fir.coordinate_of/fir.xarray_coor codegen to read the descriptor
  byte strides in order to compute the offset for the address.
  This also implies generating the related gep on i8*, and to recast the
  result address to the result type of the fir.coordinate_of/fir.xarray_coor.

- Add a fir::dyn_castPtrOrBoxEleTy, that does exactly like fir::dyn_castPtrEleTy,
  but also accepts fir.box input types.

- Define an mlir attribute name to represent fortran CONTIGUOUS attribute.
  Add a helper, fir::valueHasFirAttribute(value, attrName) that looks
  for the attribute in the funcOp argument, or allocation/address_of operations
  that created the value.
  For now, this helper will be used in lowering, but it is defined in FIR to
  make it possible to delay decisions related to FORTRAN attributes to FIR
  passes/codegen.

The missing part of this FIR updates are affine promotion update (skipped for now
because this pass is disabled, but it needs to do something with the fir.box), and
fir.embox update (or fir.rebox creation). Embox of slice of non contiguous dummy/pointers
will require to accept a fir.box argument. Embox with slices are not yet used in
lowering, so this part is skipped for now.

**2: Lower non contiguous assumed-shape and CONTIGUOUS keyword**

- Add a field in AbstractArrayBox to keep track of the fir.box
  that describes the array. Add a isContiguous helper to tell
  if the fir.box is known to be contiguous or not (looking at
  its type and attributes).

- Update symbol lowering to propagate dummy fir.box to created array SymbolBox.

- Update parts of lowering that generate fir.coordinate_of, fir.array_coor,
  and fir.array_load with such non contiguous entities to pass the fir.box
  to the fir operations instead of the bare address.

- Update the CallInterface to add a "fir.contribuous" attribute to the funcOp
  arguments of entities that have the CONTIGUOUS argument in Fortran.

- Update pointer/allocatable read to propagate the fir.box, if it exists, to
  the created AbstractArrayBox.

Note: I think that it would be nicer to make the BoxValue base mlir::Value be the fir.box rather
than to add a new field for the fir.box. But that requires more refactoring and thinking
(like should we do it also for non-contiguous/scalar entities that happens to have a fir.box).
Few things using fir::getBase(exv) are currently expecting a fir.box.
A new exv.getMemRef() is added, it returns the fir.box for discontinguous entities, or the base address otherwise. It is intended to centralize things to help migrating towards having fir.box base mlir::Value in boxvalue if we want to.