### PR TITLE
Improve TODO message by adding Fortran source location

### DIFF
--- a/flang/include/flang/Lower/Todo.h
+++ b/flang/include/flang/Lower/Todo.h
@@ -13,6 +13,7 @@
 #ifndef FORTRAN_LOWER_TODO_H
 #define FORTRAN_LOWER_TODO_H
 
+#include "flang/Optimizer/Support/FatalError.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdlib>
@@ -21,31 +22,54 @@
 // developed.
 
 #undef TODO
+// Use TODO_NOLOC if no mlir location is available to indicate the line in
+// Fortran source file that requires an unimplemented feature.
+#undef TODO_NOLOC
+
+#undef TODOQUOTE
+#define TODOQUOTE(X) #X
 
 #ifdef NDEBUG
 
 // In a release build, just give a message and exit.
-#define TODO(ToDoMsg)                                                          \
+#define TODO_NOLOC(ToDoMsg)                                                    \
   do {                                                                         \
     llvm::errs() << __FILE__ << ':' << __LINE__ << ": not yet implemented "    \
                  << ToDoMsg << '\n';                                           \
     std::exit(1);                                                              \
   } while (false)
 
+#undef TODO_DEFN
+#define TODO_DEFN(MlirLoc, ToDoMsg, ToDoFile, ToDoLine)                        \
+  do {                                                                         \
+    mlir::emitError(MlirLoc, ToDoFile                                          \
+                    ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg); \
+    std::exit(1);                                                              \
+  } while (false)
+
+#define TODO(MlirLoc, ToDoMsg) TODO_DEFN(MlirLoc, ToDoMsg, __FILE__, __LINE__)
+
 #else
 
-#undef TODOQUOTE
-#define TODOQUOTE(X) #X
-
 // In a developer build, print a message and give a backtrace.
-#undef TODODEFN
-#define TODODEFN(ToDoMsg, ToDoFile, ToDoLine)                                  \
+#undef TODO_NOLOCDEFN
+#define TODO_NOLOCDEFN(ToDoMsg, ToDoFile, ToDoLine)                            \
   do {                                                                         \
     llvm::report_fatal_error(                                                  \
         ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg);    \
   } while (false)
 
