### PR TITLE
Define new IrBoxValue SymbolBox/ExtendedValue and use it for non contiguous assumed shapes.

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -28,6 +28,7 @@
 namespace fir {
 class AbstractArrayBox;
 class ExtendedValue;
+class IrBoxValue;
 } // namespace fir
 
 namespace Fortran::lower {
@@ -253,6 +254,33 @@ public:
 private:
   const fir::KindMapping &kindMap;
 };
+
+//===--------------------------------------------------------------------===//
+// ExtendedValue inquiry helpers
+//===--------------------------------------------------------------------===//
+
+/// Read or get character length from an ExtendedValue containing a character
+/// entity. If the length value is contained in the ExtendedValue, this will
+/// not generate any code, otherwise this will generate a read of the fir.box
+/// describing the entity.
+mlir::Value readCharLen(FirOpBuilder &, mlir::Location,
+                        const fir::ExtendedValue &);
+
+/// Read or get the extent in dimension \p dim of the array described by an
+/// ExtendedValue.
+mlir::Value readExtent(FirOpBuilder &, mlir::Location,
+                       const fir::ExtendedValue &, unsigned dim);
+
+/// Read or get the lower bound in dimension \p dim of the array described by
+/// an ExtendedValue. If the lower bound is left default in the ExtendedValue,
+/// the defaultValue will be returned.
+mlir::Value readLowerBound(FirOpBuilder &, mlir::Location,
+                           const fir::ExtendedValue &, unsigned dim,
+                           mlir::Value defaultValue);
+
+/// Read extents from an IrBoxValue into \p result.
+void readExtents(FirOpBuilder &, mlir::Location, const fir::IrBoxValue &,
+                 llvm::SmallVectorImpl<mlir::Value> &result);
 
 } // namespace Fortran::lower
 

--- a/flang/test/Lower/arrexp.f90
+++ b/flang/test/Lower/arrexp.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LINE: func @_QPtest1
+! CHECK-LABEL: func @_QPtest1
 subroutine test1(a,b,c,n)
   integer :: n
   real, intent(out) :: a(n)
@@ -17,7 +17,7 @@ subroutine test1(a,b,c,n)
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
 end subroutine test1
 
-! CHECK-LINE: func @_QPtest1b
+! CHECK-LABEL: func @_QPtest1b
 subroutine test1b(a,b,c,d,n)
   integer :: n
   real, intent(out) :: a(n)
@@ -37,14 +37,14 @@ subroutine test1b(a,b,c,d,n)
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
 end subroutine test1b
 
-! CHECK-LINE: func @_QPtest2
+! CHECK-LABEL: func @_QPtest2
 subroutine test2(a,b,c)
   real, intent(out) :: a(:)
   real, intent(in) :: b(:), c(:)
 !  a = b + c
 end subroutine test2
 
-! CHECK-LINE: func @_QPtest3
+! CHECK-LABEL: func @_QPtest3
 subroutine test3(a,b,c,n)
   integer :: n
   real, intent(out) :: a(n)
@@ -61,15 +61,14 @@ subroutine test3(a,b,c,n)
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
 end subroutine test3
 
-! CHECK-LINE: func @_QPtest4
+! CHECK-LABEL: func @_QPtest4
 subroutine test4(a,b,c)
 ! TODO: this declaration fails in CallInterface lowering
 !  real, allocatable, intent(out) :: a(:)
   real :: a(100) ! FIXME: fake it for now
   real, intent(in) :: b(:), c
-  ! CHECK: %[[Ba:.*]] = fir.box_addr %arg1
   ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
