### PR TITLE
Derived types lowering updates

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -40,7 +40,8 @@ class CharBlock;
 }
 namespace semantics {
 class Symbol;
-}
+class DerivedTypeSpec;
+} // namespace semantics
 
 namespace lower {
 namespace pft {
@@ -122,6 +123,8 @@ public:
   virtual mlir::Type
   genType(Fortran::common::TypeCategory tc, int kind,
           llvm::ArrayRef<std::int64_t> lenParameters = llvm::None) = 0;
+  /// Generate the type from a DerivedTypeSpec.
+  virtual mlir::Type genType(const Fortran::semantics::DerivedTypeSpec &) = 0;
   /// Generate the type from a Variable
   virtual mlir::Type genType(const pft::Variable &) = 0;
 

--- a/flang/include/flang/Lower/ConvertType.h
+++ b/flang/include/flang/Lower/ConvertType.h
@@ -45,6 +45,7 @@ struct SomeType;
 
 namespace semantics {
 class Symbol;
+class DerivedTypeSpec;
 } // namespace semantics
 
 namespace lower {
@@ -62,6 +63,11 @@ using LenParameterTy = std::int64_t;
 /// Get a FIR type based on a category and kind.
 mlir::Type getFIRType(mlir::MLIRContext *ctxt, common::TypeCategory tc,
                       int kind, llvm::ArrayRef<LenParameterTy>);
+
+/// Get a FIR type for a derived type
+mlir::Type
+translateDerivedTypeToFIRType(Fortran::lower::AbstractConverter &,
+                              const Fortran::semantics::DerivedTypeSpec &);
 
 /// Translate a SomeExpr to an mlir::Type.
 mlir::Type translateSomeExprToFIRType(Fortran::lower::AbstractConverter &,

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -308,6 +308,10 @@ public:
     return Fortran::lower::getFIRType(&getMLIRContext(), tc, kind,
                                       lenParameters);
   }
+  mlir::Type
+  genType(const Fortran::semantics::DerivedTypeSpec &tySpec) override final {
+    return Fortran::lower::translateDerivedTypeToFIRType(*this, tySpec);
+  }
   mlir::Type genType(Fortran::common::TypeCategory tc) override final {
     return Fortran::lower::getFIRType(
         &getMLIRContext(), tc, bridge.getDefaultKinds().GetDefaultKind(tc),

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1055,6 +1055,9 @@ public:
     auto component = gen(aref.base().GetComponent());
     auto base = fir::getBase(component);
     llvm::SmallVector<mlir::Value, 8> args;
+    // FIXME: the lower bounds should be apply, and in general,
+    // this coordinate op will only work if the extents are compile
+    // time constants. Otherwise, the coordinateOp need to be collapsed.
     for (auto &subsc : aref.subscript())
       args.push_back(genunbox(subsc));
     auto ty = genSubType(base.getType(), args.size());

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -137,28 +137,33 @@ componentToExtendedValue(Fortran::lower::FirOpBuilder &builder,
                          mlir::Location loc, const fir::ExtendedValue &obj,
                          mlir::Value component) {
   auto fieldTy = fir::dyn_cast_ptrEleTy(component.getType());
-  if (Fortran::lower::CharacterExprHelper::isCharacterScalar(fieldTy)) {
-    auto cstLen =
-        Fortran::lower::CharacterExprHelper::getCharacterType(fieldTy).getLen();
+  if (fieldTy.dyn_cast<fir::BoxType>())
+    TODO("lower pointer/allocatable component ref");
+  llvm::SmallVector<mlir::Value, 4> extents;
+  if (auto seqTy = fieldTy.dyn_cast<fir::SequenceType>()) {
+    fieldTy = seqTy.getEleTy();
+    auto idxTy = builder.getIndexType();
+    for (auto extent : seqTy.getShape()) {
+      if (extent == fir::SequenceType::getUnknownExtent())
+        TODO("array component shape depending on length parameters");
+      extents.emplace_back(builder.createIntegerConstant(loc, idxTy, extent));
+    }
+  }
+  if (auto charTy = fieldTy.dyn_cast<fir::CharacterType>()) {
+    auto cstLen = charTy.getLen();
     if (cstLen == fir::CharacterType::unknownLen())
-      fir::emitFatalError(
-          loc,
-          "TODO: get character component length from length type parameters");
+      TODO("get character component length from length type parameters");
     auto len = builder.createIntegerConstant(
         loc, builder.getCharacterLengthType(), cstLen);
+    if (!extents.empty())
+      return fir::CharArrayBoxValue{component, len, extents};
     return fir::CharBoxValue{component, len};
   }
-  // TODO: array component. Currently hitting an assert in array expression
-  // code.
-  if (fieldTy.dyn_cast<fir::SequenceType>())
-    fir::emitFatalError(loc, "TODO: lower shape of array component ref");
-  if (fieldTy.dyn_cast<fir::BoxType>())
-    fir::emitFatalError(loc, "TODO: lower pointer/allocatable component ref");
   if (auto recordTy = fieldTy.dyn_cast<fir::RecordType>())
     if (recordTy.getNumLenParams() != 0)
-      fir::emitFatalError(loc, "TODO: lower component ref that is a derived "
-                               "type with length parameter");
-  // Non character intrinsic scalar.
+      TODO("lower component ref that is a derived type with length parameter");
+  if (extents.empty())
+    return fir::ArrayBoxValue{component, extents};
   return component;
 }
 
@@ -992,21 +997,19 @@ public:
     auto *base = reverseComponents(cmpt, list);
     llvm::SmallVector<mlir::Value, 4> coorArgs;
     auto obj = gen(*base);
-    const auto *sym = &cmpt.GetFirstSymbol();
-    auto ty = converter.genType(*sym);
+    auto ty = fir::dyn_cast_ptrEleTy(fir::getBase(obj).getType());
     auto loc = getLoc();
     auto fldTy = fir::FieldType::get(&converter.getMLIRContext());
     // FIXME: need to thread the LEN type parameters here.
     for (auto *field : list) {
       auto recTy = ty.cast<fir::RecordType>();
-      sym = &field->GetLastSymbol();
+      const auto *sym = &field->GetLastSymbol();
       auto name = toStringRef(sym->name());
       coorArgs.push_back(builder.create<fir::FieldIndexOp>(
           loc, fldTy, name, mlir::TypeAttr::get(recTy),
           /*lenparams=*/mlir::ValueRange{}));
       ty = recTy.getType(name);
     }
-    assert(sym && "no component(s)?");
     ty = builder.getRefType(ty);
     return componentToExtendedValue(
         builder, loc, obj,
@@ -1049,13 +1052,20 @@ public:
 
   fir::ExtendedValue
   genArrayRefComponent(const Fortran::evaluate::ArrayRef &aref) {
-    auto base = fir::getBase(gen(aref.base().GetComponent()));
+    auto component = gen(aref.base().GetComponent());
+    auto base = fir::getBase(component);
     llvm::SmallVector<mlir::Value, 8> args;
     for (auto &subsc : aref.subscript())
       args.push_back(genunbox(subsc));
     auto ty = genSubType(base.getType(), args.size());
     ty = builder.getRefType(ty);
-    return builder.create<fir::CoordinateOp>(getLoc(), ty, base, args);
+    auto addr = builder.create<fir::CoordinateOp>(getLoc(), ty, base, args);
+    // TODO: use arrayElementToExtendedValue from PR 602 once merged.
+    return component.match(
+        [&](const fir::CharArrayBoxValue &x) -> fir::ExtendedValue {
+          return fir::CharBoxValue{addr, x.getLen()};
+        },
+        [&](const auto &) -> fir::ExtendedValue { return addr; });
   }
 
   static bool isSlice(const Fortran::evaluate::ArrayRef &aref) {

--- a/flang/test/Lower/derived-types.f90
+++ b/flang/test/Lower/derived-types.f90
@@ -1,0 +1,173 @@
+! Test basic parts of derived type entities lowering
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Note: only testing non parametrized derived type here.
+
+module d
+  type r
+    real :: x
+  end type
+  type r2
+    real :: x_array(10, 20)
+  end type
+  type c
+    character(10) :: ch
+  end type
+  type c2
+    character(10) :: ch_array(20, 30)
+  end type
+contains
+
+! -----------------------------------------------------------------------------
+!            Test simple derived type symbol lowering 
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: @_QMdPderived_dummy
+! CHECK-SAME: (%{{.*}}: !fir.ref<!fir.type<r{x:f32}>>,
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>
+subroutine derived_dummy(some_r, some_c2)
+  type(r) :: some_r
+  type(c2) :: some_c2
+end subroutine
+
+! CHECK-LABEL: @_QMdPlocal_derived
+subroutine local_derived()
+  ! CHECK-DAG: fir.alloca !fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>
+  ! CHECK-DAG: fir.alloca !fir.type<r{x:f32}>
+  type(r) :: some_r
+  type(c2) :: some_c2
+end subroutine
+
+! CHECK-LABEL: @_QMdPsaved_derived
+subroutine saved_derived()
+  ! CHECK-DAG: fir.address_of(@_QMdFsaved_derivedEsome_c2) : !fir.ref<!fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>
+  ! CHECK-DAG: fir.address_of(@_QMdFsaved_derivedEsome_r) : !fir.ref<!fir.type<r{x:f32}>>
+  type(r), save :: some_r
+  type(c2), save :: some_c2
+  call use_symbols(some_r, some_c2)
+end subroutine
+
+
+! -----------------------------------------------------------------------------
+!            Test simple derived type references 
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: @_QMdPscalar_numeric_ref 
+subroutine scalar_numeric_ref()
+  ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<r{x:f32}>
+  type(r) :: some_r
+  ! CHECK: %[[field:.*]] = fir.field_index x, !fir.type<r{x:f32}>
+  ! CHECK: fir.coordinate_of %[[alloc]], %[[field]] : (!fir.ref<!fir.type<r{x:f32}>>, !fir.field) -> !fir.ref<f32>
+  call real_bar(some_r%x)
+end subroutine
+
+! CHECK-LABEL: @_QMdPscalar_character_ref 
+subroutine scalar_character_ref()
+  ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<c{ch:!fir.char<1,10>}>
+  type(c) :: some_c
+  ! CHECK: %[[field:.*]] = fir.field_index ch, !fir.type<c{ch:!fir.char<1,10>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[alloc]], %[[field]] : (!fir.ref<!fir.type<c{ch:!fir.char<1,10>}>>, !fir.field) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK-DAG: %[[c10:.*]] = constant 10 : index
+  ! CHECK-DAG: %[[conv:.*]] = fir.convert %[[coor]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: fir.emboxchar %[[conv]], %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  call char_bar(some_c%ch)
+end subroutine
+
+! FIXME: coordinate of generated for derived%array_comp(i) are not zero based as they
+! should be.
+
+! CHECK-LABEL: @_QMdParray_comp_elt_ref
+subroutine array_comp_elt_ref()
+  type(r2) :: some_r2
+  ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<r2{x_array:!fir.array<10x20xf32>}>
+  ! CHECK: %[[field:.*]] = fir.field_index x_array, !fir.type<r2{x_array:!fir.array<10x20xf32>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[alloc]], %[[field]] : (!fir.ref<!fir.type<r2{x_array:!fir.array<10x20xf32>}>>, !fir.field) -> !fir.ref<!fir.array<10x20xf32>>
+  ! CHECK: fir.coordinate_of %[[coor]], %c5{{.*}}, %c6{{.*}} : (!fir.ref<!fir.array<10x20xf32>>, i64, i64) -> !fir.ref<f32>
+  call real_bar(some_r2%x_array(5, 6))
+end subroutine
+
+
+! CHECK-LABEL: @_QMdPchar_array_comp_elt_ref
+subroutine char_array_comp_elt_ref()
+  type(c2) :: some_c2
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>, !fir.field) -> !fir.ref<!fir.array<20x30x!fir.char<1,10>>>
+  ! CHECK: fir.coordinate_of %[[coor]], %c5{{.*}}, %c6{{.*}} : (!fir.ref<!fir.array<20x30x!fir.char<1,10>>>, i64, i64) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: fir.emboxchar %{{.*}}, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  call char_bar(some_c2%ch_array(5, 6))
+end subroutine
+
+! CHECK: @_QMdParray_elt_comp_ref
+subroutine array_elt_comp_ref()
+  type(r) :: some_r_array(100)
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.array<100x!fir.type<r{x:f32}>>
+  ! CHECK: %[[index:.*]] = subi %c5{{.*}}, %c1{{.*}} : i64
+  ! CHECK: %[[elt:.*]] = fir.coordinate_of %[[alloca]], %[[index]] : (!fir.ref<!fir.array<100x!fir.type<r{x:f32}>>>, i64) -> !fir.ref<!fir.type<r{x:f32}>>
+  ! CHECK: %[[field:.*]] = fir.field_index x, !fir.type<r{x:f32}>
+  ! CHECK: fir.coordinate_of %[[elt]], %[[field]] : (!fir.ref<!fir.type<r{x:f32}>>, !fir.field) -> !fir.ref<f32>
+  call real_bar(some_r_array(5)%x)
+end subroutine
+
+! CHECK: @_QMdPchar_array_elt_comp_ref
+subroutine char_array_elt_comp_ref()
+  type(c) :: some_c_array(100)
+  ! CHECK: fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<c{ch:!fir.char<1,10>}>>>, i64) -> !fir.ref<!fir.type<c{ch:!fir.char<1,10>}>>
+  ! CHECK: fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.type<c{ch:!fir.char<1,10>}>>, !fir.field) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: fir.emboxchar %{{.*}}, %c10{{.*}} : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  call char_bar(some_c_array(5)%ch)
+end subroutine
+
+
+! -----------------------------------------------------------------------------
+!            Test returned derived types (no length parameters)
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: @_QMdPbar_return_derived
+! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.type<r{x:f32}>>) -> !fir.ref<!fir.type<r{x:f32}>>
+function bar_return_derived()
+  type(r) :: bar_return_derived
+  ! CHECK: return %[[arg0]] : !fir.ref<!fir.type<r{x:f32}>>
+end function
+
+! CHECK-LABEL: @_QMdPcall_bar_return_derived
+subroutine call_bar_return_derived()
+  ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<r{x:f32}>
+  ! CHECK: fir.call @_QMdPbar_return_derived(%[[tmp]]) : (!fir.ref<!fir.type<r{x:f32}>>) -> !fir.ref<!fir.type<r{x:f32}>>
+  ! CHECK: fir.call @_QPr_bar(%[[tmp]]) : (!fir.ref<!fir.type<r{x:f32}>>) -> ()
+  call r_bar(bar_return_derived())
+end subroutine
+
+end module
+
+! -----------------------------------------------------------------------------
+!            Test derived type with pointer/allocatable components 
+! -----------------------------------------------------------------------------
+
+module d2
+  type recursive_t
+    real :: x
+    type(recursive_t), pointer :: ptr
+  end type
+contains
+! CHECK-LABEL: @_QMd2Ptest_recursive_type
+! CHECK: (%{{.*}}: !fir.ref<!fir.type<recursive_t{x:f32,ptr:!fir.box<!fir.ptr<!fir.type<recursive_t>>>}>>)
+subroutine test_recursive_type(some_recursive)
+  type(recursive_t) :: some_recursive
+end subroutine
+end module
+
+! -----------------------------------------------------------------------------
+!            Test global derived type symbol lowering 
+! -----------------------------------------------------------------------------
+
+module data_mod
+  use d
+  type(r) :: some_r
+  type(c2) :: some_c2
+end module
+
+! Test globals
+
+! CHECK-DAG: fir.global linkonce @_QMdata_modEsome_c2 : !fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>
+! CHECK-DAG: fir.global linkonce @_QMdata_modEsome_r : !fir.type<r{x:f32}>
+! CHECK-DAG: fir.global internal @_QMdFsaved_derivedEsome_c2 : !fir.type<c2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>
+! CHECK-DAG: fir.global internal @_QMdFsaved_derivedEsome_r : !fir.type<r{x:f32}>


### PR DESCRIPTION
- Support recursive derived types (currently was creating an infinite loops)
- Support non parametrized derived type in function interface (requires exposing derived type lowering to call interface lowering)
- Fix array and character component references (substbase was not doing the right thing)

This prevents 3 of the segfaults in #610 (the last one is not related to derived types)