### PR TITLE
Fix -rpath for macos

### DIFF
--- a/flang/test/Examples/hello.f90
+++ b/flang/test/Examples/hello.f90
@@ -3,7 +3,7 @@
 ! default when they are available.
 
 ! RUN: bbc %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
-! RUN: %CC %t.o -L%L -Wl,-rpath=%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o hello
+! RUN: %CC %t.o -L%L -Wl,-rpath -Wl,%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o hello
 ! RUN: ./hello | FileCheck %s
 
 ! CHECK: Hello, World!

--- a/flang/test/Lower/associate-construct.f90
+++ b/flang/test/Lower/associate-construct.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
-! RUN: %CC %t.o -L%L -Wl,-rpath=%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o %t.out
+! RUN: %CC %t.o -L%L -Wl,-rpath -Wl,%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o %t.out
 ! RUN: %t.out | FileCheck %s
 
 program p

--- a/flang/test/Lower/end-to-end-always-exec-loopbody.f90
+++ b/flang/test/Lower/end-to-end-always-exec-loopbody.f90
@@ -1,6 +1,6 @@
-! RUN: bbc --always-execute-loop-body %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %temp.o
-! RUN: %CC %temp.o -L%L -Wl,-rpath=%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o %temp.loop
-! RUN: %temp.loop | FileCheck %s
+! RUN: bbc --always-execute-loop-body %s -o - | tco | llc --relocation-model=pic --filetype=obj -o %t.o
+! RUN: %CC %t.o -L%L -Wl,-rpath -Wl,%L -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o %t.loop
+! RUN: %t.loop | FileCheck %s
 
 program alwaysexecuteloopbody
   implicit none


### PR DESCRIPTION
The linker on macos doesn't accept `-rpath=...`, it wants the library
as a separate argument. That seems to work okay on linux too.
Also replace `%temp` with `%t` where that was intended.