### PR TITLE
Update DE/ALLOCATE statement runtime message processing

### DIFF
--- a/flang/lib/Lower/RTBuilder.h
+++ b/flang/lib/Lower/RTBuilder.h
@@ -220,6 +220,10 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor &>() {
   };
 }
 template <>
+constexpr TypeBuilderFunc getModel<const Fortran::runtime::Descriptor *>() {
+  return getModel<const Fortran::runtime::Descriptor &>();
+}
+template <>
 constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor *>() {
   return getModel<Fortran::runtime::Descriptor &>();
 }

--- a/flang/runtime/allocatable.cpp
+++ b/flang/runtime/allocatable.cpp
@@ -40,8 +40,8 @@ void RTNAME(AllocatableAssign)(Descriptor &to, const Descriptor & /*from*/) {
 }
 
 int RTNAME(MoveAlloc)(Descriptor &to, const Descriptor & /*from*/,
-    bool /*hasStat*/, Descriptor * /*errMsg*/, const char * /*sourceFile*/,
-    int /*sourceLine*/) {
+    bool /*hasStat*/, const Descriptor * /*errMsg*/,
+    const char * /*sourceFile*/, int /*sourceLine*/) {
   INTERNAL_CHECK(false); // MoveAlloc is not yet implemented
   return StatOk;
 }
