### PR TITLE
[flang] Add fir-opt tool

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2676,6 +2676,7 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     auto &builder = parser.getBuilder();
     mlir::Attribute val;
     mlir::NamedAttrList attrs;
+    llvm::SMLoc trailingTypeLoc;
     if (parser.parseAttribute(val, "fake", attrs))
       return mlir::failure();
     if (auto v = val.dyn_cast<mlir::StringAttr>())
@@ -2690,11 +2691,12 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     if (parser.parseLParen() ||
         parser.parseAttribute(sz, size(), result.attributes) ||
         parser.parseRParen() ||
+        parser.getCurrentLocation(&trailingTypeLoc) ||
         parser.parseColonType(type))
       return mlir::failure();
     auto charTy = type.dyn_cast<fir::CharacterType>();
     if (!charTy)
-      return parser.emitError(parser.getCurrentLocation(),
+      return parser.emitError(trailingTypeLoc,
                               "must have character type");
     type = fir::CharacterType::get(builder.getContext(), charTy.getFKind(),
                                    sz.getInt());
@@ -2716,7 +2718,7 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
       auto xList = xl.cast<mlir::ArrayAttr>();
       for (auto a : xList)
         if (!a.isa<mlir::IntegerAttr>())
-	  return emitOpError("values in list must be integers");
+	    return emitOpError("values in list must be integers");
     }
     return mlir::success();
   }];

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(FLANG_TEST_DEPENDS
   f18 FileCheck count not module_files
   opt llc
   tco bbc
+  fir-opt
   FortranRuntime FortranDecimal
 )
 

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1,0 +1,20 @@
+// RUN: fir-opt -split-input-file -verify-diagnostics %s
+
+// expected-error@+2{{expected integer value}}
+// expected-error@+1{{kind value expected}}
+func private @it1() -> !fir.int<A>
+
+// -----
+
+// expected-error@+1{{custom op 'fir.string_lit' must have character type}}
+%0 = fir.string_lit "Hello, World!"(13) : !fir.int<32>
+
+// -----
+
+// expected-error@+1{{custom op 'fir.string_lit' found an invalid constant}}
+%0 = fir.string_lit 20(13) : !fir.int<32>
+
+// -----
+
+// expected-error@+1{{'fir.string_lit' op values in list must be integers}}
+%2 = fir.string_lit [158, 2.0](2) : !fir.char<2>

--- a/flang/tools/CMakeLists.txt
+++ b/flang/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(f18)
 add_subdirectory(f18-parse-demo)
+add_subdirectory(fir-opt)
 add_subdirectory(bbc)
 add_subdirectory(tco)
 if(FLANG_BUILD_NEW_DRIVER)

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_flang_tool(fir-opt fir-opt.cpp)
+llvm_update_compile_flags(fir-opt)
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+target_link_libraries(fir-opt PRIVATE
+  FIROptimizer
+  ${dialect_libs}
+  MLIRIR
+  MLIRLLVMIR
+  MLIRPass
+  MLIRStandardToLLVM
+  MLIRTransforms
+  MLIRAffineToStandard
+  MLIRAnalysis
+  MLIRSCFToStandard
+  MLIREDSC
+  MLIRParser
+  MLIRStandardToLLVM
+  MLIRSupport
+  MLIRVectorToLLVM
+  MLIROptLib
+)

--- a/flang/tools/fir-opt/fir-opt.cpp
+++ b/flang/tools/fir-opt/fir-opt.cpp
@@ -1,0 +1,28 @@
+//===- fir-opt.cpp - FIR Optimizer Driver -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is to be like LLVM's opt program, only for FIR.  Such a program is
+// required for roundtrip testing, etc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Support/MlirOptMain.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/OptPasses.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+  fir::registerFIRPasses();
+  fir::registerOptPasses();
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  registry.insert<fir::FIROpsDialect>();
+  return failed(MlirOptMain(argc, argv, "FIR modular optimizer driver\n",
+      registry, /*preloadDialectsInContext*/false));
+}


### PR DESCRIPTION
Introduce a `fir-opt` tool to be able to do fir to fir tests. 

A small diagnostic test is added with this PR in order to test the tool itself. 

The tool is relying on the MLIR opt lib right now since the options needed are similar. It might diverge if we see a need for that. 