### PR TITLE
Move the interface registration out of CodeGen and put it in InitFIR

### DIFF
--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -71,6 +71,9 @@ inline void registerFIRPasses() {
   mlir::registerConvertAffineToStandardPass();
 }
 
+/// Register the interfaces needed to lower to LLVM IR.
+void registerLLVMTranslation(mlir::MLIRContext &context);
+
 } // namespace fir::support
 
 #endif // FORTRAN_OPTIMIZER_SUPPORT_INITFIR_H

--- a/flang/lib/Optimizer/CMakeLists.txt
+++ b/flang/lib/Optimizer/CMakeLists.txt
@@ -7,6 +7,7 @@ add_flang_library(FIROptimizer
   Dialect/FIRType.cpp
 
   Support/FIRContext.cpp
+  Support/InitFIR.cpp
   Support/InternalNames.cpp
   Support/KindMapping.cpp
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -33,7 +33,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR.h"
-#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -2913,19 +2912,8 @@ class FIRToLLVMLowering : public fir::FIRToLLVMLoweringBase<FIRToLLVMLowering> {
 public:
   mlir::ModuleOp getModule() { return getOperation(); }
 
-  void registerDialectInterfaces(mlir::MLIRContext *context) {
-    mlir::DialectRegistry registry;
-    registry.insert<mlir::omp::OpenMPDialect>();
-    registry
-        .addDialectInterface<mlir::omp::OpenMPDialect,
-                             mlir::OpenMPDialectLLVMIRTranslationInterface>();
-    registerLLVMDialectTranslation(registry);
-    context->appendDialectRegistry(registry);
-  }
-
   void runOnOperation() override final {
     auto *context = getModule().getContext();
-    registerDialectInterfaces(context);
     fir::LLVMTypeConverter typeConverter{getModule()};
     auto loc = mlir::UnknownLoc::get(context);
     mlir::OwningRewritePatternList pattern;

--- a/flang/lib/Optimizer/Support/InitFIR.cpp
+++ b/flang/lib/Optimizer/Support/InitFIR.cpp
@@ -1,0 +1,22 @@
+//===-- Optimizer/Support/InitFIR.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Support/InitFIR.h"
+#include "mlir/Target/LLVMIR.h"
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
+
+void fir::support::registerLLVMTranslation(mlir::MLIRContext &context) {
+  mlir::DialectRegistry registry;
+  // Register OpenMP dialect interface here as well.
+  registry.insert<mlir::omp::OpenMPDialect>();
+  registry.addDialectInterface<mlir::omp::OpenMPDialect,
+                               mlir::OpenMPDialectLLVMIRTranslationInterface>();
+  // Register LLVM-IR dialect interface.
+  registerLLVMDialectTranslation(registry);
+  context.appendDialectRegistry(registry);
+}

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -228,6 +228,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
   fir::support::registerDialects(registry);
   mlir::MLIRContext ctx(registry);
   fir::support::loadDialects(ctx);
+  fir::support::registerLLVMTranslation(ctx);
   auto &defKinds = semanticsContext.defaultKinds();
   fir::KindMapping kindMap(
       &ctx, llvm::ArrayRef<fir::KindTy>{fromDefaultKinds(defKinds)});

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -78,6 +78,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
   fir::support::registerDialects(registry);
   mlir::MLIRContext context(registry);
   fir::support::loadDialects(context);
+  fir::support::registerLLVMTranslation(context);
   auto owningRef = mlir::parseSourceFile(sourceMgr, &context);
 
   if (!owningRef) {


### PR DESCRIPTION
with the other registration functionality.

This is for upstreaming.