### PR TITLE
Tweak some of the tests. Instead of using llc and the default assembler,

### DIFF
--- a/flang/test/Fir/arr-end-end.f90
+++ b/flang/test/Fir/arr-end-end.f90
@@ -1,7 +1,7 @@
 ! Test affine pipeline
 
 ! FIXME - this test now goes into infinite loop
-!  bbc --emit-fir --gen-array-coor=true %s -o - | tco --fir-memref-dataflow-opt --fir-loop-result-opt --canonicalize  --loop-invariant-code-motion --promote-to-affine --affine-loop-invariant-code-motion --simplify-affine-structures --memref-dataflow-opt --cse --demote-affine --lower-affine | tco | llc | as -o %t
+!  bbc --emit-fir --gen-array-coor=true %s -o - | tco --fir-memref-dataflow-opt --fir-loop-result-opt --canonicalize  --loop-invariant-code-motion --promote-to-affine --affine-loop-invariant-code-motion --simplify-affine-structures --memref-dataflow-opt --cse --demote-affine --lower-affine | tco | llc --filetype=obj -o %t
 !  %CC -std=c99 %t %S/arr-driver.c
 !  ./a.out | FileCheck %s
 

--- a/flang/test/Fir/complex.fir
+++ b/flang/test/Fir/complex.fir
@@ -1,7 +1,7 @@
-// RUN: cc -c %S/print_complex.c
+// RUN: %CC -c %S/print_complex.c
 // RUN: tco --target=x86_64-unknown-linux-gnu %s | FileCheck %s --check-prefix=LLVMIR
-// RUN: tco --target=x86_64-unknown-linux-gnu %s | llc | as -o %t
-// RUN: cc %t print_complex.o
+// RUN: tco --target=x86_64-unknown-linux-gnu %s | llc --filetype=obj -o %t
+// RUN: %CC %t print_complex.o
 // RUN: ./a.out | FileCheck %s --check-prefix=EXECHECK
 
 // EXECHECK: <0.935893, 2.252526>

--- a/flang/test/Lower/array-init.f90
+++ b/flang/test/Lower/array-init.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-llvm -o - %s | tco | llc | as -o %t
+! RUN: bbc -emit-llvm -o - %s | tco | llc --filetype=obj -o %t
 ! RUN: cc %t %S/array-init-driver.c
 ! RUN: ./a.out | FileCheck %s
 

--- a/flang/test/Lower/end-to-end-character-assignment.f90
+++ b/flang/test/Lower/end-to-end-character-assignment.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-llvm -o - %s | tco | llc --relocation-model=pic | as -o %t
+! RUN: bbc -emit-llvm -o - %s | tco | llc --filetype=obj --relocation-model=pic -o %t
 ! RUN: %CXX -fPIC -std=c++17 %t %S/end-to-end-character-assignment-driver.cpp
 ! RUN: ./a.out
 


### PR DESCRIPTION
generate object files directly with llc.