### PR TITLE
[flang] Fix for #657

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2795,18 +2795,7 @@ class RealArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
       fir_ArithmeticOp<mnemonic, traits>,
       Arguments<(ins AnyRealLike:$lhs, AnyRealLike:$rhs)>;
 
-def fir_AddfOp : RealArithmeticOp<"addf", [Commutative]> {
-  let hasFolder = 1;
-}
-def fir_SubfOp : RealArithmeticOp<"subf"> {
-  let hasFolder = 1;
-}
-def fir_MulfOp : RealArithmeticOp<"mulf", [Commutative]> {
-  let hasFolder = 1;
-}
-def fir_DivfOp : RealArithmeticOp<"divf">;
 def fir_ModfOp : RealArithmeticOp<"modf">;
-// Pow is a builtin call and not a primitive
 
 def fir_CmpfOp : fir_Op<"cmpf",
     [NoSideEffect, SameTypeOperands, SameOperandsAndResultShape]> {

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -673,7 +673,7 @@ private:
     // Arithmetic expression has Real type.  Generate
     //   sum = expr + expr  [ raise an exception if expr is a NaN ]
     //   if (sum < 0.0) goto L1 else if (sum > 0.0) goto L3 else goto L2
-    auto sum = builder->create<fir::AddfOp>(loc, expr, expr);
+    auto sum = builder->create<mlir::AddFOp>(loc, expr, expr);
     auto zero = builder->create<mlir::ConstantOp>(
         loc, exprType, builder->getFloatAttr(exprType, 0.0));
     auto cond1 =

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -513,16 +513,16 @@ public:
   }
 
   GENBIN(Add, Integer, mlir::AddIOp)
-  GENBIN(Add, Real, fir::AddfOp)
+  GENBIN(Add, Real, mlir::AddFOp)
   GENBIN(Add, Complex, fir::AddcOp)
   GENBIN(Subtract, Integer, mlir::SubIOp)
-  GENBIN(Subtract, Real, fir::SubfOp)
+  GENBIN(Subtract, Real, mlir::SubFOp)
   GENBIN(Subtract, Complex, fir::SubcOp)
   GENBIN(Multiply, Integer, mlir::MulIOp)
-  GENBIN(Multiply, Real, fir::MulfOp)
+  GENBIN(Multiply, Real, mlir::MulFOp)
   GENBIN(Multiply, Complex, fir::MulcOp)
   GENBIN(Divide, Integer, mlir::SignedDivIOp)
-  GENBIN(Divide, Real, fir::DivfOp)
+  GENBIN(Divide, Real, mlir::DivFOp)
   GENBIN(Divide, Complex, fir::DivcOp)
 
   template <Fortran::common::TypeCategory TC, int KIND>
@@ -2143,16 +2143,16 @@ public:
   }
 
   GENBIN(Add, Integer, mlir::AddIOp)
-  GENBIN(Add, Real, fir::AddfOp)
+  GENBIN(Add, Real, mlir::AddFOp)
   GENBIN(Add, Complex, fir::AddcOp)
   GENBIN(Subtract, Integer, mlir::SubIOp)
-  GENBIN(Subtract, Real, fir::SubfOp)
+  GENBIN(Subtract, Real, mlir::SubFOp)
   GENBIN(Subtract, Complex, fir::SubcOp)
   GENBIN(Multiply, Integer, mlir::MulIOp)
-  GENBIN(Multiply, Real, fir::MulfOp)
+  GENBIN(Multiply, Real, mlir::MulFOp)
   GENBIN(Multiply, Complex, fir::MulcOp)
   GENBIN(Divide, Integer, mlir::SignedDivIOp)
-  GENBIN(Divide, Real, fir::DivfOp)
+  GENBIN(Divide, Real, mlir::DivFOp)
   GENBIN(Divide, Complex, fir::DivcOp)
 
   template <Fortran::common::TypeCategory TC, int KIND>

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1195,7 +1195,7 @@ mlir::Value IntrinsicLibrary::genDim(mlir::Type resultType,
   }
   assert(fir::isa_real(resultType) && "Only expects real and integer in DIM");
   auto zero = builder.createRealZeroConstant(loc, resultType);
-  auto diff = builder.create<fir::SubfOp>(loc, args[0], args[1]);
+  auto diff = builder.create<mlir::SubFOp>(loc, args[0], args[1]);
   auto cmp =
       builder.create<fir::CmpfOp>(loc, mlir::CmpFPredicate::OGT, diff, zero);
   return builder.create<mlir::SelectOp>(loc, cmp, diff, zero);
@@ -1209,7 +1209,7 @@ mlir::Value IntrinsicLibrary::genDprod(mlir::Type resultType,
          "Result must be double precision in DPROD");
   auto a = builder.createConvert(loc, resultType, args[0]);
   auto b = builder.createConvert(loc, resultType, args[1]);
-  return builder.create<fir::MulfOp>(loc, a, b);
+  return builder.create<mlir::MulFOp>(loc, a, b);
 }
 
 // FLOOR

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2674,46 +2674,6 @@ void lowerRealBinaryOp(BINOP binop, OperandTy operands,
   rewriter.replaceOpWithNewOp<LLVMOP>(binop, ty, operands);
 }
 
