### PR TITLE
Enable github actions CI

### DIFF
--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -1,0 +1,36 @@
+name: Flang Tests
+
+on:
+  push:
+    branches:
+      - fir-dev
+    paths:
+      - 'flang/**'
+      - '.github/workflows/flang-tests.yml'
+  pull_request:
+    branches:
+      - fir-dev
+    paths:
+      - 'flang/**'
+      - '.github/workflows/flang-tests.yml'
+
+jobs:
+  build_flang:
+    name: flang check-flang
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS-latest
+    steps:
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@main
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Test flang
+      uses: llvm/actions/build-test-llvm-project@main
+      with:
+        cmake_args: -G Ninja -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_PARALLEL_COMPILE_JOBS=2 -DLLVM_ENABLE_PROJECTS="clang;flang;mlir" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host
+        build_target: check-flang


### PR DESCRIPTION
-> Only enabled on Mac now (ubuntu with gcc-7.5 failed while building, general llvm issue i think).
-> Takes around 2 hrs.
-> Works for the fir-dev branch on commit and PullRequests.

We had something similar in classic-flang-llvm-project. So thought would make a copy here and check if there is interest. Can close if it is not useful.