### PR TITLE
[flang][fir] Move ShapeType to TableGen type definition

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
@@ -4,6 +4,8 @@
 set(LLVM_TARGET_DEFINITIONS FIROps.td)
 mlir_tablegen(FIROps.h.inc -gen-op-decls)
 mlir_tablegen(FIROps.cpp.inc -gen-op-defs)
+mlir_tablegen(FIROpsTypes.h.inc --gen-typedef-decls)
+mlir_tablegen(FIROpsTypes.cpp.inc --gen-typedef-defs)
 add_public_tablegen_target(FIROpsIncGen)
 
 add_custom_target(flang-doc)

--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -12,6 +12,8 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+
 
 using namespace mlir;
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -26,6 +26,8 @@ def fir_Dialect : Dialect {
   let cppNamespace = "::fir";
 }
 
+include "flang/Optimizer/Dialect/FIRTypes.td"
+
 // Types and predicates
 
 def fir_Type : Type<CPred<"fir::isa_fir_or_std_type($_self)">,
@@ -78,10 +80,9 @@ def fir_BoxProcType : Type<CPred<"$_self.isa<fir::BoxProcType>()">,
 def AnyBoxLike : TypeConstraint<Or<[fir_BoxType.predicate,
     fir_BoxCharType.predicate, fir_BoxProcType.predicate]>, "any box">;
 
-def fir_ShapeType : Type<CPred<"$_self.isa<fir::ShapeType>()">, "shape type">;
 def fir_ShapeShiftType : Type<CPred<"$_self.isa<fir::ShapeShiftType>()">,
     "shape shift type">;
