### PR TITLE
Update fir array operations to accept fir.box argument and use its strides

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGOps.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGOps.td
@@ -91,7 +91,8 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
     be converted to an extended embox. This op will have the following sets of
     arguments.
 
-       - memref: The memory reference of the array's data.
+       - memref: The memory reference of the array's data. It can be a fir.box if
+         the underlying data is not contiguous.
        - shape: A vector that is the runtime shape of the underlying array.
        - shift: A vector that is the runtime origin of the first element.
          The default is a vector of the value 1.
@@ -102,12 +103,13 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
        - LEN type parameters: A vector of runtime LEN type parameters that
          describe an correspond to the elemental derived type.
 
-    The memref, shape, and indices arguments are mandatory. The rest are
-    optional.
+    The memref and indices arguments are mandatory.
+    The shape argument is mandatory if the memref is not a box, and should be
+    omitted otherwise. The rest of the arguments are optional.
   }];
 
   let arguments = (ins
-    AnyReferenceLike:$memref,
+    AnyRefOrBox:$memref,
     Variadic<AnyIntegerType>:$shape,
     Variadic<AnyIntegerType>:$shift,
     Variadic<AnyIntegerType>:$slice,
@@ -124,7 +126,7 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
   }];
 
   let extraClassDeclaration = [{
-    unsigned getRank() { return shape().size(); }
+    unsigned getRank();
   }];
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -78,10 +78,6 @@ def fir_BoxProcType : Type<CPred<"$_self.isa<fir::BoxProcType>()">,
 def AnyBoxLike : TypeConstraint<Or<[fir_BoxType.predicate,
     fir_BoxCharType.predicate, fir_BoxProcType.predicate]>, "any box">;
 
-def AnyRefOrBox : TypeConstraint<Or<[fir_ReferenceType.predicate,
-    fir_HeapType.predicate, fir_PointerType.predicate, fir_BoxType.predicate]>,
-    "any reference or box">;
-
 def fir_ShapeType : Type<CPred<"$_self.isa<fir::ShapeType>()">, "shape type">;
 def fir_ShapeShiftType : Type<CPred<"$_self.isa<fir::ShapeShiftType>()">,
     "shape shift type">;
@@ -1568,7 +1564,7 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins
-    Arg<AnyReferenceLike, "", [MemRead]>:$memref,
+    Arg<AnyRefOrBox, "", [MemRead]>:$memref,
     Optional<AnyShapeType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyIntegerType>:$lenParams
