### PR TITLE
Fix character array compare

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1900,9 +1900,11 @@ public:
           auto [iterSpace, insPt] = genIterSpace();
           auto exv = f(iterSpace);
           auto innerArg = iterSpace.innerArgument();
+          // Convert to array elemental type is needed for logical.
+          auto eleTy = innerArg.getType().cast<fir::SequenceType>().getEleTy();
+          auto element = builder.createConvert(loc, eleTy, fir::getBase(exv));
           auto upd = builder.create<fir::ArrayUpdateOp>(
-              loc, innerArg.getType(), innerArg, fir::getBase(exv),
-              iterSpace.iterVec());
+              loc, innerArg.getType(), innerArg, element, iterSpace.iterVec());
           builder.create<fir::ResultOp>(loc, upd.getResult());
           builder.restoreInsertionPoint(insPt);
           return fir::substBase(exv, iterSpace.outerResult());

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2693,8 +2693,8 @@ public:
     auto lf = genarr(x.left());
     auto rf = genarr(x.right());
     return [=](IterSpace iters) -> ExtValue {
-      auto lhs = fir::getBase(lf(iters));
-      auto rhs = fir::getBase(rf(iters));
+      auto lhs = lf(iters);
+      auto rhs = rf(iters);
       return Fortran::lower::genCharCompare(builder, loc, pred, lhs, rhs);
     };
   }


### PR DESCRIPTION
Fixes #683 .
- `genCharCompare` takes `ExtendedValue`
- Cast needs to be inserted before `ArrayUpdateOp` because the evaluated value for the element may not have the array element type since logical follow a consumers insert the cast logic.