-struct AddfOpConversion : public FIROpConversion<fir::AddfOp> {
-  using FIROpConversion::FIROpConversion;
-
-  mlir::LogicalResult
-  matchAndRewrite(fir::AddfOp op, OperandTy operands,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    lowerRealBinaryOp<mlir::LLVM::FAddOp>(op, operands, rewriter, lowerTy());
-    return success();
-  }
-};
-struct SubfOpConversion : public FIROpConversion<fir::SubfOp> {
-  using FIROpConversion::FIROpConversion;
-
-  mlir::LogicalResult
-  matchAndRewrite(fir::SubfOp op, OperandTy operands,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    lowerRealBinaryOp<mlir::LLVM::FSubOp>(op, operands, rewriter, lowerTy());
-    return success();
-  }
-};
-struct MulfOpConversion : public FIROpConversion<fir::MulfOp> {
-  using FIROpConversion::FIROpConversion;
-
-  mlir::LogicalResult
-  matchAndRewrite(fir::MulfOp op, OperandTy operands,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    lowerRealBinaryOp<mlir::LLVM::FMulOp>(op, operands, rewriter, lowerTy());
-    return success();
-  }
-};
-struct DivfOpConversion : public FIROpConversion<fir::DivfOp> {
-  using FIROpConversion::FIROpConversion;
-
-  mlir::LogicalResult
-  matchAndRewrite(fir::DivfOp op, OperandTy operands,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    lowerRealBinaryOp<mlir::LLVM::FDivOp>(op, operands, rewriter, lowerTy());
-    return success();
-  }
-};
 struct ModfOpConversion : public FIROpConversion<fir::ModfOp> {
   using FIROpConversion::FIROpConversion;
 
@@ -2916,29 +2876,27 @@ public:
     auto loc = mlir::UnknownLoc::get(context);
     mlir::OwningRewritePatternList pattern;
     pattern.insert<
-        AbsentOpConversion, AddcOpConversion, AddfOpConversion,
-        AddrOfOpConversion, AllocaOpConversion, AllocMemOpConversion,
-        BoxAddrOpConversion, BoxCharLenOpConversion, BoxDimsOpConversion,
-        BoxEleSizeOpConversion, BoxIsAllocOpConversion, BoxIsArrayOpConversion,
-        BoxIsPtrOpConversion, BoxProcHostOpConversion, BoxRankOpConversion,
-        BoxTypeDescOpConversion, CallOpConversion, CmpcOpConversion,
-        CmpfOpConversion, ConstcOpConversion, ConvertOpConversion,
-        CoordinateOpConversion, DispatchOpConversion, DispatchTableOpConversion,
-        DivcOpConversion, DivfOpConversion, DTEntryOpConversion,
-        EmboxOpConversion, EmboxCharOpConversion, EmboxProcOpConversion,
-        FieldIndexOpConversion, FirEndOpConversion, ExtractValueOpConversion,
-        IsPresentOpConversion, FreeMemOpConversion, GenTypeDescOpConversion,
-        GlobalLenOpConversion, GlobalOpConversion, HasValueOpConversion,
-        InsertOnRangeOpConversion, InsertValueOpConversion,
-        LenParamIndexOpConversion, LoadOpConversion, ModfOpConversion,
-        MulcOpConversion, MulfOpConversion, NegcOpConversion, NegfOpConversion,
+        AbsentOpConversion, AddcOpConversion, AddrOfOpConversion,
+        AllocaOpConversion, AllocMemOpConversion, BoxAddrOpConversion,
+        BoxCharLenOpConversion, BoxDimsOpConversion, BoxEleSizeOpConversion,
+        BoxIsAllocOpConversion, BoxIsArrayOpConversion, BoxIsPtrOpConversion,
+        BoxProcHostOpConversion, BoxRankOpConversion, BoxTypeDescOpConversion,
+        CallOpConversion, CmpcOpConversion, CmpfOpConversion,
+        ConstcOpConversion, ConvertOpConversion, CoordinateOpConversion,
+        DispatchOpConversion, DispatchTableOpConversion, DivcOpConversion,
+        DTEntryOpConversion, EmboxOpConversion, EmboxCharOpConversion,
+        EmboxProcOpConversion, FieldIndexOpConversion, FirEndOpConversion,
+        ExtractValueOpConversion, IsPresentOpConversion, FreeMemOpConversion,
+        GenTypeDescOpConversion, GlobalLenOpConversion, GlobalOpConversion,
+        HasValueOpConversion, InsertOnRangeOpConversion,
+        InsertValueOpConversion, ModfOpConversion, LenParamIndexOpConversion,
+        LoadOpConversion, MulcOpConversion, NegcOpConversion, NegfOpConversion,
         NoReassocOpConversion, SelectCaseOpConversion, SelectOpConversion,
         SelectRankOpConversion, SelectTypeOpConversion, StoreOpConversion,
-        StringLitOpConversion, SubcOpConversion, SubfOpConversion,
-        UnboxCharOpConversion, UnboxOpConversion, UnboxProcOpConversion,
-        UndefOpConversion, UnreachableOpConversion, XArrayCoorOpConversion,
-        XEmboxOpConversion, XReboxOpConversion, ZeroOpConversion>(
-        context, typeConverter);
+        StringLitOpConversion, SubcOpConversion, UnboxCharOpConversion,
+        UnboxOpConversion, UnboxProcOpConversion, UndefOpConversion,
+        UnreachableOpConversion, XArrayCoorOpConversion, XEmboxOpConversion,
+        XReboxOpConversion, ZeroOpConversion>(context, typeConverter);
     mlir::populateStdToLLVMConversionPatterns(typeConverter, pattern);
     mlir::populateOpenMPToLLVMConversionPatterns(typeConverter, pattern);
     mlir::ConversionTarget target{*context};

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -72,15 +72,6 @@ static bool verifyRecordLenParams(mlir::Type inType, unsigned numLenParams) {
 }
 
 //===----------------------------------------------------------------------===//
-// AddfOp
-//===----------------------------------------------------------------------===//
-
-mlir::OpFoldResult fir::AddfOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  return mlir::constFoldBinaryOp<FloatAttr>(
-      opnds, [](APFloat a, APFloat b) { return a + b; });
-}
-
-//===----------------------------------------------------------------------===//
 // AllocaOp
 //===----------------------------------------------------------------------===//
 
