### PR TITLE
Add fir.rebox and fircg.xrebox ops

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGOps.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGOps.td
@@ -82,6 +82,50 @@ def fircg_XEmboxOp : fircg_Op<"ext_embox", [AttrSizedOperandSegments]> {
   }];
 }
 
+// Extended rebox operation.
+def fircg_XReboxOp : fircg_Op<"ext_rebox", [AttrSizedOperandSegments]> {
+  let summary = "for internal conversion only";
+
+  let description = [{
+    Prior to lowering to LLVM IR dialect, a non-scalar non-trivial rebox op will
+    be converted to an extended rebox. This op will have the following sets of
+    arguments.
+
+       - box: The box being reboxed.
+       - shape: A vector that is the new runtime shape for the array
+       - shift: A vector that is the new runtime origin of the first element.
+         The default is a vector of the value 1.
+       - slice: A vector of triples that describe an array slice.
+       - subcomponent: A vector of indices for subobject slicing.
+
+    The box argument is mandatory, the other arguments are optional.
+    There must not both be a shape and slice/subcomponent arguments
+  }];
+
+  let arguments = (ins
+    fir_BoxType:$box,
+    Variadic<AnyIntegerType>:$shape,
+    Variadic<AnyIntegerType>:$shift,
+    Variadic<AnyIntegerType>:$slice,
+    Variadic<AnyCoordinateType>:$subcomponent
+  );
+  let results = (outs fir_BoxType);
+
+  let assemblyFormat = [{
+    $box (`(`$shape^`)`)? (`origin` $shift^)? (`[`$slice^`]`)?
+      (`path` $subcomponent^) ? attr-dict
+      `:` functional-type(operands, results)
+  }];
+
+  let extraClassDeclaration = [{
+    // The rank of the entity being reboxed
+    unsigned getRank();
+    // The rank of the result box
+    unsigned getOutRank();
+  }];
+}
+
+
 // Extended array coordinate operation.
 def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> {
   let summary = "for internal conversion only";

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1104,6 +1104,57 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
   }];
 }
 
