### PR TITLE
silence unused variable warning in release builds

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2000,7 +2000,7 @@ private:
     AggregateStoreKey key = {alias.getOwningScope(), alias.getAlias()};
     auto iter = storeMap.find(key);
     assert(iter != storeMap.end());
-    return storeMap.find(key)->second;
+    return iter->second;
   }
   /// Build the name for the storage of a global equivalence.
   std::string mangleGlobalAggregateStore(

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1236,8 +1236,8 @@ public:
             TODO("");
           }
         } else {
-          auto *range = std::get_if<fir::RangeBoxValue>(&subBox);
-          assert(range && "must be a range");
+          assert(std::holds_alternative<fir::RangeBoxValue>(subBox) &&
+                 "must be a range");
           // triple notation for slicing operation
           TODO("");
         }
@@ -2748,7 +2748,7 @@ fir::AllocMemOp Fortran::lower::createSomeArrayTemp(
   auto seqTy = ty.dyn_cast<fir::SequenceType>();
   assert(seqTy && "must be an array");
   auto loc = converter.getCurrentLocation();
-  if (ty.cast<fir::SequenceType>().hasConstantShape()) {
+  if (seqTy.hasConstantShape()) {
     auto result = bldr->create<fir::AllocMemOp>(loc, ty);
     auto res = result.getResult();
     stmtCtx.attachCleanup([=]() { bldr->create<fir::FreeMemOp>(loc, res); });

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1267,9 +1267,9 @@ struct SymbolDependenceDepth {
         // 2. Add an Interval to the list of stores allocated for this unit.
         lower::pft::Variable::Interval interval(ibgn, ilen);
         if (gvarIter != setIsGlobal.end()) {
-          auto *gsym = gvarIter->second;
-          LLVM_DEBUG(llvm::dbgs() << "interval [" << ibgn << ".." << ibgn + ilen
-                                  << ") added as global " << *gsym << '\n');
+          LLVM_DEBUG(llvm::dbgs()
+                     << "interval [" << ibgn << ".." << ibgn + ilen
+                     << ") added as global " << *gvarIter->second << '\n');
           stores.emplace_back(std::move(interval), scope, pair.second,
                               isDeclaration);
         } else {


### PR DESCRIPTION
While testing #628 in release mode with clang, I noticed there was a few unused variables warning coming from things used only in assert/debugs. Fix the code.