### PR TITLE
Lowering of basic elemental functions (intrinsic and user-defined).

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -106,7 +106,9 @@ public:
     AddressAndLength,
     /// Value means passed by value at the mlir level, it is not necessarily
     /// implied by Fortran Value attribute.
-    Value
+    Value,
+    /// ValueAttribute means dummy has the the Fortran VALUE attribute.
+    ValueAttribute
   };
   /// Different properties of an entity that can be passed/returned.
   /// One-to-One mapping with PassEntityBy but for

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -108,7 +108,8 @@ public:
     /// implied by Fortran Value attribute.
     Value,
     /// ValueAttribute means dummy has the the Fortran VALUE attribute.
-    ValueAttribute
+    BaseAddressValueAttribute,
+    CharBoxValueAttribute // BoxChar with VALUE
   };
   /// Different properties of an entity that can be passed/returned.
   /// One-to-One mapping with PassEntityBy but for

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -64,6 +64,9 @@ createSomeMutableBox(mlir::Location loc, AbstractConverter &converter,
 
 /// Create and return a projection of a subspace of an array value. This is the
 /// lhs onto which a newly constructed array value can be merged.
+/// This implements copy-in, copy-out semantics. In case that require it,
+/// results will be buffered so that the rhs values are preserved and the lhs is
+/// updated only after all intermediate computation is concluded.
 fir::ArrayLoadOp
 createSomeArraySubspace(AbstractConverter &converter,
                         const evaluate::Expr<evaluate::SomeType> &expr,

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -122,12 +122,19 @@ public:
   /// given a name via a front-end `Symbol` or a `StringRef`.
   mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
                               llvm::StringRef name = {},
-                              llvm::ArrayRef<mlir::Value> shape = {});
+                              mlir::ValueRange shape = {},
+                              mlir::ValueRange lenParams = {},
+                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
   /// Create an unnamed and untracked temporary on the stack.
   mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
-                              llvm::ArrayRef<mlir::Value> shape) {
+                              mlir::ValueRange shape) {
     return createTemporary(loc, type, llvm::StringRef{}, shape);
+  }
+
+  mlir::Value createTemporary(mlir::Location loc, mlir::Type type,
+                              llvm::ArrayRef<mlir::NamedAttribute> attrs) {
+    return createTemporary(loc, type, llvm::StringRef{}, {}, {}, attrs);
   }
 
   /// Create a global value.

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -604,13 +604,15 @@ private:
       // Pass as fir.box_char
       auto boxCharTy = fir::BoxCharType::get(&mlirContext, dynamicType.kind());
       addFirInput(boxCharTy, nextPassedArgPosition(), Property::BoxChar, attrs);
-      addPassedArg(PassEntityBy::BoxChar, entity, isOptional);
+      addPassedArg(isValueAttr ? PassEntityBy::CharBoxValueAttribute
+                               : PassEntityBy::BoxChar,
+                   entity, isOptional);
     } else {
       // Pass as fir.ref
       auto refType = fir::ReferenceType::get(type);
       addFirInput(refType, nextPassedArgPosition(), Property::BaseAddress,
                   attrs);
-      addPassedArg(isValueAttr ? PassEntityBy::ValueAttribute
+      addPassedArg(isValueAttr ? PassEntityBy::BaseAddressValueAttribute
                                : PassEntityBy::BaseAddress,
                    entity, isOptional);
     }

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -544,6 +544,7 @@ private:
     using Attrs = Fortran::evaluate::characteristics::DummyDataObject::Attr;
 
     bool isOptional = false;
+    bool isValueAttr = false;
     [[maybe_unused]] auto loc = interface.converter.genLocation();
     llvm::SmallVector<mlir::NamedAttribute> attrs;
     auto addMLIRAttr = [&](llvm::StringRef attr) {
@@ -559,7 +560,7 @@ private:
     if (obj.attrs.test(Attrs::Contiguous))
       addMLIRAttr(fir::getContiguousAttrName());
     if (obj.attrs.test(Attrs::Value))
-      TODO(loc, "Value in procedure interface");
+      isValueAttr = true; // TODO: do we want an mlir::Attribute as well?
     if (obj.attrs.test(Attrs::Volatile))
       TODO(loc, "Volatile in procedure interface");
     if (obj.attrs.test(Attrs::Target))
@@ -609,7 +610,9 @@ private:
       auto refType = fir::ReferenceType::get(type);
       addFirInput(refType, nextPassedArgPosition(), Property::BaseAddress,
                   attrs);
-      addPassedArg(PassEntityBy::BaseAddress, entity, isOptional);
+      addPassedArg(isValueAttr ? PassEntityBy::ValueAttribute
+                               : PassEntityBy::BaseAddress,
+                   entity, isOptional);
     }
   }
 

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2582,12 +2582,12 @@ public:
                   }
                 } else {
                   // A regular scalar index, which does not yield an array
-                  // section. Use a degenerate slice operation
-                  // `(e:undef:undef)` in this dimension as a placeholder.
-                  // This does not necessarily change the rank of the original
-                  // array, so the iteration space must also be extended to
-                  // include this expression in this dimension to adjust to
-                  // the array's declared rank.
+                  // section. Use a degenerate slice operation `(e:undef:undef)`
+                  // in this dimension as a placeholder. This does not
+                  // necessarily change the rank of the original array, so the
+                  // iteration space must also be extended to include this
+                  // expression in this dimension to adjust to the array's
+                  // declared rank.
                   auto base = x.base();
                   ScalarExprLowering sel{loc, converter, symMap, stmtCtx};
                   auto exv = base.IsSymbol() ? sel.gen(base.GetFirstSymbol())
@@ -2741,10 +2741,9 @@ public:
     return [=](IterSpace iters) { return lambda(iters); };
   }
 
