### PR TITLE
Add hard TODO when copy-in copy-out is needed around F77 calls

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1539,7 +1539,10 @@ public:
 
       auto helper = Fortran::lower::CharacterExprHelper{builder, loc};
       if (arg.passBy == PassBy::BaseAddress) {
-        caller.placeInput(arg, fir::getBase(argRef));
+        auto baseAddr = fir::getBase(argRef);
+        if (baseAddr.getType().isa<fir::BoxType>())
+          TODO(loc, "copy-in copy-out around F77 calls");
+        caller.placeInput(arg, baseAddr);
       } else if (arg.passBy == PassBy::BoxChar) {
         auto boxChar = argRef.match(
             [&](const fir::CharBoxValue &x) { return helper.createEmbox(x); },


### PR DESCRIPTION
Current interface lowering was not building the right characteristic for implicit calls with non F77 like actual arguments and a hard TODO was missing when copy-in copy-out is needed around F77 calls.

```
subroutine foo(x)
  real :: x(:)
  call bar(x)
end subroutine
```

Now hit a TODO `not yet implemented copy-in copy-out around F77 calls` instead of silently compiling to wrong code.