### PR TITLE
Define fir attributes for OPTIONAL and CONTIGUOUS

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -126,6 +126,10 @@ public:
   /// FirPlaceHolder are place holders for the mlir inputs and outputs that are
   /// created during the first pass before the mlir::FuncOp is created.
   struct FirPlaceHolder {
+    FirPlaceHolder(mlir::Type t, int passedPosition, Property p,
+                   llvm::ArrayRef<mlir::NamedAttribute> attrs)
+        : type{t}, passedEntityPosition{passedPosition}, property{p},
+          attributes{attrs.begin(), attrs.end()} {}
     /// Type for this input/output
     mlir::Type type;
     /// Position of related passedEntity in passedArguments.
@@ -135,6 +139,8 @@ public:
     /// Indicate property of the entity passedEntityPosition that must be passed
     /// through this argument.
     Property property;
+    /// MLIR attributes for this argument
+    llvm::SmallVector<mlir::NamedAttribute, 1> attributes;
   };
 
   /// PassedEntity is what is provided back to the CallInterface user.

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -59,6 +59,21 @@ fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
                              llvm::StringRef name, mlir::Type type,
                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
+/// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
+constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
+/// Attribute to mark Fortran entities with the OPTIONAL attribute.
+constexpr llvm::StringRef getOptionalAttrName() { return "fir.optional"; }
+
+/// Tell if \p value is:
+///   - a function argument that has attribute \p attributeName
+///   - or, the result of fir.alloca/fir.allocamem op that has attribute \p
+///     attributeName
+///   - or, the result of a fir.address_of of a fir.global that has attribute \p
+///     attributeName
+///   - or, a fir.box loaded from a fir.ref<fir.box> that matches one of the
+///     previous cases.
+bool valueHasFirAttribute(mlir::Value value, llvm::StringRef attributeName);
+
 } // namespace fir
 
 #endif // OPTIMIZER_DIALECT_FIROPSSUPPORT_H

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1898,6 +1898,47 @@ fir::GlobalOp fir::createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
   return result;
 }
 
+bool fir::valueHasFirAttribute(mlir::Value value,
+                               llvm::StringRef attributeName) {
+  // If this is a fir.box that was loaded, the fir attributes will be on the
+  // related fir.ref<fir.box> creation.
+  if (value.getType().isa<fir::BoxType>())
+    if (auto definingOp = value.getDefiningOp())
+      if (auto loadOp = mlir::dyn_cast<fir::LoadOp>(definingOp))
+        value = loadOp.memref();
+  // If this is a function argument, look in the argument attributes.
+  if (auto blockArg = value.dyn_cast<mlir::BlockArgument>()) {
+    if (blockArg.getOwner() && blockArg.getOwner()->isEntryBlock())
+      if (auto funcOp =
+              mlir::dyn_cast<mlir::FuncOp>(blockArg.getOwner()->getParentOp()))
+        if (funcOp.getArgAttr(blockArg.getArgNumber(), attributeName))
+          return true;
+    return false;
+  }
+
+  if (auto definingOp = value.getDefiningOp()) {
+    // If this is an allocated value, look at the allocation attributes.
+    if (mlir::isa<fir::AllocMemOp>(definingOp) ||
+        mlir::isa<AllocaOp>(definingOp))
+      return definingOp->hasAttr(attributeName);
+    // If this is an imported global, look at AddOfOp and GlobalOp attributes.
+    // Both operations are looked at because use/host associated variable (the
+    // AddrOfOp) can have ASYNCHRONOUS/VOLATILE attributes even if the ultimate
+    // entity (the globalOp) does not have them.
+    if (auto addressOfOp = mlir::dyn_cast<fir::AddrOfOp>(definingOp)) {
+      if (addressOfOp->hasAttr(attributeName))
+        return true;
+      if (auto module = definingOp->getParentOfType<mlir::ModuleOp>())
+        if (auto globlaOp =
+                module.lookupSymbol<fir::GlobalOp>(addressOfOp.symbol()))
+          return globlaOp->hasAttr(attributeName);
+    }
+  }
+  // TODO: Construct associated entities attributes. Decide where the fir
+  // attributes must be placed/looked for in this case.
+  return false;
+}
+
 // Tablegen operators
 
 #define GET_OP_CLASSES

--- a/flang/test/Lower/attributes.f90
+++ b/flang/test/Lower/attributes.f90
@@ -1,0 +1,29 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test propagation of Fortran attributes to FIR.
+
+
+! CHECK-LABEL: func @_QPfoo1(
+! CHECK-SAME: %arg0: !fir.ref<f32> {fir.optional},
+! CHECK-SAME: %arg1: !fir.box<!fir.array<?xf32>> {fir.optional},
+! CHECK-SAME: %arg2: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.optional},
+! CHECK-SAME: %arg3: !fir.boxchar<1> {fir.optional}
+subroutine foo1(x, y, i, c)
+  real, optional :: x, y(:)
+  integer, allocatable, optional :: i(:)
+  character, optional :: c
+end subroutine
+
+! CHECK-LABEL: func @_QPfoo2(
+! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous},
+! CHECK-SAME: %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {fir.contiguous}
+subroutine foo2(x, i)
+  real, contiguous :: x(:)
+  integer, pointer, contiguous :: i(:)
+end subroutine
+
+! CHECK-LABEL: func @_QPfoo3
+! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous, fir.optional}
+subroutine foo3(x)
+  real, optional, contiguous :: x(:)
+end subroutine


### PR DESCRIPTION
OPTIONAL and CONTIGUOUS Fortran attributes will be propagated to fir as argument (and allocation/global op attribute for contiguous).
Define strings for this attributes, and add a way to check if an mlir::Value comes from an operation/function block argument that has these attributes.
For now this will be used by lowering only.

[PR EDIT:] Added lowering part that adds the OPTIONAL/CONTIGUOUS attribute to the fir arguments in a new commit. The functional parts of handling contiguous/optional argument lowering will be in a different PR.