-  /// The `Ev::Component` structure is tailmost down to head, so the
-  /// expression <code>a%b%c</code> will be presented as <code>(component
-  /// (dataref (component (dataref (symbol 'a)) (symbol 'b))) (symbol
-  /// 'c))</code>.
+  /// The `Ev::Component` structure is tailmost down to head, so the expression
+  /// <code>a%b%c</code> will be presented as <code>(component (dataref
+  /// (component (dataref (symbol 'a)) (symbol 'b))) (symbol 'c))</code>.
   void buildComponentsPath(llvm::SmallVectorImpl<mlir::Value> &components,
                            mlir::Type &recTy,
                            const Fortran::evaluate::DataRef &dr) {

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -62,6 +62,51 @@ static llvm::cl::opt<bool> generateArrayCoordinate(
     llvm::cl::desc("in lowering create ArrayCoorOp instead of CoordinateOp"),
     llvm::cl::init(false));
 
+/// The various semantics of a program constituent (or a part thereof) as it may
+/// appear in an expression.
+///
+/// Given the following Fortran declarations.
+/// ```fortran
+///   REAL :: v1, v2, v3
+///   REAL, POINTER :: vp1
+///   REAL :: a1(c), a2(c)
+///   REAL ELEMENTAL FUNCTION f1(arg) ! array -> array
+///   FUNCTION f2(arg)                ! array -> array
+///   vp1 => v3       ! 1
+///   v1 = v2 * vp1   ! 2
+///   a1 = a1 + a2    ! 3
+///   a1 = f1(a2)     ! 4
+///   a1 = f2(a2)     ! 5
+/// ```
+///
+/// In line 1, `vp1` is a BoxAddr to copy a box value into. The box value is
+/// constructed from the DataAddr of `v3`.
+/// In line 2, `v1` is a DataAddr to copy a value into. The value is constructed
+/// from the DataValue of `v2` and `vp1`. DataValue is implicitly a double
+/// dereference in the `vp1` case.
+/// In line 3, `a1` and `a2` on the rhs are RefTransparent. The `a1` on the lhs
+/// is CopyInCopyOut as `a1` is replaced elementally by the additions.
+/// In line 4, `a2` can be RefTransparent, ByValueArg, RefOpaque, or BoxAddr if
+/// `arg` is declared as C-like pass-by-value, VALUE, INTENT(?), or ALLOCATABLE/
+/// POINTER, respectively. `a1` on the lhs is CopyInCopyOut.
+///  In line 5, `a2` may be DataAddr or BoxAddr assuming f2 is transformational.
+///  `a1` on the lhs is again CopyInCopyOut.
+enum class ConstituentSemantics {
+  // Scalars : let `v` be the location in memory of a variable with value `x`
+  DataValue, // refers to the value `x`
+  DataAddr,  // refers to the address `v`
+  BoxValue,  // refers to a box value containing `v`
+  BoxAddr,   // refers to the address of a box value containing `v`
+
+  // Arrays : let `a` be the location in memory of a sequence of value `[xs]`
+  RefTransparent, // refers to the value `[xs]`
+  ByValueArg, // refers to an ephemeral address `t` containing a value `x` which
+              // is the i-th value in `[xs]` (15.5.2.3.p7 note 2)
+  CopyInCopyOut, // refers to the merge of `[xs]` with another value `[ys]`,
+                 // which is written into `a`.
+  RefOpaque      // refers to the address `a+i`, the i-th element of `a`
+};
+
 /// Convert parser's INTEGER relational operators to MLIR.  TODO: using
 /// unordered, but we may want to cons ordered in certain situation.
 static mlir::CmpIPredicate
@@ -1807,6 +1852,11 @@ private:
 };
 } // namespace
 
