### PR TITLE
Update fir.field_index codegen for static layout derived types

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -281,6 +281,9 @@ public:
   TypeList getLenParamList();
 
   mlir::Type getType(llvm::StringRef ident);
+  /// Returns the index of the field \p ident in the type list.
+  /// Returns maximum unsigned if ident is not a field of this RecordType.
+  unsigned getFieldIndex(llvm::StringRef ident);
   mlir::Type getType(unsigned index) {
     assert(index < getNumFields());
     return getTypeList()[index].second;

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -987,6 +987,13 @@ mlir::Type fir::RecordType::getType(llvm::StringRef ident) {
   return {};
 }
 
+unsigned fir::RecordType::getFieldIndex(llvm::StringRef ident) {
+  for (auto f : llvm::enumerate(getTypeList()))
+    if (ident == f.value().first)
+      return f.index();
+  return std::numeric_limits<unsigned>::max();
+}
+
 //===----------------------------------------------------------------------===//
 // Type descriptor type
 //===----------------------------------------------------------------------===//

--- a/flang/test/Fir/field-index.fir
+++ b/flang/test/Fir/field-index.fir
@@ -1,0 +1,30 @@
+// Test fir.field_index llvm code generation
+// RUN: fir-opt %s | tco | FileCheck %s
+
+
+// CHECK-DAG: %[[a:.*]] = type { float, i32 }
+// CHECK-DAG: %[[b:.*]] = type { float, i32 }
+// CHECK-DAG: %[[c:.*]] = type { float, %[[b]] }
+
+// CHECK-LABEL: @simple_field
+// CHECK-SAME: (%[[a]]* %[[arg0:.*]])
+func @simple_field(%arg0: !fir.ref<!fir.type<a{x:f32,i:i32}>>) -> i32 {
+  %1 = fir.field_index i, !fir.type<a{x:f32,i:i32}>
+  // CHECK: %[[GEP:.*]] = getelementptr %[[a]], %[[a]]* %[[arg0]], i64 0, i32 1
+  %2 = fir.coordinate_of %arg0, %1 : (!fir.ref<!fir.type<a{x:f32,i:i32}>>, !fir.field) -> !fir.ref<i32>
+  // CHECK: load i32, i32* %[[GEP]]
+  %3 = fir.load %2 : !fir.ref<i32>
+  return %3 : i32
+}
+
+// CHECK-LABEL: @derived_field
+// CHECK-SAME: (%[[c]]* %[[arg0:.*]])
+func @derived_field(%arg0: !fir.ref<!fir.type<c{x:f32,some_b:!fir.type<b{x:f32,i:i32}>}>>) -> i32 {
+  %1 = fir.field_index some_b, !fir.type<c{x:f32,some_b:!fir.type<b{x:f32,i:i32}>}>
+  %2 = fir.field_index i, !fir.type<b{x:f32,i:i32}>
+  // CHECK: %[[GEP:.*]] = getelementptr %[[c]], %[[c]]* %[[arg0]], i64 0, i32 1, i32 1
+  %3 = fir.coordinate_of %arg0, %1, %2 : (!fir.ref<!fir.type<c{x:f32,some_b:!fir.type<b{x:f32,i:i32}>}>>, !fir.field, !fir.field) -> !fir.ref<i32>
+  // CHECK: load i32, i32* %[[GEP]]
+  %4 = fir.load %3 : !fir.ref<i32>
+  return %4 : i32
+}


### PR DESCRIPTION
In field_index codegen, when the derived type has a static layout, returns the field index. All consumers are expecting an index to generate a GEP, but the codegen code only had the code making a mock runtime call to get a byte offset in case the derived type layout is dynamic. 