### PR TITLE
Now that MLIR supports floating point greater than double precision,

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -243,9 +243,9 @@ class fir_AllocatableOp<string mnemonic, Resource resource,
     static constexpr llvm::StringRef inType() { return "in_type"; }
     static constexpr llvm::StringRef lenpName() { return "len_param_count"; }
     mlir::Type getAllocatedType();
-    
+
     bool hasLenParams() { return bool{(*this)->getAttr(lenpName())}; }
-    
+
     unsigned numLenParams() {
       if (auto val = (*this)->getAttrOfType<mlir::IntegerAttr>(lenpName()))
         return val.getInt();
@@ -1559,7 +1559,7 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
     alter its composite value. This operation let's one load an array as a
     value while applying a runtime shape, shift, or slice to the memory
     reference, and its semantics guarantee immutability.
-    
+
     ```mlir
       %s = fir.shape_shift %o, %n, %p, %m : (index, index, index, index) -> !fir.shape<2>
       // load the entire array 'a'
@@ -1717,7 +1717,7 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
 
     One can use `fir.array_merge_store` to merge/copy the value of `a` in an
     array expression as shown above.
-    
+
     ```mlir
       %v = fir.array_load %a(%shape) : ...
       %r = fir.array_update %v, %f, %i, %j : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
@@ -1928,7 +1928,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
 
   let printer = [{
     p << getOperationName() << ' '
-      << (*this)->getAttrOfType<mlir::StringAttr>(fieldAttrName()).getValue() 
+      << (*this)->getAttrOfType<mlir::StringAttr>(fieldAttrName()).getValue()
       << ", " << (*this)->getAttr(typeAttrName());
     if (getNumOperands()) {
       p << '(';
@@ -2083,7 +2083,7 @@ def fir_SliceOp : fir_Op<"slice", [NoSideEffect, AttrSizedOperandSegments]> {
     To support generalized slicing of Fortran's dynamic derived types, a slice
     op can be given a component path (narrowing from the product type of the
     original array to the specific elemental type of the sliced projection).
-    
+
     ```mlir
       %fld = fir.field_index component, !fir.type<t{...component:ct...}>
       %d = fir.slice %lo, %hi, %step path %fld : (index, index, index, !fir.field) -> !fir.slice<1>
@@ -2351,7 +2351,7 @@ def fir_DoLoopOp : region_Op<"do_loop",
       (*this)->setAttr(unorderedAttrName(),
                               mlir::UnitAttr::get(getContext()));
     }
-    
+
     mlir::BlockArgument iterArgToBlockArg(mlir::Value iterArg);
     void resultToSourceOps(llvm::SmallVectorImpl<mlir::Value> &results,
                            unsigned resultNum);
@@ -2402,7 +2402,7 @@ def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
       mlir::Block &body = elseRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
-    
+
     void resultToSourceOps(llvm::SmallVectorImpl<mlir::Value> &results,
                            unsigned resultNum);
   }];
@@ -2428,7 +2428,7 @@ def fir_IterWhileOp : region_Op<"iterate_while",
     loop. The result triple is the values of %i=phi(%lo,%i+%c1),
     %ok=phi(%okIn,%okNew), and %sh=phi(%shIn,%shNew) from the last executed
     iteration.
-    
+
     ```mlir
       %v:3 = fir.iterate_while (%i = %lo to %up step %c1) and (%ok = %okIn) iter_args(%sh = %shIn) -> (index, i1, i16) {
         %shNew = fir.call @bar(%sh) : (i16) -> i16
@@ -2762,32 +2762,6 @@ class fir_UnaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 
   let printer = [{ return printUnaryOp(this->getOperation(), p); }];
-}
-
-def FirRealAttr : Attr<CPred<"$_self.isa<fir::RealAttr>()">, "FIR real attr"> {
-  let storageType = [{ fir::RealAttr }];
-  let returnType = [{ llvm::APFloat }];
-}
-
-def fir_ConstfOp : fir_Op<"constf", [NoSideEffect]> {
-  let summary = "create a floating point constant";
-
-  let description = [{
-    A floating-point constant. This operation is to augment MLIR to be able
-    to represent APFloat values that are not supported in the standard dialect.
-  }];
-
-  let arguments = (ins FirRealAttr:$constant);
-
-  let results = (outs fir_RealType:$res);
-
-  let assemblyFormat = "`(` $constant `)` attr-dict `:` type($res)";
-
-  let verifier = [{
-    if (!getType().isa<fir::RealType>())
-      return emitOpError("must be a !fir.real type");
-    return mlir::success();
-  }];
 }
 
 class RealUnaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
@@ -3274,7 +3248,7 @@ def fir_GlobalLenOp : fir_Op<"global_len", []> {
   }];
 
   let printer = [{
-    p << getOperationName() << ' ' << (*this)->getAttr(lenParamAttrName()) 
+    p << getOperationName() << ' ' << (*this)->getAttr(lenParamAttrName())
       << ", " << (*this)->getAttr(intAttrName());
   }];
 

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -37,9 +37,9 @@ static mlir::Type genRealType(mlir::MLIRContext *context, int kind) {
     case 8:
       return mlir::FloatType::getF64(context);
     case 10:
-      return fir::RealType::get(context, 10);
+      return mlir::FloatType::getF80(context);
     case 16:
-      return fir::RealType::get(context, 16);
+      return mlir::FloatType::getF128(context);
     }
   }
   llvm_unreachable("REAL type translation not implemented");

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -683,19 +683,6 @@ struct ConstcOpConversion : public FIROpConversion<fir::ConstcOp> {
   }
 };
 
-struct ConstfOpConversion : public FIROpConversion<fir::ConstfOp> {
-  using FIROpConversion::FIROpConversion;
-
-  mlir::LogicalResult
-  matchAndRewrite(fir::ConstfOp conf, OperandTy,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto ty = convertType(conf.getType());
-    auto val = conf.constantAttr();
-    rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(conf, ty, val);
-    return success();
-  }
-};
-
 static mlir::Type getComplexEleTy(mlir::Type complex) {
   if (auto cc = complex.dyn_cast<mlir::ComplexType>())
     return cc.getElementType();
@@ -2607,13 +2594,13 @@ struct FIRToLLVMLoweringPass
         BoxIsAllocOpConversion, BoxIsArrayOpConversion, BoxIsPtrOpConversion,
         BoxProcHostOpConversion, BoxRankOpConversion, BoxTypeDescOpConversion,
         CallOpConversion, CmpcOpConversion, CmpfOpConversion,
-        ConstcOpConversion, ConstfOpConversion, ConvertOpConversion,
-        CoordinateOpConversion, DispatchOpConversion, DispatchTableOpConversion,
-        DivcOpConversion, DivfOpConversion, DTEntryOpConversion,
-        EmboxOpConversion, EmboxCharOpConversion, EmboxProcOpConversion,
-        FieldIndexOpConversion, FirEndOpConversion, ExtractValueOpConversion,
-        FreeMemOpConversion, GenTypeDescOpConversion, GlobalLenOpConversion,
-        GlobalOpConversion, HasValueOpConversion, InsertOnRangeOpConversion,
+        ConstcOpConversion, ConvertOpConversion, CoordinateOpConversion,
+        DispatchOpConversion, DispatchTableOpConversion, DivcOpConversion,
+        DivfOpConversion, DTEntryOpConversion, EmboxOpConversion,
+        EmboxCharOpConversion, EmboxProcOpConversion, FieldIndexOpConversion,
+        FirEndOpConversion, ExtractValueOpConversion, FreeMemOpConversion,
+        GenTypeDescOpConversion, GlobalLenOpConversion, GlobalOpConversion,
+        HasValueOpConversion, InsertOnRangeOpConversion,
         InsertValueOpConversion, LenParamIndexOpConversion, LoadOpConversion,
         ModfOpConversion, MulcOpConversion, MulfOpConversion, NegcOpConversion,
         NegfOpConversion, NoReassocOpConversion, SelectCaseOpConversion,

--- a/flang/test/Lower/real.f90
+++ b/flang/test/Lower/real.f90
@@ -1,0 +1,104 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! Test real add on real kinds.
+
+! CHECK-LABEL: real2
+REAL(2) FUNCTION real2(x0, x1)
+  REAL(2) :: x0
+  REAL(2) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f16>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f16>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f16
+  real2 = x0 + x1
+  ! CHECK: return %{{.*}} : f16
+END FUNCTION real2
+
+! CHECK-LABEL: real3
+REAL(3) FUNCTION real3(x0, x1)
+  REAL(3) :: x0
+  REAL(3) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<bf16>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<bf16>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : bf16
+  real3 = x0 + x1
+  ! CHECK: return %{{.*}} : bf16
+END FUNCTION real3
+
+! CHECK-LABEL: real4
+REAL(4) FUNCTION real4(x0, x1)
+  REAL(4) :: x0
+  REAL(4) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f32
+  real4 = x0 + x1
+  ! CHECK: return %{{.*}} : f32
+END FUNCTION real4
+
+! CHECK-LABEL: defreal
+REAL FUNCTION defreal(x0, x1)
+  REAL :: x0
+  REAL :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f32
+  defreal = x0 + x1
+  ! CHECK: return %{{.*}} : f32
+END FUNCTION defreal
+
+! CHECK-LABEL: real8
+REAL(8) FUNCTION real8(x0, x1)
+  REAL(8) :: x0
+  REAL(8) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f64
+  real8 = x0 + x1
+  ! CHECK: return %{{.*}} : f64
+END FUNCTION real8
+
+! CHECK-LABEL: doubleprec
+DOUBLE PRECISION FUNCTION doubleprec(x0, x1)
+  DOUBLE PRECISION :: x0
+  DOUBLE PRECISION :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f64
+  doubleprec = x0 + x1
+  ! CHECK: return %{{.*}} : f64
+END FUNCTION doubleprec
+
+! CHECK-LABEL: real10
+REAL(10) FUNCTION real10(x0, x1)
+  REAL(10) :: x0
+  REAL(10) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f80>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f80>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f80
+  real10 = x0 + x1
+  ! CHECK: return %{{.*}} : f80
+END FUNCTION real10
+
+! CHECK-LABEL: real16
+REAL(16) FUNCTION real16(x0, x1)
+  REAL(16) :: x0
+  REAL(16) :: x1
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f128
+  real16 = x0 + x1
+  ! CHECK: return %{{.*}} : f128
+END FUNCTION real16
+
+! CHECK-LABEL: real16b
+REAL(16) FUNCTION real16b(x0, x1)
+  REAL(16) :: x0
+  REAL(16) :: x1
+  ! CHECK-DAG: %[[v0:.+]] = constant 4.0{{.*}} : f128
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
+  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f128
+  ! CHECK: %[[v4:.+]] = fir.subf %[[v3]], %[[v0]] : f128
+  real16b = x0 + x1 - 4.0_16
+  ! CHECK: return %{{.*}} : f128
+END FUNCTION real16b


### PR DESCRIPTION
switch lowering to use the new builtin types.