+// Helper for changing the semantics in a given context. Preserves the current
+// semantics which is resumed when the "push" goes out of scope.
+#define PushSemantics(PushVal)                                                 \
+  [[maybe_unused]] PushSemant pushSemanticsLocalVariable97201(PushVal, semant);
+
 namespace {
 class ArrayExprLowering {
   struct IterationSpace {
@@ -1844,15 +1894,19 @@ public:
   using PC =
       std::function<IterationSpace(IterSpace)>; // projection continuation
 
+  /// Entry point for when an array expression appears on the lhs of an
+  /// assignment. In the default case, the rhs is fully evaluated prior to any
+  /// of the results being written back to the lhs. (CopyInCopyOut semantics.)
   static fir::ArrayLoadOp lowerArraySubspace(
       Fortran::lower::AbstractConverter &converter,
       Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr) {
-    ArrayExprLowering ael{converter, stmtCtx, symMap, /*inProjection=*/true};
-    return ael.lowerArrayProjection(expr);
+    ArrayExprLowering ael{converter, stmtCtx, symMap,
+                          ConstituentSemantics::CopyInCopyOut};
+    return ael.lowerArraySubspace(expr);
   }
 
-  fir::ArrayLoadOp lowerArrayProjection(
+  fir::ArrayLoadOp lowerArraySubspace(
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &exp) {
     return std::visit(
         [&](const auto &e) {
@@ -1861,12 +1915,38 @@ public:
           if (auto *defOp = fir::getBase(exv).getDefiningOp())
             if (auto arrLd = mlir::dyn_cast<fir::ArrayLoadOp>(defOp))
               return arrLd;
-          llvm::report_fatal_error("array must be loaded");
+          fir::emitFatalError(getLoc(), "array must be loaded");
         },
         exp.u);
   }
 
-  /// This is the entry-point into lowering an expression with rank.
+  /// Entry point for when an array expression appears in a context where the
+  /// result must be boxed. (BoxValue semantics.)
+  static ExtValue lowerArrayExpressionBoxed(
+      Fortran::lower::AbstractConverter &converter,
+      Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
+      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr) {
+    ArrayExprLowering ael{converter, stmtCtx, symMap,
+                          ConstituentSemantics::BoxValue};
+    return ael.lowerArrayExprBoxed(expr);
+  }
+
+  ExtValue lowerArrayExprBoxed(
+      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &exp) {
+    return std::visit(
+        [&](const auto &e) {
+          auto f = genarr(e);
+          auto exv = f(IterationSpace{});
+          if (auto *defOp = fir::getBase(exv).getDefiningOp();
+              mlir::isa<fir::EmboxOp>(defOp))
+            return exv;
+          fir::emitFatalError(getLoc(), "array must be emboxed");
+        },
+        exp.u);
+  }
+
+  /// Entry point into lowering an expression with rank. This entry point is for
+  /// lowering a rhs expression, for example. (RefTransparent semantics.)
   static ExtValue lowerArrayExpression(
       Fortran::lower::AbstractConverter &converter,
       Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
@@ -1874,16 +1954,7 @@ public:
       const std::optional<Fortran::evaluate::Shape> &shape,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr) {
     ArrayExprLowering ael{converter, stmtCtx, symMap, dst, shape};
-    return ael.lowerArrayExpr(expr);
-  }
-
-  static ExtValue lowerAndBoxArrayExpression(
-      Fortran::lower::AbstractConverter &converter,
-      Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
-      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr) {
-    ArrayExprLowering ael{converter, stmtCtx, symMap};
-    ael.setUseEmbox();
-    return ael.boxArrayExpr(expr);
+    return ael.lowerArrayExpression(expr);
   }
 
   /// For an elemental array expression.
@@ -1891,7 +1962,7 @@ public:
   /// 2. Create the iteration space.
   /// 3. Create the element-by-element computation in the loop.
   /// 4. Return the resulting array value.
-  ExtValue lowerArrayExpr(
+  ExtValue lowerArrayExpression(
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &exp) {
     return std::visit(
         [&](const auto &e) {
@@ -1908,20 +1979,6 @@ public:
           builder.create<fir::ResultOp>(loc, upd.getResult());
           builder.restoreInsertionPoint(insPt);
           return fir::substBase(exv, iterSpace.outerResult());
-        },
-        exp.u);
-  }
-
-  ExtValue boxArrayExpr(
-      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &exp) {
-    return std::visit(
-        [&](const auto &e) {
-          auto f = genarr(e);
-          auto exv = f(IterationSpace{});
-          if (auto *defOp = fir::getBase(exv).getDefiningOp())
-            if (auto arrLd = mlir::dyn_cast<fir::EmboxOp>(defOp))
-              return exv;
-          llvm::report_fatal_error("array must be emboxed");
         },
         exp.u);
   }
@@ -2008,23 +2065,173 @@ public:
     return x.Rank() != 0;
   }
 
-  // Generate an error message, but no code.
-  CC errorCC(llvm::StringRef msg) {
-    mlir::emitError(getLoc(), msg);
-    return [](IterSpace) { return mlir::Value{}; };
+  // Attribute for an alloca that is a trivial adaptor for converting a value to
+  // pass-by-ref semantics for a VALUE parameter. The optimizer may be able to
+  // eliminate these.
+  mlir::NamedAttribute getAdaptToByRefAttr() {
+    return {mlir::Identifier::get("adapt.valuebyref", builder.getContext()),
+            builder.getUnitAttr()};
   }
 
+  // A procedure reference to a Fortran elemental intrinsic procedure.
+  CC genIntrinsicProcRef(
+      const Fortran::evaluate::ProcedureRef &procRef,
+      llvm::Optional<mlir::Type> retTy,
+      const Fortran::evaluate::SpecificIntrinsic &intrinsic) {
+    llvm::SmallVector<CC> operands;
+    llvm::StringRef name = intrinsic.name;
+    const auto *argLowering =
+        Fortran::lower::getIntrinsicArgumentLowering(name);
+    auto loc = getLoc();
+    for (const auto &[arg, dummy] :
+         llvm::zip(procRef.arguments(),
+                   intrinsic.characteristics.value().dummyArguments)) {
+      auto *expr = Fortran::evaluate::UnwrapExpr<
+          Fortran::evaluate::Expr<Fortran::evaluate::SomeType>>(arg);
+      if (!expr) {
+        // Absent optional.
+        operands.emplace_back([=](IterSpace) { return mlir::Value{}; });
+      } else if (!argLowering) {
+        // No argument lowering instruction, lower by value.
+        PushSemantics(ConstituentSemantics::RefTransparent);
+        auto lambda = genarr(*expr);
+        operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+      } else {
+        // Ad-hoc argument lowering handling.
+        switch (Fortran::lower::lowerIntrinsicArgumentAs(getLoc(), *argLowering,
+                                                         dummy.name)) {
+        case Fortran::lower::LowerIntrinsicArgAs::Value: {
+          PushSemantics(ConstituentSemantics::RefTransparent);
+          auto lambda = genarr(*expr);
+          operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+        } break;
+        case Fortran::lower::LowerIntrinsicArgAs::Addr: {
+          // Note: assume does not have Fortran VALUE attribute semantics.
+          PushSemantics(ConstituentSemantics::RefOpaque);
+          auto lambda = genarr(*expr);
+          operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+        } break;
+        case Fortran::lower::LowerIntrinsicArgAs::Inquired:
+          TODO(loc, "intrinsic function with inquired argument");
+          break;
+        }
+      }
+    }
+
+    // Let the intrinsic library lower the intrinsic procedure call
+    return [=](IterSpace iters) {
+      llvm::SmallVector<fir::ExtendedValue> args;
+      for (const auto &cc : operands)
+        args.push_back(cc(iters));
+      return Fortran::lower::genIntrinsicCall(builder, loc, name, retTy, args,
+                                              stmtCtx);
+    };
+  }
+
+  // A procedure reference to a user-defined elemental procedure.
+  CC genUDProcRef(const Fortran::evaluate::ProcedureRef &procRef,
+                  llvm::Optional<mlir::Type> retTy) {
+    using PassBy = Fortran::lower::CallerInterface::PassEntityBy;
+
+    Fortran::lower::CallerInterface caller(procRef, converter);
+    llvm::SmallVector<CC> operands(caller.getNumFIRArguments());
+    auto loc = getLoc();
+    auto callSiteType = caller.genFunctionType();
+    for (const auto &arg : caller.getPassedArguments()) {
+      const auto *actual = arg.entity;
+      auto argTy = callSiteType.getInput(arg.firArgument);
+      if (!actual) {
+        // Optional dummy argument for which there is no actual argument.
+        auto absent = builder.create<fir::AbsentOp>(loc, argTy);
+        operands[arg.firArgument] = [=](IterSpace) { return absent; };
+        continue;
+      }
+      const auto *expr = actual->UnwrapExpr();
+      if (!expr)
+        TODO(loc, "assumed type actual argument lowering");
+
+      LLVM_DEBUG(expr->AsFortran(llvm::dbgs()
+                                 << "argument: " << arg.firArgument << " = [")
+                 << "]\n");
+      switch (arg.passBy) {
+      case PassBy::Value: {
+        // True pass-by-value semantics.
+        PushSemantics(ConstituentSemantics::RefTransparent);
+        auto lambda = genarr(*expr);
+        operands[arg.firArgument] = [=](IterSpace iters) {
+          return lambda(iters);
+        };
+      } break;
+      case PassBy::ValueAttribute: {
+        // VALUE attribute or pass-by-reference to a copy semantics. (byval*)
+        PushSemantics(ConstituentSemantics::ByValueArg);
+        auto lambda = genarr(*expr);
+        operands[arg.firArgument] = [=](IterSpace iters) {
+          return lambda(iters);
+        };
+      } break;
+      case PassBy::BaseAddress: {
+        PushSemantics(ConstituentSemantics::RefOpaque);
+        auto lambda = genarr(*expr);
+        operands[arg.firArgument] = [=](IterSpace iters) {
+          return lambda(iters);
+        };
+      } break;
+      case PassBy::BoxChar:
+        TODO(loc, "character");
+        break;
+      case PassBy::AddressAndLength:
+        TODO(loc, "address and length argument");
+        break;
+      case PassBy::Box:
+      case PassBy::MutableBox:
+        // See C15100 and C15101
+        fir::emitFatalError(loc, "cannot be POINTER, ALLOCATABLE");
+      default:
+        llvm_unreachable("pass by value not handled here");
+        break;
+      }
+    }
+
+    if (caller.getIfIndirectCallSymbol())
+      TODO(loc, "indirect call");
+    auto funcSym = builder.getSymbolRefAttr(caller.getMangledName());
+    auto resTys = caller.getFuncOp().getType().getResults();
+    if (caller.getFuncOp().getType().getResults() !=
+        caller.genFunctionType().getResults())
+      TODO(loc, "type adaption");
+    return [=](IterSpace iters) -> ExtValue {
+      llvm::SmallVector<mlir::Value> args;
+      for (const auto &cc : operands)
+        args.push_back(fir::getBase(cc(iters)));
+      auto call = builder.create<fir::CallOp>(loc, resTys, funcSym, args);
+      return call.getResult(0);
+    };
+  }
+
+  // A procedure reference.
   CC genProcRef(const Fortran::evaluate::ProcedureRef &procRef,
                 llvm::Optional<mlir::Type> retTy) {
     auto loc = getLoc();
     if (procRef.IsElemental()) {
       if (const auto *intrin = procRef.proc().GetSpecificIntrinsic()) {
-        (void)intrin; // NB: LLVM_ATTRIBUTE_UNUSED doesn't suppress warning
-        TODO(loc, "elemental intrinsic");
+        // Elemental intrinsic call.
+        // The intrinsic procedure is called once per element of the array.
+        return genIntrinsicProcRef(procRef, retTy, *intrin);
       }
       if (ScalarExprLowering::isStatementFunctionCall(procRef))
-        TODO(loc, "elemental statement function");
-      TODO(loc, "elemental procedure ref");
+        fir::emitFatalError(loc, "statement function cannot be elemental");
+
+      // Elemental call.
+      // The procedure is called once per element of the array argument(s).
+      return genUDProcRef(procRef, retTy);
+    }
+
+    // Transformational call.
+    // The procedure is called once and produces a value of rank > 0.
+    if (const auto *intrin = procRef.proc().GetSpecificIntrinsic()) {
+      (void)intrin;
+      TODO(loc, "non-elemental intrinsic ref");
     }
     TODO(loc, "non-elemental procedure ref");
   }
@@ -2034,7 +2241,8 @@ public:
   }
   CC genarr(const Fortran::evaluate::ProcedureRef &x) {
     if (x.hasAlternateReturns())
-      return errorCC("array procedure reference with alt-return");
+      fir::emitFatalError(getLoc(),
+                          "array procedure reference with alt-return");
     return genProcRef(x, llvm::None);
   }
   template <typename A, typename = std::enable_if_t<Fortran::common::HasMember<
@@ -2057,9 +2265,9 @@ public:
                                              TC2> &x) {
     assert(isArray(x));
     auto loc = getLoc();
-    auto lf = genarr(x.left());
+    auto lambda = genarr(x.left());
     return [=](IterSpace iters) -> ExtValue {
-      auto val = fir::getBase(lf(iters));
+      auto val = fir::getBase(lambda(iters));
       auto ty = converter.genType(TC1, KIND);
       return builder.createConvert(loc, ty, val);
     };
@@ -2067,10 +2275,10 @@ public:
   template <int KIND>
   CC genarr(const Fortran::evaluate::ComplexComponent<KIND> &x) {
     auto loc = getLoc();
-    auto lf = genarr(x.left());
+    auto lambda = genarr(x.left());
     auto isImagPart = x.isImaginaryPart;
     return [=](IterSpace iters) -> ExtValue {
-      auto lhs = fir::getBase(lf(iters));
+      auto lhs = fir::getBase(lambda(iters));
       return Fortran::lower::ComplexExprHelper{builder, loc}.extractComplexPart(
           lhs, isImagPart);
     };
@@ -2127,10 +2335,10 @@ public:
   template <typename OP, typename A>
   CC createBinaryOp(const A &evEx) {
     auto loc = getLoc();
-    auto lf = genarr(evEx.left());
+    auto lambda = genarr(evEx.left());
     auto rf = genarr(evEx.right());
     return [=](IterSpace iters) -> ExtValue {
-      auto left = fir::getBase(lf(iters));
+      auto left = fir::getBase(lambda(iters));
       auto right = fir::getBase(rf(iters));
       return builder.create<OP>(loc, left, right);
     };
@@ -2240,9 +2448,9 @@ public:
     };
   }
 
-  // A vector subscript expression may be wrapped with a cast to INTEGER*8. Get
-  // rid of it here so the vector can be loaded. Add it back when generating the
-  // elemental evaluation (inside the loop nest).
+  // A vector subscript expression may be wrapped with a cast to INTEGER*8.
+  // Get rid of it here so the vector can be loaded. Add it back when
+  // generating the elemental evaluation (inside the loop nest).
   static Fortran::evaluate::Expr<Fortran::evaluate::SomeType>
   ignoreEvConvert(const Fortran::evaluate::Expr<Fortran::evaluate::Type<
                       Fortran::common::TypeCategory::Integer, 8>> &x) {
@@ -2261,8 +2469,8 @@ public:
     return toEvExpr(x);
   }
 
-  // Get the `Se::Symbol*` for the subscript expression, `x`. This symbol can be
-  // used to determine the lbound, ubound of the vector.
+  // Get the `Se::Symbol*` for the subscript expression, `x`. This symbol can
+  // be used to determine the lbound, ubound of the vector.
   template <typename A>
   static const Fortran::semantics::Symbol *
   extractSubscriptSymbol(const Fortran::evaluate::Expr<A> &x) {
@@ -2284,9 +2492,9 @@ public:
   ///
   /// There are two "slicing" primitives that may be applied on a dimension by
   /// dimension basis: (1) triple notation and (2) vector addressing. Since
-  /// dimensions can be selectively sliced, some dimensions may contain regular
-  /// scalar expressions and those dimensions do not participate in the array
-  /// expression evaluation.
+  /// dimensions can be selectively sliced, some dimensions may contain
+  /// regular scalar expressions and those dimensions do not participate in
+  /// the array expression evaluation.
   CC genarr(const Fortran::evaluate::ArrayRef &x) {
     llvm::SmallVector<mlir::Value> trips;
     auto loc = getLoc();
@@ -2374,12 +2582,12 @@ public:
                   }
                 } else {
                   // A regular scalar index, which does not yield an array
-                  // section. Use a degenerate slice operation `(e:undef:undef)`
-                  // in this dimension as a placeholder. This does not
-                  // necessarily change the rank of the original array, so the
-                  // iteration space must also be extended to include this
-                  // expression in this dimension to adjust to the array's
-                  // declared rank.
+                  // section. Use a degenerate slice operation
+                  // `(e:undef:undef)` in this dimension as a placeholder.
+                  // This does not necessarily change the rank of the original
+                  // array, so the iteration space must also be extended to
+                  // include this expression in this dimension to adjust to
+                  // the array's declared rank.
                   auto base = x.base();
                   ScalarExprLowering sel{loc, converter, symMap, stmtCtx};
                   auto exv = base.IsSymbol() ? sel.gen(base.GetFirstSymbol())
@@ -2408,8 +2616,8 @@ public:
               }},
           sub.value().u);
     }
-    auto lf = genSlice(x.base(), trips);
-    return [=](IterSpace iters) { return lf(pc(iters)); };
+    auto lambda = genSlice(x.base(), trips);
+    return [=](IterSpace iters) { return lambda(pc(iters)); };
   }
   CC genarr(const Fortran::evaluate::NamedEntity &entity) {
     if (entity.IsSymbol())
@@ -2462,7 +2670,7 @@ public:
                    << eleTy << ", " << arrTy << '\n');
       }
     }