-#define TODO(ToDoMsg) TODODEFN(ToDoMsg, __FILE__, __LINE__)
+#define TODO_NOLOC(ToDoMsg) TODO_NOLOCDEFN(ToDoMsg, __FILE__, __LINE__)
+
+#undef TODO_DEFN
+#define TODO_DEFN(MlirLoc, ToDoMsg, ToDoFile, ToDoLine)                        \
+  do {                                                                         \
+    fir::emitFatalError(                                                       \
+        MlirLoc,                                                               \
+        ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg);    \
+  } while (false)
+
+#define TODO(MlirLoc, ToDoMsg) TODO_DEFN(MlirLoc, ToDoMsg, __FILE__, __LINE__)
 
 #endif
 

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -388,14 +388,14 @@ struct ErrorManagementValues {
              const ::Fortran::lower::SomeExpr *errMsgExpr) {
     auto builder = converter.getFirOpBuilder();
     if (statExpr) {
-      TODO("lower stat expr in allocate and deallocate");
+      TODO(loc, "lower stat expr in allocate and deallocate");
       hasStat = builder.createBool(loc, true);
     } else {
       hasStat = builder.createBool(loc, false);
     }
 
     if (errMsgExpr)
-      TODO("errmsg in allocate and deallocate");
+      TODO(loc, "errmsg in allocate and deallocate");
     else
       errMsgBoxAddr = builder.createNullConstant(loc);
     sourceFile = converter.locationToFilename(loc);
@@ -427,11 +427,11 @@ public:
     // Create a landing block after all allocations so that
     // we can jump there in case of error.
     if (errorManagement.hasErrorRecovery())
-      TODO("error recovery");
+      TODO(loc, "error recovery");
 
     // TODO lower source and mold.
     if (sourceExpr || moldExpr)
-      TODO("lower MOLD/SOURCE expr in allocate");
+      TODO(loc, "lower MOLD/SOURCE expr in allocate");
 
     for (const auto &allocation :
          std::get<std::list<Fortran::parser::Allocation>>(stmt.t))
@@ -511,7 +511,7 @@ private:
   void handleError() {
     // Ensure allocation status was not modified and create jump to end
     // on allocate statement in case an error was met.
-    TODO("Error hanlding in allocate statement");
+    TODO(loc, "Error hanlding in allocate statement");
   }
 
   static bool lowerBoundsAreOnes(const Allocation &alloc) {
@@ -595,7 +595,7 @@ private:
     // Use runtime. sync MutableBoxValue and descriptor before and after calls.
     Fortran::lower::getMutableIRBox(builder, loc, box);
     if (alloc.hasCoarraySpec())
-      TODO("coarray allocation");
+      TODO(loc, "coarray allocation");
     if (alloc.type.IsPolymorphic())
       genSetType(alloc, box);
     genSetDeferredLengthParameters(alloc, box);
@@ -666,17 +666,17 @@ private:
       genAllocatableInitCharRtCall(builder, loc, box, lenParams[0]);
 
     if (box.isDerived())
-      TODO("derived type length parameters in allocate");
+      TODO(loc, "derived type length parameters in allocate");
   }
 
   void genSourceAllocation(const Allocation &, const fir::MutableBoxValue &) {
-    TODO("SOURCE allocation lowering");
+    TODO(loc, "SOURCE allocation lowering");
   }
   void genMoldAllocation(const Allocation &, const fir::MutableBoxValue &) {
-    TODO("MOLD allocation lowering");
+    TODO(loc, "MOLD allocation lowering");
   }
   void genSetType(const Allocation &, const fir::MutableBoxValue &) {
-    TODO("Polymorphic entity allocation lowering");
+    TODO(loc, "Polymorphic entity allocation lowering");
   }
 
   mlir::Value getSourceLine() const {
@@ -774,7 +774,7 @@ void Fortran::lower::genDeallocateStmt(
                },
                statOrErr.u);
   if (statExpr || errMsgExpr)
-    TODO("error recovery in deallocate");
+    TODO(loc, "error recovery in deallocate");
   ErrorManagementValues errorManagement;
   auto &builder = converter.getFirOpBuilder();
   errorManagement.lower(converter, loc, statExpr, errMsgExpr);
@@ -913,9 +913,9 @@ Fortran::lower::genMutableBoxRead(Fortran::lower::FirOpBuilder &builder,
                                   mlir::Location loc,
                                   const fir::MutableBoxValue &box) {
   if (box.hasAssumedRank())
-    TODO("Assumed rank allocatables or pointers");
+    TODO(loc, "Assumed rank allocatables or pointers");
   if (box.isPointer())
-    TODO("pointer"); // deal with non contiguity;
+    TODO(loc, "pointer"); // deal with non contiguity;
   llvm::SmallVector<mlir::Value, 2> lbounds;
   llvm::SmallVector<mlir::Value, 2> extents;
   llvm::SmallVector<mlir::Value, 2> lengths;
@@ -929,7 +929,7 @@ Fortran::lower::genMutableBoxRead(Fortran::lower::FirOpBuilder &builder,
     return fir::CharBoxValue{addr, len};
   }
   if (box.isDerived())
-    TODO("derived type MutableBoxValue opening");
+    TODO(loc, "derived type MutableBoxValue opening");
   if (rank)
     return fir::ArrayBoxValue{addr, extents, lbounds};
   return fir::AbstractBox{addr};

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -514,6 +514,7 @@ private:
     using Attrs = Fortran::evaluate::characteristics::DummyDataObject::Attr;
 
     bool isOptional = false;
+    [[maybe_unused]] auto loc = interface.converter.genLocation();
     llvm::SmallVector<mlir::NamedAttribute, 2> attrs;
     if (obj.attrs.test(Attrs::Optional)) {
       attrs.emplace_back(
@@ -522,26 +523,26 @@ private:
       isOptional = true;
     }
     if (obj.attrs.test(Attrs::Asynchronous))
-      TODO("Asynchronous in procedure interface");
+      TODO(loc, "Asynchronous in procedure interface");
     if (obj.attrs.test(Attrs::Contiguous))
       attrs.emplace_back(
           mlir::Identifier::get(fir::getContiguousAttrName(), &mlirContext),
           UnitAttr::get(&mlirContext));
     if (obj.attrs.test(Attrs::Value))
-      TODO("Value in procedure interface");
+      TODO(loc, "Value in procedure interface");
     if (obj.attrs.test(Attrs::Volatile))
-      TODO("Volatile in procedure interface");
+      TODO(loc, "Volatile in procedure interface");
     if (obj.attrs.test(Attrs::Target))
-      TODO("Target in procedure interface");
+      TODO(loc, "Target in procedure interface");
 
     // TODO: intents that require special care (e.g finalization)
 
     using ShapeAttrs = Fortran::evaluate::characteristics::TypeAndShape::Attr;
     const auto &shapeAttrs = obj.type.attrs();
     if (shapeAttrs.test(ShapeAttrs::AssumedRank))
-      TODO("Assumed Rank in procedure interface");
+      TODO(loc, "Assumed Rank in procedure interface");
     if (shapeAttrs.test(ShapeAttrs::Coarray))
-      TODO("Coarray in procedure interface");
+      TODO(loc, "Coarray in procedure interface");
 
     // So far assume that if the argument cannot be passed by implicit interface
     // it must be by box. That may no be always true (e.g for simple optionals)
@@ -605,7 +606,8 @@ private:
 
   void handleExplicitResult(
       const Fortran::evaluate::characteristics::FunctionResult &) {
-    TODO("lowering interface with result requiring explicit interface");
+    TODO(interface.converter.genLocation(),
+         "lowering interface with result requiring explicit interface");
   }
 
   fir::SequenceType::Shape getBounds(const Fortran::evaluate::Shape &shape) {
@@ -639,7 +641,8 @@ private:
     interface.outputs.emplace_back(
         FirPlaceHolder{type, entityPosition, p, attributes});
   }
-  void addPassedArg(PassEntityBy p, FortranEntity entity, bool isOptional = false) {
+  void addPassedArg(PassEntityBy p, FortranEntity entity,
+                    bool isOptional = false) {
     interface.passedArguments.emplace_back(
         PassedEntity{p, entity, emptyValue(), emptyValue(), isOptional});
   }

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -200,7 +200,7 @@ Fortran::lower::CharacterExprHelper::createEmbox(const fir::CharBoxValue &box) {
 fir::CharBoxValue Fortran::lower::CharacterExprHelper::toScalarCharacter(
     const fir::CharArrayBoxValue &box) {
   if (box.getBuffer().getType().isa<fir::PointerType>())
-    TODO("concatenating non contiguous character array into a scalar");
+    TODO(loc, "concatenating non contiguous character array into a scalar");
 
   // TODO: add a fast path multiplying new length at compile time if the info is
   // in the array type.
@@ -529,7 +529,7 @@ void Fortran::lower::CharacterExprHelper::createAssign(
       return;
     }
   }
-  TODO("character array assignment");
+  TODO(loc, "character array assignment");
   // Note that it is not sure the array aspect should be handled
   // by this utility.
 }

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -75,7 +75,7 @@ Fortran::lower::genCharCompare(Fortran::lower::AbstractConverter &converter,
                                const fir::ExtendedValue &rhs) {
   auto &builder = converter.getFirOpBuilder();
   if (lhs.getBoxOf<fir::BoxValue>() || rhs.getBoxOf<fir::BoxValue>())
-    TODO("character compare from descriptors");
+    TODO(loc, "character compare from descriptors");
   auto allocateIfNotInMemory = [&](mlir::Value base) -> mlir::Value {
     if (fir::isa_ref_type(base.getType()))
       return base;

--- a/flang/lib/Lower/Coarray.cpp
+++ b/flang/lib/Lower/Coarray.cpp
@@ -27,27 +27,27 @@ void Fortran::lower::genChangeTeamConstruct(
     Fortran::lower::AbstractConverter &converter,
     Fortran::lower::pft::Evaluation &,
     const Fortran::parser::ChangeTeamConstruct &) {
-  TODO("CHANGE TEAM construct");
+  TODO(converter.genLocation(), "CHANGE TEAM construct");
 }
 
 void Fortran::lower::genChangeTeamStmt(
     Fortran::lower::AbstractConverter &converter,
     Fortran::lower::pft::Evaluation &,
     const Fortran::parser::ChangeTeamStmt &) {
-  TODO("CHANGE TEAM stmt");
+  TODO(converter.genLocation(), "CHANGE TEAM stmt");
 }
 
 void Fortran::lower::genEndChangeTeamStmt(
     Fortran::lower::AbstractConverter &converter,
     Fortran::lower::pft::Evaluation &,
     const Fortran::parser::EndChangeTeamStmt &) {
-  TODO("END CHANGE TEAM");
+  TODO(converter.genLocation(), "END CHANGE TEAM");
 }
 
 void Fortran::lower::genFormTeamStatement(
     Fortran::lower::AbstractConverter &converter,
     Fortran::lower::pft::Evaluation &, const Fortran::parser::FormTeamStmt &) {
-  TODO("FORM TEAM");
+  TODO(converter.genLocation(), "FORM TEAM");
 }
 
 //===----------------------------------------------------------------------===//
@@ -59,10 +59,10 @@ fir::ExtendedValue Fortran::lower::CoarrayExprHelper::genAddr(
   (void)converter;
   (void)symMap;
   (void)loc;
-  TODO("co-array address");
+  TODO(converter.genLocation(), "co-array address");
 }
 
 fir::ExtendedValue Fortran::lower::CoarrayExprHelper::genValue(
     const Fortran::evaluate::CoarrayRef &expr) {
-  TODO("co-array value");
+  TODO(converter.genLocation(), "co-array value");
 }

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -154,7 +154,7 @@ struct TypeBuilder {
     auto shapeExpr =
         Fortran::evaluate::GetShape(converter.getFoldingContext(), expr);
     if (!shapeExpr)
-      TODO("Assumed rank expression type lowering");
+      TODO(converter.genLocation(), "Assumed rank expression type lowering");
     fir::SequenceType::Shape shape;
     translateShape(shape, std::move(*shapeExpr));
     if (!shape.empty())
@@ -234,7 +234,7 @@ struct TypeBuilder {
       auto shapeExpr = Fortran::evaluate::GetShapeHelper{
           converter.getFoldingContext()}(ultimate);
       if (!shapeExpr)
-        TODO("assumed rank symbol type lowering");
+        TODO(loc, "assumed rank symbol type lowering");
       fir::SequenceType::Shape shape;
       translateShape(shape, std::move(*shapeExpr));
       ty = fir::SequenceType::get(shape, ty);
@@ -312,7 +312,7 @@ struct TypeBuilder {
     if (category == Fortran::common::TypeCategory::Character)
       params.push_back(getCharacterLength(exprOrSym));
     else if (category == Fortran::common::TypeCategory::Derived)
-      TODO("lowering derived type length parameters");
+      TODO(converter.genLocation(), "lowering derived type length parameters");
     return;
   }
   Fortran::lower::LenParameterTy

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -526,7 +526,7 @@ genBuffer(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
       [&](const fir::BoxValue &) -> ValuePair {
         // May need to copy before after IO to handle contiguous
         // aspect. Not sure descriptor can get here though.
-        TODO("character descriptor to contiguous buffer");
+        TODO(loc, "character descriptor to contiguous buffer");
       },
       [&](const auto &) -> ValuePair {
         llvm::report_fatal_error(
@@ -686,9 +686,9 @@ mlir::Value genIOOption<Fortran::parser::ConnectSpec::CharExpr>(
     ioFunc = getIORuntimeFunc<mkIOKey(SetCarriagecontrol)>(loc, builder);
     break;
   case Fortran::parser::ConnectSpec::CharExpr::Kind::Convert:
-    TODO("CONVERT not part of the runtime::io interface");
+    TODO(loc, "CONVERT not part of the runtime::io interface");
   case Fortran::parser::ConnectSpec::CharExpr::Kind::Dispose:
-    TODO("DISPOSE not part of the runtime::io interface");
+    TODO(loc, "DISPOSE not part of the runtime::io interface");
   }
   mlir::FunctionType ioFuncTy = ioFunc.getType();
   auto tup = lowerStringLit(
@@ -722,7 +722,7 @@ genIOOption<Fortran::parser::Name>(Fortran::lower::AbstractConverter &converter,
                                    mlir::Location loc, mlir::Value cookie,
                                    Fortran::lower::StatementContext &stmtCtx,
                                    const Fortran::parser::Name &spec) {
-  TODO("namelist");
+  TODO(loc, "namelist");
 }
 
 template <>
@@ -778,7 +778,7 @@ mlir::Value genIOOption<Fortran::parser::IdVariable>(
     Fortran::lower::AbstractConverter &converter, mlir::Location loc,
     mlir::Value cookie, Fortran::lower::StatementContext &stmtCtx,
     const Fortran::parser::IdVariable &spec) {
-  TODO("asynchronous ID not implemented");
+  TODO(loc, "asynchronous ID not implemented");
 }
 
 template <>
@@ -1018,7 +1018,7 @@ static bool isDataTransferAsynchronous(const A &stmt) {
   if (auto *asynch =
           getIOControl<Fortran::parser::IoControlSpec::Asynchronous>(stmt)) {
     // FIXME: should contain a string of YES or NO
-    TODO("asynchronous transfers not implemented in runtime");
+    TODO_NOLOC("asynchronous transfers not implemented in runtime");
   }
   return false;
 }
@@ -1454,7 +1454,7 @@ void genBeginCallArguments(llvm::SmallVectorImpl<mlir::Value> &ioArgs,
                                  ioFuncTy.getInput(ioArgs.size()), stmtCtx));
       if (isAsynch) {
         // unknown-thingy, [buff, LEN]
-        TODO("asynchrous");
+        TODO(loc, "asynchrous");
       }
       return;
     }
@@ -1462,7 +1462,7 @@ void genBeginCallArguments(llvm::SmallVectorImpl<mlir::Value> &ioArgs,
     if (!isIntern) {
       if (isNml) {
         // namelist group, ...
-        TODO("namelist");
+        TODO(loc, "namelist");
       } else if (!isList) {
         // | [format, LEN], ...
         auto pair =
@@ -1486,7 +1486,7 @@ void genBeginCallArguments(llvm::SmallVectorImpl<mlir::Value> &ioArgs,
           builder.createConvert(loc, ioFuncTy.getInput(ioArgs.size()), desc));
       if (isNml) {
         // namelist group, ...
-        TODO("namelist");
+        TODO(loc, "namelist");
       } else if (isOtherIntern && !isList) {
         // | [format, LEN], ...
         auto pair =

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1293,7 +1293,7 @@ IntrinsicLibrary::genLenTrim(mlir::Type resultType,
   Fortran::lower::CharacterExprHelper helper{builder, loc};
   auto *charBox = args[0].getCharBox();
   if (!charBox)
-    TODO("character array len_trim");
+    TODO(loc, "character array len_trim");
   auto len = helper.createLenTrim(*charBox);
   return builder.createConvert(loc, resultType, len);
 }

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -115,7 +115,7 @@ Fortran::lower::mangle::mangleName(const Fortran::semantics::Symbol &symbol) {
           [&](const Fortran::semantics::CommonBlockDetails &) {
             return fir::NameUniquer::doCommonBlock(symbolName);
           },
-          [](const auto &) -> std::string { TODO(""); },
+          [](const auto &) -> std::string { TODO_NOLOC("symbol mangling"); },
       },
       ultimateSymbol.details());
 }

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -634,11 +634,13 @@ genACC(Fortran::lower::AbstractConverter &converter,
       std::get<Fortran::parser::AccClauseList>(beginCombinedDirective.t);
 
   if (combinedDirective.v == llvm::acc::ACCD_kernels_loop) {
-    TODO("OpenACC Kernels Loop construct not lowered yet!");
+    TODO(converter.genLocation(),
+         "OpenACC Kernels Loop construct not lowered yet!");
   } else if (combinedDirective.v == llvm::acc::ACCD_parallel_loop) {
     genACCParallelLoopOps(converter, accClauseList);
   } else if (combinedDirective.v == llvm::acc::ACCD_serial_loop) {
-    TODO("OpenACC Serial Loop construct not lowered yet!");
+    TODO(converter.genLocation(),
+         "OpenACC Serial Loop construct not lowered yet!");
   } else {
     llvm::report_fatal_error(
         "Unknown combined construct encountered in lowering");
@@ -919,7 +921,7 @@ genACC(Fortran::lower::AbstractConverter &converter,
   } else if (standaloneDirective.v == llvm::acc::Directive::ACCD_shutdown) {
     genACCInitShutdownOp<mlir::acc::ShutdownOp>(converter, accClauseList);
   } else if (standaloneDirective.v == llvm::acc::Directive::ACCD_set) {
-    TODO("OpenACC set directive not lowered yet!");
+    TODO(converter.genLocation(), "OpenACC set directive not lowered yet!");
   } else if (standaloneDirective.v == llvm::acc::Directive::ACCD_update) {
     genACCUpdateOp(converter, accClauseList);
   }
@@ -1015,16 +1017,19 @@ void Fortran::lower::genOpenACCConstruct(
           },
           [&](const Fortran::parser::OpenACCRoutineConstruct
                   &routineConstruct) {
-            TODO("OpenACC Routine construct not lowered yet!");
+            TODO(converter.genLocation(),
+                 "OpenACC Routine construct not lowered yet!");
           },
           [&](const Fortran::parser::OpenACCCacheConstruct &cacheConstruct) {
-            TODO("OpenACC Cache construct not lowered yet!");
+            TODO(converter.genLocation(),
+                 "OpenACC Cache construct not lowered yet!");
           },
           [&](const Fortran::parser::OpenACCWaitConstruct &waitConstruct) {
             genACC(converter, eval, waitConstruct);
           },
           [&](const Fortran::parser::OpenACCAtomicConstruct &atomicConstruct) {
-            TODO("OpenACC Atomic construct not lowered yet!");
+            TODO(converter.genLocation(),
+                 "OpenACC Atomic construct not lowered yet!");
           },
       },
       accConstruct.u);

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -95,13 +95,13 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
         converter.getCurrentLocation());
     break;
   case llvm::omp::Directive::OMPD_target_enter_data:
-    TODO("");
+    TODO(converter.getCurrentLocation(), "OMPD_target_enter_data");
   case llvm::omp::Directive::OMPD_target_exit_data:
-    TODO("");
+    TODO(converter.getCurrentLocation(), "OMPD_target_exit_data");
   case llvm::omp::Directive::OMPD_target_update:
-    TODO("");
+    TODO(converter.getCurrentLocation(), "OMPD_target_update");
   case llvm::omp::Directive::OMPD_ordered:
-    TODO("");
+    TODO(converter.getCurrentLocation(), "OMPD_ordered");
   }
 }
 
@@ -130,10 +130,12 @@ genOMP(Fortran::lower::AbstractConverter &converter,
                 converter.getCurrentLocation(), operandRange);
           },
           [&](const Fortran::parser::OpenMPCancelConstruct &cancelConstruct) {
-            TODO("");
+            TODO(converter.getCurrentLocation(), "OpenMPCancelConstruct");
           },
           [&](const Fortran::parser::OpenMPCancellationPointConstruct
-                  &cancellationPointConstruct) { TODO(""); },
+                  &cancellationPointConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPCancelConstruct");
+          },
       },
       standaloneConstruct.u);
 }
@@ -448,22 +450,30 @@ void Fortran::lower::genOpenMPConstruct(
             genOMP(converter, eval, standaloneConstruct);
           },
           [&](const Fortran::parser::OpenMPSectionsConstruct
-                  &sectionsConstruct) { TODO(""); },
+                  &sectionsConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPSectionsConstruct");
+          },
           [&](const Fortran::parser::OpenMPLoopConstruct &loopConstruct) {
             genOMP(converter, eval, loopConstruct);
           },
           [&](const Fortran::parser::OpenMPDeclarativeAllocate
-                  &execAllocConstruct) { TODO(""); },
+                  &execAllocConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPDeclarativeAllocate");
+          },
           [&](const Fortran::parser::OpenMPExecutableAllocate
-                  &execAllocConstruct) { TODO(""); },
+                  &execAllocConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPExecutableAllocate");
+          },
           [&](const Fortran::parser::OpenMPBlockConstruct &blockConstruct) {
             genOMP(converter, eval, blockConstruct);
           },
           [&](const Fortran::parser::OpenMPAtomicConstruct &atomicConstruct) {
-            TODO("");
+            TODO(converter.getCurrentLocation(), "OpenMPAtomicConstruct");
           },
           [&](const Fortran::parser::OpenMPCriticalConstruct
-                  &criticalConstruct) { TODO(""); },
+                  &criticalConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPCriticalConstruct");
+          },
       },
       ompConstruct.u);
 }

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -850,7 +850,7 @@ struct DispatchOpConversion : public FIROpConversion<fir::DispatchOp> {
     // get the table, lookup the method, fetch the func-ptr
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(dispatch, ty, operands,
                                                     None);
-    TODO("");
+    TODO(dispatch.getLoc(), "fir.dispatch codegen");
     return success();
   }
 };
