### PR TITLE
Add fir.target attribute on dummy arguments

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -63,6 +63,8 @@ fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
 constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
 /// Attribute to mark Fortran entities with the OPTIONAL attribute.
 constexpr llvm::StringRef getOptionalAttrName() { return "fir.optional"; }
+/// Attribute to mark Fortran entities with the TARGET attribute.
+constexpr llvm::StringRef getTargetAttrName() { return "fir.target"; }
 
 /// Tell if \p value is:
 ///   - a function argument that has attribute \p attributeName

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -516,24 +516,24 @@ private:
     bool isOptional = false;
     [[maybe_unused]] auto loc = interface.converter.genLocation();
     llvm::SmallVector<mlir::NamedAttribute, 2> attrs;
+    auto addMLIRAttr = [&](llvm::StringRef attr) {
+      attrs.emplace_back(mlir::Identifier::get(attr, &mlirContext),
+                         UnitAttr::get(&mlirContext));
+    };
     if (obj.attrs.test(Attrs::Optional)) {
-      attrs.emplace_back(
-          mlir::Identifier::get(fir::getOptionalAttrName(), &mlirContext),
-          UnitAttr::get(&mlirContext));
+      addMLIRAttr(fir::getOptionalAttrName());
       isOptional = true;
     }
     if (obj.attrs.test(Attrs::Asynchronous))
       TODO(loc, "Asynchronous in procedure interface");
     if (obj.attrs.test(Attrs::Contiguous))
-      attrs.emplace_back(
-          mlir::Identifier::get(fir::getContiguousAttrName(), &mlirContext),
-          UnitAttr::get(&mlirContext));
+      addMLIRAttr(fir::getContiguousAttrName());
     if (obj.attrs.test(Attrs::Value))
       TODO(loc, "Value in procedure interface");
     if (obj.attrs.test(Attrs::Volatile))
       TODO(loc, "Volatile in procedure interface");
     if (obj.attrs.test(Attrs::Target))
-      TODO(loc, "Target in procedure interface");
+      addMLIRAttr(fir::getTargetAttrName());
 
     // TODO: intents that require special care (e.g finalization)
 

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -122,8 +122,9 @@ mlir::Value Fortran::lower::FirOpBuilder::allocateLocal(
   });
   llvm::SmallVector<mlir::NamedAttribute, 2> attrs;
   if (asTarget)
-    attrs.emplace_back(mlir::Identifier::get("target", getContext()),
-                       getUnitAttr());
+    attrs.emplace_back(
+        mlir::Identifier::get(fir::getTargetAttrName(), getContext()),
+        getUnitAttr());
   return create<fir::AllocaOp>(loc, ty, nm, llvm::None, indices, attrs);
 }
 

--- a/flang/test/Lower/dummy-arguments.f90
+++ b/flang/test/Lower/dummy-arguments.f90
@@ -30,3 +30,12 @@ function sub2(r)
   ! CHECK: return %{{.*}} : f32
 end function sub2
 
+! Test TARGET attribute lowering
+! CHECK-LABEL: func @_QPtest_target(
+! CHECK-SAME: !fir.ref<i32> {fir.target},
+! CHECK-SAME: !fir.box<!fir.array<?xf32>> {fir.target})
+subroutine test_target(i, x)
+  integer, target :: i
+  real, target :: x(:)
+  print *, xs, xa
+end subroutine

--- a/flang/test/Lower/procedure-declarations.f90
+++ b/flang/test/Lower/procedure-declarations.f90
@@ -165,5 +165,24 @@ subroutine call_foo8_2(i)
   call foo8(i)
 end subroutine 
 
+! Test that target attribute is lowered in declaration of functions that are
+! not defined in this file.
+! CHECK-LABEL:func @_QPtest_target_in_iface
+subroutine test_target_in_iface()
+  interface
+  subroutine test_target(i, x)
+    integer, target :: i
+    real, target :: x(:)
+  end subroutine
+  end interface
+  integer :: i
+  real :: x(10)
+  ! CHECK: fir.call @_QPtest_target
+  call test_target(i, x)
+end subroutine
+
 ! CHECK: func private @_QPfoo6(!fir.ref<!fir.array<10xi32>>)
 ! CHECK: func private @_QPfoo7()
+
+! Test declaration from test_target_in_iface
+! CHECK-LABEL: func private @_QPtest_target(!fir.ref<i32> {fir.target}, !fir.box<!fir.array<?xf32>> {fir.target})

--- a/flang/test/Lower/variable.f90
+++ b/flang/test/Lower/variable.f90
@@ -6,7 +6,7 @@ subroutine s
   integer, allocatable :: ally
   ! CHECK-DAG: fir.alloca !fir.box<!fir.ptr<i32>> {name = "{{.*}}Epointy"} 
   integer, pointer :: pointy
-  ! CHECK-DAG: fir.alloca i32 {name = "{{.*}}Ebullseye", target}
+  ! CHECK-DAG: fir.alloca i32 {fir.target, name = "{{.*}}Ebullseye"}
   integer, target :: bullseye
   ! CHECK: return
 end subroutine s


### PR DESCRIPTION
- Define `getTargetAttrName` to centralize "fir.target" string usages in
  mlir attributes for the Fortran TARGET attribute.
- Add it to mlir arguments that correspond to Fortran dummies with the
  TARGET attribute.