-    if (useEmbox) {
+    if (isBoxValue()) {
       auto boxTy = fir::BoxType::get(reduceRank(arrTy, slice));
       if (memref.getType().isa<fir::BoxType>())
         TODO(loc, "use fir.rebox for array section of fir.box");
@@ -2470,11 +2678,33 @@ public:
           loc, boxTy, memref, shape, slice, /*lenParams=*/llvm::None);
       return [=](IterSpace) -> ExtValue { return fir::IrBoxValue(embox); };
     }
+    auto eleTy = arrTy.cast<fir::SequenceType>().getEleTy();
+    if (isReferentiallyOpaque()) {
+      auto refEleTy = builder.getRefType(eleTy);
+      return [=](IterSpace iters) -> ExtValue {
+        mlir::Value coor = builder.create<fir::ArrayCoorOp>(
+            loc, refEleTy, memref, shape, slice, iters.iterVec(),
+            /*lenParams=*/llvm::None);
+        return coor;
+      };
+    }
     mlir::Value arrLd = builder.create<fir::ArrayLoadOp>(
         loc, arrTy, memref, shape, slice, /*lenParams=*/llvm::None);
-    if (inProjection)
+    if (isCopyInCopyOut())
       return [=](IterSpace) -> ExtValue { return arrLd; };