@@ -752,8 +743,8 @@ struct UndoComplexPattern : public mlir::RewritePattern {
 
 void fir::InsertValueOp::getCanonicalizationPatterns(
     mlir::OwningRewritePatternList &results, mlir::MLIRContext *context) {
-  results.insert<UndoComplexPattern<fir::AddfOp, fir::AddcOp>,
-                 UndoComplexPattern<fir::SubfOp, fir::SubcOp>>(context);
+  results.insert<UndoComplexPattern<mlir::AddFOp, fir::AddcOp>,
+                 UndoComplexPattern<mlir::SubFOp, fir::SubcOp>>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1230,15 +1221,6 @@ mlir::Value fir::DoLoopOp::blockArgToSourceOp(unsigned blockArgNum) {
   if (blockArgNum > 0 && blockArgNum <= initArgs().size())
     return initArgs()[blockArgNum - 1];
   return {};
-}
-
-//===----------------------------------------------------------------------===//
-// MulfOp
-//===----------------------------------------------------------------------===//
-
-mlir::OpFoldResult fir::MulfOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  return mlir::constFoldBinaryOp<FloatAttr>(
-      opnds, [](APFloat a, APFloat b) { return a * b; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1764,15 +1746,6 @@ mlir::Type fir::StoreOp::elementType(mlir::Type refType) {
 bool fir::StringLitOp::isWideValue() {
   auto eleTy = getType().cast<fir::SequenceType>().getEleTy();
   return eleTy.cast<fir::CharacterType>().getFKind() != 1;
-}
-
-//===----------------------------------------------------------------------===//
-// SubfOp
-//===----------------------------------------------------------------------===//
-
-mlir::OpFoldResult fir::SubfOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  return mlir::constFoldBinaryOp<FloatAttr>(
-      opnds, [](APFloat a, APFloat b) { return a - b; });
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/test/Fir/arrexp.fir
+++ b/flang/test/Fir/arrexp.fir
@@ -124,7 +124,7 @@ func @f5(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: !fir.box<!fir.array<?xf32>>,
     // CHECK: %[[B_VAL:.*]] = load float, float* %[[B_ADDR]]
     // CHECK: fadd float %[[B_VAL]], %[[F]]
     %5 = fir.array_fetch %3, %arg3 : (!fir.array<?xf32>, index) -> f32
-    %6 = fir.addf %5, %arg2 : f32
+    %6 = addf %5, %arg2 : f32
     %7 = fir.array_update %arg4, %6, %arg3 : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
     fir.result %7 : !fir.array<?xf32>
   }
@@ -158,7 +158,7 @@ func @f6(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: f32) {
   %4 = fir.array_load %arg0 [%3] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
   %5 = fir.do_loop %arg2 = %c0 to %c9 step %c1 iter_args(%arg3 = %2) -> (!fir.array<?xf32>) {
     %6 = fir.array_fetch %4, %arg2 : (!fir.array<?xf32>, index) -> f32
-    %7 = fir.addf %6, %arg1 : f32
+    %7 = addf %6, %arg1 : f32
     %8 = fir.array_update %arg3, %7, %arg2 : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
     fir.result %8 : !fir.array<?xf32>
   }

--- a/flang/test/Fir/cse.fir
+++ b/flang/test/Fir/cse.fir
@@ -69,7 +69,7 @@ func @foo(%arg0: !fir.ref<f32>) -> f32 {
   %cst_0 = constant 1.000000e+00 : f32
   // CHECK: load float, float* %[[var]]
   %4 = fir.load %0 : !fir.ref<f32>
-  %5 = fir.addf %4, %cst_0 : f32
+  %5 = addf %4, %cst_0 : f32
   fir.store %5 to %0 : !fir.ref<f32>
   // CHECK: load float, float* %[[var]]
   %6 = fir.load %0 : !fir.ref<f32>

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -442,44 +442,44 @@ fir.dispatch_table @dispatch_tbl {
 }
 
 // CHECK-LABEL: func @compare_real(
-// CHECK-SAME: [[VAL_133:%.*]]: !fir.real<16>, [[VAL_134:%.*]]: !fir.real<16>) {
-func @compare_real(%a : !fir.real<16>, %b : !fir.real<16>) {
+// CHECK-SAME: [[VAL_133:%.*]]: f128, [[VAL_134:%.*]]: f128) {
+func @compare_real(%a : f128, %b : f128) {
 
-// CHECK: [[VAL_135:%.*]] = fir.cmpf "false", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_136:%.*]] = fir.cmpf "oeq", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_137:%.*]] = fir.cmpf "ogt", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_138:%.*]] = fir.cmpf "oge", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-  %d0 = fir.cmpf "false", %a, %b : !fir.real<16>
-  %d1 = fir.cmpf "oeq", %a, %b : !fir.real<16>
-  %d2 = fir.cmpf "ogt", %a, %b : !fir.real<16>
-  %d3 = fir.cmpf "oge", %a, %b : !fir.real<16>
+// CHECK: [[VAL_135:%.*]] = fir.cmpf "false", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_136:%.*]] = fir.cmpf "oeq", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_137:%.*]] = fir.cmpf "ogt", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_138:%.*]] = fir.cmpf "oge", [[VAL_133]], [[VAL_134]] : f128
+  %d0 = fir.cmpf "false", %a, %b : f128
+  %d1 = fir.cmpf "oeq", %a, %b : f128
+  %d2 = fir.cmpf "ogt", %a, %b : f128
+  %d3 = fir.cmpf "oge", %a, %b : f128
 
-// CHECK: [[VAL_139:%.*]] = fir.cmpf "olt", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_140:%.*]] = fir.cmpf "ole", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_141:%.*]] = fir.cmpf "one", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_142:%.*]] = fir.cmpf "ord", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-  %a0 = fir.cmpf "olt", %a, %b : !fir.real<16>
-  %a1 = fir.cmpf "ole", %a, %b : !fir.real<16>
-  %a2 = fir.cmpf "one", %a, %b : !fir.real<16>
-  %a3 = fir.cmpf "ord", %a, %b : !fir.real<16>
+// CHECK: [[VAL_139:%.*]] = fir.cmpf "olt", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_140:%.*]] = fir.cmpf "ole", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_141:%.*]] = fir.cmpf "one", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_142:%.*]] = fir.cmpf "ord", [[VAL_133]], [[VAL_134]] : f128
+  %a0 = fir.cmpf "olt", %a, %b : f128
+  %a1 = fir.cmpf "ole", %a, %b : f128
+  %a2 = fir.cmpf "one", %a, %b : f128
+  %a3 = fir.cmpf "ord", %a, %b : f128
 
-// CHECK: [[VAL_143:%.*]] = fir.cmpf "ueq", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_144:%.*]] = fir.cmpf "ugt", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_145:%.*]] = fir.cmpf "uge", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_146:%.*]] = fir.cmpf "ult", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-  %b0 = fir.cmpf "ueq", %a, %b : !fir.real<16>
-  %b1 = fir.cmpf "ugt", %a, %b : !fir.real<16>
-  %b2 = fir.cmpf "uge", %a, %b : !fir.real<16>
-  %b3 = fir.cmpf "ult", %a, %b : !fir.real<16>
+// CHECK: [[VAL_143:%.*]] = fir.cmpf "ueq", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_144:%.*]] = fir.cmpf "ugt", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_145:%.*]] = fir.cmpf "uge", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_146:%.*]] = fir.cmpf "ult", [[VAL_133]], [[VAL_134]] : f128
+  %b0 = fir.cmpf "ueq", %a, %b : f128
+  %b1 = fir.cmpf "ugt", %a, %b : f128
+  %b2 = fir.cmpf "uge", %a, %b : f128
+  %b3 = fir.cmpf "ult", %a, %b : f128
 
-// CHECK: [[VAL_147:%.*]] = fir.cmpf "ule", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_148:%.*]] = fir.cmpf "une", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_149:%.*]] = fir.cmpf "uno", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-// CHECK: [[VAL_150:%.*]] = fir.cmpf "true", [[VAL_133]], [[VAL_134]] : !fir.real<16>
-  %c0 = fir.cmpf "ule", %a, %b : !fir.real<16>
-  %c1 = fir.cmpf "une", %a, %b : !fir.real<16>
-  %c2 = fir.cmpf "uno", %a, %b : !fir.real<16>
-  %c3 = fir.cmpf "true", %a, %b : !fir.real<16>
+// CHECK: [[VAL_147:%.*]] = fir.cmpf "ule", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_148:%.*]] = fir.cmpf "une", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_149:%.*]] = fir.cmpf "uno", [[VAL_133]], [[VAL_134]] : f128
+// CHECK: [[VAL_150:%.*]] = fir.cmpf "true", [[VAL_133]], [[VAL_134]] : f128
+  %c0 = fir.cmpf "ule", %a, %b : f128
+  %c1 = fir.cmpf "une", %a, %b : f128
+  %c2 = fir.cmpf "uno", %a, %b : f128
+  %c3 = fir.cmpf "true", %a, %b : f128
 
 // CHECK: return
 // CHECK: }
@@ -531,28 +531,28 @@ func @compare_complex(%a : !fir.complex<16>, %b : !fir.complex<16>) {
 }
 
 // CHECK-LABEL: func @arith_real(
-// CHECK-SAME: [[VAL_169:%.*]]: !fir.real<16>, [[VAL_170:%.*]]: !fir.real<16>) -> !fir.real<16> {
-func @arith_real(%a : !fir.real<16>, %b : !fir.real<16>) -> !fir.real<16> {
+// CHECK-SAME: [[VAL_169:%.*]]: f128, [[VAL_170:%.*]]: f128) -> f128 {
+func @arith_real(%a : f128, %b : f128) -> f128 {
 
 // CHECK: [[VAL_171:%.*]] = constant 1.0
-// CHECK: [[VAL_172:%.*]] = fir.convert [[VAL_171]] : (f32) -> !fir.real<16>
-// CHECK: [[VAL_173:%.*]] = fir.negf [[VAL_169]] : !fir.real<16>
-// CHECK: [[VAL_174:%.*]] = fir.addf [[VAL_172]], [[VAL_173]] : !fir.real<16>
-// CHECK: [[VAL_175:%.*]] = fir.subf [[VAL_174]], [[VAL_170]] : !fir.real<16>
-// CHECK: [[VAL_176:%.*]] = fir.mulf [[VAL_173]], [[VAL_175]] : !fir.real<16>
-// CHECK: [[VAL_177:%.*]] = fir.divf [[VAL_176]], [[VAL_169]] : !fir.real<16>
-// CHECK: [[VAL_178:%.*]] = fir.modf [[VAL_177]], [[VAL_170]] : !fir.real<16>
+// CHECK: [[VAL_172:%.*]] = fir.convert [[VAL_171]] : (f32) -> f128
+// CHECK: [[VAL_173:%.*]] = fir.negf [[VAL_169]] : f128
+// CHECK: [[VAL_174:%.*]] = addf [[VAL_172]], [[VAL_173]] : f128
+// CHECK: [[VAL_175:%.*]] = subf [[VAL_174]], [[VAL_170]] : f128
+// CHECK: [[VAL_176:%.*]] = mulf [[VAL_173]], [[VAL_175]] : f128
+// CHECK: [[VAL_177:%.*]] = divf [[VAL_176]], [[VAL_169]] : f128
+// CHECK: [[VAL_178:%.*]] = fir.modf [[VAL_177]], [[VAL_170]] : f128
   %c1 = constant 1.0 : f32
-  %0 = fir.convert %c1 : (f32) -> !fir.real<16>
-  %1 = fir.negf %a : !fir.real<16>
-  %2 = fir.addf %0, %1 : !fir.real<16>
-  %3 = fir.subf %2, %b : !fir.real<16>
-  %4 = fir.mulf %1, %3 : !fir.real<16>
-  %5 = fir.divf %4, %a : !fir.real<16>
-  %6 = fir.modf %5, %b : !fir.real<16>
-// CHECK: return [[VAL_178]] : !fir.real<16>
+  %0 = fir.convert %c1 : (f32) -> f128
+  %1 = fir.negf %a : f128
+  %2 = addf %0, %1 : f128
+  %3 = subf %2, %b : f128
+  %4 = mulf %1, %3 : f128
+  %5 = divf %4, %a : f128
+  %6 = fir.modf %5, %b : f128
+// CHECK: return [[VAL_178]] : f128
 // CHECK: }
-  return %6 : !fir.real<16>
+  return %6 : f128
 }
 
 // CHECK-LABEL: func @arith_complex(

--- a/flang/test/Fir/real.fir
+++ b/flang/test/Fir/real.fir
@@ -3,49 +3,49 @@
 // RUN: tco %s | FileCheck %s
 
 // CHECK-LABEL: @bar
-func @bar(%a : !fir.real<2>, %b : !fir.real<4>, %c : !fir.real<8>, %d : !fir.real<10>, %e : !fir.real<16>) -> !fir.real<10> {
+func @bar(%a : f16, %b : f32, %c : f64, %d : f80, %e : f128) -> f80 {
   // CHECK: fpext half %{{.*}} to x86_fp80
-  %1 = fir.convert %a : (!fir.real<2>) -> !fir.real<10>
+  %1 = fir.convert %a : (f16) -> f80
   // CHECK: fpext float %{{.*}} to x86_fp80
-  %2 = fir.convert %b : (!fir.real<4>) -> !fir.real<10>
+  %2 = fir.convert %b : (f32) -> f80
   // CHECK: fpext double %{{.*}} to x86_fp80
-  %3 = fir.convert %c : (!fir.real<8>) -> !fir.real<10>
+  %3 = fir.convert %c : (f64) -> f80
   // CHECK-NOT: fpext
   // CHECK-NOT: fptrunc
-  %4 = fir.convert %d : (!fir.real<10>) -> !fir.real<10>
+  %4 = fir.convert %d : (f80) -> f80
   // CHECK: fptrunc fp128 %{{.*}} to x86_fp80
-  %5 = fir.convert %e : (!fir.real<16>) -> !fir.real<10>
+  %5 = fir.convert %e : (f128) -> f80
   // CHECK-NEXT: call x86_fp80
-  %6 = call @foop(%1, %2, %3, %4, %5) : (!fir.real<10>, !fir.real<10>, !fir.real<10>, !fir.real<10>, !fir.real<10>) -> !fir.real<10>
-  return %6 : !fir.real<10>
+  %6 = call @foop(%1, %2, %3, %4, %5) : (f80, f80, f80, f80, f80) -> f80
+  return %6 : f80
 }
 
 // CHECK-LABEL: @foo
-func @foo(%a : !fir.real<16>, %b : !fir.real<16>, %c : !fir.real<16>, %d : !fir.real<16>, %e : !fir.real<16>) -> !fir.real<16> {
+func @foo(%a : f128, %b : f128, %c : f128, %d : f128, %e : f128) -> f128 {
   // CHECK: fadd fp128
-  %1 = fir.addf %a, %b : !fir.real<16>
+  %1 = addf %a, %b : f128
   // CHECK: fmul fp128
-  %2 = fir.mulf %1, %c : !fir.real<16>
+  %2 = mulf %1, %c : f128
   // CHECK: fsub fp128
-  %3 = fir.subf %2, %d : !fir.real<16>
+  %3 = subf %2, %d : f128
   // CHECK: fdiv fp128
-  %4 = fir.divf %3, %e : !fir.real<16>
+  %4 = divf %3, %e : f128
   // CHECK: frem fp128
-  %5 = fir.modf %4, %a : !fir.real<16>
-  return %5 : !fir.real<16>
+  %5 = fir.modf %4, %a : f128
+  return %5 : f128
 }
 
 // CHECK-LABEL: @foop
-func @foop(%a : !fir.real<10>, %b : !fir.real<10>, %c : !fir.real<10>, %d : !fir.real<10>, %e : !fir.real<10>) -> !fir.real<10> {
+func @foop(%a : f80, %b : f80, %c : f80, %d : f80, %e : f80) -> f80 {
   // CHECK: fadd x86_fp80
-  %1 = fir.addf %a, %b : !fir.real<10>
+  %1 = addf %a, %b : f80
   // CHECK: fmul x86_fp80
-  %2 = fir.mulf %1, %c : !fir.real<10>
+  %2 = mulf %1, %c : f80
   // CHECK: fsub x86_fp80
-  %3 = fir.subf %2, %d : !fir.real<10>
+  %3 = subf %2, %d : f80
   // CHECK: fdiv x86_fp80
-  %4 = fir.divf %3, %e : !fir.real<10>
+  %4 = divf %3, %e : f80
   // CHECK: frem x86_fp80
-  %5 = fir.modf %4, %a : !fir.real<10>
-  return %5 : !fir.real<10>
+  %5 = fir.modf %4, %a : f80
+  return %5 : f80
 }

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -11,7 +11,7 @@ subroutine test1(a,b,c,n)
   ! CHECK: %[[T:.*]] = fir.do_loop
   ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[B]]
   ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[C]]
-  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: %[[rv:.*]] = addf %[[Bi]], %[[Ci]]
   ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
   a = b + c
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
@@ -29,9 +29,9 @@ subroutine test1b(a,b,c,d,n)
   ! CHECK: %[[T:.*]] = fir.do_loop
   ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[B]]
   ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[C]]
-  ! CHECK: %[[rv1:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: %[[rv1:.*]] = addf %[[Bi]], %[[Ci]]
   ! CHECK: %[[Di:.*]] = fir.array_fetch %[[D]]
-  ! CHECK: %[[rv:.*]] = fir.addf %[[rv1]], %[[Di]]
+  ! CHECK: %[[rv:.*]] = addf %[[rv1]], %[[Di]]
   ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
   a = b + c + d
   ! CHECK: fir.array_merge_store %[[A]], %[[T]] to %arg0
@@ -54,7 +54,7 @@ subroutine test3(a,b,c,n)
   ! CHECK-DAG: %[[C:.*]] = fir.load %arg2
   ! CHECK: %[[T:.*]] = fir.do_loop
   ! CHECK: %[[Bi:.*]] = fir.array_fetch %[[B]]
-  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[C]]
+  ! CHECK: %[[rv:.*]] = addf %[[Bi]], %[[C]]
   ! CHECK: %[[Ti:.*]] = fir.array_update %{{.*}}, %[[rv]], %
   ! CHECK: fir.result %[[Ti]]
   a = b + c
@@ -113,7 +113,7 @@ subroutine test7(a,b,n)
   ! CHECK: %[[T:.*]] = fir.do_loop
   ! CHECK-DAG: %[[Bi:.*]] = fir.array_fetch %[[Ain]]
   ! CHECK-DAG: %[[Ci:.*]] = fir.array_fetch %[[B]]
-  ! CHECK: %[[rv:.*]] = fir.addf %[[Bi]], %[[Ci]]
+  ! CHECK: %[[rv:.*]] = addf %[[Bi]], %[[Ci]]
   ! CHECK: fir.array_update %{{.*}}, %[[rv]], %
   a = a + b
   ! CHECK: fir.array_merge_store %[[Aout]], %[[T]] to %arg0
@@ -178,7 +178,7 @@ subroutine test11(a,b,c,d)
   ! CHECK: %[[bar_in:.*]] = fir.do_loop
   !  CHECK-DAG: %[[c_i:.*]] = fir.array_fetch %[[C]]
   !  CHECK-DAG: %[[d_i:.*]] = fir.array_fetch %[[D]]
-  !  CHECK: %[[sum:.*]] = fir.addf %[[c_i]], %[[d_i]]
+  !  CHECK: %[[sum:.*]] = addf %[[c_i]], %[[d_i]]
   !  CHECK: fir.array_update %{{.*}}, %[[sum]], %
   ! CHECK: fir.array_merge_store %[[T]], %[[bar_in]] to %[[tmp]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[tmp]]
@@ -187,7 +187,7 @@ subroutine test11(a,b,c,d)
   !    a <- b + bar(?)
   ! CHECK: %[[S:.*]] = fir.do_loop
   !  CHECK: %[[b_i:.*]] = fir.array_fetch %[[B]], %
-  !  CHECK: %[[sum2:.*]] = fir.addf %[[b_i]], %[[bar_out]]
+  !  CHECK: %[[sum2:.*]] = addf %[[b_i]], %[[bar_out]]
   !  CHECK: fir.array_update %{{.*}}, %[[sum2]], %
   ! CHECK: fir.array_merge_store %[[A]], %[[S]] to %arg0
   a = b + bar(c + d)

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -67,7 +67,7 @@ subroutine dim_testr(x, y, z)
   ! CHECK-DAG: %[[x:.*]] = fir.load %arg0
   ! CHECK-DAG: %[[y:.*]] = fir.load %arg1
   ! CHECK-DAG: %[[zero:.*]] = constant 0.0
-  ! CHECK-DAG: %[[diff:.*]] = fir.subf %[[x]], %[[y]]
+  ! CHECK-DAG: %[[diff:.*]] = subf %[[x]], %[[y]]
   ! CHECK: %[[cmp:.*]] = fir.cmpf "ogt", %[[diff]], %[[zero]]
   ! CHECK: %[[res:.*]] = select %[[cmp]], %[[diff]], %[[zero]]
   ! CHECK: fir.store %[[res]] to %arg2
@@ -96,7 +96,7 @@ subroutine dprod_test (x, y, z)
   ! CHECK-DAG: %[[y:.*]] = fir.load %arg1
   ! CHECK-DAG: %[[a:.*]] = fir.convert %[[x]] : (f32) -> f64 
   ! CHECK-DAG: %[[b:.*]] = fir.convert %[[y]] : (f32) -> f64 
-  ! CHECK: %[[res:.*]] = fir.mulf %[[a]], %[[b]]
+  ! CHECK: %[[res:.*]] = mulf %[[a]], %[[b]]
   ! CHECK: fir.store %[[res]] to %arg2
 end subroutine
 

--- a/flang/test/Lower/real-operations-1.f90
+++ b/flang/test/Lower/real-operations-1.f90
@@ -8,7 +8,7 @@ REAL(2) FUNCTION real2(x0, x1)
   REAL(2) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f16>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f16>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f16
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f16
   real2 = x0 + x1
   ! CHECK: return %{{.*}} : f16
 END FUNCTION real2
@@ -19,7 +19,7 @@ REAL(3) FUNCTION real3(x0, x1)
   REAL(3) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<bf16>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<bf16>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : bf16
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : bf16
   real3 = x0 + x1
   ! CHECK: return %{{.*}} : bf16
 END FUNCTION real3
@@ -30,7 +30,7 @@ REAL(4) FUNCTION real4(x0, x1)
   REAL(4) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f32
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f32
   real4 = x0 + x1
   ! CHECK: return %{{.*}} : f32
 END FUNCTION real4
@@ -41,7 +41,7 @@ REAL FUNCTION defreal(x0, x1)
   REAL :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f32
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f32
   defreal = x0 + x1
   ! CHECK: return %{{.*}} : f32
 END FUNCTION defreal
@@ -52,7 +52,7 @@ REAL(8) FUNCTION real8(x0, x1)
   REAL(8) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f64
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f64
   real8 = x0 + x1
   ! CHECK: return %{{.*}} : f64
 END FUNCTION real8
@@ -63,7 +63,7 @@ DOUBLE PRECISION FUNCTION doubleprec(x0, x1)
   DOUBLE PRECISION :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f64
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f64
   doubleprec = x0 + x1
   ! CHECK: return %{{.*}} : f64
 END FUNCTION doubleprec
@@ -74,7 +74,7 @@ REAL(10) FUNCTION real10(x0, x1)
   REAL(10) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f80>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f80>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f80
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f80
   real10 = x0 + x1
   ! CHECK: return %{{.*}} : f80
 END FUNCTION real10
@@ -85,7 +85,7 @@ REAL(16) FUNCTION real16(x0, x1)
   REAL(16) :: x1
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f128
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f128
   real16 = x0 + x1
   ! CHECK: return %{{.*}} : f128
 END FUNCTION real16
@@ -97,8 +97,8 @@ REAL(16) FUNCTION real16b(x0, x1)
   ! CHECK-DAG: %[[v0:.+]] = constant 4.0{{.*}} : f128
   ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
   ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
-  ! CHECK: %[[v3:.+]] = fir.addf %[[v1]], %[[v2]] : f128
-  ! CHECK: %[[v4:.+]] = fir.subf %[[v3]], %[[v0]] : f128
+  ! CHECK: %[[v3:.+]] = addf %[[v1]], %[[v2]] : f128
+  ! CHECK: %[[v4:.+]] = subf %[[v3]], %[[v0]] : f128
   real16b = x0 + x1 - 4.0_16
   ! CHECK: return %{{.*}} : f128
 END FUNCTION real16b

--- a/flang/test/Lower/real-operations-2.f90
+++ b/flang/test/Lower/real-operations-2.f90
@@ -74,7 +74,7 @@ REAL(4) :: x0
 REAL(4) :: x1
 ! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
 ! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:fir.addf [[reg1]], [[reg2]] : f32
+! CHECK:addf [[reg1]], [[reg2]] : f32
 add6_test = x0 + x1
 END FUNCTION
 
@@ -84,7 +84,7 @@ REAL(4) :: x0
 REAL(4) :: x1
 ! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
 ! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:fir.subf [[reg1]], [[reg2]] : f32
+! CHECK:subf [[reg1]], [[reg2]] : f32
 sub7_test = x0 - x1
 END FUNCTION
 
@@ -94,7 +94,7 @@ REAL(4) :: x0
 REAL(4) :: x1
 ! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
 ! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:fir.mulf [[reg1]], [[reg2]] : f32
+! CHECK:mulf [[reg1]], [[reg2]] : f32
 mult8_test = x0 * x1
 END FUNCTION
 
@@ -104,7 +104,7 @@ REAL(4) :: x0
 REAL(4) :: x1
 ! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
 ! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:fir.divf [[reg1]], [[reg2]] : f32
+! CHECK:divf [[reg1]], [[reg2]] : f32
 div9_test = x0 / x1
 END FUNCTION
 

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -10,7 +10,7 @@ real function test_stmt_0(x)
 
   ! CHECK-DAG: %[[x:.*]] = fir.load %arg0
   ! CHECK-DAG: %[[cst:.*]] = constant 1.234560e-01
-  ! CHECK: %[[eval:.*]] = fir.addf %[[x]], %[[cst]]
+  ! CHECK: %[[eval:.*]] = addf %[[x]], %[[cst]]
   ! CHECK: fir.store %[[eval]] to %[[resmem:.*]] : !fir.ref<f32>
   test_stmt_0 = func(x)
 
@@ -29,7 +29,7 @@ real(4) function test_stmt_only_eval_arg_once()
   ! Note: using -emit-fir, so the faked pass-by-reference is exposed
   ! CHECK: %[[x2:.*]] = fir.alloca f32
   ! CHECK: fir.store %[[x1]] to %[[x2]]
-  ! CHECK: fir.addf %{{.*}}, %{{.*}}
+  ! CHECK: addf %{{.*}}, %{{.*}}
   test_stmt_only_eval_arg_once = func(only_once())
 end function
 
@@ -51,21 +51,21 @@ real function test_stmt_1(x, a)
   ! CHECK-DAG: fir.store %[[cst_8]] to %[[tmp1:.*]] : !fir.ref<f32>
   ! CHECK-DAG: %[[foocall1:.*]] = fir.call @_QPfoo(%[[tmp1]])
   ! CHECK-DAG: %[[aload1:.*]] = fir.load %arg1
-  ! CHECK: %[[add1:.*]] = fir.addf %[[aload1]], %[[foocall1]]
+  ! CHECK: %[[add1:.*]] = addf %[[aload1]], %[[foocall1]]
   ! CHECK: fir.store %[[add1]] to %[[res1]]
   res1 =  func1(8.)
 
   ! CHECK-DAG: %[[a2:.*]] = fir.load %arg1
   ! CHECK-DAG: %[[foocall2:.*]] = fir.call @_QPfoo(%arg0)
-  ! CHECK-DAG: %[[add2:.*]] = fir.addf %[[a2]], %[[foocall2]]
+  ! CHECK-DAG: %[[add2:.*]] = addf %[[a2]], %[[foocall2]]
   ! CHECK-DAG: %[[b:.*]] = fir.load %[[bmem]]
-  ! CHECK: %[[add3:.*]] = fir.addf %[[add2]], %[[b]]
+  ! CHECK: %[[add3:.*]] = addf %[[add2]], %[[b]]
   ! CHECK: fir.store %[[add3]] to %[[res2]]
   res2 = func2(x)
 
   ! CHECK-DAG: %[[res12:.*]] = fir.load %[[res1]]
   ! CHECK-DAG: %[[res22:.*]] = fir.load %[[res2]]
-  ! CHECK: = fir.addf %[[res12]], %[[res22]] : f32
+  ! CHECK: = addf %[[res12]], %[[res22]] : f32
   test_stmt_1 = res1 + res2
   ! CHECK: return %{{.*}} : f32
 end function
@@ -76,12 +76,12 @@ end function
 ! CHECK-LABEL: func @_QPtest_stmt_no_args
 real function test_stmt_no_args(x, y)
   func() = x + y
-  ! CHECK: fir.addf
+  ! CHECK: addf
   a = func()
   ! CHECK: fir.call @_QPfoo_may_modify_xy
   call foo_may_modify_xy(x, y)
-  ! CHECK: fir.addf
-  ! CHECK: fir.addf
+  ! CHECK: addf
+  ! CHECK: addf
   test_stmt_no_args = func() + a
 end function
   


### PR DESCRIPTION
TODO: Remainging Ops ModfOp, CmpfOp

This test case if failing after above changes: (I'm not sure `fir.real<10>`)
Part of `real.fir`
```
// CHECK-LABEL: @foop
func @foop(%a : !fir.real<10>, %b : !fir.real<10>, %c : !fir.real<10>, %d : !fir.real<10>, %e : !fir.real<10>) -> !fir.real<10> {
  // CHECK: fadd x86_fp80
  %1 = fir.addf %a, %b : !fir.real<10>
  // CHECK: fmul x86_fp80
  %2 = fir.mulf %1, %c : !fir.real<10>
  // CHECK: fsub x86_fp80
  %3 = fir.subf %2, %d : !fir.real<10>
  // CHECK: fdiv x86_fp80
  %4 = fir.divf %3, %e : !fir.real<10>
  // CHECK: frem x86_fp80
  %5 = fir.modf %4, %a : !fir.real<10>
  return %5 : !fir.real<10>
}}
```
Err:
```
tco test.f90
loc("real.fir":2:17): error: expected non-function type
Error can't load file real.fir
```
I tried: with this modification
```
// CHECK-LABEL: @foop
func @foop(%a : f10, %b : f10, %c : f10, %d : f10, %e : f10) -> f10 {
  // CHECK: fadd x86_fp80
  %1 = addf %a, %b : f10
  // CHECK: fmul x86_fp80
  %2 = mulf %1, %c : f10
  // CHECK: fsub x86_fp80
  %3 = subf %2, %d : f10
  // CHECK: fdiv x86_fp80
  %4 = divf %3, %e : f10
  // CHECK: frem x86_fp80
  %5 = fir.modf %4, %a : f10
  return %5 : f10
}

```