### PR TITLE
[NFC] move locationToFilename and createStringLiteral to FirOpBuilder

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -139,11 +139,6 @@ public:
   /// Generate the location as converted from a CharBlock
   virtual mlir::Location genLocation(const Fortran::parser::CharBlock &) = 0;
 
-  /// Generate a string literal containing the file name and return its address
-  virtual mlir::Value locationToFilename(mlir::Location) = 0;
-  /// Generate a constant of the given type with the location line number
-  virtual mlir::Value locationToLineNo(mlir::Location, mlir::Type) = 0;
-
   //===--------------------------------------------------------------------===//
   // FIR/MLIR
   //===--------------------------------------------------------------------===//
@@ -156,10 +151,6 @@ public:
   virtual mlir::MLIRContext &getMLIRContext() = 0;
   /// Unique a symbol
   virtual std::string mangleName(const Fortran::semantics::Symbol &) = 0;
-  /// Unique a compiler generated identifier. A short prefix should be provided
-  /// to hint at the origin of the identifier.
-  virtual std::string uniqueCGIdent(llvm::StringRef prefix,
-                                    llvm::StringRef name) = 0;
   /// Get the KindMap.
   virtual fir::KindMapping &getKindMap() = 0;
 

--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -17,11 +17,11 @@ class ExtendedValue;
 
 namespace Fortran {
 namespace lower {
-class AbstractConverter;
+class FirOpBuilder;
 
 /// Generate call to a character comparison for two ssa-values of type
 /// `boxchar`.
-mlir::Value genCharCompare(AbstractConverter &converter, mlir::Location loc,
+mlir::Value genCharCompare(FirOpBuilder &builder, mlir::Location loc,
                            mlir::CmpIPredicate cmp,
                            const fir::ExtendedValue &lhs,
                            const fir::ExtendedValue &rhs);
@@ -30,7 +30,7 @@ mlir::Value genCharCompare(AbstractConverter &converter, mlir::Location loc,
 /// are 4 arguments, 2 for the lhs and 2 for the rhs. Each CHARACTER must pass a
 /// reference to its buffer (`ref<char<K>>`) and its LEN type parameter (some
 /// integral type).
-mlir::Value genRawCharCompare(AbstractConverter &converter, mlir::Location loc,
+mlir::Value genRawCharCompare(FirOpBuilder &builder, mlir::Location loc,
                               mlir::CmpIPredicate cmp, mlir::Value lhsBuff,
                               mlir::Value lhsLen, mlir::Value rhsBuff,
                               mlir::Value rhsLen);

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -62,12 +62,6 @@ createSomeMutableBox(mlir::Location loc, AbstractConverter &converter,
                      const evaluate::Expr<evaluate::SomeType> &expr,
                      SymMap &symMap);
 
-/// Create a string literal. Lowers `str` to the MLIR representation of a
-/// literal CHARACTER value. (KIND is assumed to be 1.)
-fir::ExtendedValue createStringLiteral(mlir::Location loc,
-                                       AbstractConverter &converter,
-                                       llvm::StringRef str, std::uint64_t len);
-
 /// Create and return a projection of a subspace of an array value. This is the
 /// lhs onto which a newly constructed array value can be merged.
 fir::ArrayLoadOp

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -159,8 +159,8 @@ public:
   }
 
   /// Convert a StringRef string into a fir::StringLitOp.
-  fir::StringLitOp createStringLit(mlir::Location loc, mlir::Type eleTy,
-                                   llvm::StringRef string);
+  fir::StringLitOp createStringLitOp(mlir::Location loc,
+                                     llvm::StringRef string);
 
   //===--------------------------------------------------------------------===//
   // Linkage helpers (inline). The default linkage is external.
@@ -281,6 +281,28 @@ mlir::Value readLowerBound(FirOpBuilder &, mlir::Location,
 /// Read extents from an IrBoxValue into \p result.
 void readExtents(FirOpBuilder &, mlir::Location, const fir::IrBoxValue &,
                  llvm::SmallVectorImpl<mlir::Value> &result);
+
+//===--------------------------------------------------------------------===//
+// String literal helper helpers
+//===--------------------------------------------------------------------===//
+
+/// Create a !fir.char<1> string literal global and returns a
+/// fir::CharBoxValue with its address en length.
+fir::ExtendedValue createStringLiteral(FirOpBuilder &, mlir::Location,
+                                       llvm::StringRef string);
+
+/// Unique a compiler generated identifier. A short prefix should be provided
+/// to hint at the origin of the identifier.
+std::string uniqueCGIdent(llvm::StringRef prefix, llvm::StringRef name);
+
+//===--------------------------------------------------------------------===//
+// Location helpers
+//===--------------------------------------------------------------------===//
+
+/// Generate a string literal containing the file name and return its address
+mlir::Value locationToFilename(FirOpBuilder &, mlir::Location);
+/// Generate a constant of the given type with the location line number
+mlir::Value locationToLineNo(FirOpBuilder &, mlir::Location, mlir::Type);
 
 } // namespace Fortran::lower
 

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -398,8 +398,9 @@ struct ErrorManagementValues {
       TODO(loc, "errmsg in allocate and deallocate");
     else
       errMsgBoxAddr = builder.createNullConstant(loc);
-    sourceFile = converter.locationToFilename(loc);
-    sourceLine = converter.locationToLineNo(loc, builder.getIntegerType(32));
+    sourceFile = Fortran::lower::locationToFilename(builder, loc);
+    sourceLine = Fortran::lower::locationToLineNo(builder, loc,
+                                                  builder.getIntegerType(32));
   }
   bool hasErrorRecovery() const { return static_cast<bool>(statAddr); }
   // Values always initialized before lowering individual allocations

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -38,11 +38,10 @@ static int discoverKind(mlir::Type ty) {
 //===----------------------------------------------------------------------===//
 
 mlir::Value
-Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
+Fortran::lower::genRawCharCompare(Fortran::lower::FirOpBuilder &builder,
                                   mlir::Location loc, mlir::CmpIPredicate cmp,
                                   mlir::Value lhsBuff, mlir::Value lhsLen,
                                   mlir::Value rhsBuff, mlir::Value rhsLen) {
-  auto &builder = converter.getFirOpBuilder();
   mlir::FuncOp beginFunc;
   switch (discoverKind(lhsBuff.getType())) {
   case 1:
@@ -69,11 +68,10 @@ Fortran::lower::genRawCharCompare(Fortran::lower::AbstractConverter &converter,
 }
 
 mlir::Value
-Fortran::lower::genCharCompare(Fortran::lower::AbstractConverter &converter,
+Fortran::lower::genCharCompare(Fortran::lower::FirOpBuilder &builder,
                                mlir::Location loc, mlir::CmpIPredicate cmp,
                                const fir::ExtendedValue &lhs,
                                const fir::ExtendedValue &rhs) {
-  auto &builder = converter.getFirOpBuilder();
   if (lhs.getBoxOf<fir::BoxValue>() || rhs.getBoxOf<fir::BoxValue>())
     TODO(loc, "character compare from descriptors");
   auto allocateIfNotInMemory = [&](mlir::Value base) -> mlir::Value {
@@ -85,6 +83,6 @@ Fortran::lower::genCharCompare(Fortran::lower::AbstractConverter &converter,
   };
   auto lhsBuffer = allocateIfNotInMemory(fir::getBase(lhs));
   auto rhsBuffer = allocateIfNotInMemory(fir::getBase(rhs));
-  return genRawCharCompare(converter, loc, cmp, lhsBuffer, fir::getLen(lhs),
+  return genRawCharCompare(builder, loc, cmp, lhsBuffer, fir::getLen(lhs),
                            rhsBuffer, fir::getLen(rhs));
 }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -319,8 +319,7 @@ public:
   mlir::Value createCharCompare(mlir::CmpIPredicate pred,
                                 const fir::ExtendedValue &left,
                                 const fir::ExtendedValue &right) {
-    return Fortran::lower::genCharCompare(converter, getLoc(), pred, left,
-                                          right);
+    return Fortran::lower::genCharCompare(builder, getLoc(), pred, left, right);
   }
 
   template <typename A>
@@ -2674,7 +2673,7 @@ public:
     return [=](IterSpace iters) -> ExtValue {
       auto lhs = fir::getBase(lf(iters));
       auto rhs = fir::getBase(rf(iters));
-      return Fortran::lower::genCharCompare(converter, loc, pred, lhs, rhs);
+      return Fortran::lower::genCharCompare(builder, loc, pred, lhs, rhs);
     };
   }
   template <int KIND>


### PR DESCRIPTION
This refactoring is preliminary work for lowering more intrinsic using runtime.
The intrinsic framework does not take an `AbstractConverter` because it does not work with front-end data structures. However, it may needs to place some runtime calls that needs to take the filename as argument. Currently, this required the `AbstractConverter`, although no conversion from front-end data structure to fir/mlir data structures was happening (the function is `mlir::Location` to `mlir::Value`, and fits well with something the `FirOpBuilder` would do).

This PR refactors things to avoid requiring the `AbstractConverter ` in places that do not deal with converting front-end representations/data structures to fir/mlir.

The main obstacle was to move the ascii string literal creation logic to the `FirOpBuilder`, like for the other constants, instead of relying on ConvertExpr logic.