### PR TITLE
[NFC] Remove old BoxValue class and rename IrBoxValue to BoxValue

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -28,7 +28,7 @@
 namespace fir {
 class AbstractArrayBox;
 class ExtendedValue;
-class IrBoxValue;
+class BoxValue;
 } // namespace fir
 
 namespace Fortran::lower {
@@ -278,8 +278,8 @@ mlir::Value readLowerBound(FirOpBuilder &, mlir::Location,
                            const fir::ExtendedValue &, unsigned dim,
                            mlir::Value defaultValue);
 
-/// Read extents from an IrBoxValue into \p result.
-void readExtents(FirOpBuilder &, mlir::Location, const fir::IrBoxValue &,
+/// Read extents from an BoxValue into \p result.
+void readExtents(FirOpBuilder &, mlir::Location, const fir::BoxValue &,
                  llvm::SmallVectorImpl<mlir::Value> &result);
 
 //===--------------------------------------------------------------------===//

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1250,8 +1250,11 @@ private:
                           sym, value.getAddr(), value.getLen(),
                           value.getExtents(), value.getLBounds());
                   },
-                  [&](const fir::BoxValue &) {
-                    TODO(toLocation(), "association selector of derived type");
+                  [&](const fir::BoxValue &value) {
+                    localSymbols.addBoxSymbol(sym, value.getAddr(),
+                                              value.getLBounds(),
+                                              value.getExplicitParameters(),
+                                              value.getExplicitExtents());
                   },
                   [&](const auto &) {
                     mlir::emitError(toLocation(),

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -681,13 +681,13 @@ static void instantiateCommon(Fortran::lower::AbstractConverter &converter,
 // Lower Variables specification expressions and attributes
 //===--------------------------------------------------------------===//
 
-/// Helper to decide if a dummy argument must be tracked in an IrBox.
-static bool lowerToIrBox(const Fortran::semantics::Symbol &sym,
-                         mlir::Value dummyArg) {
-  // Only dummy arguments coming as fir.box can be tracked in an IrBox.
+/// Helper to decide if a dummy argument must be tracked in an BoxValue.
+static bool lowerToBoxValue(const Fortran::semantics::Symbol &sym,
+                            mlir::Value dummyArg) {
+  // Only dummy arguments coming as fir.box can be tracked in an BoxValue.
   if (!dummyArg || !dummyArg.getType().isa<fir::BoxType>())
     return false;
-  // Non contiguous arrays must be tracked in an IrBox.
+  // Non contiguous arrays must be tracked in an BoxValue.
   if (sym.Rank() > 0 && !sym.attrs().test(Fortran::semantics::Attr::CONTIGUOUS))
     return true;
   // Assumed rank and optional fir.box cannot yet be read while lowering the
@@ -855,7 +855,7 @@ void Fortran::lower::mapSymbolAttributes(
 
   if (isDummy) {
     auto dummyArg = symMap.lookupSymbol(sym).getAddr();
-    if (lowerToIrBox(sym, dummyArg)) {
+    if (lowerToBoxValue(sym, dummyArg)) {
       llvm::SmallVector<mlir::Value, 4> lbounds;
       llvm::SmallVector<mlir::Value, 4> extents;
       llvm::SmallVector<mlir::Value, 2> explicitParams;
@@ -869,8 +869,8 @@ void Fortran::lower::mapSymbolAttributes(
       lowerExplicitLowerBounds(converter, loc, sba, lbounds, symMap, stmtCtx);
       lowerExplicitExtents(converter, loc, sba, lbounds, extents, symMap,
                            stmtCtx);
-      symMap.addIrBoxSymbol(sym, dummyArg, lbounds, explicitParams, extents,
-                            replace);
+      symMap.addBoxSymbol(sym, dummyArg, lbounds, explicitParams, extents,
+                          replace);
       return;
     }
   }


### PR DESCRIPTION
Note there is a tiny bug fix in `BoxValue::verify`, I could not help noticing the `&&` instead of `||` while reading the comments in the updated. Apart from that, sed did most of this PR.

After this PR, remaining clean-up around extended values that I see:
- We need to clarify the status of `Unboxed`/`ArrayBoxValue`. Should we officially use them for non polymorphic derive types with no length parameters (F95 derived types) ? If yes, some comments/names need to be updated (e.g `SymbolBox::Intrinsic`). If not, may want new extended value category for them.
- MutableBoxValue need to be added to ExtendedValue variant.