### PR TITLE
Lower initial data target

### DIFF
--- a/flang/test/Lower/pointer-initial-target-2.f90
+++ b/flang/test/Lower/pointer-initial-target-2.f90
@@ -1,0 +1,79 @@
+! Test lowering of pointer initial target
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! This tests focus on the scope context of initial data target.
+! More complete tests regarding the initial data target expression
+! are done in pointer-initial-target.f90.
+
+! Test pointer initial data target in modules
+module some_mod
+  real, target :: x(100)
+  real, pointer :: p(:) => x
+! CHECK-LABEL: fir.global linkonce @_QMsome_modEp : !fir.box<!fir.ptr<!fir.array<?xf32>>> {
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QMsome_modEx) : !fir.ref<!fir.array<100xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+end module
+
+! Test initial data target in a common block
+module some_mod_2
+  real, target :: x(100), y(10:209)
+  common /com/ x, y
+  save :: /com/
+  real, pointer :: p(:) => y
+! CHECK-LABEL: fir.global linkonce @_QMsome_mod_2Ep : !fir.box<!fir.ptr<!fir.array<?xf32>>> {
+  ! CHECK: %[[c:.*]] = fir.address_of(@_QBcom) : !fir.ref<!fir.array<1200xi8>>
+  ! CHECK: %[[com:.*]] = fir.convert %[[c]] : (!fir.ref<!fir.array<1200xi8>>) -> !fir.ref<!fir.array<?xi8>>
+  ! CHECK: %[[yRaw:.*]] = fir.coordinate_of %[[com]], %c400{{.*}} : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+  ! CHECK: %[[y:.*]] = fir.convert %[[yRaw]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<200xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape_shift %c10{{.*}}, %c200{{.*}} : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[y]](%[[shape]]) : (!fir.ref<!fir.array<200xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+end module
+
+! Test pointer initial data target with pointer in common blocks
+block data
+  real, pointer :: p
+  real, save, target :: b
+  common /a/ p
+  data p /b/
+! CHECK-LABEL: fir.global @_QBa : tuple<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[b:.*]] = fir.address_of(@_QEb) : !fir.ref<f32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[b]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: %[[a:.*]] = fir.insert_value %[[undef]], %[[box]], %c0{{.*}} : (tuple<!fir.box<!fir.ptr<f32>>>, !fir.box<!fir.ptr<f32>>, index) -> tuple<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: fir.has_value %[[a]] : tuple<!fir.box<!fir.ptr<f32>>>
+end block data
+
+! Test pointer in a common with initial target in the same common.
+block data snake
+  integer, target :: b = 42
+  integer, pointer :: p => b
+  common /snake/ p, b
+! CHECK-LABEL: fir.global @_QBsnake : tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: %[[tuple0:.*]] = fir.undefined tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: %[[snakeAddr:.*]] = fir.address_of(@_QBsnake) : !fir.ref<tuple<!fir.box<!fir.ptr<i32>>, i32>>
+  ! CHECK: %[[byteView:.*]] = fir.convert %[[snakeAddr:.*]] : (!fir.ref<tuple<!fir.box<!fir.ptr<i32>>, i32>>) -> !fir.ref<!fir.array<?xi8>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[byteView]], %c24{{.*}} : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+  ! CHECK: %[[bAddr:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[bAddr]] : (!fir.ref<i32>) -> !fir.box<!fir.ptr<i32>>
+  ! CHECK: %[[tuple1:.*]] = fir.insert_value %[[tuple0]], %[[box]], %c0{{.*}} : (tuple<!fir.box<!fir.ptr<i32>>, i32>, !fir.box<!fir.ptr<i32>>, index) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple1]], %c42{{.*}}, %c1{{.*}} : (tuple<!fir.box<!fir.ptr<i32>>, i32>, i32, index) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: fir.has_value %[[tuple2]] : tuple<!fir.box<!fir.ptr<i32>>, i32>
+end block data
+
+! Test two common depending on each others because of initial data
+! targets
+block data tied
+  real, target :: x1 = 42
+  real, target :: x2 = 43
+  real, pointer :: p1 => x2
+  real, pointer :: p2 => x1
+  common /c1/ x1, p1
+  common /c2/ x2, p2
+! CHECK-LABEL: fir.global @_QBc1 : tuple<f32, !fir.array<4xi8>, !fir.box<!fir.ptr<f32>>>
+  ! CHECK: fir.address_of(@_QBc2) : !fir.ref<tuple<f32, !fir.array<4xi8>, !fir.box<!fir.ptr<f32>>>>
+! CHECK-LABEL: fir.global @_QBc2 : tuple<f32, !fir.array<4xi8>, !fir.box<!fir.ptr<f32>>>
+  ! CHECK: fir.address_of(@_QBc1) : !fir.ref<tuple<f32, !fir.array<4xi8>, !fir.box<!fir.ptr<f32>>>>
+end block data

