### PR TITLE
[flang] Add -split-input-file -verify-diagnostics options to TCO

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -243,9 +243,9 @@ class fir_AllocatableOp<string mnemonic, Resource resource,
     static constexpr llvm::StringRef inType() { return "in_type"; }
     static constexpr llvm::StringRef lenpName() { return "len_param_count"; }
     mlir::Type getAllocatedType();
-    
+
     bool hasLenParams() { return bool{(*this)->getAttr(lenpName())}; }
-    
+
     unsigned numLenParams() {
       if (auto val = (*this)->getAttrOfType<mlir::IntegerAttr>(lenpName()))
         return val.getInt();
@@ -1598,7 +1598,7 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
     alter its composite value. This operation let's one load an array as a
     value while applying a runtime shape, shift, or slice to the memory
     reference, and its semantics guarantee immutability.
-    
+
     ```mlir
       %s = fir.shape_shift %o, %n, %p, %m : (index, index, index, index) -> !fir.shape<2>
       // load the entire array 'a'
@@ -1786,7 +1786,7 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
 
     One can use `fir.array_merge_store` to merge/copy the value of `a` in an
     array expression as shown above.
-    
+
     ```mlir
       %v = fir.array_load %a(%shape) : ...
       %r = fir.array_update %v, %f, %i, %j : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
@@ -2058,7 +2058,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
 
   let printer = [{
     p << getOperationName() << ' '
-      << (*this)->getAttrOfType<mlir::StringAttr>(fieldAttrName()).getValue() 
+      << (*this)->getAttrOfType<mlir::StringAttr>(fieldAttrName()).getValue()
       << ", " << (*this)->getAttr(typeAttrName());
     if (getNumOperands()) {
       p << '(';
@@ -2213,7 +2213,7 @@ def fir_SliceOp : fir_Op<"slice", [NoSideEffect, AttrSizedOperandSegments]> {
     To support generalized slicing of Fortran's dynamic derived types, a slice
     op can be given a component path (narrowing from the product type of the
     original array to the specific elemental type of the sliced projection).
-    
+
     ```mlir
       %fld = fir.field_index component, !fir.type<t{...component:ct...}>
       %d = fir.slice %lo, %hi, %step path %fld : (index, index, index, !fir.field) -> !fir.slice<1>
@@ -2481,7 +2481,7 @@ def fir_DoLoopOp : region_Op<"do_loop",
       (*this)->setAttr(unorderedAttrName(),
                               mlir::UnitAttr::get(getContext()));
     }
-    
+
     mlir::BlockArgument iterArgToBlockArg(mlir::Value iterArg);
     void resultToSourceOps(llvm::SmallVectorImpl<mlir::Value> &results,
                            unsigned resultNum);
@@ -2532,7 +2532,7 @@ def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
       mlir::Block &body = elseRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
-    
+
     void resultToSourceOps(llvm::SmallVectorImpl<mlir::Value> &results,
                            unsigned resultNum);
   }];
@@ -2558,7 +2558,7 @@ def fir_IterWhileOp : region_Op<"iterate_while",
     loop. The result triple is the values of %i=phi(%lo,%i+%c1),
     %ok=phi(%okIn,%okNew), and %sh=phi(%shIn,%shNew) from the last executed
     iteration.
-    
+
     ```mlir
       %v:3 = fir.iterate_while (%i = %lo to %up step %c1) and (%ok = %okIn) iter_args(%sh = %shIn) -> (index, i1, i16) {
         %shNew = fir.call @bar(%sh) : (i16) -> i16
@@ -2806,6 +2806,7 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     auto &builder = parser.getBuilder();
     mlir::Attribute val;
     mlir::NamedAttrList attrs;
+    llvm::SMLoc trailingTypeLoc;
     if (parser.parseAttribute(val, "fake", attrs))
       return mlir::failure();
     if (auto v = val.dyn_cast<mlir::StringAttr>())
@@ -2820,11 +2821,12 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     if (parser.parseLParen() ||
         parser.parseAttribute(sz, size(), result.attributes) ||
         parser.parseRParen() ||
+        parser.getCurrentLocation(&trailingTypeLoc) ||
         parser.parseColonType(type))
       return mlir::failure();
     auto charTy = type.dyn_cast<fir::CharacterType>();
     if (!charTy)
-      return parser.emitError(parser.getCurrentLocation(),
+      return parser.emitError(trailingTypeLoc,
                               "must have character type");
     type = fir::CharacterType::get(builder.getContext(), charTy.getFKind(), sz.getInt());
     if (!type || parser.addTypesToList(type, result.types))
@@ -2845,7 +2847,7 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
       auto xList = xl.cast<mlir::ArrayAttr>();
       for (auto a : xList)
         if (!a.isa<mlir::IntegerAttr>())
-	  return emitOpError("values in list must be integers");
+	    return emitOpError("values in list must be integers");
     }
     return mlir::success();
   }];
@@ -3403,7 +3405,7 @@ def fir_GlobalLenOp : fir_Op<"global_len", []> {
   }];
 
   let printer = [{
-    p << getOperationName() << ' ' << (*this)->getAttr(lenParamAttrName()) 
+    p << getOperationName() << ' ' << (*this)->getAttr(lenParamAttrName())
       << ", " << (*this)->getAttr(intAttrName());
   }];
 

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1,0 +1,20 @@
+// RUN: tco -emit-fir -split-input-file -verify-diagnostics %s
+
+// expected-error@+2{{expected integer value}}
+// expected-error@+1{{kind value expected}}
+func private @it1() -> !fir.int<A>
+
+// -----
+
+// expected-error@+1{{custom op 'fir.string_lit' must have character type}}
+%0 = fir.string_lit "Hello, World!"(13) : !fir.int<32>
+
+// -----
+
+// expected-error@+1{{custom op 'fir.string_lit' found an invalid constant}}
+%0 = fir.string_lit 20(13) : !fir.int<32>
+
+// -----
+
+// expected-error@+1{{'fir.string_lit' op values in list must be integers}}
+%2 = fir.string_lit [158, 2.0](2) : !fir.char<2>

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/ToolUtilities.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorOr.h"
@@ -52,50 +53,51 @@ static cl::opt<std::string> targetTriple("target",
                                          cl::desc("specify a target triple"),
                                          cl::init("native"));
 
+static cl::opt<bool>
+    splitInputFile("split-input-file",
+                   cl::desc("Split the input file into pieces and process each "
+                            "chunk independently"),
+                   cl::init(false));
+
+static cl::opt<bool>
+    verifyDiagnostics("verify-diagnostics",
+                      cl::desc("Check that emitted diagnostics match "
+                               "expected-* lines on the corresponding line"),
+                      cl::init(false));
+
 static void printModuleBody(mlir::ModuleOp mod, raw_ostream &output) {
   for (auto &op : mod.getBody()->without_terminator())
     output << op << '\n';
 }
 
-// compile a .fir file
 static mlir::LogicalResult
-compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
-  // check that there is a file to load
-  ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrErr =
-      MemoryBuffer::getFileOrSTDIN(inputFilename);
+performActions(raw_ostream &os, SourceMgr &sourceMgr,
+               const mlir::PassPipelineCLParser &passPipeline, bool emitFir,
+               mlir::MLIRContext *context) {
+  // Disable multi-threading when parsing the input file. This removes the
+  // unnecessary/costly context synchronization when parsing.
+  bool wasThreadingEnabled = context->isMultithreadingEnabled();
+  context->disableMultithreading();
 
-  if (std::error_code EC = fileOrErr.getError()) {
-    errs() << "Could not open file: " << EC.message() << '\n';
+  // Parse the input file and reset the context threading state.
+  mlir::OwningModuleRef module(parseSourceFile(sourceMgr, context));
+  context->enableMultithreading(wasThreadingEnabled);
+  if (!module)
     return mlir::failure();
-  }
 
-  // load the file into a module
-  SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
-  mlir::MLIRContext context;
-  fir::registerAndLoadDialects(context);
-  auto owningRef = mlir::parseSourceFile(sourceMgr, &context);
-
-  if (!owningRef) {
-    errs() << "Error can't load file " << inputFilename << '\n';
-    return mlir::failure();
-  }
-  if (mlir::failed(owningRef->verify())) {
+  if (mlir::failed(module->verify())) {
     errs() << "Error verifying FIR module\n";
     return mlir::failure();
   }
 
-  std::error_code ec;
-  ToolOutputFile out(outputFilename, ec, sys::fs::OF_None);
-
   // run passes
   llvm::Triple triple(fir::determineTargetTriple(targetTriple));
   fir::NameUniquer uniquer;
-  fir::KindMapping kindMap{&context};
-  fir::setTargetTriple(*owningRef, triple);
-  fir::setNameUniquer(*owningRef, uniquer);
-  fir::setKindMapping(*owningRef, kindMap);
-  mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+  fir::KindMapping kindMap{context};
+  fir::setTargetTriple(*module, triple);
+  fir::setNameUniquer(*module, uniquer);
+  fir::setKindMapping(*module, kindMap);
+  mlir::PassManager pm(context, mlir::OpPassManager::Nesting::Implicit);
   pm.enableVerifier(/*verifyPasses=*/true);
   mlir::applyPassManagerCLOptions(pm);
   if (emitFir) {
@@ -103,7 +105,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     // -emit-fir intentionally disables all the passes
   } else if (passPipeline.hasAnyOccurrences()) {
     passPipeline.addToPipeline(pm, [&](const Twine &msg) {
-      mlir::emitError(mlir::UnknownLoc::get(&context)) << msg;
+      mlir::emitError(mlir::UnknownLoc::get(context)) << msg;
       return mlir::failure();
     });
   } else {
@@ -126,22 +128,86 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     pm.addPass(fir::createFirCodeGenRewritePass());
     pm.addPass(fir::createFirTargetRewritePass());
     pm.addPass(fir::createFIRToLLVMPass(uniquer));
-    pm.addPass(fir::createLLVMDialectToLLVMPass(out.os()));
+    pm.addPass(fir::createLLVMDialectToLLVMPass(os));
   }
 
   // run the pass manager
-  if (mlir::succeeded(pm.run(*owningRef))) {
+  if (mlir::succeeded(pm.run(*module))) {
     // passes ran successfully, so keep the output
     if (emitFir || passPipeline.hasAnyOccurrences())
-      printModuleBody(*owningRef, out.os());
-    out.keep();
+      printModuleBody(*module, os);
     return mlir::success();
   }
 
-  // pass manager failed
-  printModuleBody(*owningRef, errs());
-  errs() << "\n\nFAILED: " << inputFilename << '\n';
   return mlir::failure();
+}
+
+static mlir::LogicalResult
+processBuffer(raw_ostream &os, std::unique_ptr<MemoryBuffer> ownedBuffer,
+              const mlir::PassPipelineCLParser &passPipeline, bool emitFir,
+              bool verifyDiagnostics) {
+  // Tell sourceMgr about this buffer, which is what the parser will pick up.
+  SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(ownedBuffer), SMLoc());
+
+  mlir::MLIRContext context;
+  fir::registerAndLoadDialects(context);
+  context.printOpOnDiagnostic(!verifyDiagnostics);
+
+  if (!verifyDiagnostics) {
+    mlir::SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
+    return performActions(os, sourceMgr, passPipeline, emitFir, &context);
+  }
+
+  mlir::SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr,
+                                                            &context);
+
+  // Do any processing requested by command line flags.  We don't care whether
+  // these actions succeed or fail, we only care what diagnostics they produce
+  // and whether they match our expectations.
+  performActions(os, sourceMgr, passPipeline, emitFir, &context);
+
+  // Verify the diagnostic handler to make sure that each of the diagnostics
+  // matched.
+  return sourceMgrHandler.verify();
+}
+
+// compile a .fir file
+static mlir::LogicalResult
+compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
+  // check that there is a file to load
+  ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrErr =
+      MemoryBuffer::getFileOrSTDIN(inputFilename);
+
+  if (std::error_code EC = fileOrErr.getError()) {
+    errs() << "Could not open file: " << EC.message() << '\n';
+    return mlir::failure();
+  }
+
+  mlir::MLIRContext context;
+  fir::registerAndLoadDialects(context);
+
+  std::error_code ec;
+  ToolOutputFile out(outputFilename, ec, sys::fs::OF_None);
+
+  if (splitInputFile)
+    return mlir::splitAndProcessBuffer(
+        std::move(*fileOrErr),
+        [&](std::unique_ptr<MemoryBuffer> chunkBuffer, raw_ostream &os) {
+          return processBuffer(out.os(), std::move(chunkBuffer), passPipeline,
+                               emitFir, verifyDiagnostics);
+        },
+        out.os());
+
+  if (failed(processBuffer(out.os(), std::move(*fileOrErr), passPipeline,
+                           emitFir, verifyDiagnostics))) {
+    errs() << "\n\nFAILED: " << inputFilename << '\n';
+    return mlir::failure();
+  }
+
+  // Keep the output file if the invocation was successful.
+  out.keep();
+  return mlir::success();
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR adds the `-split-input-file` and `-verify-diagnostics` options to the `tco` tool in order to have diagnostics verification test. 

These options are used in `flang/test/Fir/invalid.fir`. This test is not meant to be complete now but just includes a couple of diagnostics test to make sure the options are working properly. 

`flang/test/Fir/invalid.fir` will be completed in a future PR/patch. 