### PR TITLE
Remove libc++ linking from end-to-end tests

### DIFF
--- a/flang/test/Examples/hello.f90
+++ b/flang/test/Examples/hello.f90
@@ -1,13 +1,9 @@
-! Note: The Fortran runtime libraries have dependences on the C++ runtime and
-! LLVM libraries.  To work around the former, this test explicitly links in
-! libstdc++.a.  To work around the latter, the source of Common/enum-set.h was
-! hacked to exclude references to llvm ADTs.
 ! Note: On linux, the Fortran runtime wants to include libm as well.
 ! Note: Add pic to the compilation as gcc will use shared libraries by
 ! default when they are available.
 
 ! RUN: bbc %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
-! RUN: %CC %t.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm -o hello
+! RUN: %CC %t.o -L%L -lFortranRuntime -lFortranDecimal -lm -o hello
 ! RUN: ./hello | FileCheck %s
 
 ! CHECK: Hello, World!

--- a/flang/test/Lower/associate-construct.f90
+++ b/flang/test/Lower/associate-construct.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
-! RUN: %CC %t.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm -o %t.out
+! RUN: %CC %t.o -L%L -lFortranRuntime -lFortranDecimal -lm -o %t.out
 ! RUN: %t.out | FileCheck %s
 
 program p

--- a/flang/test/Lower/end-to-end-always-exec-loopbody.f90
+++ b/flang/test/Lower/end-to-end-always-exec-loopbody.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc --always-execute-loop-body %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %temp.o
-! RUN: %CC %temp.o -L%L -lFortranRuntime -lFortranDecimal -lstdc++ -lm -o %temp.loop
+! RUN: %CC %temp.o -L%L -lFortranRuntime -lFortranDecimal -lm -o %temp.loop
 ! RUN: %temp.loop | FileCheck %s
 
 program alwaysexecuteloopbody


### PR DESCRIPTION
The runtime dependence upon C++ runtime has been fixed. Remove the workaround linking from tests.

Tested OK with both clang++ and g++. The original issue was fixed in the runtime a while ago, if it turns out this still break on some machine, we will need to forward to the issue to the runtime development. 