### PR TITLE
PFT and bridge updates

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1265,10 +1265,11 @@ private:
           auto &sym = *std::get<Fortran::parser::Name>(assoc.t).symbol;
           const auto &selector =
               *sym.get<Fortran::semantics::AssocEntityDetails>().expr();
-          if (Fortran::evaluate::IsVariable(selector) &&
+          if (Fortran::evaluate::IsVariable(selector) && selector.Rank() &&
               !Fortran::evaluate::UnwrapWholeSymbolDataRef(selector) &&
               !Fortran::evaluate::HasVectorSubscript(selector)) {
-            TODO("subobject association selector");
+            TODO("array section association selector");
+            continue;
           }
           genExprAddr(selector, stmtCtx)
               .match(


### PR DESCRIPTION
 - Eliminate PFT member localBlocks in favor of on-the-fly generation
   of local blocks for do loops and arithmetic ifs
 - Change the scope of some statement context finalization calls,
   particularly for do loops
 - Remove dead code in function addEvaluation
 - Rename several PFT types and some objects of these types:
    * ParentVariant -> PftNode
    * parentVariantStack -> pftParentStack
 - Move nop genFIR calls in Bridge.cpp below non-nop calls