### PR TITLE
[OpenMP] Fixes for worksharing loop lowering

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -69,8 +69,8 @@ public:
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
 
-  /// Set the mlir instance corresponding to a symbol.
-  virtual void setSymbolAddress(const SymbolRef sym, mlir::Value val) = 0;
+  /// Bind the symbol to an mlir value.
+  virtual void bindSymbol(const SymbolRef sym, mlir::Value val) = 0;
 
   /// Get the label set associated with a symbol.
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -69,6 +69,9 @@ public:
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
 
+  /// Set the mlir instance corresponding to a symbol.
+  virtual void setSymbolAddress(const SymbolRef sym, mlir::Value val) = 0;
+
   /// Get the label set associated with a symbol.
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -243,8 +243,10 @@ public:
     return lookupSymbol(sym).getAddr();
   }
 
-  void setSymbolAddress(Fortran::lower::SymbolRef sym,
-                        mlir::Value val) override final {
+  // TODO: Consider returning a vlue when the FIXME below is fixed.
+  void bindSymbol(Fortran::lower::SymbolRef sym,
+                  mlir::Value val) override final {
+    // FIXME: removed forced when symbol lookup stop following host association.
     addSymbol(sym, val, /*forced=*/true);
   }
 
@@ -1150,12 +1152,10 @@ private:
     // If loop is part of an OpenMP Construct then the OpenMP dialect
     // workshare loop operation has already been created. Only the
     // body needs to be created here and the do_loop can be skipped.
-    Fortran::lower::pft::Evaluation *curEval{nullptr};
-    if (std::get_if<Fortran::parser::OpenMPLoopConstruct>(&omp.u)) {
-      curEval = &getEval().getFirstNestedEvaluation();
-    } else {
-      curEval = &getEval();
-    }
+    Fortran::lower::pft::Evaluation *curEval =
+        std::get_if<Fortran::parser::OpenMPLoopConstruct>(&omp.u)
+            ? &getEval().getFirstNestedEvaluation()
+            : &getEval();
     for (auto &e : curEval->getNestedEvaluations())
       genFIR(e);
     localSymbols.popScope();

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -60,7 +60,7 @@ static void createBodyOfOp(Op &op, Fortran::lower::AbstractConverter &converter,
   // uses of the induction variable should use this mlir value.
   if (arg) {
     firOpBuilder.createBlock(&op.getRegion(), {}, {converter.genType(*arg)});
-    converter.setSymbolAddress(*arg, op.getRegion().front().getArgument(0));
+    converter.bindSymbol(*arg, op.getRegion().front().getArgument(0));
   } else {
     firOpBuilder.createBlock(&op.getRegion());
   }
@@ -349,9 +349,9 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
 
   const auto &loopControl =
       std::get<std::optional<Fortran::parser::LoopControl>>(doStmt->t);
-  const Fortran::parser::LoopControl::Bounds *bounds{
-      std::get_if<Fortran::parser::LoopControl::Bounds>(&loopControl->u)};
-  Fortran::semantics::Symbol *iv{nullptr};
+  const Fortran::parser::LoopControl::Bounds *bounds =
+      std::get_if<Fortran::parser::LoopControl::Bounds>(&loopControl->u);
+  Fortran::semantics::Symbol *iv = nullptr;
   if (bounds) {
     Fortran::lower::StatementContext stmtCtx;
     lowerBound.push_back(fir::getBase(converter.genExprValue(


### PR DESCRIPTION
The OpenMP worksharing loop operation in the dialect is a proper loop
operation and not a container of a loop. We have to lower the OpenMP
loop construct and the do-loop inside the construct to a omp.wsloop
operation and there should not be a fir.do_loop inside it. In this fix
this is achieved by skipping fir.do_loop creation and calling genFIR
for the nested evaluations in the lowering of the do construct. When a
worksharing loop is created an index is created for it. All usage of the
index in the loop is replaced with this index.

Note:
1) I have added a new function to the AbstractConverter interface to
set the mlir value/address corresponding to a symbol and this had to
be a forced setting. Is this OK?
2) I have modified the createBodyofOp function to take in the converter
instead of the builder and it also takes in an optional block argument.