### PR TITLE
Lower absent optional argument and PRESENT intrinsic

### DIFF
--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -84,4 +84,10 @@ mlir::Value getMutableIRBox(Fortran::lower::FirOpBuilder &, mlir::Location,
 void syncMutableBoxFromIRBox(Fortran::lower::FirOpBuilder &, mlir::Location,
                              const fir::MutableBoxValue &);
 
+/// Generate allocation or association status test and returns the resulting
+/// i1. This is testing this for a valid/non-null base address value.
+mlir::Value genIsAllocatedOrAssociatedTest(Fortran::lower::FirOpBuilder &,
+                                           mlir::Location,
+                                           const fir::MutableBoxValue &);
+
 } // namespace Fortran::lower

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -154,6 +154,8 @@ public:
     FortranEntity entity;
     FirValue firArgument;
     FirValue firLength; /* only for AddressAndLength */
+    /// Is the dummy argument optional ?
+    bool isOptional = false;
   };
 
   /// Return the mlir::FuncOp. Note that front block is added by this

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -79,6 +79,14 @@ public:
   /// Get character length type
   mlir::Type getCharacterLengthType() { return getIndexType(); }
 
+  /// Get the integer type whose bit width corresponds to the width of pointer
+  /// types, or is bigger.
+  mlir::Type getIntPtrType() {
+    // TODO: Delay the need of such type until codegen or find a way to use
+    // llvm::DataLayout::getPointerSizeInBits here.
+    return getI64Type();
+  }
+
   /// Create a null constant memory reference of type \p ptrType.
   /// If \p ptrType is not provided, !fir.ref<none> type will be used.
   mlir::Value createNullConstant(mlir::Location loc, mlir::Type ptrType = {});

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -62,6 +62,9 @@ def AnyAddressableLike : TypeConstraint<Or<[fir_ReferenceType.predicate,
 def AnyBoxLike : TypeConstraint<Or<[fir_BoxType.predicate,
     fir_BoxCharType.predicate, fir_BoxProcType.predicate]>, "any box">;
 
+// Reference and Box like types
+def AnyRefOrBoxLike : TypeConstraint<Or<[AnyReferenceLike.predicate, AnyBoxLike.predicate]>,
+    "any reference or box like">;
 def AnyShapeLike : TypeConstraint<Or<[fir_ShapeType.predicate,
     fir_ShapeShiftType.predicate]>, "any legal shape type">;
 def AnyShapeType : Type<AnyShapeLike.predicate, "any legal shape type">;
@@ -3436,7 +3439,7 @@ def fir_AbsentOp : fir_OneResultOp<"absent", [NoSideEffect]> {
     ```
   }];
 
-  let results = (outs AnyRefOrBox:$intype);
+  let results = (outs AnyRefOrBoxLike:$intype);
 
   let assemblyFormat = "type($intype) attr-dict";
 }
@@ -3454,7 +3457,7 @@ def fir_IsPresentOp : fir_SimpleOp<"is_present", [NoSideEffect]> {
     ```
   }];
 
-  let arguments = (ins AnyRefOrBox:$val);
+  let arguments = (ins AnyRefOrBoxLike:$val);
 
   let results = (outs BoolLike);
 }

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -935,6 +935,17 @@ Fortran::lower::genMutableBoxRead(Fortran::lower::FirOpBuilder &builder,
   return fir::AbstractBox{addr};
 }
 
+mlir::Value Fortran::lower::genIsAllocatedOrAssociatedTest(
+    Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+    const fir::MutableBoxValue &box) {
+  auto addr = MutablePropertyReader(builder, loc, box).readBaseAddress();
+  auto intPtrTy = builder.getIntPtrType();
+  auto ptrToInt = builder.createConvert(loc, intPtrTy, addr);
+  auto c0 = builder.createIntegerConstant(loc, intPtrTy, 0);
+  return builder.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ne, ptrToInt,
+                                      c0);
+}
+
 //===----------------------------------------------------------------------===//
 // MutableBoxValue syncing implementation
 //===----------------------------------------------------------------------===//

--- a/flang/test/Fir/optional.fir
+++ b/flang/test/Fir/optional.fir
@@ -33,3 +33,20 @@ func @bar2() -> i1 {
   %1 = fir.call @foo2(%0) : (!fir.ref<i64>) -> i1
   return %1 : i1
 }
+
+// CHECK-LABEL: @foo3
+func @foo3(%arg0: !fir.boxchar<1>) -> i1 {
+  // CHECK: %[[extract:.*]] = extractvalue { i8*, i64 } %{{.*}}, 0
+  // CHECK: %[[ptr:.*]] = ptrtoint i8* %[[extract]] to i64
+  // CHECK: icmp ne i64 %[[ptr]], 0
+  %0 = fir.is_present %arg0 : (!fir.boxchar<1>) -> i1
+  return %0 : i1
+}
+
+// CHECK-LABEL: @bar3
+func @bar3() -> i1 {
+  %0 = fir.absent !fir.boxchar<1>
+  // CHECK: call i1 @foo3(i8* null, i64 undef)
+  %1 = fir.call @foo3(%0) : (!fir.boxchar<1>) -> i1
+  return %1 : i1
+}