@@ -863,7 +863,7 @@ struct DispatchTableOpConversion
   mlir::LogicalResult
   matchAndRewrite(fir::DispatchTableOp dispTab, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    TODO("");
+    TODO(dispTab.getLoc(), "fir.dispatch_table codegen");
     return success();
   }
 };
@@ -875,7 +875,7 @@ struct DTEntryOpConversion : public FIROpConversion<fir::DTEntryOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::DTEntryOp dtEnt, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    TODO("");
+    TODO(dtEnt.getLoc(), "fir.dt_entry codegen");
     return success();
   }
 };
@@ -1033,15 +1033,14 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
       return getSizeAndTypeCode(loc, rewriter, seqTy.getEleTy(), lenParams);
     }
     if (boxEleTy.isa<fir::RecordType>()) {
-      TODO("");
+      TODO(loc, "record type fir.box codegen");
     }
     if (fir::isa_ref_type(boxEleTy)) {
       // FIXME: use the target pointer size rather than sizeof(void*)
       return {this->genConstantOffset(loc, rewriter, sizeof(void *)),
               this->genConstantOffset(loc, rewriter, CFI_type_cptr)};
     }
-    // fail: unhandled case
-    TODO("");
+    fir::emitFatalError(loc, "unhandled type in fir.box code generation");
   }
 
   /// Basic pattern to write a field in the descriptor
