### PR TITLE
[flang] Potential fix for #611

### DIFF
--- a/flang/test/Lower/call-site-mangling.f90
+++ b/flang/test/Lower/call-site-mangling.f90
@@ -77,3 +77,30 @@ function foo4()
   foo4 = bar4()
 end function
 
+module test_bindmodule
+  contains
+  ! CHECK: func @modulecproc()
+  ! CHECK: func @bind_modulecproc()
+    subroutine modulecproc() bind(c)
+    end subroutine
+    subroutine modulecproc_1() bind(c, name="bind_modulecproc")
+    end subroutine
+end module
+! CHECK-LABEL: func @_QPtest_bindmodule_call() {
+subroutine test_bindmodule_call
+  use test_bindmodule
+  interface
+     subroutine somecproc() bind(c)
+     end subroutine
+     subroutine somecproc_1() bind(c, name="bind_somecproc")
+     end subroutine
+  end interface
+  ! CHECK: fir.call @modulecproc()
+  ! CHECK: fir.call @bind_modulecproc()
+  ! CHECK: fir.call @somecproc()
+  ! CHECK: fir.call @bind_somecproc()
+  call modulecproc()
+  call modulecproc_1()
+  call somecproc()
+  call somecproc_1()
+end subroutine

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -125,6 +125,15 @@ program test
 ! CHECK: }
 end program
 
+! CHECK-LABEL: func @omp_get_num_threads() -> f32 {
+function omp_get_num_threads() bind(c)
+! CHECK: }
+end function
+
+! CHECK-LABEL: func @get_threads() -> f32 {
+function omp_get_num_threads_1() bind(c, name ="get_threads")
+! CHECK: }
+end function
+
 ! CHECK-LABEL: fir.global internal @_QFfooEpi : f32 {
 ! CHECK-LABEL: fir.global internal @_QFfunctnECpi constant : f32 {
-


### PR DESCRIPTION
Do not mangle name for functions/subroutines with `BIND(C)` attribute, as they can be call to external RTL.
