### PR TITLE
[flang][OpenMP] Create `MasterOp` without arguments

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -284,11 +284,9 @@ genOMP(Fortran::lower::AbstractConverter &converter,
         converter, eval,
         std::get<Fortran::parser::OmpBeginBlockDirective>(blockConstruct.t));
   } else if (blockDirective.v == llvm::omp::OMPD_master) {
-    llvm::ArrayRef<mlir::Type> argTy;
     auto &firOpBuilder = converter.getFirOpBuilder();
     auto currentLocation = converter.getCurrentLocation();
-    auto masterOp =
-        firOpBuilder.create<mlir::omp::MasterOp>(currentLocation, argTy);
+    auto masterOp = firOpBuilder.create<mlir::omp::MasterOp>(currentLocation);
     createBodyOfOp<omp::MasterOp>(masterOp, firOpBuilder, currentLocation);
   }
 }


### PR DESCRIPTION
Addresses concerns WRT creation of `MasterOp` by @schweitz
in https://github.com/flang-compiler/f18-llvm-project/pull/568#discussion_r551483519