-    auto eleTy = arrTy.cast<fir::SequenceType>().getEleTy();
+    if (isValueAttribute())
+      return [=](IterSpace iters) -> ExtValue {
+        auto arrFetch = builder.create<fir::ArrayFetchOp>(loc, eleTy, arrLd,
+                                                          iters.iterVec());
+        auto exv =
+            arrayElementToExtendedValue(builder, loc, extMemref, arrFetch);
+        auto base = fir::getBase(exv);
+        auto temp = builder.createTemporary(
+            loc, base.getType(),
+            llvm::ArrayRef<mlir::NamedAttribute>{getAdaptToByRefAttr()});
+        builder.create<fir::StoreOp>(loc, base, temp);
+        return temp;
+      };
     return [=](IterSpace iters) -> ExtValue {
       auto arrFetch =
           builder.create<fir::ArrayFetchOp>(loc, eleTy, arrLd, iters.iterVec());
@@ -2507,13 +2737,14 @@ public:
     const auto &sym = x.GetFirstSymbol();
     auto recTy = converter.genType(sym);
     buildComponentsPath(components, recTy, x.base());
-    auto lf = genPathSlice(sym, components);
-    return [=](IterSpace iters) { return lf(iters); };
+    auto lambda = genPathSlice(sym, components);
+    return [=](IterSpace iters) { return lambda(iters); };
   }
 