-  ! CHECK-DAG: %[[B:.*]] = fir.array_load %[[Ba]](%
+  ! CHECK-DAG: %[[B:.*]] = fir.array_load %arg1
   ! CHECK: fir.do_loop
   ! CHECK: fir.array_fetch %[[B]], %
   ! CHECK: fir.array_update
@@ -77,7 +76,7 @@ subroutine test4(a,b,c)
   ! CHECK: fir.array_merge_store %[[A]], %{{.*}} to %arg0
 end subroutine test4
 
-! CHECK-LINE: func @_QPtest5
+! CHECK-LABEL: func @_QPtest5
 subroutine test5(a,b,c)
 ! TODO: this declaration fails in CallInterface lowering
 !  real, allocatable, intent(out) :: a(:)
@@ -93,7 +92,7 @@ subroutine test5(a,b,c)
   ! CHECK: fir.array_merge_store %[[A]], %{{.*}} to %arg0
 end subroutine test5
 
-! CHECK-LINE: func @_QPtest6
+! CHECK-LABEL: func @_QPtest6
 subroutine test6(a,b,c,n,m)
   integer :: n, m
   real, intent(out) :: a(n)
@@ -103,7 +102,7 @@ end subroutine test6
 
 ! This is NOT a conflict. `a` appears on both the lhs and rhs here, but there
 ! are no loop-carried dependences and no copy is needed.
-! CHECK-LINE: func @_QPtest7
+! CHECK-LABEL: func @_QPtest7
 subroutine test7(a,b,n)
   integer :: n
   real, intent(inout) :: a(n)
@@ -120,7 +119,7 @@ subroutine test7(a,b,n)
   ! CHECK: fir.array_merge_store %[[Aout]], %[[T]] to %arg0
 end subroutine test7
 
-! CHECK-LINE: func @_QPtest8
+! CHECK-LABEL: func @_QPtest8
 subroutine test8(a,b)
   integer :: a(100), b(100)
   ! CHECK-DAG: %[[A:.*]] = fir.array_load %arg0(%
@@ -135,7 +134,7 @@ end subroutine test8
 ! This FORALL construct does present a potential loop-carried dependence if
 ! implemented naively (and incorrectly). The final value of a(3) must be the
 ! value of a(2) before alistair begins execution added to b(2).
-! CHECK-LINE: func @_QPtest9
+! CHECK-LABEL: func @_QPtest9
 subroutine test9(a,b,n)
   integer :: n
   real, intent(inout) :: a(n)
@@ -146,7 +145,7 @@ subroutine test9(a,b,n)
   END FORALL alistair
 end subroutine test9
 
-! CHECK-LINE: func @_QPtest10
+! CHECK-LABEL: func @_QPtest10
 subroutine test10(a,b,c,d)
   interface
      function foo(a) result(res)
@@ -164,7 +163,7 @@ subroutine test10(a,b,c,d)
 !  a = b + foo(c + foo(d + bar(a)))
 end subroutine test10
 
-! CHECK-LINE: func @_QPtest11
+! CHECK-LABEL: func @_QPtest11
 subroutine test11(a,b,c,d)
   real, external :: bar
   real :: a(100), b(100), c(100), d(100)
@@ -194,7 +193,7 @@ subroutine test11(a,b,c,d)
   a = b + bar(c + d)
 end subroutine test11
 
-! CHECK-LINE: func @_QPtest12
+! CHECK-LABEL: func @_QPtest12
 subroutine test12(a,b,c,d,n,m)
   integer :: n, m
   ! CHECK: %[[n:.*]] = fir.load %arg4
@@ -221,7 +220,7 @@ subroutine test12(a,b,c,d,n,m)
   ! CHECK: fir.freemem %[[tmp]] : !fir.heap<!fir.array<?xf32>>
 end subroutine test12
 
-! CHECK-LINE: func @_QPtest12
+! CHECK-LABEL: func @_QPtest13
 subroutine test13(a,b,c,d,n,m,i)
   real :: a(n), b(m)
   complex :: c(n), d(m)

--- a/flang/test/Lower/assumed-shaped-callee.f90
+++ b/flang/test/Lower/assumed-shaped-callee.f90
@@ -2,9 +2,15 @@
 
 ! Test assumed shape dummy argument on callee side
 
-! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>>) 
+! TODO: These tests rely on looking at how a new fir.box is made for an assumed shape
+! to see if lowering lowered and mapped the assumed shape symbol properties.
+! However, the argument fir.box of the assumed shape could also be used instead
+! of making a new fir.box and this would break all these tests. In fact, for non
+! contiguous arrays, this is the case. Find a better way to tests symbol lowering/mapping.
+
+! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.contiguous}) 
 subroutine test_assumed_shape_1(x)
-  integer :: x(:)
+  integer, contiguous :: x(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
   ! CHECK: %[[c0:.*]] = constant 0 : index
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %[[c0]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
@@ -20,9 +26,9 @@ subroutine test_assumed_shape_1(x)
 end subroutine
 
 ! lower bounds all ones
-! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>>)
+! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.contiguous})
 subroutine test_assumed_shape_2(x)
-  real :: x(1:, 1:)
+  real, contiguous :: x(1:, 1:)
   ! CHECK: fir.box_addr
   ! CHECK: %[[dims1:.*]]:3 = fir.box_dims
   ! CHECK: %[[dims2:.*]]:3 = fir.box_dims
@@ -32,9 +38,9 @@ subroutine test_assumed_shape_2(x)
 end subroutine
 
 ! explicit lower bounds different from 1
-! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>>)
+! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>> {fir.contiguous})
 subroutine test_assumed_shape_3(x)
-  integer :: x(2:, 3:, 42:)
+  integer, contiguous :: x(2:, 3:, 42:)
   ! CHECK: fir.box_addr
   ! CHECK: fir.box_dim
   ! CHECK: %[[c2_i64:.*]] = constant 2 : i64
