### PR TITLE
Fix len_trim lowering

### DIFF
--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -479,8 +479,10 @@ mlir::Value Fortran::lower::CharacterExprHelper::createLenTrim(
   auto index = iterWhile.getInductionVar();
   // Look for first non-blank from the right of the character.
   auto fromBuff = getCharBoxBuffer(str);
-  auto c = createLoadCharAt(fromBuff, index);
-  c = builder.createConvert(loc, blank.getType(), c);
+  auto elemAddr = createElementAddr(fromBuff, index);
+  auto codeAddr =
+      builder.createConvert(loc, builder.getRefType(blank.getType()), elemAddr);
+  auto c = builder.create<fir::LoadOp>(loc, codeAddr);
   auto isBlank =
       builder.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::eq, blank, c);
   llvm::SmallVector<mlir::Value, 2> results = {isBlank, index};

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -258,6 +258,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"dble", &I::genConversion},
     {"dprod", &I::genDprod},
     {"floor", &I::genFloor},
+    {"iachar", &I::genIchar},
     {"iand", &I::genIAnd},
     {"ichar", &I::genIchar},
     {"ieor", &I::genIEOr},

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -442,8 +442,7 @@ mlir::OpFoldResult fir::ConvertOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
 
 bool fir::ConvertOp::isIntegerCompatible(mlir::Type ty) {
   return ty.isa<mlir::IntegerType>() || ty.isa<mlir::IndexType>() ||
-         ty.isa<fir::IntegerType>() || ty.isa<fir::LogicalType>() ||
-         ty.isa<fir::CharacterType>();
+         ty.isa<fir::IntegerType>() || ty.isa<fir::LogicalType>();
 }
 
 bool fir::ConvertOp::isFloatCompatible(mlir::Type ty) {

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -237,8 +237,8 @@ integer function len_trim_test(c)
   ! CHECK-DAG: %[[lastChar:.*]] = subi {{.*}}, %[[c1]]
   ! CHECK: %[[iterateResult:.*]]:2 = fir.iterate_while (%[[index:.*]] = %[[lastChar]] to %[[c0]] step %[[cm1]]) and ({{.*}}) iter_args({{.*}}) {
     ! CHECK: %[[addr:.*]] = fir.coordinate_of {{.*}}, %[[index]]
-    ! CHECK: %[[char:.*]] = fir.load %[[addr]]
-    ! CHECK: %[[code:.*]] = fir.convert %[[char]]
+    ! CHECK: %[[codeAddr:.*]] = fir.convert %[[addr]]
+    ! CHECK: %[[code:.*]] = fir.load %[[codeAddr]]
     ! CHECK: %[[bool:.*]] = cmpi eq
     ! CHECK: fir.result %[[bool]], %[[index]]
   ! CHECK: }


### PR DESCRIPTION
Since the big character refactoring, `fir.convert` between an integer and `fir.char` is not possible anymore since `fir.char` is an sequence like type, and such convert would face some issues (what if the length is not 1...).

LEN_TRIM lowering, implemented before that, was using such conversion. Fix this, and officially forbid integer to `fir.char` in `fir.convert` verifier.

Also lower IACHAR, since I noticed it was not plugged in the intrinsic lowering table.