@@ -1698,10 +1694,10 @@ def fir_ArrayUpdateOp : fir_Op<"array_update", [NoSideEffect]> {
 def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
     TypesMatchWith<"type of 'original' matches element type of 'memref'",
                      "memref", "original",
-                     "fir::dyn_cast_ptrEleTy($_self)">,
+                     "fir::dyn_cast_ptrOrBoxEleTy($_self)">,
     TypesMatchWith<"type of 'sequence' matches element type of 'memref'",
                      "memref", "sequence",
-                     "fir::dyn_cast_ptrEleTy($_self)">]> {
+                     "fir::dyn_cast_ptrOrBoxEleTy($_self)">]> {
 
   let summary = "Store merged array value to memory.";
 
@@ -1730,7 +1726,7 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
   let arguments = (ins
     fir_SequenceType:$original,
     fir_SequenceType:$sequence,
-    Arg<AnyReferenceLike, "", [MemWrite]>:$memref
+    Arg<AnyRefOrBox, "", [MemWrite]>:$memref
   );
 
   let assemblyFormat = "$original `,` $sequence `to` $memref attr-dict `:` type($memref)";
@@ -1774,7 +1770,7 @@ def fir_ArrayCoorOp : fir_Op<"array_coor",
   }];
 
   let arguments = (ins
-    AnyReferenceLike:$memref,
+    AnyRefOrBox:$memref,
     Optional<AnyShapeType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyCoordinateType>:$indices,

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -97,6 +97,10 @@ bool isa_aggregate(mlir::Type t);
 /// not a memory reference type, then returns a null `Type`.
 mlir::Type dyn_cast_ptrEleTy(mlir::Type t);
 
+/// Extract the `Type` pointed to from a FIR memory reference or box type. If
+/// `t` is not a memory reference or box type, then returns a null `Type`.
+mlir::Type dyn_cast_ptrOrBoxEleTy(mlir::Type t);
+
 // Intrinsic types
 
 /// Model of the Fortran CHARACTER intrinsic type, including the KIND type

--- a/flang/include/flang/Optimizer/TypePredicates.td
+++ b/flang/include/flang/Optimizer/TypePredicates.td
@@ -49,4 +49,9 @@ def AnyCoordinateLike : TypeConstraint<Or<[AnySignlessInteger.predicate,
 
 def AnyCoordinateType : Type<AnyCoordinateLike.predicate, "coordinate type">;
 
+// Reference and Box types
+def AnyRefOrBox : TypeConstraint<Or<[fir_ReferenceType.predicate,
+    fir_HeapType.predicate, fir_PointerType.predicate, fir_BoxType.predicate]>,
+    "any reference or box">;
+
 #endif

--- a/flang/lib/Optimizer/CodeGen/CGOps.cpp
+++ b/flang/lib/Optimizer/CodeGen/CGOps.cpp
@@ -39,3 +39,12 @@ unsigned fir::cg::XEmboxOp::getOutRank() {
   assert(outRank >= 1);
   return outRank;
 }
+
+unsigned fir::cg::XArrayCoorOp::getRank() {
+  auto memrefTy = memref().getType();
+  if (memrefTy.isa<fir::BoxType>())
+    if (auto seqty =
+            fir::dyn_cast_ptrOrBoxEleTy(memrefTy).dyn_cast<fir::SequenceType>())
+      return seqty.getDimension();
+  return shape().size();
+}

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -123,17 +123,15 @@ public:
   matchAndRewrite(ArrayCoorOp arrCoor,
                   mlir::PatternRewriter &rewriter) const override {
     auto loc = arrCoor.getLoc();
-    auto shapeVal = arrCoor.shape();
-    auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp());
     llvm::SmallVector<mlir::Value, 8> shapeOpers;
     llvm::SmallVector<mlir::Value, 8> shiftOpers;
-    if (shapeOp) {
-      populateShape(shapeOpers, shapeOp);
-    } else if (auto shiftOp =
-                   dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp())) {
-      populateShapeAndShift(shapeOpers, shiftOpers, shiftOp);
-    } else {
-      return mlir::failure();
+    if (auto shapeVal = arrCoor.shape()) {
+      if (auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp()))
+        populateShape(shapeOpers, shapeOp);
+      else if (auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp()))
+        populateShapeAndShift(shapeOpers, shiftOpers, shiftOp);
+      else
+        return mlir::failure();
     }
     llvm::SmallVector<mlir::Value, 8> sliceOpers;
     llvm::SmallVector<mlir::Value, 8> subcompOpers;

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -128,9 +128,9 @@ mlir::Type fir::AllocMemOp::wrapResultType(mlir::Type intype) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
   if (!eleTy)
-    return op.emitOpError("must be a reference type");
+    return op.emitOpError("must be a reference or box type");
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
@@ -174,9 +174,9 @@ std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
 }
 
 static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
   if (!eleTy)