+def fir_ReboxOp : fir_Op<"rebox", [NoSideEffect, AttrSizedOperandSegments]> {
+  let summary = "create a box given another box and (optional) dimension information";
+
+  let description = [{
+    Create a new boxed reference value from another box. This is meant to be used
+    when the taking a reference to part of a boxed value, or to an entire boxed value with
+    new shape or type information.
+
+    The new extra information can be:
+      - new shape information (new lower bounds, new rank, or new extents.
+        New rank/extents can only be provided if the original fir.box is
+        contiguous in all dimension but maybe the first one). The shape
+        operand must be provided to set new shape information.
+      - new type (only for derived types). It is possible to set the dynamic type
+        of the new box to one of the parent types of the input box dynamic type.
+        Type parameters cannot be changed. This change is reflected in the requested
+        result type of the new box.
+
+    A slice argument can be provided to build a reference to part of a boxed value.
+    In this case, the shape operand must be absent or be a fir.shift that can be
+    used to provide a non default origin for the slice.
+
+    The following example illustrates creating a fir.box for x(10:33:2)
+    where x is described by a fir.box and has non default lower bounds,
+    and then applying a new 2-dimension shape to this fir.box.
+
+    ```mlir
+      %0 = fir.slice %c10, %c33, %c2 : (index, index, index) -> !fir.slice<1>
+      %1 = fir.shift %c0 : (index) -> !fir.shift<1>
+      %2 = fir.rebox %x(%1) [%0] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+      %3 = fir.shape %c3, %c4 : (index, index) -> !fir.shape<2>
+      %4 = fir.rebox %2(%3) : (!fir.box<!fir.array<?xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf32>>
+    ```
+
+  }];
+
+  let arguments = (ins
+    fir_BoxType:$box,
+    Optional<AnyShapeOrShiftType>:$shape,
+    Optional<fir_SliceType>:$slice
+  );
+
+  let results = (outs fir_BoxType);
+
+  let assemblyFormat = [{
+    $box (`(` $shape^ `)`)? (`[` $slice^ `]`)? attr-dict `:` functional-type(operands, results)
+  }];
+
+  let verifier = [{ return ::verify(*this); }];
+}
+
 def fir_EmboxCharOp : fir_Op<"emboxchar", [NoSideEffect]> {
   let summary = "boxes a given CHARACTER reference and its LEN parameter";
 

--- a/flang/lib/Optimizer/CodeGen/CGOps.cpp
+++ b/flang/lib/Optimizer/CodeGen/CGOps.cpp
@@ -40,6 +40,20 @@ unsigned fir::cg::XEmboxOp::getOutRank() {
   return outRank;
 }
 
+unsigned fir::cg::XReboxOp::getOutRank() {
+  if (auto seqTy =
+          fir::dyn_cast_ptrOrBoxEleTy(getType()).dyn_cast<fir::SequenceType>())
+    return seqTy.getDimension();
+  return 0;
+}
+
+unsigned fir::cg::XReboxOp::getRank() {
+  if (auto seqTy = fir::dyn_cast_ptrOrBoxEleTy(box().getType())
+                       .dyn_cast<fir::SequenceType>())
+    return seqTy.getDimension();
+  return 0;
+}
+
 unsigned fir::cg::XArrayCoorOp::getRank() {
   auto memrefTy = memref().getType();
   if (memrefTy.isa<fir::BoxType>())

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -695,3 +695,24 @@ func @test_shift(%arg0: !fir.box<!fir.array<?xf32>>) -> !fir.ref<f32> {
   %1 = fir.array_coor %arg0(%0) %c100 : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
   return %1 : !fir.ref<f32>
 } 
+
+func private @bar_rebox_test(!fir.box<!fir.array<?x?xf32>>)
+// CHECK-LABEL: @test_rebox(
+func @test_rebox(%arg0: !fir.box<!fir.array<?xf32>>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c4 = constant 4 : index
+  %c10 = constant 10 : index
+  %c33 = constant 33 : index
+  %0 = fir.slice %c10, %c33, %c2 : (index, index, index) -> !fir.slice<1>
+  %1 = fir.shift %c0 : (index) -> !fir.shift<1>
+  // CHECK: fir.rebox %{{.*}}(%{{.*}}) [%{{.*}}] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  %2 = fir.rebox %arg0(%1) [%0] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  %3 = fir.shape %c3, %c4 : (index, index) -> !fir.shape<2>
+  // CHECK: fir.rebox %{{.*}}(%{{.*}}) : (!fir.box<!fir.array<?xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf32>>
+  %4 = fir.rebox %2(%3) : (!fir.box<!fir.array<?xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<?x?xf32>>
+  fir.call @bar_rebox_test(%4) : (!fir.box<!fir.array<?x?xf32>>) -> ()
+  return
+}

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -18,3 +18,118 @@ func private @it1() -> !fir.int<A>
 
 // expected-error@+1{{'fir.string_lit' op values in list must be integers}}
 %2 = fir.string_lit [158, 2.0](2) : !fir.char<2>
+
+// -----
+
+func @bad_rebox_1(%arg0: !fir.ref<!fir.array<?x?xf32>>) {
+  %c10 = constant 10 : index
+  %0 = fir.shape %c10 : (index) -> !fir.shape<1>
+  // expected-error@+1{{op operand #0 must be The type of a Fortran descriptor, but got '!fir.ref<!fir.array<?x?xf32>>'}}
+  %1 = fir.rebox %arg0(%0) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_2(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c10 = constant 10 : index
+  %0 = fir.shape %c10 : (index) -> !fir.shape<1>
+  // expected-error@+1{{op result #0 must be The type of a Fortran descriptor, but got '!fir.ref<!fir.array<?xf32>>'}}
+  %1 = fir.rebox %arg0(%0) : (!fir.box<!fir.array<?x?xf32>>, !fir.shape<1>) -> !fir.ref<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_3(%arg0: !fir.box<!fir.array<*:f32>>) {
+  %c10 = constant 10 : index
+  %0 = fir.shape %c10 : (index) -> !fir.shape<1>
+  // expected-error@+1{{op box operand must not have unknown rank or type}}
+  %1 = fir.rebox %arg0(%0) : (!fir.box<!fir.array<*:f32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_4(%arg0: !fir.box<!fir.array<?xf32>>) {
+  // expected-error@+1{{op result type must not have unknown rank or type}}
+  %0 = fir.rebox %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<*:f32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_5(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %0 = fir.slice %c1, %c10, %c1 : (index, index, index) -> !fir.slice<1>
+  // expected-error@+1{{op slice operand rank must match box operand rank}}
+  %1 = fir.rebox %arg0 [%0] : (!fir.box<!fir.array<?x?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_6(%arg0: !fir.box<!fir.array<?xf32>>) {
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %0 = fir.slice %c1, %c10, %c1 : (index, index, index) -> !fir.slice<1>
+  %1 = fir.shift %c1, %c1 : (index, index) -> !fir.shift<2>
+  // expected-error@+1{{shape operand and input box ranks must match when there is a slice}}
+  %2 = fir.rebox %arg0(%1) [%0] : (!fir.box<!fir.array<?xf32>>, !fir.shift<2>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_7(%arg0: !fir.box<!fir.array<?xf32>>) {
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %0 = fir.slice %c1, %c10, %c1 : (index, index, index) -> !fir.slice<1>
+  %1 = fir.shape %c10 : (index) -> !fir.shape<1>
+  // expected-error@+1{{shape operand must absent or be a fir.shift when there is a slice}}
+  %2 = fir.rebox %arg0(%1) [%0] : (!fir.box<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_8(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %undef = fir.undefined index
+  %0 = fir.slice %c1, %undef, %undef, %c1, %c10, %c1 : (index, index, index, index, index, index) -> !fir.slice<2>
+  // expected-error@+1{{result type rank and rank after applying slice operand must match}}
+  %1 = fir.rebox %arg0 [%0] : (!fir.box<!fir.array<?x?xf32>>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_9(%arg0: !fir.box<!fir.array<?xf32>>) {
+  %c10 = constant 10 : index
+  %0 = fir.shift %c10, %c10 : (index, index) -> !fir.shift<2>
+  // expected-error@+1{{shape operand and input box ranks must match when the shape is a fir.shift}}
+  %1 = fir.rebox %arg0(%0) : (!fir.box<!fir.array<?xf32>>, !fir.shift<2>) -> !fir.box<!fir.array<?x?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_10(%arg0: !fir.box<!fir.array<?xf32>>) {
+  %c10 = constant 10 : index
+  %0 = fir.shape %c10, %c10 : (index, index) -> !fir.shape<2>
+  // expected-error@+1{{result type and shape operand ranks must match}}
+  %1 = fir.rebox %arg0(%0) : (!fir.box<!fir.array<?xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @bad_rebox_11(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c42 = constant 42 : index
+  %0 = fir.shape %c42 : (index) -> !fir.shape<1>
+  // expected-error@+1{{op input and output element types must match for intrinsic types}}
+  %1 = fir.rebox %arg0(%0) : (!fir.box<!fir.array<?x?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf64>>
+  return
+}

--- a/flang/test/Fir/rebox.fir
+++ b/flang/test/Fir/rebox.fir
@@ -1,0 +1,110 @@
+// RUN: fir-opt %s | tco | FileCheck %s
+
+// Test applying slice on fir.box
+//   subroutine foo(x)
+//     real :: x(3:, 4:)
+//     call bar(x(5, 6:80:3))
+//   end subroutine
+
+func private @bar1(!fir.box<!fir.array<?xf32>>)
+// CHECK-LABEL: define void @test_rebox_1(
+// CHECK-SAME: { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX:.*]])
+func @test_rebox_1(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  // CHECK: %[[OUTBOX_ALLOC:.*]] = alloca { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c4 = constant 4 : index
+  %c5 = constant 5 : index
+  %c6 = constant 6 : index
+  %c80 = constant 80 : index
+  %undef = fir.undefined index
+  %0 = fir.slice %c5, %undef, %undef, %c6, %c80, %c3 : (index, index, index, index, index, index) -> !fir.slice<2>
+  %1 = fir.shift %c3, %c4 : (index, index) -> !fir.shift<2>
+
+  // CHECK: %[[INSTRIDE_0_GEP:.*]] = getelementptr { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX]], i32 0, i32 7, i64 0, i32 2
+  // CHECK: %[[INSTRIDE_0:.]] = load i64, i64* %[[INSTRIDE_0_GEP]]
+  // CHECK: %[[INSTRIDE_1_GEP:.*]] = getelementptr { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX]], i32 0, i32 7, i64 1, i32 2
+  // CHECK: %[[INSTRIDE_1:.*]] = load i64, i64* %[[INSTRIDE_1_GEP]]
+  // CHECK: %[[INBASE_GEP:.*]] = getelementptr { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX]], i32 0, i32 0
+  // CHECK: %[[INBASE:.*]] = load float*, float** %[[INBASE_GEP]]
+  // CHECK: %[[VOIDBASE:.*]] = bitcast float* %[[INBASE]] to i8*
+  // CHECK: %[[OFFSET_0:.*]] = mul i64 2, %[[INSTRIDE_0]]
+  // CHECK: %[[VOIDBASE0:.*]] = getelementptr i8, i8* %[[VOIDBASE]], i64 %[[OFFSET_0]]
+  // CHECK: %[[OFFSET_1:.*]] = mul i64 2, %[[INSTRIDE_1]]
+  // CHECK: %[[VOIDBASE1:.*]] = getelementptr i8, i8* %[[VOIDBASE0]], i64 %[[OFFSET_1]]
+  // CHECK: %[[OUTSTRIDE0:.*]] = mul i64 3, %[[INSTRIDE_1]]
+  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 1, i8 25, i8 0, i8 0, [1 x [3 x i64]] [{{.*}} [i64 1, i64 25, i64 undef]] }, i64 %[[OUTSTRIDE0]], 7, 0, 2
+  // CHECK: %[[OUTBASE:.*]] = bitcast i8* %[[VOIDBASE1]] to float*
+  // CHECK: %[[OUTBOX1:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } %[[OUTBOX0]], float* %[[OUTBASE]], 0
+  // CHECK: store { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } %[[OUTBOX1]], { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[OUTBOX_ALLOC]], align 8
+  %2 = fir.rebox %arg0(%1) [%0] : (!fir.box<!fir.array<?x?xf32>>, !fir.shift<2>, !fir.slice<2>) -> !fir.box<!fir.array<?xf32>>
+  // CHECK: call void @bar1({ float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[OUTBOX_ALLOC]])
+  fir.call @bar1(%2) : (!fir.box<!fir.array<?xf32>>) -> ()
+  return
+}
+
+// Test that character length is propagated in rebox
+//   subroutine foo(x)
+//     character(*) :: x(:, :)
+//     call bar(x(4:30:1, 4:30:1))
+//   end subroutine
+
+func private @bar_rebox_test2(!fir.box<!fir.array<?x?x!fir.char<1,?>>>)
+// CHECK-LABEL: define void @test_rebox_2(
+// CHECK-SAME: { i8*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX:.*]])
+func @test_rebox_2(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>>) {
+  %c1 = constant 1 : index
+  %c4 = constant 4 : index
+  %c30 = constant 30 : index
+  %0 = fir.slice %c4, %c30, %c1, %c4, %c30, %c1 : (index, index, index, index, index, index) -> !fir.slice<2>
+  // CHECK: %[[OUTBOX:.*]] = alloca { i8*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }
+  // CHECK: %[[LEN_GEP:.*]] = getelementptr { i8*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }, { i8*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] }* %[[INBOX]], i32 0, i32 1
+  // CHECK: %[[LEN:.*]] = load i64, i64* %[[LEN_GEP]]
+  // CHECK: insertvalue { i8*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } undef, i64 %[[LEN]], 1
+
+  %1 = fir.rebox %arg0 [%0]  : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>, !fir.slice<2>) -> !fir.box<!fir.array<?x?x!fir.char<1,?>>>
+  fir.call @bar_rebox_test2(%1) : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> ()
+  return
+}
+
+
+// Test setting a new shape on a fir.box
+//   subroutine foo(x)
+//     real :: x(:)
+//     real, pointer(:, :, :), p
+//     p(2:5, 3:7, 4:9) => x
+//     call bar(p)
+//   end subroutine
+
+func private @bar_rebox_test3(!fir.box<!fir.array<?x?x?xf32>>)
+// CHECK-LABEL: define void @test_rebox_3(
+// CHECK-SAME: { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[INBOX:.*]])
+func @test_rebox_3(%arg0: !fir.box<!fir.array<?xf32>>) {
+  // CHECK: %[[OUTBOX_ALLOC:.*]] = alloca { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] }
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c4 = constant 4 : index
+  %c5 = constant 5 : index
+  %1 = fir.shape_shift %c2, %c3, %c3, %c4, %c4, %c5 : (index, index, index, index, index, index) -> !fir.shapeshift<3>
+  // CHECK: %[[INSTRIDE_GEP:.*]] = getelementptr { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[INBOX]], i32 0, i32 7, i64 0, i32 2
+  // CHECK: %[[INSTRIDE:.*]] = load i64, i64* %[[INSTRIDE_GEP]]
+  // CHECK: %[[INBASE_GEP:.*]] = getelementptr { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[INBOX]], i32 0, i32 0
+  // CHECK: %[[INBASE:.*]] = load float*, float** %[[INBASE_GEP]]
+  // CHECK: %[[VOIDBASE:.*]] = bitcast float* %[[INBASE]] to i8*
+  // CHECK: %[[OUTSTRIDE1:.*]] = mul i64 3, %[[INSTRIDE]]
+  // CHECK: %[[OUTSTRIDE2:.*]] = mul i64 4, %[[OUTSTRIDE1]]
+  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 3, i8 25, i8 0, i8 0, [3 x [3 x i64]] [{{.*}} [i64 2, i64 3, i64 undef], [3 x i64] undef, [3 x i64] undef] }, i64 %[[INSTRIDE]], 7, 0, 2
+  // CHECK: %[[OUTBOX1:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX0]], i64 3, 7, 1, 0
+  // CHECK: %[[OUTBOX2:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX1]], i64 4, 7, 1, 1
+  // CHECK: %[[OUTBOX3:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX2]], i64 %[[OUTSTRIDE1]], 7, 1, 2
+  // CHECK: %[[OUTBOX4:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX3]], i64 4, 7, 2, 0
+  // CHECK: %[[OUTBOX5:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX4]], i64 5, 7, 2, 1
+  // CHECK: %[[OUTBOX6:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX5]], i64 %[[OUTSTRIDE2]], 7, 2, 2
+  // CHECK: %[[OUTBASE:.*]] = bitcast i8* %[[VOIDBASE]] to float*
+  // CHECK: %[[OUTBOX7:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX6]], float* %[[OUTBASE]], 0
+  // CHECK: store { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX7]], { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] }* %[[OUTBOX_ALLOC]]
+  %2 = fir.rebox %arg0(%1) : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<3>) -> !fir.box<!fir.array<?x?x?xf32>>
+  // CHECK: call void @bar_rebox_test3({ float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] }* %[[OUTBOX_ALLOC]])
+  fir.call @bar_rebox_test3(%2) : (!fir.box<!fir.array<?x?x?xf32>>) -> ()
+  return
+}


### PR DESCRIPTION
- Add a fir.rebox operations that creates new box from another box.
The intended use is to create fir.box describing part of another boxed reference
(array sections of a fir.box), or describing the same data but with a different
shape (to implement pointer bounds remapping for instance).
- Add the related fircg.xrebox op and implement pre-codegen rewrite pass.
- Add the codegen conversion class for xrebox, ~~but leave the actual
  implementation TODO for now. It will be implemented in its own
  patch/commit.~~

~~[edit:] #606 that introduces fir.shift is required to build and run this patch.~~ [edit 3:] rebased with fir-dev containing 606.
[edit 2:] Added codegen implementation and test in its own commit. 