### PR TITLE
Add fir.absent and fir.is_present operations

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3393,4 +3393,42 @@ def fir_DTEntryOp : fir_Op<"dt_entry", []> {
   }];
 }
 
+def fir_AbsentOp : fir_OneResultOp<"absent", [NoSideEffect]> {
+  let summary = "create value to be passed for absent optional function argument";
+  let description = [{
+    Given the type of a function argument, create a value that will signal that
+    an optional argument is absent in the call. On the caller side, fir.is_present
+    can be used to query if the value of an optional argument was created with
+    a fir.absent operation. 
+    It is undefined to use a value that was created by a fir.absent op in any other
+    operation than fir.call and fir.is_present.
+    ```mlir
+      %1 = fir.absent fir.box<fir.array<?xf32>>
+      fir.call @_QPfoo(%1) : (fir.box<fir.array<?xf32>>) -> ()
+    ```
+  }];
+
+  let results = (outs AnyRefOrBox:$intype);
+
+  let assemblyFormat = "type($intype) attr-dict";
+}
+
+def fir_IsPresentOp : fir_SimpleOp<"is_present", [NoSideEffect]> {
+  let summary = "is this optional function argument present?";
+
+  let description = [{
+    Determine if an optional function argument is PRESENT (i.e. that it was not
+    created by a fir.absent op on the caller side).
+    ```mlir
+      func @_QPfoo(%arg0: !fir.box<!fir.array<?xf32>>) {
+        %0 = fir.is_present %arg0 : (!fir.box<!fir.array<?xf32>>) -> i1
+        ...
+    ```
+  }];
+
+  let arguments = (ins AnyRefOrBox:$val);
+
+  let results = (outs BoolLike);
+}
+
 #endif

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -634,3 +634,18 @@ func @array_access(%arr : !fir.ref<!fir.array<?x?xf32>>) {
   }
   return
 }
+
+// CHECK-LABEL: @test_is_present
+func @test_is_present(%arg0: !fir.box<!fir.array<?xf32>>) -> i1 {
+  // CHECK: fir.is_present %{{.*}} : (!fir.box<!fir.array<?xf32>>) -> i1
+  %0 = fir.is_present %arg0 : (!fir.box<!fir.array<?xf32>>) -> i1
+  return %0 : i1
+}
+// CHECK-LABEL: @test_absent
+func @test_absent() -> i1 {
+  // CHECK: fir.absent !fir.box<!fir.array<?xf32>>
+  %0 = fir.absent !fir.box<!fir.array<?xf32>>
+  %1 = fir.call @_QPfoo(%0) : (!fir.box<!fir.array<?xf32>>) -> i1
+  return %1 : i1
+}
+

--- a/flang/test/Fir/optional.fir
+++ b/flang/test/Fir/optional.fir
@@ -1,0 +1,35 @@
+// RUN: tco %s | FileCheck %s
+
+// Test fir.is_present and fir.absent codegen
+
+// CHECK-LABEL: @foo1
+func @foo1(%arg0: !fir.box<!fir.array<?xf32>>) -> i1 {
+  // CHECK: %[[ptr:.*]] = ptrtoint { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %{{.*}} to i64
+  // CHECK: icmp ne i64 %[[ptr]], 0
+  %0 = fir.is_present %arg0 : (!fir.box<!fir.array<?xf32>>) -> i1
+  return %0 : i1
+}
+
+// CHECK-LABEL: @bar1
+func @bar1() -> i1 {
+  %0 = fir.absent !fir.box<!fir.array<?xf32>>
+  // CHECK: call i1 @foo1({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* null)
+  %1 = fir.call @foo1(%0) : (!fir.box<!fir.array<?xf32>>) -> i1
+  return %1 : i1
+}
+
+// CHECK-LABEL: @foo2
+func @foo2(%arg0: !fir.ref<i64>) -> i1 {
+  // CHECK: %[[ptr:.*]] = ptrtoint i64* %{{.*}} to i64
+  // CHECK: icmp ne i64 %[[ptr]], 0
+  %0 = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  return %0 : i1
+}
+
+// CHECK-LABEL: @bar2
+func @bar2() -> i1 {
+  %0 = fir.absent !fir.ref<i64>
+  // CHECK: call i1 @foo2(i64* null)
+  %1 = fir.call @foo2(%0) : (!fir.ref<i64>) -> i1
+  return %1 : i1
+}


### PR DESCRIPTION
It is not possible to express a fir.box argument as being
null pointer pointer in fir (casts between fir.box and fir.ref are
forbidden). To implement Fortran OPTIONAL argument, it is needed to
create fir.box as null pointer on the caller side and to be able to
check if they are null pointers on the callee side.

To avoid exposing fir.box as being pointer in all situations, create ad-hoc
fir.absent and fir.is_present operations.
fir.absent will create a fir.box that is a null pointer in LLVM.