-    return op.emitOpError("must be a reference type");
+    return op.emitOpError("must be a reference or box type");
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
@@ -1298,7 +1298,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&...additionalArgs) {
+                        AdditionalArgs &&... additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -1002,6 +1002,19 @@ mlir::Type dyn_cast_ptrEleTy(mlir::Type t) {
       .Default([](mlir::Type) { return mlir::Type{}; });
 }
 
+mlir::Type dyn_cast_ptrOrBoxEleTy(mlir::Type t) {
+  return llvm::TypeSwitch<mlir::Type, mlir::Type>(t)
+      .Case<fir::ReferenceType, fir::PointerType, fir::HeapType>(
+          [](auto p) { return p.getEleTy(); })
+      .Case<fir::BoxType>([](auto p) {
+        auto eleTy = p.getEleTy();
+        if (auto ty = fir::dyn_cast_ptrEleTy(eleTy))
+          return ty;
+        return eleTy;
+      })
+      .Default([](mlir::Type) { return mlir::Type{}; });
+}
+
 } // namespace fir
 
 // CHARACTER

--- a/flang/test/Fir/arrexp.fir
+++ b/flang/test/Fir/arrexp.fir
@@ -98,3 +98,71 @@ func @f4(%a : !fir.ref<!fir.array<?x?xf32>>, %b : !fir.ref<!fir.array<?x?xf32>>,
   return
 }
 
+// Array expression assignment with potentially non contiguous arrays (e.g.
+// `a = b + f`, with and v assumed shapes.
+// Tests that the stride from the descriptor is used.
+// CHECK-LINE: define void @f6
+// CHECK: ({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[A:[^,]*]], { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[B:[^,]*]], float %[[F:.*]])
+func @f5(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: !fir.box<!fir.array<?xf32>>, %arg2: f32) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+  %1 = subi %0#1, %c1 : index
+  %2 = fir.array_load %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  %3 = fir.array_load %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  // CHECK: icmp sgt
+  %4 = fir.do_loop %arg3 = %c0 to %1 step %c1 iter_args(%arg4 = %2) -> (!fir.array<?xf32>) {
+    // CHECK: %[[B_STRIDE_GEP:.*]] = getelementptr {{.*}}* %[[B]], i32 0, i32 7, i64 0, i32 2
+    // CHECK: %[[B_STRIDE:.*]] = load i64, i64* %[[B_STRIDE_GEP]]
+    // CHECK: %[[B_DIM_OFFSET:.*]] = mul i64 %{{.*}}, %[[B_STRIDE]]
+    // CHECK: %[[B_OFFSET:.*]] =  add i64 %[[B_DIM_OFFSET]], 0
+    // CHECK: %[[B_BASE_GEP:.*]] = getelementptr {{.*}}* %1, i32 0, i32 0
+    // CHECK: %[[B_BASE:.*]] = load float*, float** %[[B_BASE_GEP]]
+    // CHECK: %[[B_VOID_BASE:.*]] = bitcast float* %[[B_BASE]] to i8*
+    // CHECK: %[[B_VOID_ADDR:.*]] = getelementptr i8, i8* %[[B_VOID_BASE]], i64 %[[B_OFFSET]]
+    // CHECK: %[[B_ADDR:.*]] = bitcast i8* %[[B_VOID_ADDR]] to float*
+    // CHECK: %[[B_VAL:.*]] = load float, float* %[[B_ADDR]]
+    // CHECK: fadd float %[[B_VAL]], %[[F]]
+    %5 = fir.array_fetch %3, %arg3 : (!fir.array<?xf32>, index) -> f32
+    %6 = fir.addf %5, %arg2 : f32
+    %7 = fir.array_update %arg4, %6, %arg3 : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+    fir.result %7 : !fir.array<?xf32>
+  }
+  fir.array_merge_store %2, %4 to %arg0 : !fir.box<!fir.array<?xf32>>
+  // CHECK: ret void
+  return
+}
+
+
+// Overlapping array expression assignment with a potentially non
+// contiguous array (e.g. `a(2:10:1) = a(1:9:1) + f`, with a assumed shape).
+// Test that a temp is created.
+// CHECK-LINE: define void @f6
+// CHECK: ({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[A:[^,]*]], float %[[F:.*]])
+func @f6(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: f32) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c9 = constant 9 : index
+  %c10 = constant 10 : index
+
+  // CHECK: %[[EXT_GEP:.*]] = getelementptr {{.*}} %[[A]], i32 0, i32 7, i64 0, i32 1
+  // CHECK: %[[EXTENT:.*]] = load i64, i64* %[[EXT_GEP]]
+  // CHECK: %[[SIZE:.*]] = mul i64 4, %[[EXTENT]]
+  // CHECK: %[[MALLOC:.*]] = call i8* @malloc(i64 %[[SIZE]])
+  // CHECK: %[[TMP:.*]] = bitcast i8* %[[MALLOC]] to float*
+
+  %1 = fir.slice %c2, %c10, %c1 : (index, index, index) -> !fir.slice<1>
+  %2 = fir.array_load %arg0 [%1] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
+  %3 = fir.slice %c1, %c9, %c1 : (index, index, index) -> !fir.slice<1>
+  %4 = fir.array_load %arg0 [%3] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
+  %5 = fir.do_loop %arg2 = %c0 to %c9 step %c1 iter_args(%arg3 = %2) -> (!fir.array<?xf32>) {
+    %6 = fir.array_fetch %4, %arg2 : (!fir.array<?xf32>, index) -> f32
+    %7 = fir.addf %6, %arg1 : f32
+    %8 = fir.array_update %arg3, %7, %arg2 : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+    fir.result %8 : !fir.array<?xf32>
+  }
+  fir.array_merge_store %2, %5 to %arg0 : !fir.box<!fir.array<?xf32>>
+  // CHECK: ret void
+  return
+}