-  /// The `Ev::Component` structure is tailmost down to head, so the expression
-  /// <code>a%b%c</code> will be presented as <code>(component (dataref
-  /// (component (dataref (symbol 'a)) (symbol 'b))) (symbol 'c))</code>.
+  /// The `Ev::Component` structure is tailmost down to head, so the
+  /// expression <code>a%b%c</code> will be presented as <code>(component
+  /// (dataref (component (dataref (symbol 'a)) (symbol 'b))) (symbol
+  /// 'c))</code>.
   void buildComponentsPath(llvm::SmallVectorImpl<mlir::Value> &components,
                            mlir::Type &recTy,
                            const Fortran::evaluate::DataRef &dr) {
@@ -2548,8 +2779,8 @@ public:
     auto offset = builder.createIntegerConstant(
         loc, i32Ty,
         x.part() == Fortran::evaluate::ComplexPart::Part::RE ? 0 : 1);
-    auto lf = genPathSlice(x.complex(), {offset});
-    return [=](IterSpace iters) { return lf(iters); };
+    auto lambda = genPathSlice(x.complex(), {offset});
+    return [=](IterSpace iters) { return lambda(iters); };
   }
 
   template <typename A>
@@ -2621,10 +2852,10 @@ public:
   CC genarr(const Fortran::evaluate::Not<KIND> &x) {
     auto loc = getLoc();
     auto i1Ty = builder.getI1Type();
-    auto lf = genarr(x.left());
+    auto lambda = genarr(x.left());
     auto truth = builder.createBool(loc, true);
     return [=](IterSpace iters) -> ExtValue {
-      auto logical = fir::getBase(lf(iters));
+      auto logical = fir::getBase(lambda(iters));
       auto val = builder.createConvert(loc, i1Ty, logical);
       return builder.create<mlir::XOrOp>(loc, val, truth);
     };
@@ -2738,6 +2969,17 @@ public:
   }
 
 private:
