### PR TITLE
[flang] Adding ability to customize the printer of the LLVMIRLoweringPass

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -12,6 +12,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
 #include <memory>
 
 namespace fir {
@@ -36,9 +38,13 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createFirTargetRewritePass(
 /// Convert FIR to the LLVM IR dialect
 std::unique_ptr<mlir::Pass> createFIRToLLVMPass();
 
+using LLVMIRLoweringPrinter =
+    std::function<void(llvm::Module &, llvm::raw_ostream &)>;
 /// Convert the LLVM IR dialect to LLVM-IR proper
-std::unique_ptr<mlir::Pass>
-createLLVMDialectToLLVMPass(llvm::raw_ostream &output);
+std::unique_ptr<mlir::Pass> createLLVMDialectToLLVMPass(
+    llvm::raw_ostream &output,
+    LLVMIRLoweringPrinter printer =
+        [](llvm::Module &M, llvm::raw_ostream &out) { M.print(out, nullptr); });
 
 // declarative passes
 #define GEN_PASS_REGISTRATION


### PR DESCRIPTION
I would like to have the ability to customize the printer in the LLVMIRLoweringPass in order to just print the global variable initializations in the flange flow.

Currently, the pass does 2 things, it lowers and prints with a hardcoded llvmModule->print(output, nullptr)
I started with my own copy of LLVMIRLoweringPass and just changed the part that does the printing to meet my needs but maybe we can avoid the cut-and-paste.

To that end, I am adding an extra argument to the creation of the pass which is an optional printer. If none is provided a default is created to do what it currently does (llvmModule->print(output, nullptr)). This way the client code does need to change. 