-def AnyShapeLike : TypeConstraint<Or<[fir_ShapeType.predicate,
+def AnyShapeLike : TypeConstraint<Or<[ShapeType.predicate,
     fir_ShapeShiftType.predicate]>, "any legal shape type">;
 def AnyShapeType : Type<AnyShapeLike.predicate, "any legal shape type">;
 def fir_SliceType : Type<CPred<"$_self.isa<fir::SliceType>()">, "slice type">;
@@ -1978,7 +1979,7 @@ def fir_ShapeOp : fir_Op<"shape", [NoSideEffect]> {
 
   let arguments = (ins Variadic<AnyIntegerType>:$extents);
 
-  let results = (outs fir_ShapeType);
+  let results = (outs ShapeType);
 
   let assemblyFormat = [{
     operands attr-dict `:` functional-type(operands, results)
@@ -3399,7 +3400,7 @@ def fir_AbsentOp : fir_OneResultOp<"absent", [NoSideEffect]> {
     Given the type of a function argument, create a value that will signal that
     an optional argument is absent in the call. On the caller side, fir.is_present
     can be used to query if the value of an optional argument was created with
-    a fir.absent operation. 
+    a fir.absent operation.
     It is undefined to use a value that was created by a fir.absent op in any other
     operation than fir.call and fir.is_present.
     ```mlir

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -17,6 +17,9 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/SmallVector.h"
 
+#define GET_TYPEDEF_CLASSES
+#include "flang/Optimizer/Dialect/FIROpsTypes.h.inc"
+
 namespace llvm {
 class raw_ostream;
 class StringRef;
@@ -54,7 +57,6 @@ struct RealTypeStorage;
 struct RecordTypeStorage;
 struct ReferenceTypeStorage;
 struct SequenceTypeStorage;
-struct ShapeTypeStorage;
 struct ShapeShiftTypeStorage;
 struct SliceTypeStorage;
 struct TypeDescTypeStorage;
@@ -223,16 +225,6 @@ public:
                                                           mlir::Type eleTy);
 };
 
-/// Type of a vector of runtime values that define the shape of a
-/// multidimensional array object. The vector is the extents of each array
-/// dimension. The rank of a ShapeType must be at least 1.
-class ShapeType : public mlir::Type::TypeBase<ShapeType, mlir::Type,
-                                              detail::ShapeTypeStorage> {
-public:
-  using Base::Base;
-  static ShapeType get(mlir::MLIRContext *ctx, unsigned rank);
-  unsigned getRank() const;
-};
 
 /// Type of a vector of runtime values that define the shape and the origin of a
 /// multidimensional array object. The vector is of pairs, origin offset and

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -1,0 +1,51 @@
+//===- FIRTypes.td - FIR types -----------------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the FIR dialect types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FIR_DIALECT_FIR_TYPES
+#define FIR_DIALECT_FIR_TYPES
+
+//===----------------------------------------------------------------------===//
+// FIR Types
+//===----------------------------------------------------------------------===//
+
+class FIR_Type<string name, string typeMnemonic> : TypeDef<fir_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+def ShapeType : FIR_Type<"Shape", "shape"> {
+  let summary = "shape of a multidimensional array object";
+
+  let description = [{
+    Type of a vector of runtime values that define the shape of a
+    multidimensional array object. The vector is the extents of each array
+    dimension. The rank of a ShapeType must be at least 1.
+  }];
+
+  let parameters = (ins "unsigned":$rank);
+
+  let printer = [{
+    $_printer << "shape<" << getImpl()->rank << ">";
+  }];
+
+  let parser = [{
+    if ($_parser.parseLess())
+      return Type();
+    int rank;
+    if ($_parser.parseInteger(rank))
+      return Type();
+    if ($_parser.parseGreater())
+      return Type();
+    return get(context, rank);
+  }];
+}
+
+#endif // FIR_DIALECT_FIR_TYPES

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -20,6 +20,9 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#define GET_TYPEDEF_CLASSES
+#include "flang/Optimizer/Dialect/FIROpsTypes.cpp.inc"
+
 using namespace fir;
 
 namespace {
@@ -110,11 +113,6 @@ CharacterType parseCharacter(mlir::DialectAsmParser &parser) {
 // `complex` `<` kind `>`
 fir::ComplexType parseComplex(mlir::DialectAsmParser &parser) {
   return parseKindSingleton<fir::ComplexType>(parser);
-}
-
-// `shape` `<` rank `>`
-ShapeType parseShape(mlir::DialectAsmParser &parser) {
-  return parseRankSingleton<ShapeType>(parser);
 }
 
 // `shapeshift` `<` rank `>`
@@ -352,7 +350,8 @@ inline bool singleIndirectionLevel(mlir::Type ty) {
 
 // Implementation of the thin interface from dialect to type parser
 
-mlir::Type fir::parseFirType(FIROpsDialect *, mlir::DialectAsmParser &parser) {
+mlir::Type fir::parseFirType(FIROpsDialect *dialect,
+                             mlir::DialectAsmParser &parser) {
   llvm::StringRef typeNameLit;
   if (mlir::failed(parser.parseKeyword(&typeNameLit)))
     return {};
@@ -387,7 +386,8 @@ mlir::Type fir::parseFirType(FIROpsDialect *, mlir::DialectAsmParser &parser) {
   if (typeNameLit == "ref")
     return parseReference(parser, loc);
   if (typeNameLit == "shape")
-    return parseShape(parser);
+    // TODO move to generatedTypeParser when all types have been moved
+    return ShapeType::parse(dialect->getContext(), parser);
   if (typeNameLit == "shapeshift")
     return parseShapeShift(parser);
   if (typeNameLit == "slice")
@@ -441,29 +441,6 @@ private:
   CharacterTypeStorage() = delete;
   explicit CharacterTypeStorage(KindTy kind, CharacterType::LenType len)
       : kind{kind}, len{len} {}
-};
-
-struct ShapeTypeStorage : public mlir::TypeStorage {
-  using KeyTy = unsigned;
-
-  static unsigned hashKey(const KeyTy &key) { return llvm::hash_combine(key); }
-
-  bool operator==(const KeyTy &key) const { return key == getRank(); }
-
-  static ShapeTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
-                                     unsigned rank) {
-    auto *storage = allocator.allocate<ShapeTypeStorage>();
-    return new (storage) ShapeTypeStorage{rank};
-  }
-
-  unsigned getRank() const { return rank; }
-
-protected:
-  unsigned rank;
-
-private:
-  ShapeTypeStorage() = delete;
-  explicit ShapeTypeStorage(unsigned rank) : rank{rank} {}
 };
 
 struct ShapeShiftTypeStorage : public mlir::TypeStorage {
@@ -1285,14 +1262,6 @@ llvm::hash_code fir::hash_value(const SequenceType::Shape &sh) {
   return llvm::hash_combine(0);
 }
 
-// Shape
-
-ShapeType fir::ShapeType::get(mlir::MLIRContext *ctxt, unsigned rank) {
-  return Base::get(ctxt, rank);
-}
-
-unsigned fir::ShapeType::getRank() const { return getImpl()->getRank(); }
-
 // Shapeshift
 
 ShapeShiftType fir::ShapeShiftType::get(mlir::MLIRContext *ctxt,
@@ -1491,7 +1460,9 @@ void fir::printFirType(FIROpsDialect *, mlir::Type ty,
     return;
   }
   if (auto type = ty.dyn_cast<ShapeType>()) {
-    os << "shape<" << type.getRank() << '>';
+    // TODO when all type are moved to TableGen can be replaced by
+    // generatedTypePrinter
+    type.print(p);
     return;
   }
   if (auto type = ty.dyn_cast<ShapeShiftType>()) {


### PR DESCRIPTION
This PR is setting up the files for types and move the ShapeType to TableGen.

This is comparable to upstream Differential Revision: https://reviews.llvm.org/D96422