--- a/flang/test/Lower/pointer-initial-target.f90
+++ b/flang/test/Lower/pointer-initial-target.f90
@@ -1,0 +1,159 @@
+! Test lowering of pointer initial target
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! -----------------------------------------------------------------------------
+!     Test scalar initial data target that are simple names
+! -----------------------------------------------------------------------------
+
+subroutine scalar()
+  real, save, target :: x
+  real, pointer :: p => x
+! CHECK-LABEL: fir.global internal @_QFscalarEp : !fir.box<!fir.ptr<f32>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalarEx) : !fir.ref<f32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<f32>>
+end subroutine
+
+subroutine scalar_char()
+  character(10), save, target :: x
+  character(:), pointer :: p => x
+! CHECK-LABEL: fir.global internal @_QFscalar_charEp : !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalar_charEx) : !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[xCast:.*]] = fir.convert %[[x]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ptr<!fir.char<1,?>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[xCast]] typeparams %c10{{.*}} : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.char<1,?>>>
+end subroutine
+
+subroutine scalar_char_2()
+  character(10), save, target :: x
+  character(10), pointer :: p => x
+! CHECK-LABEL: fir.global internal @_QFscalar_char_2Ep : !fir.box<!fir.ptr<!fir.char<1,10>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalar_char_2Ex) : !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.char<1,10>>>
+end subroutine
+
+subroutine scalar_derived()
+  type t
+    real :: x
+    integer :: i
+  end type
+  type(t), save, target :: x
+  type(t), pointer :: p => x
+! CHECK-LABEL: fir.global internal @_QFscalar_derivedEp : !fir.box<!fir.ptr<!fir.type<_QFscalar_derivedTt{x:f32,i:i32}>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalar_derivedEx) : !fir.ref<!fir.type<_QFscalar_derivedTt{x:f32,i:i32}>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QFscalar_derivedTt{x:f32,i:i32}>>) -> !fir.box<!fir.ptr<!fir.type<_QFscalar_derivedTt{x:f32,i:i32}>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.type<_QFscalar_derivedTt{x:f32,i:i32}>>>
+end subroutine
+
+subroutine scalar_null()
+  real, pointer :: p => NULL()
+! CHECK-LABEL: fir.global internal @_QFscalar_nullEp : !fir.box<!fir.ptr<f32>>
+  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ref<none>
+  ! CHECK: %[[box:.*]] = fir.embox %[[zero]] : (!fir.ref<none>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<f32>>
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test array initial data target that are simple names
+! -----------------------------------------------------------------------------
+
+subroutine array()
+  real, save, target :: x(100)
+  real, pointer :: p(:) => x
+! CHECK-LABEL: fir.global internal @_QFarrayEp : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFarrayEx) : !fir.ref<!fir.array<100xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+end subroutine
+
+subroutine array_char()
+  character(10), save, target :: x(20)
+  character(:), pointer :: p(:) => x
+! CHECK-LABEL: fir.global internal @_QFarray_charEp : !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFarray_charEx) : !fir.ref<!fir.array<20x!fir.char<1,10>>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[xCast:.*]] = fir.convert %[[x]] : (!fir.ref<!fir.array<20x!fir.char<1,10>>>) -> !fir.ptr<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[xCast]](%[[shape]]) typeparams %c10{{.*}} : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+end subroutine
+
+subroutine array_char_2()
+  character(10), save, target :: x(20)
+  character(10), pointer :: p(:) => x
+! CHECK-LABEL: fir.global internal @_QFarray_char_2Ep : !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFarray_char_2Ex) : !fir.ref<!fir.array<20x!fir.char<1,10>>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) : (!fir.ref<!fir.array<20x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,10>>>>
+end subroutine
+
+subroutine array_derived()
+  type t
+    real :: x
+    integer :: i
+  end type
+  type(t), save, target :: x(100)
+  type(t), pointer :: p(:) => x
+! CHECK-LABEL: fir.global internal @_QFarray_derivedEp : !fir.box<!fir.ptr<!fir.array<?x!fir.type<_QFarray_derivedTt{x:f32,i:i32}>>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFarray_derivedEx) : !fir.ref<!fir.array<100x!fir.type<_QFarray_derivedTt{x:f32,i:i32}>>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) : (!fir.ref<!fir.array<100x!fir.type<_QFarray_derivedTt{x:f32,i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?x!fir.type<_QFarray_derivedTt{x:f32,i:i32}>>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?x!fir.type<_QFarray_derivedTt{x:f32,i:i32}>>>>
+end subroutine
+
+subroutine array_null()
+  real, pointer :: p(:) => NULL()
+! CHECK-LABEL: fir.global internal @_QFarray_nullEp : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ref<none>
+  ! CHECK: %[[box:.*]] = fir.embox %[[zero]] : (!fir.ref<none>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test scalar initial data target that are data references
+! -----------------------------------------------------------------------------
+
+subroutine scalar_ref()
+  real, save, target :: x(4:100)
+  real, pointer :: p => x(50)
+! CHECK-LABEL: fir.global internal @_QFscalar_refEp : !fir.box<!fir.ptr<f32>> {
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalar_refEx) : !fir.ref<!fir.array<97xf32>>
+  ! CHECK: %[[lb:.*]] = fir.convert %c4 : (index) -> i64
+  ! CHECK: %[[idx:.*]] = subi %c50{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[elt:.*]] = fir.coordinate_of %[[x]], %[[idx]] : (!fir.ref<!fir.array<97xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[elt]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<f32>>
+end subroutine
+
+subroutine scalar_char_ref()
+  character(20), save, target :: x(100)
+  character(10), pointer :: p => x(6)(7:16)
+! CHECK-LABEL: fir.global internal @_QFscalar_char_refEp : !fir.box<!fir.ptr<!fir.char<1,10>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFscalar_char_refEx) : !fir.ref<!fir.array<100x!fir.char<1,20>>>
+  ! CHECK: %[[idx:.*]] = subi %c6{{.*}}, %c1{{.*}} : i64
+  ! CHECK: %[[elt:.*]] = fir.coordinate_of %[[x]], %[[idx]] : (!fir.ref<!fir.array<100x!fir.char<1,20>>>, i64) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK: %[[eltCast:.*]] = fir.convert %[[elt:.*]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<!fir.array<20x!fir.char<1>>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[eltCast]], %{{.*}} : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[substring:.*]] = fir.convert %[[coor]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[substringCast:.*]] = fir.convert %[[substring]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ptr<!fir.char<1,10>>
+  ! CHECK: %[[box:.*]] = fir.embox %[[substringCast]] : (!fir.ptr<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.char<1,10>>>
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test array initial data target that are data references
+! -----------------------------------------------------------------------------
+
+subroutine array_ref()
+  real, save, target :: x(4:103, 5:104)
+  real, pointer :: p(:) => x(10, 20:100:2)
+! CHECK-LABEL: fir.global internal @_QFarray_refEp : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[x:.*]] = fir.address_of(@_QFarray_refEx) : !fir.ref<!fir.array<100x100xf32>>
+  ! CHECK-DAG: %[[undef:.*]] = fir.undefined index
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape_shift %c4, %c100, %c5, %c100_0 : (index, index, index, index) -> !fir.shapeshift<2>
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c10{{.*}}, %[[undef]], %[[undef]], %c20{{.*}}, %c100{{.*}}, %c2{{.*}} : (i64, index, index, i64, i64, i64) -> !fir.slice<2>
+  ! CHECK: %[[box:.*]] = fir.embox %[[x]](%[[shape]]) {{.}}%[[slice]]{{.}} : (!fir.ref<!fir.array<100x100xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+end subroutine


### PR DESCRIPTION
Create a function `genInitialDataTarget` to create a `fir.box` for a pointer initial data target. In `defineGlobal` and `defineCommon`, use it if the global (or common member) is a pointer with an initial data target.

This is not added to `defineGlobalAggregateStore` because `C8106` prevents pointer/derived type with pointer component to be used in equivalences.
The fact that the initial data target cannot be in an equivalence (C8108 + C765) also simplifies the logic (there is no need to try instantiating aggregate stores inside global op initializer).
The main Fortran difficulty was that the initial data target can be in common block, and so can the pointer. This is covered by the `instantiateVar(var)` call on the initial data target that will declare the common block if needed (as this call it does in normal context).

Most of the complexity of  `genInitialDataTarget` stems from the fact that it is not possible to use `fir.rebox` in a global initializer (which we normally used in some pointer assignment case). I tried making this possible, but it was driving too much weird changes in `fir.rebox` codegen to support both an in memory and a struct descriptor argument. So I went for an ad-hoc handling of this corner case.

The last test cases `block data snake` and `block data tied` in `pointer-initial-target-2.f90` lowers fine to FIR and LLVM dialect, but crashes the LLVM dialect to LLVM IR pass. I am working on a simple fix for this, the issue turned out to be that the translation passes declare global op and define their body in the same pass, which is an issue if they are forward reference from an initializer to a globalOp not yet declared in LLVM IR.

Derived type with length parameters are left TODOs. I can't prepare much here without more general work on them.