### PR TITLE
Lower pointer assignments and update nullify

### DIFF
--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -21,7 +21,8 @@ class Location;
 
 namespace fir {
 class MutableBoxValue;
-}
+class ExtendedValue;
+} // namespace fir
 
 namespace Fortran::parser {
 struct AllocateStmt;
@@ -80,6 +81,31 @@ fir::MutableBoxValue createTempMutableBox(Fortran::lower::FirOpBuilder &,
 Fortran::lower::SymbolBox genMutableBoxRead(Fortran::lower::FirOpBuilder &,
                                             mlir::Location,
                                             const fir::MutableBoxValue &);
+
+/// Update a MutableBoxValue to describe entity \p source (that must be in
+/// memory). If \lbounds is not empty, it is used to defined the MutableBoxValue
+/// lower bounds, otherwise, the lower bounds from \p source are used.
+void associateMutableBox(Fortran::lower::FirOpBuilder &, mlir::Location,
+                         const fir::MutableBoxValue &,
+                         const fir::ExtendedValue &source,
+                         mlir::ValueRange lbounds);
+
+/// Update a MutableBoxValue to describe entity \p source (that must be in
+/// memory) with a new array layout given by \p lbounds and \p ubounds.
+/// \p source must be known to be contiguous at compile time, or it must have
+/// rank 1.
+void associateMutableBoxWithRemap(Fortran::lower::FirOpBuilder &,
+                                  mlir::Location, const fir::MutableBoxValue &,
+                                  const fir::ExtendedValue &source,
+                                  mlir::ValueRange lbounds,
+                                  mlir::ValueRange ubounds);
+
+/// Set the association status of a MutableBoxValue to
+/// disassociated/unallocated. Nothing is done with the entity that was
+/// previously associated/allocated. The function generates code that sets the
+/// address field of the MutableBoxValue to zero.
+void disassociateMutableBox(Fortran::lower::FirOpBuilder &, mlir::Location,
+                            const fir::MutableBoxValue &);
 
 /// Returns the fir.ref<fir.box<T>> of a MutableBoxValue filled with the current
 /// association / allocation properties. If the fir.ref<fir.box> already exists

--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -85,15 +85,15 @@ Fortran::lower::SymbolBox genMutableBoxRead(Fortran::lower::FirOpBuilder &,
 /// Update a MutableBoxValue to describe entity \p source (that must be in
 /// memory). If \lbounds is not empty, it is used to defined the MutableBoxValue
 /// lower bounds, otherwise, the lower bounds from \p source are used.
-void associateMutableBox(Fortran::lower::FirOpBuilder &, mlir::Location,
-                         const fir::MutableBoxValue &,
-                         const fir::ExtendedValue &source,
-                         mlir::ValueRange lbounds);
+void associateMutableBoxWithShift(Fortran::lower::FirOpBuilder &,
+                                  mlir::Location, const fir::MutableBoxValue &,
+                                  const fir::ExtendedValue &source,
+                                  mlir::ValueRange lbounds);
 
 /// Update a MutableBoxValue to describe entity \p source (that must be in
 /// memory) with a new array layout given by \p lbounds and \p ubounds.
 /// \p source must be known to be contiguous at compile time, or it must have
-/// rank 1.
+/// rank 1 (constraint from Fortran 2018 standard 10.2.2.3 point 9).
 void associateMutableBoxWithRemap(Fortran::lower::FirOpBuilder &,
                                   mlir::Location, const fir::MutableBoxValue &,
                                   const fir::ExtendedValue &source,

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -277,6 +277,7 @@ public:
 /// for the entity.
 class IrBoxValue : public AbstractIrBox {
 public:
+  IrBoxValue(mlir::Value addr) : AbstractIrBox{addr} { assert(verify()); }
   IrBoxValue(mlir::Value addr, llvm::ArrayRef<mlir::Value> lbounds,
              llvm::ArrayRef<mlir::Value> explicitParams,
              llvm::ArrayRef<mlir::Value> explicitExtents = {})

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2443,7 +2443,7 @@ public:
         TODO(loc, "use fir.rebox for array section of fir.box");
       mlir::Value embox = builder.create<fir::EmboxOp>(
           loc, boxTy, memref, shape, slice, /*lenParams=*/llvm::None);
-      return [=](IterSpace) -> ExtValue { return embox; };
+      return [=](IterSpace) -> ExtValue { return fir::IrBoxValue(embox); };
     }
     mlir::Value arrLd = builder.create<fir::ArrayLoadOp>(
         loc, arrTy, memref, shape, slice, /*lenParams=*/llvm::None);

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -60,11 +60,8 @@ mlir::Type Fortran::lower::FirOpBuilder::getVarLenSeqTy(mlir::Type eleTy) {
 mlir::Value
 Fortran::lower::FirOpBuilder::createNullConstant(mlir::Location loc,
                                                  mlir::Type ptrType) {
-  auto indexType = getIndexType();
-  auto zero = createIntegerConstant(loc, indexType, 0);
-  if (!ptrType)
-    ptrType = getRefType(getNoneType());
-  return createConvert(loc, ptrType, zero);
+  auto ty = ptrType ? ptrType : getRefType(getNoneType());
+  return create<fir::ZeroOp>(loc, ty);
 }
 
 mlir::Value Fortran::lower::FirOpBuilder::createIntegerConstant(

--- a/flang/test/Lower/allocatable-globals.f90
+++ b/flang/test/Lower/allocatable-globals.f90
@@ -33,40 +33,40 @@ subroutine test_globals()
 end subroutine
 
 ! CHECK-LABEL: fir.global linkonce @_QMmod_allocatablesEc : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {
-  ! CHECK-DAG: %[[modcNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[modcNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,10>>>
   ! CHECK-DAG: %[[modcShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK: %[[modcInitBox:.*]] = fir.embox %[[modcNullAddr]](%[[modcShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
   ! CHECK: fir.has_value %[[modcInitBox]] : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc1 : !fir.box<!fir.heap<!fir.char<1,?>>>
-  ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
   ! CHECK: %[[gc1InitBox:.*]] = fir.embox %[[gc1NullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK: fir.has_value %[[gc1InitBox]] : !fir.box<!fir.heap<!fir.char<1,?>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc2 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
-  ! CHECK-DAG: %[[gc2NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[gc2NullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x?x!fir.char<1,?>>>
   ! CHECK-DAG: %[[gc2NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
   ! CHECK: %[[gc2InitBox:.*]] = fir.embox %[[gc2NullAddr]](%[[gc2NullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, index) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
   ! CHECK: fir.has_value %[[gc2InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc3 : !fir.box<!fir.heap<!fir.char<1,10>>>
-  ! CHECK-DAG: %[[gc3NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK-DAG: %[[gc3NullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,10>>
   ! CHECK: %[[gc3InitBox:.*]] = fir.embox %[[gc3NullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
   ! CHECK: fir.has_value %[[gc3InitBox]] : !fir.box<!fir.heap<!fir.char<1,10>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc4 : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
-  ! CHECK-DAG: %[[gc4NullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[gc4NullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x?x!fir.char<1,10>>>
   ! CHECK-DAG: %[[gc4NullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
   ! CHECK: %[[gc4InitBox:.*]] = fir.embox %[[gc4NullAddr]](%[[gc4NullShape]]) : (!fir.heap<!fir.array<?x?x!fir.char<1,10>>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
   ! CHECK: fir.has_value %[[gc4InitBox]] : !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,10>>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgx : !fir.box<!fir.heap<i32>>
-  ! CHECK: %[[gxNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<i32>
+  ! CHECK: %[[gxNullAddr:.*]] = fir.zero_bits !fir.heap<i32>
   ! CHECK: %[[gxInitBox:.*]] = fir.embox %0 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
   ! CHECK: fir.has_value %[[gxInitBox]] : !fir.box<!fir.heap<i32>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgy : !fir.box<!fir.heap<!fir.array<?x?xi32>>> {
-  ! CHECK-DAG: %[[gyNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xi32>>
+  ! CHECK-DAG: %[[gyNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x?xi32>>
   ! CHECK-DAG: %[[gyShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
   ! CHECK: %[[gyInitBox:.*]] = fir.embox %[[gyNullAddr]](%[[gyShape]]) : (!fir.heap<!fir.array<?x?xi32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xi32>>>
   ! CHECK: fir.has_value %[[gyInitBox]] : !fir.box<!fir.heap<!fir.array<?x?xi32>>>

--- a/flang/test/Lower/allocatable-runtime.f90
+++ b/flang/test/Lower/allocatable-runtime.f90
@@ -5,19 +5,19 @@
 subroutine foo()
   real, allocatable :: x(:), y(:, :), z
   ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
-  ! CHECK-DAG: %[[xNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[xNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
   ! CHECK-DAG: %[[xNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK: %[[xInitEmbox:.*]] = fir.embox %[[xNullAddr]](%[[xNullShape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
   ! CHECK: fir.store %[[xInitEmbox]] to %[[xBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 
   ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
-  ! CHECK-DAG: %[[yNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK-DAG: %[[yNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x?xf32>>
   ! CHECK-DAG: %[[yNullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
   ! CHECK: %[[yInitEmbox:.*]] = fir.embox %[[yNullAddr]](%[[yNullShape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
   ! CHECK: fir.store %[[yInitEmbox]] to %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 
   ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
-  ! CHECK: %[[zNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
+  ! CHECK: %[[zNullAddr:.*]] = fir.zero_bits !fir.heap<f32>
   ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
   ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 
@@ -65,12 +65,12 @@ subroutine char_deferred(n)
   integer :: n
   character(:), allocatable :: scalar, array(:)
   ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_deferredEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 
   ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_deferredEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
   ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
@@ -113,12 +113,12 @@ subroutine char_explicit_cst(n)
   integer :: n
   character(10), allocatable :: scalar, array(:)
   ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFchar_explicit_cstEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,10>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
 
   ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFchar_explicit_cstEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,10>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
   ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
@@ -138,14 +138,14 @@ subroutine char_explicit_dyn(n, l1, l2)
   character(l1), allocatable :: scalar
   ! CHECK-DAG: %[[l1:.*]] = fir.load %arg1 : !fir.ref<i32>
   ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_explicit_dynEscalar"}
-  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %[[l1]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 
   character(l2), allocatable :: array(:)
   ! CHECK-DAG: %[[l2:.*]] = fir.load %arg2 : !fir.ref<i32>
   ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_explicit_dynEarray"}
-  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %[[l2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, i32) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
   ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -6,7 +6,7 @@ subroutine fooscalar()
   ! Test lowering of local allocatable specification
   real, allocatable :: x
   ! CHECK: %[[xAddrVar:.*]] = fir.alloca !fir.heap<f32> {name = "_QFfooscalarEx.addr"}
-  ! CHECK: %[[nullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<f32>
+  ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<f32>
   ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 
   ! Test allocation of local allocatables
@@ -23,7 +23,7 @@ subroutine fooscalar()
   deallocate(x)
   ! CHECK: %[[xAddr2:.*]] = fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
   ! CHECK: fir.freemem %[[xAddr2]] : !fir.heap<f32>
-  ! CHECK: %[[nullAddr1:.*]] = fir.convert %c0_0 : (index) -> !fir.heap<f32>
+  ! CHECK: %[[nullAddr1:.*]] = fir.zero_bits !fir.heap<f32>
   ! fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 end subroutine
 
@@ -34,7 +34,7 @@ subroutine foodim1()
   ! CHECK-DAG: %[[xAddrVar:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {name = "_QFfoodim1Ex.addr"}
   ! CHECK-DAG: %[[xLbVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.lb0"}
   ! CHECK-DAG: %[[xExtVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.ext0"}
-  ! CHECK: %[[nullAddr:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
   ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
 
   ! Test allocation of local allocatables
@@ -57,7 +57,7 @@ subroutine foodim1()
   deallocate(x)
   ! CHECK: %[[xAddr1:.*]] = fir.load %1 : !fir.ref<!fir.heap<!fir.array<?xf32>>>
   ! CHECK: fir.freemem %[[xAddr1]] : !fir.heap<!fir.array<?xf32>>
-  ! CHECK: %[[nullAddr1:.*]] = fir.convert %c0{{.*}} : (index) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[nullAddr1:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
   ! CHECK: fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
 end subroutine
 

--- a/flang/test/Lower/nullify.f90
+++ b/flang/test/Lower/nullify.f90
@@ -1,9 +1,9 @@
-! Test lowering of pointer disassociation
+! Test lowering of nullify-statement
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 
 ! -----------------------------------------------------------------------------
-!     Test p => NULL()
+!     Test NULLIFY(p)
 ! -----------------------------------------------------------------------------
 
 
@@ -14,7 +14,7 @@ subroutine test_scalar(p)
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<f32>
   ! CHECK: %[[box:.*]] = fir.embox %[[null]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
   ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
-  p => NULL()
+  nullify(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_scalar_char(
@@ -24,7 +24,7 @@ subroutine test_scalar_char(p)
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
   ! CHECK: %[[box:.*]] = fir.embox %[[null]] typeparams %c0{{.*}} : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
   ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
-  p => NULL()
+  nullify(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array(
@@ -35,20 +35,18 @@ subroutine test_array(p)
   ! CHECK: %[[shape:.*]] = fir.shape %c0{{.*}}
   ! CHECK: %[[box:.*]] = fir.embox %[[null]](%[[shape]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
   ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  p => NULL()
+  nullify(p)
 end subroutine
 
-! Test p(lb, ub) => NULL() which is none sens but is not illegal.
-! CHECK-LABEL: func @_QPtest_array_remap(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
-subroutine test_array_remap(p)
-  real, pointer :: p(:)
-  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
-  ! CHECK: %[[shape:.*]] = fir.shape %c0{{.*}}
-  ! CHECK: %[[box:.*]] = fir.embox %[[null]](%[[shape]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  p(10:20) => NULL()
+! CHECK-LABEL: func @_QPtest_list(
+! CHECK-SAME: %[[p1:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
+! CHECK-SAME: %[[p2:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+subroutine test_list(p1, p2)
+  real, pointer :: p1, p2(:)
+  ! CHECK: fir.zero_bits !fir.ptr<f32>
+  ! CHECK: fir.store %{{.*}} to %[[p1]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+
+  ! CHECK: fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: fir.store %{{.*}} to %[[p2]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  nullify(p1, p2)
 end subroutine
-
-
-! TODO: p => NULL(MOLD). Requires array function/intrinsic lowering work.

--- a/flang/test/Lower/pointer-assignments.f90
+++ b/flang/test/Lower/pointer-assignments.f90
@@ -52,7 +52,7 @@ subroutine test_array_char(p, x)
   ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[xaddr:.*]] = fir.convert %[[c]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<100x!fir.char<1,?>>>
   ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}}
-  ! CHECK: %[[box:.*]] = fir.embox %[[xaddr]](%[[shape]]) typeparams %[[c]]#1 
+  ! CHECK: %[[box:.*]] = fir.embox %[[xaddr]](%[[shape]]) typeparams %[[c]]#1
   ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
   p => x
 end subroutine
@@ -87,7 +87,7 @@ subroutine test_array_with_new_lbs(p, x)
   p(4:) => x
 end subroutine
 
-! Test F2018 10.2.2.3 point 9: bounds remapping  
+! Test F2018 10.2.2.3 point 9: bounds remapping
 ! CHECK-LABEL: func @_QPtest_array_remap(
 ! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
 ! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {fir.target})
@@ -191,7 +191,7 @@ subroutine test_array_non_contig_rhs_new_lbs(p, x)
   p(4:) => x
 end subroutine
 
-! Test F2018 10.2.2.3 point 9: bounds remapping  
+! Test F2018 10.2.2.3 point 9: bounds remapping
 ! CHECK-LABEL: func @_QPtest_array_non_contig_remap(
 ! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
 ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})

--- a/flang/test/Lower/pointer-assignments.f90
+++ b/flang/test/Lower/pointer-assignments.f90
@@ -1,0 +1,226 @@
+! Test lowering of pointer assignments
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+
+! Note that p => NULL() are tested in pointer-disassociate.f90
+
+! -----------------------------------------------------------------------------
+!     Test simple pointer assignments to contiguous right-hand side
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest_scalar(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.ref<f32> {fir.target})
+subroutine test_scalar(p, x)
+  real, target :: x
+  real, pointer :: p
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  p => x
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_scalar_char(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target})
+subroutine test_scalar_char(p, x)
+  character(*), target :: x
+  character(:), pointer :: p
+  ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[box:.*]] = fir.embox %[[c]]#0 typeparams %[[c]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+  p => x
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {fir.target})
+subroutine test_array(p, x)
+  real, target :: x(100)
+  real, pointer :: p(:)
+  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => x
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array_char(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target}) {
+subroutine test_array_char(p, x)
+  character(*), target :: x(100)
+  character(:), pointer :: p(:)
+  ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[xaddr:.*]] = fir.convert %[[c]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<100x!fir.char<1,?>>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[xaddr]](%[[shape]]) typeparams %[[c]]#1 
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
+  p => x
+end subroutine
+
+! Test 10.2.2.3 point 10: lower bounds requirements:
+! pointer takes lbounds from rhs if no bounds spec.
+! CHECK-LABEL: func @_QPtest_array_with_lbs(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+subroutine test_array_with_lbs(p, x)
+  real, target :: x(51:150)
+  real, pointer :: p(:)
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %c51{{.*}}, %c100{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %{{.*}}(%[[shape]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => x
+end subroutine
+
+! -----------------------------------------------------------------------------
+!    Test pointer assignments with bound specs to contiguous right-hand side
+! -----------------------------------------------------------------------------
+
+! Test 10.2.2.3 point 10: lower bounds requirements:
+! pointer takes lbounds from bound spec if specified
+! CHECK-LABEL: func @_QPtest_array_with_new_lbs(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+subroutine test_array_with_new_lbs(p, x)
+  real, target :: x(51:150)
+  real, pointer :: p(:)
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %c4{{.*}}, %c100{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %{{.*}}(%[[shape]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p(4:) => x
+end subroutine
+
+! Test F2018 10.2.2.3 point 9: bounds remapping  
+! CHECK-LABEL: func @_QPtest_array_remap(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {fir.target})
+subroutine test_array_remap(p, x)
+  real, target :: x(100)
+  real, pointer :: p(:, :)
+  ! CHECK-DAG: %[[c2_idx:.*]] = fir.convert %c2{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[c11_idx:.*]] = fir.convert %c11{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[diff0:.*]] = subi %[[c11_idx]], %[[c2_idx]] : index
+  ! CHECK-DAG: %[[ext0:.*]] = addi %[[diff0:.*]], %c1{{.*}} : index
+  ! CHECK-DAG: %[[c3_idx:.*]] = fir.convert %c3{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[c12_idx:.*]] = fir.convert %c12{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[diff1:.*]] = subi %[[c12_idx]], %[[c3_idx]] : index
+  ! CHECK-DAG: %[[ext1:.*]] = addi %[[diff1]], %c1{{.*}} : index
+  ! CHECK-DAG: %[[addrCast:.*]] = fir.convert %[[x]] : (!fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %c2{{.*}}, %[[ext0]], %c3{{.*}}, %[[ext1]]
+  ! CHECK: %[[box:.*]] = fir.embox %[[addrCast]](%[[shape]]) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+  p(2:11, 3:12) => x
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array_char_remap(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target})
+subroutine test_array_char_remap(p, x)
+  ! CHECK: %[[unbox:.*]]:2 = fir.unboxchar %[[x]]
+  character(*), target :: x(100)
+  character(:), pointer :: p(:, :)
+  ! CHECK: subi
+  ! CHECK: %[[ext0:.*]] = addi
+  ! CHECK: subi
+  ! CHECK: %[[ext1:.*]] = addi
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %c2{{.*}}, %[[ext0]], %c3{{.*}}, %[[ext1]]
+  ! CHECK: %[[box:.*]] = fir.embox %{{.*}}(%[[shape]]) typeparams %[[unbox]]#1 : (!fir.ref<!fir.array<?x?x!fir.char<1,?>>>, !fir.shapeshift<2>, index) -> !fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>
+  ! CHECK: fir.store %[[box]] to %[[p]]
+  p(2:11, 3:12) => x
+end subroutine
+
+! -----------------------------------------------------------------------------
+!  Test simple pointer assignments to non contiguous right-hand side
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest_array_non_contig_rhs(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+subroutine test_array_non_contig_rhs(p, x)
+  real, target :: x(:)
+  real, pointer :: p(:)
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => x
+end subroutine
+
+! Test 10.2.2.3 point 10: lower bounds requirements:
+! pointer takes lbounds from rhs if no bounds spec.
+! CHECK-LABEL: func @_QPtest_array_non_contig_rhs_lbs(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+subroutine test_array_non_contig_rhs_lbs(p, x)
+  real, target :: x(7:)
+  real, pointer :: p(:)
+  ! CHECK: %[[c7_idx:.*]] = fir.convert %c7{{.*}} : (i64) -> index
+  ! CHECK: %[[shift:.*]] = fir.shift %[[c7_idx]] : (index) -> !fir.shift<1>
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[x]](%[[shift]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => x
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array_non_contig_rhs2(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<200xf32>> {fir.target})
+subroutine test_array_non_contig_rhs2(p, x)
+  real, target :: x(200)
+  real, pointer :: p(:)
+  ! CHECK: %[[shape:.*]] = fir.shape %c200{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[slice:.*]] = fir.slice %c10{{.*}}, %c160{{.*}}, %c3{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) {{.}}%[[slice]]{{.}} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => x(10:160:3)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!  Test pointer assignments with bound specs to non contiguous right-hand side
+! -----------------------------------------------------------------------------
+
+
+! Test 10.2.2.3 point 10: lower bounds requirements:
+! pointer takes lbounds from bound spec if specified
+! CHECK-LABEL: func @_QPtest_array_non_contig_rhs_new_lbs(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+subroutine test_array_non_contig_rhs_new_lbs(p, x)
+  real, target :: x(7:)
+  real, pointer :: p(:)
+  ! CHECK: %[[shift:.*]] = fir.shift %c4{{.*}}
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[x]](%[[shift]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p(4:) => x
+end subroutine
+
+! Test F2018 10.2.2.3 point 9: bounds remapping  
+! CHECK-LABEL: func @_QPtest_array_non_contig_remap(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+subroutine test_array_non_contig_remap(p, x)
+  real, target :: x(:)
+  real, pointer :: p(:, :)
+  ! CHECK: subi
+  ! CHECK: %[[ext0:.*]] = addi
+  ! CHECK: subi
+  ! CHECK: %[[ext1:.*]] = addi
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %{{.*}}, %[[ext0]], %{{.*}}, %[[ext1]]
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[x]](%[[shape]]) : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+  p(2:11, 3:12) => x
+end subroutine
+
+! Test remapping a slice
+! CHECK-LABEL: func @_QPtest_array_non_contig_remap_slice(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<400xf32>> {fir.target})
+subroutine test_array_non_contig_remap_slice(p, x)
+  real, target :: x(400)
+  real, pointer :: p(:, :)
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape %c400{{.*}}
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c51{{.*}}, %c350{{.*}}, %c3{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) {{.}}%[[slice]]{{.}} : (!fir.ref<!fir.array<400xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+
+  ! CHECK: %[[reshape:.*]] = fir.shape_shift %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[box]](%[[reshape]]) : (!fir.box<!fir.array<?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+  ! CHECK: fir.store %[[rebox]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+  p(2:11, 3:12) => x(51:350:3)
+end subroutine

--- a/flang/test/Lower/pointer-disassociate.f90
+++ b/flang/test/Lower/pointer-disassociate.f90
@@ -1,0 +1,55 @@
+! Test lowering of pointer disassociation
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+
+! -----------------------------------------------------------------------------
+!     Test p => NULL()
+! -----------------------------------------------------------------------------
+
+
+! CHECK-LABEL: func @_QPtest_scalar(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>)
+subroutine test_scalar(p)
+  real, pointer :: p
+  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<f32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[null]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  p => NULL()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_scalar_char(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>)
+subroutine test_scalar_char(p)
+  character(:), pointer :: p
+  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[null]] typeparams %c0{{.*}} : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+  p => NULL()
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+subroutine test_array(p)
+  real, pointer :: p(:)
+  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c0{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[null]](%[[shape]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => NULL()
+end subroutine
+
+! Test p(lb, ub) => NULL() which is none sens but is not illegal.
+! CHECK-LABEL: func @_QPtest_array_remap(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+subroutine test_array_remap(p)
+  real, pointer :: p(:)
+  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c0{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[null]](%[[shape]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p(10:20) => NULL()
+end subroutine
+
+
+! TODO: p => NULL(MOLD). Requires array function/intrinsic lowering work. 
+


### PR DESCRIPTION
Split in three commits:
- Preliminary small clean-up: use `fir.zero_bits` in `builder.createNullConstant()`
- Lower pointer assignments, including the special case `p =>  NULL`
- Lower nullify statement (very similar to p => NULL).

Note that pointer assignments have two flavor: `p([lb:]) => target` (normal case) and the `p(ub:lb) => target` case (pointer bounds remapping). Both are implemented in this PR. They are quite different, so get their own functions, though the implementation flow is very similar.

A TODO is left for pointer assignment with polymorphic because they have tricky semantics and can anyway not be implemented currently.
Otherwise, derived type pointer assignment should be OK, but they are not yet testable since they hit a couple other TODOs/issue. So an update with tests and potential fixes should be done when possible.