@@ -54,7 +54,7 @@ void RTNAME(AllocatableSetBounds)(Descriptor &descriptor, int zeroBasedDim,
 }
 
 int RTNAME(AllocatableAllocate)(Descriptor &descriptor, bool hasStat,
-    Descriptor *errMsg, const char *sourceFile, int sourceLine) {
+    const Descriptor *errMsg, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
   if (!descriptor.IsAllocatable()) {
     return ReturnError(terminator, StatInvalidDescriptor, errMsg, hasStat);
@@ -66,7 +66,7 @@ int RTNAME(AllocatableAllocate)(Descriptor &descriptor, bool hasStat,
 }
 
 int RTNAME(AllocatableDeallocate)(Descriptor &descriptor, bool hasStat,
-    Descriptor *errMsg, const char *sourceFile, int sourceLine) {
+    const Descriptor *errMsg, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
   if (!descriptor.IsAllocatable()) {
     return ReturnError(terminator, StatInvalidDescriptor, errMsg, hasStat);

--- a/flang/runtime/allocatable.h
+++ b/flang/runtime/allocatable.h
@@ -42,7 +42,7 @@ void RTNAME(AllocatableInitDerived)(
 // this API allows the error to be caught before descriptor is modified.)
 // Return 0 on success (deallocated state), else the STAT= value.
 int RTNAME(AllocatableCheckAllocated)(Descriptor &,
-    Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
+    const Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
     int sourceLine = 0);
 
 // For MOLD= allocation; sets bounds, cobounds, and length type
@@ -72,7 +72,7 @@ void RTNAME(AllocatableSetDerivedLength)(
 // Returns 0 for success, or the STAT= value on failure with hasStat==true.
 int RTNAME(AllocatableCheckLengthParameter)(Descriptor &,
     int which /* 0 for CHARACTER length */, SubscriptValue other,
-    bool hasStat = false, Descriptor *errMsg = nullptr,
+    bool hasStat = false, const Descriptor *errMsg = nullptr,
     const char *sourceFile = nullptr, int sourceLine = 0);
 
 // Allocates an allocatable.  The allocatable descriptor must have been
@@ -85,10 +85,10 @@ int RTNAME(AllocatableCheckLengthParameter)(Descriptor &,
 // derived type, and is always initialized by AllocatableAllocateSource().
 // Performs all necessary coarray synchronization and validation actions.
 int RTNAME(AllocatableAllocate)(Descriptor &, bool hasStat = false,
-    Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
+    const Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
     int sourceLine = 0);
 int RTNAME(AllocatableAllocateSource)(Descriptor &, const Descriptor &source,
-    bool hasStat = false, Descriptor *errMsg = nullptr,
+    bool hasStat = false, const Descriptor *errMsg = nullptr,
     const char *sourceFile = nullptr, int sourceLine = 0);
 
 // Assigns to a whole allocatable, with automatic (re)allocation when the
@@ -105,14 +105,14 @@ void RTNAME(AllocatableAssign)(Descriptor &to, const Descriptor &from);
 // with the other APIs for allocatables.)  The destination descriptor
 // must be initialized.
 int RTNAME(MoveAlloc)(Descriptor &to, const Descriptor &from,
-    bool hasStat = false, Descriptor *errMsg = nullptr,
+    bool hasStat = false, const Descriptor *errMsg = nullptr,
     const char *sourceFile = nullptr, int sourceLine = 0);
 
 // Deallocates an allocatable.  Finalizes elements &/or components as needed.
 // The allocatable is left in an initialized state suitable for reallocation
 // with the same bounds, cobounds, and length type parameters.
 int RTNAME(AllocatableDeallocate)(Descriptor &, bool hasStat = false,
-    Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
+    const Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
     int sourceLine = 0);
 }
 } // namespace Fortran::runtime

--- a/flang/runtime/stat.cpp
+++ b/flang/runtime/stat.cpp
@@ -55,7 +55,7 @@ const char *StatErrorString(int stat) {
   }
 }
 
-int ToErrmsg(Descriptor *errmsg, int stat) {
+int ToErrmsg(const Descriptor *errmsg, int stat) {
   if (stat != StatOk && errmsg && errmsg->raw().base_addr &&
       errmsg->type() == TypeCode(TypeCategory::Character, 1) &&
       errmsg->rank() == 0) {
@@ -63,7 +63,7 @@ int ToErrmsg(Descriptor *errmsg, int stat) {
       char *buffer{errmsg->OffsetElement()};
       std::size_t bufferLength{errmsg->ElementBytes()};
       std::size_t msgLength{std::strlen(msg)};
-      if (msgLength <= bufferLength) {
+      if (msgLength >= bufferLength) {
         std::memcpy(buffer, msg, bufferLength);
       } else {
         std::memcpy(buffer, msg, msgLength);
@@ -75,7 +75,7 @@ int ToErrmsg(Descriptor *errmsg, int stat) {
 }
 
 int ReturnError(
-    Terminator &terminator, int stat, Descriptor *errmsg, bool hasStat) {
+    Terminator &terminator, int stat, const Descriptor *errmsg, bool hasStat) {
   if (stat == StatOk || hasStat) {
     return ToErrmsg(errmsg, stat);
   } else if (const char *msg{StatErrorString(stat)}) {

--- a/flang/runtime/stat.h
+++ b/flang/runtime/stat.h
@@ -47,8 +47,8 @@ enum Stat {
 };
 
 const char *StatErrorString(int);
-int ToErrmsg(Descriptor *errmsg, int stat); // returns stat
-int ReturnError(
-    Terminator &, int stat, Descriptor *errmsg = nullptr, bool hasStat = false);
+int ToErrmsg(const Descriptor *errmsg, int stat); // returns stat
+int ReturnError(Terminator &, int stat, const Descriptor *errmsg = nullptr,
+    bool hasStat = false);
 } // namespace Fortran::runtime
 #endif // FORTRAN_RUNTIME_STAT_H

--- a/flang/test/Lower/allocatable-runtime.f90
+++ b/flang/test/Lower/allocatable-runtime.f90
@@ -21,8 +21,8 @@ subroutine foo()
   ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
   ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 
-
   allocate(x(42:100), y(43:50, 51), z)
+  ! CHECK-DAG: %[[errMsg:.*]] = fir.absent !fir.box<none>
   ! CHECK-DAG: %[[xlb:.*]] = constant 42 : i32
   ! CHECK-DAG: %[[xub:.*]] = constant 100 : i32
   ! CHECK-DAG: %[[xBoxCast2:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
@@ -30,9 +30,8 @@ subroutine foo()
   ! CHECK-DAG: %[[xubCast:.*]] = fir.convert %[[xub]] : (i32) -> i64
   ! CHECK: fir.call @{{.*}}AllocatableSetBounds(%[[xBoxCast2]], %c0{{.*}}, %[[xlbCast]], %[[xubCast]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
   ! CHECK-DAG: %[[xBoxCast3:.*]] = fir.convert %[[xBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[errMsg:.*]] = fir.convert %{{.*}} : (!fir.ref<none>) -> !fir.ref<!fir.box<none>>
   ! CHECK-DAG: %[[sourceFile:.*]] = fir.convert %{{.*}} -> !fir.ref<i8>
-  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[xBoxCast3]], %false{{.*}}, %[[errMsg]], %[[sourceFile]], %{{.*}}) : (!fir.ref<!fir.box<none>>, i1, !fir.ref<!fir.box<none>>, !fir.ref<i8>, i32) -> i32
+  ! CHECK: fir.call @{{.*}}AllocatableAllocate(%[[xBoxCast3]], %false{{.*}}, %[[errMsg]], %[[sourceFile]], %{{.*}}) : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 
   ! Simply check that we are emitting the right numebr of set bound for y and z. Otherwise, this is just like x.
   ! CHECK: fir.convert %[[yBoxAddr]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>


### PR DESCRIPTION
Make error message descriptors on runtime DE/ALLOCATE API calls constant.
Fix a bug in error message truncation/padding.

(A separate FE PR for the {stat,allocatable}.{h,cpp} changes has been
approved.)