@@ -51,9 +57,9 @@ subroutine test_assumed_shape_3(x)
 end subroutine
 
 ! Constant length
-! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>>)
+! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>> {fir.contiguous})
 subroutine test_assumed_shape_char(c)
-  character(10) :: c(:)
+  character(10), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>) -> !fir.ref<!fir.array<?x!fir.char<1,10>>>
 
   ! CHECK: %[[dims:.*]]:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>, index) -> (index, index, index)
@@ -65,9 +71,9 @@ subroutine test_assumed_shape_char(c)
 end subroutine
 
 ! Assumed length
-! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>>)
+! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.contiguous})
 subroutine test_assumed_shape_char_2(c)
-  character(*) :: c(:)
+  character(*), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
   ! CHECK: %[[len:.*]] = fir.box_elesize %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
 
@@ -81,9 +87,9 @@ end subroutine
 
 
 ! lower bounds all 1.
-! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>>)
+! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>> {fir.contiguous})
 subroutine test_assumed_shape_char_3(c)
-  character(*) :: c(1:, 1:)
+  character(*), contiguous :: c(1:, 1:)
   ! CHECK: fir.box_addr
   ! CHECK: fir.box_elesize
   ! CHECK: %[[dims1:.*]]:3 = fir.box_dims

--- a/flang/test/Lower/dummy-arg-contiguity.f90
+++ b/flang/test/Lower/dummy-arg-contiguity.f90
@@ -1,0 +1,140 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir -gen-array-coor %s -o - | FileCheck %s --check-prefix=ArrayCoorCHECK
+
+! Test that non-contiguous assumed-shape memory layout is handled in lowering.
+! In practice, test that input fir.box is propagated to fir operations 
+
+! Also test that when the contiguous keyword is present, lowering adds the
+! attribute to the fir argument and that is takes the contiguity into account
+! In practice, test that the input fir.box is not propagated to fir operations.
+
+! CHECK-LABEL: func @_QPtest_element_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! ArrayCoorCHECK-LABEL: func @_QPtest_element_ref
+subroutine test_element_ref(x, y)
+  real, contiguous :: x(:)
+  ! CHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(4:)
+  ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
+
+  call bar(x(100))
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  call bar(y(100))
+  ! Test that for an entity that is not know to be contiguous, the fir.box is passed
+  ! to coordinate of and that the lower bounds is already applied by lowering.
+  ! CHECK: %[[c4_2:.*]] = fir.convert %[[c4]] : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c100{{.*}}, %[[c4_2]] : i64
+  ! CHECK: fir.coordinate_of %arg1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+
+
+  ! Repeat test when lowering is using fir.array_coor
+  ! ArrayCoorCHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  ! ArrayCoorCHECK-DAG: %[[xshape:.*]] = fir.shape
+  ! ArrayCoorCHECK-DAG: %[[c100:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %[[xaddr]](%[[xshape]]) %[[c100]] : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK-DAG: %[[c100_1:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK-DAG: %[[shift:.*]] = fir.shift %{{.*}} : (index) -> !fir.shift<1>
+  ! ArrayCoorCHECK: fir.array_coor %arg1(%[[shift]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_element_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+!  ArrayCoorCHECK-LABEL: func @_QPtest_element_assign
+subroutine test_element_assign(x, y)
+  real, contiguous :: x(:)
+  ! CHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(4:)
+  ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
+  x(100) = 42.
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  y(100) = 42.
+  ! CHECK: %[[c4_2:.*]] = fir.convert %[[c4]] : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c100{{.*}}, %[[c4_2]] : i64
+  ! CHECK: fir.coordinate_of %arg1, %{{.*}} : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK-DAG: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  ! ArrayCoorCHECK-DAG: %[[xshape:.*]] = fir.shape
+  ! ArrayCoorCHECK-DAG: %[[c100:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK: fir.array_coor %[[xaddr]](%[[xshape]]) %[[c100]] : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, index) -> !fir.ref<f32>
+
+  ! ArrayCoorCHECK-DAG: %[[c100_1:.*]] = fir.convert %c100{{.*}} : (i64) -> index
+  ! ArrayCoorCHECK-DAG: %[[shift:.*]] = fir.shift %{{.*}} : (index) -> !fir.shift<1>
+  ! ArrayCoorCHECK: fir.array_coor %arg1(%[[shift]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_ref_in_array_expr(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+subroutine test_ref_in_array_expr(x, y)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  call bar2(x+1.)
+  ! CHECK: fir.array_load %[[xaddr]](%{{.*}}) : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  call bar2(y+1.)
+  ! CHECK: fir.array_load %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+end subroutine
+
+
+! CHECK-LABEL: func @_QPtest_assign_in_array_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+subroutine test_assign_in_array_ref(x, y)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  x = 42.
+  ! CHECK: %[[xload:.*]] = fir.array_load %[[xaddr]]({{.*}}) : (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  ! CHECK: %[[xloop:.*]] = fir.do_loop {{.*}} iter_args(%arg3 = %[[xload]]) -> (!fir.array<?xf32>)
+  ! CHECK: fir.array_merge_store %[[xload]], %[[xloop]] to %[[xaddr]] : !fir.ref<!fir.array<?xf32>>
+  y = 42.
+  ! CHECK: %[[yload:.*]] = fir.array_load %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  ! CHECK: %[[yloop:.*]] = fir.do_loop {{.*}} iter_args(%arg3 = %[[yload]]) -> (!fir.array<?xf32>) {
+  ! CHECK: fir.array_merge_store %[[yload]], %[[yloop]] to %arg1 : !fir.box<!fir.array<?xf32>>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_slice_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+subroutine test_slice_ref(x, y, z1, z2, i, j, k, n)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  integer :: i, j, k, n
+  real :: z1(n), z2(n)
+  z2 = x(i:j:k)
+  ! CHECK: %[[xslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %[[xaddr]]{{.*}}%[[xslice]]{{.*}}: (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+  z1 = y(i:j:k)
+  ! CHECK: %[[yslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %arg1 {{.*}}%[[yslice]]{{.*}} : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_slice_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+subroutine test_slice_assign(x, y, i, j, k)
+  real, contiguous :: x(:)
+  ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real :: y(:)
+  integer :: i, j, k
+  x(i:j:k) = 42.
+  ! CHECK: %[[xslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %[[xaddr]]{{.*}}%[[xslice]]{{.*}}: (!fir.ref<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+  y(i:j:k) = 42.
+  ! CHECK: %[[yslice:.*]] = fir.slice
+  ! CHECK: fir.array_load %arg1 {{.*}}%[[yslice]]{{.*}}: (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
+end subroutine
+
+! test that allocatable are considered contiguous.
+! CHECK-LABEL: func @_QPfoo
+subroutine foo(x)
+  real, allocatable :: x(:)
+  call bar(x(100))
+  ! CHECK: fir.coordinate_of {{.*}} (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+end subroutine
+
+! Test that non-contiguous dummy are propagated with their memory layout (we
+! mainly do not want to create a new box that would ignore the original layout).
+! CHECK: func @_QPpropagate(%arg0: !fir.box<!fir.array<?xf32>>)
+subroutine propagate(x)
+  interface
+    subroutine bar3(x)
+      real :: x(:)
+    end subroutine
+  end interface
+  real :: x(:)
+  call bar3(x)
+ ! CHECK: fir.call @_QPbar3(%arg0) : (!fir.box<!fir.array<?xf32>>) -> ()
+end subroutine

--- a/flang/test/Lower/optional.f90
+++ b/flang/test/Lower/optional.f90
@@ -75,9 +75,8 @@ end subroutine
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional})
 subroutine assumed_shape(x)
   implicit none
-  ! CHECK: %[[boxaddr:.*]] = fir.box_addr %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
   real, optional :: x(:)
-  ! CHECK: fir.is_present %[[boxaddr]] : (!fir.ref<!fir.array<?xf32>>) -> i1
+  ! CHECK: fir.is_present %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> i1
   print *, present(x)
 end subroutine
 ! CHECK: func @_QMoptPcall_assumed_shape()


### PR DESCRIPTION
Add new `IrBoxValue` SymbolBox/ExtendedValue for all kinds of entity based on a fir.box, that are not pointers or allocatables, and that cannot be represented in other categories, either because the fir.box cannot be read while lowering the symbol specification (e.g. optional, assumed rank, or assumed type) or because they contain data that is not meant to be represented by other value categories (e.g non contiguous strides or polymorphic entities).
On top of the fir.box, this value may contain optional explicit bounds/parameters.

Add `AbstractIrBox` base class to share type helpers with `MutableBoxValue` (allocatable/pointers) that is also related to a fir.box type.

Remove top-level getLen/getExtent from SymbolBox and replace them by FirOpBuilder member function that may read lengths/extents from a fir.box when this is needed.

Lower Optional and non contiguous entities to this new IrBoxValue category.

Implement Descriptor inquiries needed by the tests.

[Edit Note:] ~~Depends on #596 to build, an on #597 to pass the tests.~~
[Edit 2]: Rebased with latest fir-dev containing dependencies that were merged. No PR code changes.
[Edit 3]: Rebased, solved conflicts. Plugged-in shiftOp now that is merged.