### PR TITLE
Add support for intrinsic temp results and lower TRIM

### DIFF
--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/StringRef.h"
+
 namespace mlir {
 class Value;
 class ValueRange;
@@ -62,6 +64,14 @@ fir::MutableBoxValue createMutableBox(Fortran::lower::AbstractConverter &,
                                       const Fortran::lower::pft::Variable &var,
                                       mlir::Value boxAddr,
                                       mlir::ValueRange nonDeferredParams);
+
+/// Create a MutableBoxValue for a temporary allocatable.
+/// The created MutableBoxValue wraps a fir.ref<fir.box<fir.heap<type>>> and is
+/// initialized to unallocated/diassociated status. An optional name can be
+/// given to the created !fir.ref<fir.box>.
+fir::MutableBoxValue createTempMutableBox(Fortran::lower::FirOpBuilder &,
+                                          mlir::Location, mlir::Type type,
+                                          llvm::StringRef name = {});
 
 /// Read all mutable properties into a normal symbol box.
 /// It is OK to call this on unassociated/unallocated boxes but any use of the

--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -34,6 +34,12 @@ mlir::Value genRawCharCompare(FirOpBuilder &builder, mlir::Location loc,
                               mlir::CmpIPredicate cmp, mlir::Value lhsBuff,
                               mlir::Value lhsLen, mlir::Value rhsBuff,
                               mlir::Value rhsLen);
+/// Generate call to trim runtime.
+///   \p resultBox must be an unallocated allocatable used for the temporary
+///   result. \p stringBox must be a fir.box describing trim string argument.
+/// The runtime will always allocate the resultBox.
+void genTrim(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+             mlir::Value resultBox, mlir::Value stringBox);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/IntrinsicCall.h
+++ b/flang/include/flang/Lower/IntrinsicCall.h
@@ -18,16 +18,21 @@ class ExtendedValue;
 
 namespace Fortran::lower {
 
+class StatementContext;
+
 // TODO: Error handling interface ?
 // TODO: Implementation is incomplete. Many intrinsics to tbd.
 
 /// Generate the FIR+MLIR operations for the generic intrinsic \p name
 /// with arguments \p args and expected result type \p resultType.
 /// Returned mlir::Value is the returned Fortran intrinsic value.
+/// If the result is an allocated temporary, its clean-up is added to the
+/// StatementContext.
 fir::ExtendedValue genIntrinsicCall(FirOpBuilder &, mlir::Location,
                                     llvm::StringRef name,
                                     llvm::Optional<mlir::Type> resultType,
-                                    llvm::ArrayRef<fir::ExtendedValue> args);
+                                    llvm::ArrayRef<fir::ExtendedValue> args,
+                                    StatementContext &);
 
 /// Enum specifying how intrinsic argument evaluate::Expr should be
 /// lowered to fir::ExtendedValue to be passed to genIntrinsicCall.

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -905,6 +905,19 @@ fir::MutableBoxValue Fortran::lower::createMutableBox(
   return box;
 }
 
+fir::MutableBoxValue
+Fortran::lower::createTempMutableBox(Fortran::lower::FirOpBuilder &builder,
+                                     mlir::Location loc, mlir::Type type,
+                                     llvm::StringRef name) {
+  auto boxType = fir::BoxType::get(fir::HeapType::get(type));
+  auto boxAddr = builder.createTemporary(loc, boxType, name);
+  auto box =
+      fir::MutableBoxValue(boxAddr, /*nonDeferredParams*/ mlir::ValueRange(),
+                           /*mutableProperties*/ {});
+  MutablePropertyWriter{builder, loc, box}.setUnallocatedSatus();
+  return box;
+}
+
 //===----------------------------------------------------------------------===//
 // MutableBoxValue reading interface implementation
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -86,3 +86,20 @@ Fortran::lower::genCharCompare(Fortran::lower::FirOpBuilder &builder,
   return genRawCharCompare(builder, loc, cmp, lhsBuffer, fir::getLen(lhs),
                            rhsBuffer, fir::getLen(rhs));
 }
+
+void Fortran::lower::genTrim(Fortran::lower::FirOpBuilder &builder,
+                             mlir::Location loc, mlir::Value resultBox,
+                             mlir::Value stringBox) {
+  auto trimFunc = getRuntimeFunc<mkRTKey(Trim)>(loc, builder);
+  auto fTy = trimFunc.getType();
+  auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
+  auto sourceLine =
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(3));
+
+  llvm::SmallVector<mlir::Value, 4> args;
+  args.emplace_back(builder.createConvert(loc, fTy.getInput(0), resultBox));
+  args.emplace_back(builder.createConvert(loc, fTy.getInput(1), stringBox));
+  args.emplace_back(builder.createConvert(loc, fTy.getInput(2), sourceFile));
+  args.emplace_back(builder.createConvert(loc, fTy.getInput(3), sourceLine));
+  builder.create<fir::CallOp>(loc, trimFunc, args);
+}

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1406,7 +1406,7 @@ public:
     }
     // Let the intrinsic library lower the intrinsic procedure call
     return Fortran::lower::genIntrinsicCall(builder, getLoc(), name, resultType,
-                                            operands);
+                                            operands, stmtCtx);
   }
 
   template <typename A>

--- a/flang/test/Lower/intrinsics.f90
+++ b/flang/test/Lower/intrinsics.f90
@@ -294,3 +294,22 @@ subroutine sqrt_testr(a, b)
   ! CHECK: fir.call {{.*}}sqrt
   b = sqrt(a)
 end subroutine
+
+! TRIM
+! CHECK-LABEL: trim_test
+! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1>)
+subroutine trim_test(c)
+  character(*) :: c
+  ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK-DAG: %[[c:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK-DAG: %[[cBox:.*]] = fir.embox %[[c]]#0 typeparams %[[c]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+  ! CHECK-DAG: %[[cBoxNone:.*]] = fir.convert %[[cBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[resBox:.*]] = fir.convert %[[tmpBox]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}Trim(%[[resBox]], %[[cBoxNone]], {{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+  ! CHECK-DAG: %[[tmpAddr:.*]] = fir.box_addr
+  ! CHECK-DAG: fir.box_elesize
+  ! CHECK: fir.call @{{.*}}bar_trim_test
+  call bar_trim_test(trim(c))
+  ! CHECK: fir.freemem %[[tmpAddr]] : !fir.heap<!fir.char<1,?>>
+  return
+end subroutine


### PR DESCRIPTION
- Thread the `StatementContext` to the intrinsic lowering helper.
- Add `createTempMutableBox` to create `MutableBox` describing a temp. This is needed to interact with the runtime that allocate result storage and fill-in a descriptor to provide the result.

- Implement TRIM with the runtime API, which must be provided with an allocatable descriptors for the result. Use the StatementContext to insert the deallocation of the memory that was allocated by the runtime after the intrinsic result has been used.

Note 1: This PR depends on the  `locationToFilename` refactoring in #636.
Note 2: There is a small bug in TRIM runtime. The fix will be pushed directly into llvm (it is not needed to build/compile programs with this patch, but end-to-end tests will crash in the runtime).