--- a/flang/test/Lower/optional.f90
+++ b/flang/test/Lower/optional.f90
@@ -1,0 +1,135 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Test OPTIONAL lowering on caller/callee and PRESENT intrinsic.
+module opt
+contains
+
+! Test simple scalar optional
+! CHECK-LABEL: func @_QMoptPintrinsic_scalar
+! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<f32> {fir.optional})
+subroutine intrinsic_scalar(x)
+  implicit none
+  real, optional :: x
+  ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<f32>) -> i1
+  print *, present(x)
+end subroutine
+! CHECK-LABEL: @_QMoptPcall_intrinsic_scalar()
+subroutine call_intrinsic_scalar()
+  implicit none
+  ! CHECK: %[[x:.*]] = fir.alloca f32
+  real :: x
+  ! CHECK: fir.call @_QMoptPintrinsic_scalar(%[[x]]) : (!fir.ref<f32>) -> ()
+  call intrinsic_scalar(x)
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.ref<f32>
+  ! CHECK: fir.call @_QMoptPintrinsic_scalar(%[[absent]]) : (!fir.ref<f32>) -> ()
+  call intrinsic_scalar()
+end subroutine
+
+! Test explicit shape array optional
+! CHECK-LABEL: func @_QMoptPintrinsic_f77_array
+! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.array<100xf32>> {fir.optional})
+subroutine intrinsic_f77_array(x)
+  implicit none
+  real, optional :: x(100)
+  ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.array<100xf32>>) -> i1
+  print *, present(x)
+end subroutine
+! CHECK-LABEL: func @_QMoptPcall_intrinsic_f77_array()
+subroutine call_intrinsic_f77_array()
+  implicit none
+  ! CHECK: %[[x:.*]] = fir.alloca !fir.array<100xf32>
+  real :: x(100)
+  ! CHECK: fir.call @_QMoptPintrinsic_f77_array(%[[x]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+  call intrinsic_f77_array(x)
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.ref<!fir.array<100xf32>>
+  ! CHECK: fir.call @_QMoptPintrinsic_f77_array(%[[absent]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+  call intrinsic_f77_array()
+end subroutine
+
+! Test optional character scalar
+! CHECK-LABEL: func @_QMoptPcharacter_scalar
+! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1> {fir.optional})
+subroutine character_scalar(x)
+  implicit none
+  ! CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  character(10), optional :: x
+  ! CHECK: fir.is_present %[[unboxed]]#0 : (!fir.ref<!fir.char<1,?>>) -> i1
+  print *, present(x)
+end subroutine
+! CHECK-LABEL: func @_QMoptPcall_character_scalar()
+subroutine call_character_scalar()
+  implicit none
+  ! CHECK: %[[addr:.*]] = fir.alloca !fir.char<1,10>
+  character(10) :: x
+  ! CHECK: %[[addrCast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[x:.*]] = fir.emboxchar %[[addrCast]], {{.*}}
+  ! CHECK: fir.call @_QMoptPcharacter_scalar(%[[x]]) : (!fir.boxchar<1>) -> ()
+  call character_scalar(x)
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.boxchar<1>
+  ! CHECK: fir.call @_QMoptPcharacter_scalar(%[[absent]]) : (!fir.boxchar<1>) -> ()
+  call character_scalar()
+end subroutine
+
+! Test optional assumed shape
+! CHECK-LABEL: func @_QMoptPassumed_shape
+! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional})
+subroutine assumed_shape(x)
+  implicit none
+  ! CHECK: %[[boxaddr:.*]] = fir.box_addr %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  real, optional :: x(:)
+  ! CHECK: fir.is_present %[[boxaddr]] : (!fir.ref<!fir.array<?xf32>>) -> i1
+  print *, present(x)
+end subroutine
+! CHECK: func @_QMoptPcall_assumed_shape()
+subroutine call_assumed_shape()
+  implicit none
+  ! CHECK: %[[addr:.*]] = fir.alloca !fir.array<100xf32>
+  real :: x(100)
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]]
+  ! CHECK: %[[x:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<100xf32>>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QMoptPassumed_shape(%[[x]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call assumed_shape(x)
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QMoptPassumed_shape(%[[absent]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call assumed_shape()
+end subroutine
+
+! Test optional allocatable
+! CHECK: func @_QMoptPallocatable_array
+! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.optional})
+subroutine allocatable_array(x)
+  implicit none
+  real, allocatable, optional :: x(:)
+  ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> i1
+  print *, present(x)
+end subroutine
+! CHECK: func @_QMoptPcall_allocatable_array()
+subroutine call_allocatable_array()
+  implicit none
+  ! CHECK: %[[x:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>>
+  real, allocatable :: x(:)
+  ! CHECK: fir.call @_QMoptPallocatable_array(%[[x]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> ()
+  call allocatable_array(x)
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: fir.call @_QMoptPallocatable_array(%[[absent]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> ()
+  call allocatable_array()
+end subroutine
+
+! CHECK: func @_QMoptPallocatable_to_assumed_optional_array
+! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
+subroutine allocatable_to_assumed_optional_array(x)
+  implicit none
+  real, allocatable :: x(:)
+  ! CHECK: %[[embox:.*]] = fir.embox %{{.*}}
+
+  ! CHECK: %[[xboxload:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[xptr:.*]] = fir.box_addr %[[xboxload]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[xaddr:.*]] = fir.convert %[[xptr]] : (!fir.heap<!fir.array<?xf32>>) -> i64
+  ! CHECK: %[[isAlloc:.*]] = cmpi ne, %[[xaddr]], %c0{{.*}} : i64
+  ! CHECK: %[[absent:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[actual:.*]] = select %[[isAlloc]], %[[embox]], %[[absent]] : !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QMoptPassumed_shape(%[[actual]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call assumed_shape(x)
+end subroutine
+
+end module


### PR DESCRIPTION
- Add fir.boxchar support to fir.absent/fir.is_present
- Lower absent optional argument (and the unallocated pointer/allocatable actual to optional assume shape case)
- Lower PRESENT intrinsic (needed to update the interface so that intrinsic lowering can configure how argument should be lowered instead of always lowering everything to a value. That will be useful for many f95+ intrinsics).