+  struct PushSemant {
+    PushSemant(ConstituentSemantics newVal, ConstituentSemantics &oldVal)
+        : ref{oldVal} {
+      saved = oldVal;
+      oldVal = newVal;
+    }
+    ~PushSemant() { ref = saved; }
+    ConstituentSemantics saved;
+    ConstituentSemantics &ref;
+  };
+
   explicit ArrayExprLowering(Fortran::lower::AbstractConverter &converter,
                              Fortran::lower::StatementContext &stmtCtx,
                              Fortran::lower::SymMap &symMap,
@@ -2755,14 +2997,32 @@ private:
 
   explicit ArrayExprLowering(Fortran::lower::AbstractConverter &converter,
                              Fortran::lower::StatementContext &stmtCtx,
-                             Fortran::lower::SymMap &symMap, bool projection,
+                             Fortran::lower::SymMap &symMap,
+                             ConstituentSemantics sem,
                              fir::ArrayLoadOp dst = {})
       : converter{converter}, builder{converter.getFirOpBuilder()},
-        stmtCtx{stmtCtx}, symMap{symMap}, destination{dst}, inProjection{
-                                                                projection} {}
+        stmtCtx{stmtCtx}, symMap{symMap}, destination{dst}, semant{sem} {}
 
   mlir::Location getLoc() { return converter.getCurrentLocation(); }
-  void setUseEmbox(bool embox = true) { useEmbox = embox; }
+
+  /// Array appears in a lhs context such that it is assigned after the rhs is
+  /// fully evaluated.
+  bool isCopyInCopyOut() {
+    return semant == ConstituentSemantics::CopyInCopyOut;
+  }
+
+  /// Array appears in a context where it must be boxed.
+  bool isBoxValue() { return semant == ConstituentSemantics::BoxValue; }
+
+  /// Array appears in a context where differences in the memory reference can
+  /// be observable in the computational results. For example, an array
+  /// element is passed to an impure procedure.
+  bool isReferentiallyOpaque() {
+    return semant == ConstituentSemantics::RefOpaque;
+  }
+
+  /// Array appears in a context where it is passed as a VALUE argument.
+  bool isValueAttribute() { return semant == ConstituentSemantics::ByValueArg; }
 
   Fortran::lower::AbstractConverter &converter;
   Fortran::lower::FirOpBuilder &builder;
@@ -2772,9 +3032,8 @@ private:
   std::optional<Fortran::evaluate::Shape> destShape;
   llvm::SmallVector<mlir::Value> sliceTriple;
   llvm::SmallVector<mlir::Value> slicePath;
-  bool useEmbox{false};
+  ConstituentSemantics semant{ConstituentSemantics::RefTransparent};
   bool inSlice{false};
-  bool inProjection{false};
 };
 } // namespace
 