--- a/flang/test/Fir/coordinateof.fir
+++ b/flang/test/Fir/coordinateof.fir
@@ -28,9 +28,15 @@ func @foo3(%box : !fir.box<!fir.array<?xi32>>, %i : i32) -> i32 {
   %ii = fir.convert %i : (i32) -> index
   // CHECK: %[[gep0:.*]] = getelementptr { i32*
   // CHECK: %[[boxptr:.*]] = load i32*, i32** %[[gep0]]
-  // CHECK: %[[gep1:.*]] = getelementptr i32, i32* %[[boxptr]], i64 %
+  // CHECK: %[[gep1:.*]] = getelementptr { i32*, i64, {{.*}} i32 7
+  // CHECK: %[[stride:.*]] = load i64, i64* %[[gep1]]
+  // CHECK: %[[dimoffset:.*]] = mul i64 %[[cvt]], %[[stride]]
+  // CHECK: %[[offset:.*]] = add i64 %[[dimoffset]], 0
+  // CHECK: %[[voidptr:.*]] = bitcast i32* %[[boxptr]] to i8*
+  // CHECK: %[[gep2:.*]] = getelementptr i8, i8* %[[voidptr]], i64 %[[offset]]
+  // CHECK: %[[i32ptr:.*]] = bitcast i8* %[[gep2]] to i32*
   %1 = fir.coordinate_of %box, %ii : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-  // CHECK: load i32, i32* %[[gep1]]
+  // CHECK: load i32, i32* %[[i32ptr]]
   %rv = fir.load %1 : !fir.ref<i32>
   return %rv : i32
 }


### PR DESCRIPTION
- Update `fir.array_coor`, `fir.array_load`, `array_merge_store`, `fircg.xarray_coor` to accept a fir.box as main argument to support fir array expressions with a non contiguous base array.
- In codegen/transformation related to this ops, Extents are not taken from the shape arguments (that may be omitted with fir.box). Instead, it is read from the fir.box when needed.
- Update `fircg.xarray_coor` codegen to use the byte stride from the fir.box when the base is a fir.box, and to read the base address from it.
- Implement TODO in `fir.coordinate_of` related to fir.box handling (reading the stride from fir.box).


Remaining TODO in codegen regarding handling non contiguous arrays (described by fir.box) are:
- adding a ShiftOp to be used in `fir.array_coor` when local bounds are specified for a dummy argument fir.box (though this could also be dealt directly in lowering).
- adding a fir.rebox op to handle creating fir.box for array section with a non contiguous base (itself described with a fir.box).