### PR TITLE
Lowering of basic elemental functions (intrinsic and user-defined).

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -122,12 +122,19 @@ public:
   /// given a name via a front-end `Symbol` or a `StringRef`.
   mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
                               llvm::StringRef name = {},
-                              llvm::ArrayRef<mlir::Value> shape = {});
+                              mlir::ValueRange shape = {},
+                              mlir::ValueRange lenParams = {},
+                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
   /// Create an unnamed and untracked temporary on the stack.
   mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
-                              llvm::ArrayRef<mlir::Value> shape) {
+                              mlir::ValueRange shape) {
     return createTemporary(loc, type, llvm::StringRef{}, shape);
+  }
+
+  mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
+                              llvm::ArrayRef<mlir::NamedAttribute> attrs) {
+    return createTemporary(loc, type, llvm::StringRef{}, {}, {}, attrs);
   }
 
   /// Create a global value.


### PR DESCRIPTION
This handles the lowering of the basic cases. There are several TODOs in
the code for other variants.

This lowers expressions like the following where a and b are arrays.

  a = f(b)
  a = abs(b)

These are transformed into loop (nests) where the right-hand side is
fully evaluated by applying the function to each element in the array
and then the resulting array is copied-out to the left-hand side.