@@ -1125,7 +1124,7 @@ struct EmboxOpConversion : public EmboxCommonConversion<fir::EmboxOp> {
     dest = insertField(rewriter, embox.getLoc(), dest, {0}, operands[0],
                        /*bitCast=*/true);
     if (isDerivedType(boxTy))
-      TODO("derived type");
+      TODO(embox.getLoc(), "derived type fir.embox codegen");
     auto result = placeInMemoryIfNotGlobalInit(rewriter, embox.getLoc(), dest);
     rewriter.replaceOp(embox, result);
     return success();
@@ -1223,12 +1222,12 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::cg::XEmboxOp> {
       // For each field in the path add the offset to base. In the most general
       // case, some offsets must be computed since they are not be known until
       // runtime.
-      TODO("intra-entity slice");
+      TODO(xbox.getLoc(), "intra-entity slice in fir.embox codegen");
     }
     dest = insertField(rewriter, xbox.getLoc(), dest, {0}, base,
                        /*bitCast=*/true);
     if (isDerivedType(boxTy))
-      TODO("derived type");
+      TODO(xbox.getLoc(), "derived type in fir.embox codegen");
 
     auto result = placeInMemoryIfNotGlobalInit(rewriter, xbox.getLoc(), dest);
     rewriter.replaceOp(xbox, result);
@@ -1511,7 +1510,7 @@ struct XArrayCoorOpConversion
       // Working with byte offsets. The base address is read from the fir.box.
       // and need to be casted to void* to do the pointer arithmetic.
       if (!coor.subcomponent().empty())
-        TODO("arrayCoorOp with subcomponent on non contiguous base");
+        TODO(loc, "arrayCoorOp with subcomponent on non contiguous base");
       auto baseTy = getBaseAddrTypeFromBox(operands[0].getType());
       auto base = loadBaseAddrFromBox(loc, baseTy, operands[0], rewriter);
       auto voidPtrTy = getVoidPtrType(coor.getContext());
@@ -1614,7 +1613,7 @@ struct CoordinateOpConversion
       base = loadBaseAddrFromBox(loc, baseTy, base, rewriter);
       auto arrTy = cpnTy.dyn_cast<fir::SequenceType>();
       if (!arrTy || arrTy.getDimension() + 1 != operands.size())
-        TODO("fir.coordinateOf codegen with fir.box and record types");
+        TODO(loc, "fir.coordinateOf codegen with fir.box and record types");
 
       // Applies byte strides from the box. Ignore lower bound from box since
       // fir.coordinate_of indexes are zero based. Lowering takes care of
@@ -1951,7 +1950,7 @@ struct GlobalLenOpConversion : public FIROpConversion<fir::GlobalLenOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::GlobalLenOp globalLen, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    TODO("");
+    TODO(globalLen.getLoc(), "GlobalLenOp codegen");
     return success();
   }
 };

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -165,7 +165,7 @@ public:
       auto rowTy = getExtendedDescFieldTypeModel<10>()(&getContext());
       unsigned numLenParams = 0; // FIXME
       parts.push_back(mlir::LLVM::LLVMArrayType::get(rowTy, numLenParams));
-      TODO("extended descriptor");
+      TODO_NOLOC("extended descriptor");
     }
     return mlir::LLVM::LLVMPointerType::get(
         mlir::LLVM::LLVMStructType::getLiteral(&getContext(), parts,


### PR DESCRIPTION
- Add a TODO_AT marco that also prints the Fortran source line that requires the not implemented feature.
- Update expression lowering TODOs to use it,  update some message on the way that were empty, change some to fatalError when they are not TODOs anymore but the feature is implemented elsewhere (mainly array expressions TODO in the scalar part).

For instance, if there is a reference to an allocatable component in line 6 of foo.f90, the TODO message printed would now be:
`error: loc("./foo.f90":6:12):  [...]flang/lib/Lower/ConvertExpr.cpp:141: not yet implemented lower pointer/allocatable component ref`
 instead of :
`[...]flang/lib/Lower/ConvertExpr.cpp:141: not yet implemented lower pointer/allocatable component ref`

I think it gives a feedback both useful for developers that cares about where is the TODO in fir-dev files and and user/tester that cares about what is blocking flang in their Fortran source file.

Of course, it is only useable if we have the source line when we are facing the TODO, so keep the previous TODO macro for the spots where we do not have easy access to the source line.