### PR TITLE
Add fir.shift op to be used with fir.box

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -69,6 +69,9 @@ def fir_ShapeShiftType : Type<CPred<"$_self.isa<fir::ShapeShiftType>()">,
 def AnyShapeLike : TypeConstraint<Or<[ShapeType.predicate,
     fir_ShapeShiftType.predicate]>, "any legal shape type">;
 def AnyShapeType : Type<AnyShapeLike.predicate, "any legal shape type">;
+def AnyShapeOrShiftLike : TypeConstraint<Or<[ShapeType.predicate,
+    fir_ShapeShiftType.predicate, fir_ShiftType.predicate]>, "any legal shape or shift type">;
+def AnyShapeOrShiftType : Type<AnyShapeOrShiftLike.predicate, "any legal shape or shift type">;
 def fir_SliceType : Type<CPred<"$_self.isa<fir::SliceType>()">, "slice type">;
 
 // A type descriptor's type
@@ -1554,7 +1557,7 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
 
   let arguments = (ins
     Arg<AnyRefOrBox, "", [MemRead]>:$memref,
-    Optional<AnyShapeType>:$shape,
+    Optional<AnyShapeOrShiftType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyIntegerType>:$lenParams
   );
@@ -1760,7 +1763,7 @@ def fir_ArrayCoorOp : fir_Op<"array_coor",
 
   let arguments = (ins
     AnyRefOrBox:$memref,
-    Optional<AnyShapeType>:$shape,
+    Optional<AnyShapeOrShiftType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyCoordinateType>:$indices,
     Variadic<AnyIntegerType>:$lenParams
@@ -2046,6 +2049,46 @@ def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
         if (i.index() & 1)
           result.push_back(i.value());
       return result;
+    }
+  }];
+}
+
+def fir_ShiftOp : fir_Op<"shift", [NoSideEffect]> {
+
+  let summary = "generate an abstract shift vector of type `!fir.shift`";
+
+  let description = [{
+    The arguments are an ordered list of integral type values that define the
+    runtime lower bound of each dimension of an array. The shape information is
+    given in the same row-to-column order as Fortran. This abstract shift value
+    must be applied to a reified object, so all shift information must be
+    specified.
+
+    ```mlir
+      %d = fir.shift %row_lb, %col_lb : (index, index) -> !fir.shift<2>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyIntegerType>:$origins);
+
+  let results = (outs fir_ShiftType);
+
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+
+  let verifier = [{
+    auto size = origins().size();
+    auto shiftTy = getType().dyn_cast<fir::ShiftType>();
+    assert(shiftTy && "must be a shift type");
+    if (shiftTy.getRank() != size)
+      return emitOpError("shift type rank mismatch");
+    return mlir::success();
+  }];
+
+  let extraClassDeclaration = [{
+    std::vector<mlir::Value> getOrigins() {
+      return {origins().begin(), origins().end()};
     }
   }];
 }

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -90,6 +90,33 @@ def ShapeType : FIR_Type<"Shape", "shape"> {
   }];
 }
 
+def fir_ShiftType : FIR_Type<"Shift", "shift"> {
+  let summary = "lower bounds of a multidimensional array object";
+
+  let description = [{
+    Type of a vector of runtime values that define the lower bounds of a
+    multidimensional array object. The vector is the lower bounds of each array
+    dimension. The rank of a ShiftType must be at least 1.
+  }];
+
+  let parameters = (ins "unsigned":$rank);
+
+  let printer = [{
+    $_printer << "shift<" << getImpl()->rank << ">";
+  }];
+
+  let parser = [{
+    if ($_parser.parseLess())
+      return Type();
+    int rank;
+    if ($_parser.parseInteger(rank))
+      return Type();
+    if ($_parser.parseGreater())
+      return Type();
+    return get(context, rank);
+  }];
+}
+
 def fir_CharacterType : FIR_Type<"Character", "char"> {
   let summary = "FIR character type";
 

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -44,6 +44,11 @@ static void populateShapeAndShift(llvm::SmallVectorImpl<mlir::Value> &shapeVec,
   }
 }
 
+static void populateShift(llvm::SmallVectorImpl<mlir::Value> &vec,
+                          ShiftOp shift) {
+  vec.append(shift.origins().begin(), shift.origins().end());
+}
+
 namespace {
 
 /// Convert fir.embox to the extended form where necessary.
@@ -130,6 +135,8 @@ public:
         populateShape(shapeOpers, shapeOp);
       else if (auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp()))
         populateShapeAndShift(shapeOpers, shiftOpers, shiftOp);
+      else if (auto shiftOp = dyn_cast<ShiftOp>(shapeVal.getDefiningOp()))
+        populateShift(shiftOpers, shiftOp);
       else
         return mlir::failure();
     }
@@ -217,12 +224,16 @@ public:
       opsToErase.push_back(op);
     }
 
-    // Erase all fir.shape, fir.shape_shift, and fir.slice ops.
+    // Erase all fir.shape, fir.shape_shift, fir.shift, and fir.slice ops.
     if (isa<ShapeOp>(op)) {
       assert(op->use_empty());
       opsToErase.push_back(op);
     }
     if (isa<ShapeShiftOp>(op)) {
+      assert(op->use_empty());
+      opsToErase.push_back(op);
+    }
+    if (isa<ShiftOp>(op)) {
       assert(op->use_empty());
       opsToErase.push_back(op);
     }

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -63,7 +63,7 @@ fir::FIROpsDialect::FIROpsDialect(mlir::MLIRContext *ctx)
   addTypes<BoxType, BoxCharType, BoxProcType, CharacterType, fir::ComplexType,
            FieldType, HeapType, fir::IntegerType, LenType, LogicalType,
            PointerType, RealType, RecordType, ReferenceType, SequenceType,
-           ShapeType, ShapeShiftType, SliceType, TypeDescType,
+           ShapeType, ShapeShiftType, ShiftType, SliceType, TypeDescType,
            fir::VectorType>();
   addAttributes<ClosedIntervalAttr, ExactTypeAttr, LowerBoundAttr, OpaqueAttr,
                 PointIntervalAttr, RealAttr, SubclassAttr, UpperBoundAttr>();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -141,9 +141,13 @@ static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
     unsigned shapeTyRank = 0;
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
       shapeTyRank = s.getRank();
-    } else {
-      auto ss = shapeTy.cast<fir::ShapeShiftType>();
+    } else if (auto ss = shapeTy.dyn_cast<fir::ShapeShiftType>()) {
       shapeTyRank = ss.getRank();
+    } else {
+      auto s = shapeTy.cast<fir::ShiftType>();
+      shapeTyRank = s.getRank();
+      if (!op.memref().getType().isa<fir::BoxType>())
+        return op.emitOpError("shift can only be provided with fir.box memref");
     }
     if (arrDim && arrDim != shapeTyRank)
       return op.emitOpError("rank of dimension mismatched");
@@ -187,9 +191,13 @@ static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
     unsigned shapeTyRank = 0;
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
       shapeTyRank = s.getRank();
-    } else {
-      auto ss = shapeTy.cast<fir::ShapeShiftType>();
+    } else if (auto ss = shapeTy.dyn_cast<fir::ShapeShiftType>()) {
       shapeTyRank = ss.getRank();
+    } else {
+      auto s = shapeTy.cast<fir::ShiftType>();
+      shapeTyRank = s.getRank();
+      if (!op.memref().getType().isa<fir::BoxType>())
+        return op.emitOpError("shift can only be provided with fir.box memref");
     }
     if (arrDim && arrDim != shapeTyRank)
       return op.emitOpError("rank of dimension mismatched");

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -193,8 +193,8 @@ static bool isaIntegerType(mlir::Type ty) {
 bool verifyRecordMemberType(mlir::Type ty) {
   return !(ty.isa<BoxType>() || ty.isa<BoxCharType>() ||
            ty.isa<BoxProcType>() || ty.isa<ShapeType>() ||
-           ty.isa<ShapeShiftType>() || ty.isa<SliceType>() ||
-           ty.isa<FieldType>() || ty.isa<LenType>() ||
+           ty.isa<ShapeShiftType>() || ty.isa<ShiftType>() ||
+           ty.isa<SliceType>() || ty.isa<FieldType>() || ty.isa<LenType>() ||
            ty.isa<ReferenceType>() || ty.isa<TypeDescType>());
 }
 
@@ -357,6 +357,8 @@ mlir::Type fir::parseFirType(FIROpsDialect *dialect,
     return ShapeType::parse(dialect->getContext(), parser);
   if (typeNameLit == "shapeshift")
     return parseShapeShift(parser);
+  if (typeNameLit == "shift")
+    return generatedTypeParser(dialect->getContext(), parser, typeNameLit);
   if (typeNameLit == "slice")
     return parseSlice(parser);
   if (typeNameLit == "tdesc")
@@ -932,9 +934,9 @@ mlir::LogicalResult
 fir::ReferenceType::verifyConstructionInvariants(mlir::Location loc,
                                                  mlir::Type eleTy) {
   if (eleTy.isa<ShapeType>() || eleTy.isa<ShapeShiftType>() ||
-      eleTy.isa<SliceType>() || eleTy.isa<FieldType>() ||
-      eleTy.isa<LenType>() || eleTy.isa<ReferenceType>() ||
-      eleTy.isa<TypeDescType>())
+      eleTy.isa<ShiftType>() || eleTy.isa<SliceType>() ||
+      eleTy.isa<FieldType>() || eleTy.isa<LenType>() ||
+      eleTy.isa<ReferenceType>() || eleTy.isa<TypeDescType>())
     return mlir::emitError(loc, "cannot build a reference to type: ")
            << eleTy << '\n';
   return mlir::success();
@@ -954,10 +956,11 @@ mlir::Type fir::PointerType::getEleTy() const {
 static bool canBePointerOrHeapElementType(mlir::Type eleTy) {
   return eleTy.isa<BoxType>() || eleTy.isa<BoxCharType>() ||
          eleTy.isa<BoxProcType>() || eleTy.isa<ShapeType>() ||
-         eleTy.isa<ShapeShiftType>() || eleTy.isa<SliceType>() ||
-         eleTy.isa<FieldType>() || eleTy.isa<LenType>() ||
-         eleTy.isa<HeapType>() || eleTy.isa<PointerType>() ||
-         eleTy.isa<ReferenceType>() || eleTy.isa<TypeDescType>();
+         eleTy.isa<ShiftType>() || eleTy.isa<ShapeShiftType>() ||
+         eleTy.isa<SliceType>() || eleTy.isa<FieldType>() ||
+         eleTy.isa<LenType>() || eleTy.isa<HeapType>() ||
+         eleTy.isa<PointerType>() || eleTy.isa<ReferenceType>() ||
+         eleTy.isa<TypeDescType>();
 }
 
 mlir::LogicalResult
@@ -1043,8 +1046,9 @@ mlir::LogicalResult fir::SequenceType::verifyConstructionInvariants(
   // DIMENSION attribute can only be applied to an intrinsic or record type
   if (eleTy.isa<BoxType>() || eleTy.isa<BoxCharType>() ||
       eleTy.isa<BoxProcType>() || eleTy.isa<ShapeType>() ||
-      eleTy.isa<ShapeShiftType>() || eleTy.isa<SliceType>() ||
-      eleTy.isa<FieldType>() || eleTy.isa<LenType>() || eleTy.isa<HeapType>() ||
+      eleTy.isa<ShapeShiftType>() || eleTy.isa<ShiftType>() ||
+      eleTy.isa<SliceType>() || eleTy.isa<FieldType>() ||
+      eleTy.isa<LenType>() || eleTy.isa<HeapType>() ||
       eleTy.isa<PointerType>() || eleTy.isa<ReferenceType>() ||
       eleTy.isa<TypeDescType>() || eleTy.isa<fir::VectorType>() ||
       eleTy.isa<SequenceType>())
@@ -1148,9 +1152,10 @@ fir::TypeDescType::verifyConstructionInvariants(mlir::Location loc,
                                                 mlir::Type eleTy) {
   if (eleTy.isa<BoxType>() || eleTy.isa<BoxCharType>() ||
       eleTy.isa<BoxProcType>() || eleTy.isa<ShapeType>() ||
-      eleTy.isa<ShapeShiftType>() || eleTy.isa<SliceType>() ||
-      eleTy.isa<FieldType>() || eleTy.isa<LenType>() ||
-      eleTy.isa<ReferenceType>() || eleTy.isa<TypeDescType>())
+      eleTy.isa<ShapeShiftType>() || eleTy.isa<ShiftType>() ||
+      eleTy.isa<SliceType>() || eleTy.isa<FieldType>() ||
+      eleTy.isa<LenType>() || eleTy.isa<ReferenceType>() ||
+      eleTy.isa<TypeDescType>())
     return mlir::emitError(loc, "cannot build a type descriptor of type: ")
            << eleTy << '\n';
   return mlir::success();

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -96,6 +96,13 @@ private:
 
   bool analyzeReference(mlir::Value memref, mlir::Operation *op) {
     if (auto acoOp = memref.getDefiningOp<ArrayCoorOp>()) {
+      if (acoOp.memref().getType().isa<fir::BoxType>()) {
+        // TODO: Look if and how fir.box can be promoted to affine.
+        LLVM_DEBUG(llvm::dbgs() << "AffineLoopAnalysis: cannot promote loop, "
+                                   "array memory operation uses fir.box\n";
+                   op->dump(); acoOp.dump(););
+        return false;
+      }
       bool canPromote = true;
       for (auto coordinate : acoOp.indices())
         canPromote = canPromote && analyzeCoordinate(coordinate, op);

--- a/flang/test/Fir/arrexp.fir
+++ b/flang/test/Fir/arrexp.fir
@@ -166,3 +166,20 @@ func @f6(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: f32) {
   // CHECK: ret void
   return
 }
+
+// Non contiguous array with lower bounds (x = y(100), with y(4:))
+// Test array_coor offset computation.
+// CHECK-LABEL:  define void @f7(
+// CHECK: float* %[[X:[^,]*]], { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[Y:.*]])
+func @f7(%arg0: !fir.ref<f32>, %arg1: !fir.box<!fir.array<?xf32>>) {
+  %c4 = constant 4 : index
+  %c100 = constant 100 : index
+  %0 = fir.shift %c4 : (index) -> !fir.shift<1>
+  // CHECK: %[[STRIDE_GEP:.*]] = getelementptr {{.*}}* %[[Y]], i32 0, i32 7, i64 0, i32 2
+  // CHECK: %[[STRIDE:.*]] = load i64, i64* %[[STRIDE_GEP]]
+  // CHECK: mul i64 96, %[[STRIDE]]
+  %1 = fir.array_coor %arg1(%0) %c100 : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
+  %2 = fir.load %1 : !fir.ref<f32>
+  fir.store %2 to %arg0 : !fir.ref<f32>
+  return
+} 

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -688,3 +688,13 @@ func @test_misc_ops(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m : index, %n : inde
 
   return
 }
+
+// CHECK-LABEL: @test_shift
+func @test_shift(%arg0: !fir.box<!fir.array<?xf32>>) -> !fir.ref<f32> {
+  %c4 = constant 4 : index
+  %c100 = constant 100 : index
+  // CHECK: fir.shift %{{.*}} : (index) -> !fir.shift<1>
+  %0 = fir.shift %c4 : (index) -> !fir.shift<1>
+  %1 = fir.array_coor %arg0(%0) %c100 : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
+  return %1 : !fir.ref<f32>
+} 


### PR DESCRIPTION
When working with `fir.box` in fir array operation (`fir.array_coor` and `fir.array_load`), the extents are not added to the operation since they are already in the `fir.box`. However, local lower bounds may not be reflected in the `fir.box`.
This patch adds a `fir.shift` type and operation to provide lower bounds only to fir array operations when the memref arg is a `fir.box`.