@@ -2876,8 +3135,8 @@ fir::ExtendedValue Fortran::lower::createSomeArrayBox(
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx) {
   LLVM_DEBUG(expr.AsFortran(llvm::dbgs() << "box designator: ") << '\n');
-  return ArrayExprLowering::lowerAndBoxArrayExpression(converter, symMap,
-                                                       stmtCtx, expr);
+  return ArrayExprLowering::lowerArrayExpressionBoxed(converter, symMap,
+                                                      stmtCtx, expr);
 }
 
 fir::MutableBoxValue Fortran::lower::createSomeMutableBox(
@@ -2887,7 +3146,8 @@ fir::MutableBoxValue Fortran::lower::createSomeMutableBox(
   // MutableBox lowering StatementContext does not need to be propagated
   // to the caller because the result value is a variable, not a temporary
   // expression. The StatementContext clean-up can occur before using the
-  // resulting MutableBoxValue.
+  // resulting MutableBoxValue. Variables of all other types are handled in the
+  // bridge.
   Fortran::lower::StatementContext dummyStmtCtx;
   return ScalarExprLowering{loc, converter, symMap, dummyStmtCtx}
       .genMutableBoxValue(expr);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1855,7 +1855,8 @@ private:
 // Helper for changing the semantics in a given context. Preserves the current
 // semantics which is resumed when the "push" goes out of scope.
 #define PushSemantics(PushVal)                                                 \
-  [[maybe_unused]] PushSemant pushSemanticsLocalVariable97201(PushVal, semant);
+  [[maybe_unused]] auto pushSemanticsLocalVariable97201 =                      \
+      Fortran::common::ScopedSet(semant, PushVal);
 
 namespace {
 class ArrayExprLowering {
@@ -2074,7 +2075,7 @@ public:
   }
 
   // A procedure reference to a Fortran elemental intrinsic procedure.
-  CC genIntrinsicProcRef(
+  CC genElementalIntrinsicProcRef(
       const Fortran::evaluate::ProcedureRef &procRef,
       llvm::Optional<mlir::Type> retTy,
       const Fortran::evaluate::SpecificIntrinsic &intrinsic) {
@@ -2129,8 +2130,9 @@ public:
   }
 
   // A procedure reference to a user-defined elemental procedure.
-  CC genUDProcRef(const Fortran::evaluate::ProcedureRef &procRef,
-                  llvm::Optional<mlir::Type> retTy) {
+  CC genElementalUserDefinedProcRef(
+      const Fortran::evaluate::ProcedureRef &procRef,
+      llvm::Optional<mlir::Type> retTy) {
     using PassBy = Fortran::lower::CallerInterface::PassEntityBy;
 
     Fortran::lower::CallerInterface caller(procRef, converter);
@@ -2162,7 +2164,7 @@ public:
           return lambda(iters);
         };
       } break;
-      case PassBy::ValueAttribute: {
+      case PassBy::BaseAddressValueAttribute: {
         // VALUE attribute or pass-by-reference to a copy semantics. (byval*)
         PushSemantics(ConstituentSemantics::ByValueArg);
         auto lambda = genarr(*expr);
@@ -2177,8 +2179,11 @@ public:
           return lambda(iters);
         };
       } break;
+      case PassBy::CharBoxValueAttribute:
+        TODO(loc, "CHARACTER, VALUE");
+        break;
       case PassBy::BoxChar:
-        TODO(loc, "character");
+        TODO(loc, "CHARACTER");
         break;
       case PassBy::AddressAndLength:
         TODO(loc, "address and length argument");
@@ -2188,18 +2193,18 @@ public:
         // See C15100 and C15101
         fir::emitFatalError(loc, "cannot be POINTER, ALLOCATABLE");
       default:
-        llvm_unreachable("pass by value not handled here");
+        llvm_unreachable("pass by ? not handled here");
         break;
       }
     }
 
     if (caller.getIfIndirectCallSymbol())
-      TODO(loc, "indirect call");
+      fir::emitFatalError(loc, "cannot be indirect call");
     auto funcSym = builder.getSymbolRefAttr(caller.getMangledName());
     auto resTys = caller.getFuncOp().getType().getResults();
     if (caller.getFuncOp().getType().getResults() !=
         caller.genFunctionType().getResults())
-      TODO(loc, "type adaption");
+      fir::emitFatalError(loc, "type mismatch on declared function");
     return [=](IterSpace iters) -> ExtValue {
       llvm::SmallVector<mlir::Value> args;
       for (const auto &cc : operands)
@@ -2217,14 +2222,14 @@ public:
       if (const auto *intrin = procRef.proc().GetSpecificIntrinsic()) {
         // Elemental intrinsic call.
         // The intrinsic procedure is called once per element of the array.
-        return genIntrinsicProcRef(procRef, retTy, *intrin);
+        return genElementalIntrinsicProcRef(procRef, retTy, *intrin);
       }
       if (ScalarExprLowering::isStatementFunctionCall(procRef))
         fir::emitFatalError(loc, "statement function cannot be elemental");
 
       // Elemental call.
       // The procedure is called once per element of the array argument(s).
-      return genUDProcRef(procRef, retTy);
+      return genElementalUserDefinedProcRef(procRef, retTy);
     }
 
     // Transformational call.
@@ -2696,14 +2701,12 @@ public:
       return [=](IterSpace iters) -> ExtValue {
         auto arrFetch = builder.create<fir::ArrayFetchOp>(loc, eleTy, arrLd,
                                                           iters.iterVec());
-        auto exv =
-            arrayElementToExtendedValue(builder, loc, extMemref, arrFetch);
-        auto base = fir::getBase(exv);
+        auto base = arrFetch.getResult();
         auto temp = builder.createTemporary(
             loc, base.getType(),
             llvm::ArrayRef<mlir::NamedAttribute>{getAdaptToByRefAttr()});
         builder.create<fir::StoreOp>(loc, base, temp);
-        return temp;
+        return arrayElementToExtendedValue(builder, loc, extMemref, temp);
       };
     return [=](IterSpace iters) -> ExtValue {
       auto arrFetch =
@@ -2968,17 +2971,6 @@ public:
   }
 
 private:
-  struct PushSemant {
-    PushSemant(ConstituentSemantics newVal, ConstituentSemantics &oldVal)
-        : ref{oldVal} {
-      saved = oldVal;
-      oldVal = newVal;
-    }
-    ~PushSemant() { ref = saved; }
-    ConstituentSemantics saved;
-    ConstituentSemantics &ref;
-  };
-
   explicit ArrayExprLowering(Fortran::lower::AbstractConverter &converter,
                              Fortran::lower::StatementContext &stmtCtx,
                              Fortran::lower::SymMap &symMap,


### PR DESCRIPTION
This handles the lowering of the basic cases. There are several TODOs in
the code for other variants.

This lowers expressions like the following where a and b are arrays.

  a = f(b)
  a = abs(b)

These are transformed into loop (nests) where the right-hand side is
fully evaluated by applying the function to each element in the array
and then the resulting array is copied-out to the left-hand side.