### PR TITLE
Update SmallVector declarations

### DIFF
--- a/flang/docs/tutorials/addingIntrinsics.md
+++ b/flang/docs/tutorials/addingIntrinsics.md
@@ -318,7 +318,7 @@ void Fortran::lower::genTrim(Fortran::lower::FirOpBuilder &builder,
   auto sourceLine =
       Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(3));
 
-  llvm::SmallVector<mlir::Value, 4> args;
+  llvm::SmallVector<mlir::Value> args;
   args.emplace_back(builder.createConvert(loc, fTy.getInput(0), resultBox));
   args.emplace_back(builder.createConvert(loc, fTy.getInput(1), stringBox));
   args.emplace_back(builder.createConvert(loc, fTy.getInput(2), sourceFile));

--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -402,7 +402,7 @@ struct Variable {
                    bool isDeclaration = false)
         : interval{std::move(interval)}, scope{&scope}, isDecl{isDeclaration} {}
     AggregateStore(Interval &&interval, const Fortran::semantics::Scope &scope,
-                   const llvm::SmallVector<const semantics::Symbol *, 8> &vars,
+                   const llvm::SmallVector<const semantics::Symbol *> &vars,
                    bool isDeclaration = false)
         : interval{std::move(interval)}, scope{&scope}, vars{vars},
           isDecl{isDeclaration} {}
@@ -415,7 +415,7 @@ struct Variable {
     Interval interval{};
     /// scope in which the interval is.
     const Fortran::semantics::Scope *scope;
-    llvm::SmallVector<const semantics::Symbol *, 8> vars{};
+    llvm::SmallVector<const semantics::Symbol *> vars{};
     /// Is this a declaration of a storage defined in another scope ?
     bool isDecl;
   };
@@ -640,7 +640,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   /// Current index into entryPointList.  Index 0 is the primary entry point.
   int activeEntry = 0;
   /// Dummy arguments that are not universal across entry points.
-  llvm::SmallVector<const semantics::Symbol *, 3> nonUniversalDummyArguments;
+  llvm::SmallVector<const semantics::Symbol *, 1> nonUniversalDummyArguments;
   /// Primary result for function subprograms with alternate entries.  This
   /// is one of the largest result values, not necessarily the first one.
   const semantics::Symbol *primaryResult{nullptr};

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -111,8 +111,8 @@ class fir_AllocatableOp<string mnemonic, Resource resource,
       return mlir::failure();
     auto &builder = parser.getBuilder();
     result.addAttribute(inType(), mlir::TypeAttr::get(intype));
-    llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> operands;
-    llvm::SmallVector<mlir::Type, 8> typeVec;
+    llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
+    llvm::SmallVector<mlir::Type> typeVec;
     bool hasOperands = false;
     if (!parser.parseOptionalLParen()) {
       // parse the LEN params of the derived type. (<params> : <types>)
@@ -200,7 +200,7 @@ class fir_AllocatableOp<string mnemonic, Resource resource,
 
   // Verify checks common to all allocation operations
   string allocVerify = [{
-    llvm::SmallVector<llvm::StringRef, 8> visited;
+    llvm::SmallVector<llvm::StringRef> visited;
     if (verifyInType(getInType(), visited, numShapeOperands()))
       return emitOpError("invalid type for allocation");
     if (verifyRecordLenParams(getInType(), numLenParams()))
@@ -578,7 +578,7 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
     CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes),
     [{
       $_state.addOperands(selector);
-      llvm::SmallVector<mlir::Attribute, 8> ivalues;
+      llvm::SmallVector<mlir::Attribute> ivalues;
       for (auto iv : compareOperands)
         ivalues.push_back($_builder.getI64IntegerAttr(iv));
       ivalues.push_back($_builder.getUnitAttr());
@@ -587,7 +587,7 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
       for (auto d : destinations)
         $_state.addSuccessors(d);
       const auto opCount = destOperands.size();
-      llvm::SmallVector<int32_t, 8> argOffs;
+      llvm::SmallVector<int32_t> argOffs;
       int32_t sumArgs = 0;
       for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {
         if (i < opCount) {
@@ -613,13 +613,13 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
     if (parseSelector(parser, result, selector, type))
       return mlir::failure();
 
-    llvm::SmallVector<mlir::Attribute, 8> ivalues;
-    llvm::SmallVector<mlir::Block *, 8> dests;
-    llvm::SmallVector<llvm::SmallVector<mlir::Value, 8>, 8> destArgs;
+    llvm::SmallVector<mlir::Attribute> ivalues;
+    llvm::SmallVector<mlir::Block *> dests;
+    llvm::SmallVector<llvm::SmallVector<mlir::Value>> destArgs;
     while (true) {
       mlir::Attribute ivalue; // Integer or Unit
       mlir::Block *dest;
-      llvm::SmallVector<mlir::Value, 8> destArg;
+      llvm::SmallVector<mlir::Value> destArg;
       mlir::NamedAttrList temp;
       if (parser.parseAttribute(ivalue, "i", temp) ||
           parser.parseComma() ||
@@ -635,7 +635,7 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
     }
     auto &bld = parser.getBuilder();
     result.addAttribute(getCasesAttr(), bld.getArrayAttr(ivalues));
-    llvm::SmallVector<int32_t, 8> argOffs;
+    llvm::SmallVector<int32_t> argOffs;
     int32_t sumArgs = 0;
     const auto count = dests.size();
     for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {
@@ -869,7 +869,7 @@ def fir_SelectTypeOp : fir_SwitchTerminatorOp<"select_type"> {
       for (auto d : destinations)
         $_state.addSuccessors(d);
       const auto opCount = destOperands.size();
-      llvm::SmallVector<int32_t, 8> argOffs;
+      llvm::SmallVector<int32_t> argOffs;
       int32_t sumArgs = 0;
       for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {
         if (i < opCount) {
@@ -1889,8 +1889,8 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
       return mlir::failure();
     result.addAttribute(typeAttrName(), mlir::TypeAttr::get(recty));
     if (!parser.parseOptionalLParen()) {
-      llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> operands;
-      llvm::SmallVector<mlir::Type, 8> types;
+      llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
+      llvm::SmallVector<mlir::Type> types;
       auto loc = parser.getNameLoc();
       if (parser.parseOperandList(operands,
                                   mlir::OpAsmParser::Delimiter::None) ||
@@ -2622,7 +2622,7 @@ def fir_DispatchOp : fir_Op<"dispatch", []> {
 
   let parser = [{
     mlir::FunctionType calleeType;
-    llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> operands;
+    llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
     auto calleeLoc = parser.getNameLoc();
     llvm::StringRef calleeName;
     if (failed(parser.parseOptionalKeyword(&calleeName))) {

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -405,7 +405,7 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
 
   let extraClassDeclaration = [{
     using Extent = int64_t;
-    using Shape = llvm::SmallVector<Extent, 8>;
+    using Shape = llvm::SmallVector<Extent>;
     using ShapeRef = llvm::ArrayRef<int64_t>;
     unsigned getConstantRows() const;
 

--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -53,10 +53,10 @@ struct NameUniquer {
         : modules{modules.begin(), modules.end()}, host{host}, name{name},
           kinds{kinds.begin(), kinds.end()} {}
 
-    llvm::SmallVector<std::string, 2> modules;
+    llvm::SmallVector<std::string> modules;
     llvm::Optional<std::string> host;
     std::string name;
-    llvm::SmallVector<std::int64_t, 4> kinds;
+    llvm::SmallVector<std::int64_t> kinds;
   };
 
   /// Unique a common block name

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -119,9 +119,9 @@ static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
                                     mlir::Value upperBound) {
   auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableSetBounds)>(
       loc, builder);
-  llvm::SmallVector<mlir::Value, 4> args{boxAddress, dimIndex, lowerBound,
-                                         upperBound};
-  llvm::SmallVector<mlir::Value, 4> operands;
+  llvm::SmallVector<mlir::Value> args{boxAddress, dimIndex, lowerBound,
+                                      upperBound};
+  llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   builder.create<fir::CallOp>(loc, callee, operands);
@@ -142,7 +142,7 @@ static void genAllocatableInitCharacter(Fortran::lower::FirOpBuilder &builder,
         loc, "AllocatableInitCharacter runtime interface not as expected");
     return;
   }
-  llvm::SmallVector<mlir::Value, 5> args;
+  llvm::SmallVector<mlir::Value> args;
   args.push_back(builder.createConvert(loc, inputTypes[0], box.getAddr()));
   args.push_back(builder.createConvert(loc, inputTypes[1], len));
   auto kind = box.getEleTy().cast<fir::CharacterType>().getFKind();
@@ -162,10 +162,10 @@ static mlir::Value genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
                                           ErrorManager &errorManager) {
   auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableAllocate)>(
       loc, builder);
-  llvm::SmallVector<mlir::Value, 5> args{
+  llvm::SmallVector<mlir::Value> args{
       boxAddress, errorManager.hasStat, errorManager.errMsgAddr,
       errorManager.sourceFile, errorManager.sourceLine};
-  llvm::SmallVector<mlir::Value, 5> operands;
+  llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
@@ -178,10 +178,10 @@ genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
                          ErrorManager &errorManager) {
   auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableDeallocate)>(
       loc, builder);
-  llvm::SmallVector<mlir::Value, 5> args{
+  llvm::SmallVector<mlir::Value> args{
       boxAddress, errorManager.hasStat, errorManager.errMsgAddr,
       errorManager.sourceFile, errorManager.sourceLine};
-  llvm::SmallVector<mlir::Value, 5> operands;
+  llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   return builder.create<fir::CallOp>(loc, callee, operands).getResult(0);
@@ -343,9 +343,9 @@ public:
   void syncMutablePropertiesFromIRBox() {
     if (!box.isDescribedByVariables())
       return;
-    llvm::SmallVector<mlir::Value, 2> lbounds;
-    llvm::SmallVector<mlir::Value, 2> extents;
-    llvm::SmallVector<mlir::Value, 2> lengths;
+    llvm::SmallVector<mlir::Value> lbounds;
+    llvm::SmallVector<mlir::Value> extents;
+    llvm::SmallVector<mlir::Value> lengths;
     auto addr =
         MutablePropertyReader{builder, loc, box, /*forceIRBoxRead=*/true}.read(
             lbounds, extents, lengths);
@@ -356,9 +356,9 @@ public:
   void syncIRBoxFromMutableProperties() {
     if (!box.isDescribedByVariables())
       return;
-    llvm::SmallVector<mlir::Value, 2> lbounds;
-    llvm::SmallVector<mlir::Value, 2> extents;
-    llvm::SmallVector<mlir::Value, 2> lengths;
+    llvm::SmallVector<mlir::Value> lbounds;
+    llvm::SmallVector<mlir::Value> extents;
+    llvm::SmallVector<mlir::Value> lengths;
     auto addr = MutablePropertyReader{builder, loc, box}.read(lbounds, extents,
                                                               lengths);
     updateIRBox(addr, lbounds, extents, lengths);
@@ -375,7 +375,7 @@ private:
             fir::ShapeType::get(builder.getContext(), extents.size());
         shape = builder.create<fir::ShapeOp>(loc, shapeType, extents);
       } else {
-        llvm::SmallVector<mlir::Value, 2> shapeShiftBounds;
+        llvm::SmallVector<mlir::Value> shapeShiftBounds;
         for (auto [lb, extent] : llvm::zip(lbounds, extents)) {
           shapeShiftBounds.emplace_back(lb);
           shapeShiftBounds.emplace_back(extent);
@@ -389,7 +389,7 @@ private:
     mlir::Value emptySlice;
     // Ignore lengths if already constant in the box type (this would trigger an
     // error in the embox).
-    llvm::SmallVector<mlir::Value, 2> cleanedLengths;
+    llvm::SmallVector<mlir::Value> cleanedLengths;
     if (auto charTy = box.getEleTy().dyn_cast<fir::CharacterType>()) {
       if (charTy.getLen() == fir::CharacterType::unknownLen())
         cleanedLengths.append(lengths.begin(), lengths.end());
@@ -579,8 +579,8 @@ private:
   /// Only for intrinsic types. No coarrays, no polymorphism. No error recovery.
   void genInlinedAllocation(const Allocation &alloc,
                             const fir::MutableBoxValue &box) {
-    llvm::SmallVector<mlir::Value, 2> lbounds;
-    llvm::SmallVector<mlir::Value, 2> extents;
+    llvm::SmallVector<mlir::Value> lbounds;
+    llvm::SmallVector<mlir::Value> extents;
     Fortran::lower::StatementContext stmtCtx;
     auto idxTy = builder.getIndexType();
     auto lBoundsAreOnes = lowerBoundsAreOnes(alloc);
@@ -608,7 +608,7 @@ private:
       }
     }
 
-    llvm::SmallVector<mlir::Value, 2> lengths;
+    llvm::SmallVector<mlir::Value> lengths;
     if (auto charTy = box.getEleTy().dyn_cast<fir::CharacterType>()) {
       if (charTy.getLen() == fir::CharacterType::unknownLen()) {
         if (box.hasNonDeferredLenParams())
@@ -625,7 +625,7 @@ private:
 
     // FIXME: AllocMemOp is ignoring its length arguments. Squeezed in into the
     // extents for now.
-    llvm::SmallVector<mlir::Value, 2> sizes = extents;
+    llvm::SmallVector<mlir::Value> sizes = extents;
     sizes.append(lengths.begin(), lengths.end());
     mlir::Value heap = builder.create<fir::AllocMemOp>(
         loc, box.getBaseTy(), mangleAlloc(alloc), llvm::None, sizes);
@@ -741,7 +741,7 @@ private:
   const Fortran::lower::SomeExpr *errMsgExpr{nullptr};
   // If the allocate has a type spec, lenParams contains the
   // value of the length parameters that were specified inside.
-  llvm::SmallVector<mlir::Value, 2> lenParams;
+  llvm::SmallVector<mlir::Value> lenParams;
   ErrorManager errorManager;
 
   mlir::Location loc;
@@ -826,13 +826,13 @@ Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
   mlir::Value shape;
   if (auto seqTy = type.dyn_cast<fir::SequenceType>()) {
     auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
-    llvm::SmallVector<mlir::Value, 2> extents(seqTy.getDimension(), zero);
+    llvm::SmallVector<mlir::Value> extents(seqTy.getDimension(), zero);
     shape = builder.createShape(
         loc, fir::ArrayBoxValue{nullAddr, extents, /*lbounds=*/llvm::None});
   }
   // Provide dummy length parameters if they are dynamic. If a length parameter
   // is deferred. it is set to zero here and will be set on allocation.
-  llvm::SmallVector<mlir::Value, 2> lenParams;
+  llvm::SmallVector<mlir::Value> lenParams;
   if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
     if (charTy.getLen() == fir::CharacterType::unknownLen()) {
       if (!nonDeferredParams.empty()) {
@@ -981,9 +981,9 @@ Fortran::lower::genMutableBoxRead(Fortran::lower::FirOpBuilder &builder,
                                   const fir::MutableBoxValue &box) {
   if (box.hasAssumedRank())
     TODO(loc, "Assumed rank allocatables or pointers");
-  llvm::SmallVector<mlir::Value, 2> lbounds;
-  llvm::SmallVector<mlir::Value, 2> extents;
-  llvm::SmallVector<mlir::Value, 2> lengths;
+  llvm::SmallVector<mlir::Value> lbounds;
+  llvm::SmallVector<mlir::Value> extents;
+  llvm::SmallVector<mlir::Value> lengths;
   if (readToBoxValue(box)) {
     auto reader = MutablePropertyReader(builder, loc, box);
     reader.getLowerBounds(lbounds);
@@ -1080,7 +1080,7 @@ void Fortran::lower::associateMutableBoxWithRemap(
     mlir::ValueRange lbounds, mlir::ValueRange ubounds) {
 
   // Compute new extents
-  llvm::SmallVector<mlir::Value, 4> extents;
+  llvm::SmallVector<mlir::Value> extents;
   if (!lbounds.empty()) {
     auto idxTy = builder.getIndexType();
     auto one = builder.createIntegerConstant(loc, idxTy, 1);
@@ -1127,7 +1127,7 @@ void Fortran::lower::associateMutableBoxWithRemap(
         // Rebox right-hand side fir.box with a new shape and type.
         auto shapeType =
             fir::ShapeShiftType::get(builder.getContext(), extents.size());
-        SmallVector<mlir::Value, 8> shapeArgs;
+        SmallVector<mlir::Value> shapeArgs;
         auto idxTy = builder.getIndexType();
         for (auto [lbnd, ext] : llvm::zip(lbounds, extents)) {
           auto lb = builder.createConvert(loc, idxTy, lbnd);

--- a/flang/lib/Lower/BoxAnalyzer.h
+++ b/flang/lib/Lower/BoxAnalyzer.h
@@ -66,7 +66,7 @@ struct ScalarStaticDerived : ScalarSym {
       : ScalarSym{sym}, lens{std::move(lens)} {}
 
 private:
-  llvm::SmallVector<int64_t, 8> lens;
+  llvm::SmallVector<int64_t> lens;
 };
 
 /// Scalar of dependent type CHARACTER, dynamic LEN.
@@ -98,7 +98,7 @@ struct ScalarDynamicDerived : ScalarSym {
       : ScalarSym{sym}, lens{std::move(lens)} {}
 
 private:
-  llvm::SmallVector<Fortran::semantics::SomeExpr, 8> lens;
+  llvm::SmallVector<Fortran::semantics::SomeExpr> lens;
 };
 
 struct LBoundsAndShape {
@@ -112,8 +112,8 @@ struct LBoundsAndShape {
     return llvm::all_of(lbounds, [](int64_t v) { return v == 1; });
   }
 
-  llvm::SmallVector<int64_t, 8> lbounds;
-  llvm::SmallVector<int64_t, 8> shapes;
+  llvm::SmallVector<int64_t> lbounds;
+  llvm::SmallVector<int64_t> shapes;
 };
 
 /// Array of T with statically known origin (lbounds) and shape.
@@ -143,7 +143,7 @@ struct DynamicBound {
     });
   }
 
-  llvm::SmallVector<const Fortran::semantics::ShapeSpec *, 8> bounds;
+  llvm::SmallVector<const Fortran::semantics::ShapeSpec *> bounds;
 };
 
 /// Array of T with dynamic origin and/or shape.
@@ -381,9 +381,9 @@ public:
   void analyze(const Fortran::semantics::Symbol &sym) {
     if (symIsArray(sym)) {
       auto isConstant = true;
-      llvm::SmallVector<int64_t, 8> lbounds;
-      llvm::SmallVector<int64_t, 8> shapes;
-      llvm::SmallVector<const Fortran::semantics::ShapeSpec *, 8> bounds;
+      llvm::SmallVector<int64_t> lbounds;
+      llvm::SmallVector<int64_t> shapes;
+      llvm::SmallVector<const Fortran::semantics::ShapeSpec *> bounds;
       for (const auto &subs : getSymShape(sym)) {
         bounds.push_back(&subs);
         if (!isConstant)

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -77,7 +77,7 @@ struct IncrementLoopInfo {
   const Fortran::semantics::SomeExpr *stepExpr;
   const Fortran::semantics::SomeExpr *maskExpr = nullptr;
   bool isUnordered; // do concurrent, forall
-  llvm::SmallVector<const Fortran::semantics::Symbol *, 4> localInitSymList;
+  llvm::SmallVector<const Fortran::semantics::Symbol *> localInitSymList;
   mlir::Value loopVariable = nullptr;
   mlir::Value stepValue = nullptr; // possible uses in multiple blocks
 
@@ -93,7 +93,7 @@ struct IncrementLoopInfo {
   mlir::Block *exitBlock = nullptr;   // loop exit target block
 };
 
-using IncrementLoopNestInfo = llvm::SmallVector<IncrementLoopInfo, 4>;
+using IncrementLoopNestInfo = llvm::SmallVector<IncrementLoopInfo>;
 } // namespace
 
 /// Clone subexpression and wrap it as a generic `Fortran::evaluate::Expr`.
@@ -573,8 +573,8 @@ private:
       return; // "Normal" subroutine call.
     // Call with alternate return specifiers.
     // The call returns an index that selects an alternate return branch target.
-    llvm::SmallVector<int64_t, 5> indexList;
-    llvm::SmallVector<mlir::Block *, 5> blockList;
+    llvm::SmallVector<int64_t> indexList;
+    llvm::SmallVector<mlir::Block *> blockList;
     int64_t index = 0;
     for (const auto &arg :
          std::get<std::list<Fortran::parser::ActualArgSpec>>(stmt.v.t)) {
@@ -599,8 +599,8 @@ private:
                           std::get<Fortran::parser::ScalarIntExpr>(stmt.t)),
                       stmtCtx);
     stmtCtx.finalize();
-    llvm::SmallVector<int64_t, 8> indexList;
-    llvm::SmallVector<mlir::Block *, 8> blockList;
+    llvm::SmallVector<int64_t> indexList;
+    llvm::SmallVector<mlir::Block *> blockList;
     int64_t index = 0;
     for (auto &label : std::get<std::list<Fortran::parser::Label>>(stmt.t)) {
       indexList.push_back(++index);
@@ -625,9 +625,9 @@ private:
       // Arithmetic expression has Integer type.  Generate a SelectCaseOp
       // with ranges {(-inf:-1], 0=default, [1:inf)}.
       MLIRContext *context = builder->getContext();
-      llvm::SmallVector<mlir::Attribute, 3> attrList;
-      llvm::SmallVector<mlir::Value, 3> valueList;
-      llvm::SmallVector<mlir::Block *, 3> blockList;
+      llvm::SmallVector<mlir::Attribute> attrList;
+      llvm::SmallVector<mlir::Value> valueList;
+      llvm::SmallVector<mlir::Block *> blockList;
       attrList.push_back(fir::UpperBoundAttr::get(context));
       valueList.push_back(builder->createIntegerConstant(loc, exprType, -1));
       blockList.push_back(blockOfLabel(eval, std::get<1>(stmt.t)));
@@ -684,8 +684,8 @@ private:
       exit(1);
     }
     auto labelSet = iter->second;
-    llvm::SmallVector<int64_t, 10> indexList;
-    llvm::SmallVector<mlir::Block *, 10> blockList;
+    llvm::SmallVector<int64_t> indexList;
+    llvm::SmallVector<mlir::Block *> blockList;
     auto addLabel = [&](Fortran::parser::Label label) {
       indexList.push_back(label);
       blockList.push_back(blockOfLabel(eval, label));
@@ -1476,8 +1476,8 @@ private:
     auto loc = toLocation();
     auto indexType = builder->getIndexType();
     auto selector = builder->createConvert(loc, indexType, iostat);
-    llvm::SmallVector<int64_t, 5> indexList;
-    llvm::SmallVector<mlir::Block *, 4> blockList;
+    llvm::SmallVector<int64_t> indexList;
+    llvm::SmallVector<mlir::Block *> blockList;
     if (eorBlock) {
       indexList.push_back(Fortran::runtime::io::IostatEor);
       blockList.push_back(eorBlock);
@@ -1696,7 +1696,7 @@ private:
               if ((lhsType && lhsType->IsPolymorphic()) ||
                   (rhsType && rhsType->IsPolymorphic()))
                 TODO(loc, "pointer assignment involving polymorphic entity");
-              llvm::SmallVector<mlir::Value, 4> lbounds;
+              llvm::SmallVector<mlir::Value> lbounds;
               for (const auto &lbExpr : lbExprs)
                 lbounds.push_back(
                     fir::getBase(genExprValue(toEvExpr(lbExpr), stmtCtx)));
@@ -1724,8 +1724,8 @@ private:
               if ((lhsType && lhsType->IsPolymorphic()) ||
                   (rhsType && rhsType->IsPolymorphic()))
                 TODO(loc, "pointer assignment involving polymorphic entity");
-              llvm::SmallVector<mlir::Value, 4> lbounds;
-              llvm::SmallVector<mlir::Value, 4> ubounds;
+              llvm::SmallVector<mlir::Value> lbounds;
+              llvm::SmallVector<mlir::Value> ubounds;
               for (const auto &[lbExpr, ubExpr] : boundExprs) {
                 lbounds.push_back(
                     fir::getBase(genExprValue(toEvExpr(lbExpr), stmtCtx)));
@@ -1980,7 +1980,7 @@ private:
 
     // Note: not storing Variable references because getOrderedSymbolTable
     // below returns a temporary.
-    llvm::SmallVector<Fortran::lower::pft::Variable, 4> deferredFuncResultList;
+    llvm::SmallVector<Fortran::lower::pft::Variable> deferredFuncResultList;
 
     // Backup actual argument for entry character results
     // with different lengths. It needs to be added to the non

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -112,7 +112,7 @@ Fortran::lower::CharacterExprHelper::toExtendedValue(mlir::Value character,
   auto type = character.getType();
   auto base = fir::isa_passbyref_type(type) ? character : mlir::Value{};
   auto resultLen = len;
-  llvm::SmallVector<mlir::Value, 2> extents;
+  llvm::SmallVector<mlir::Value> extents;
 
   if (auto eleType = fir::dyn_cast_ptrEleTy(type))
     type = eleType;
@@ -330,7 +330,7 @@ Fortran::lower::CharacterExprHelper::createCharacterTemp(mlir::Type type,
     typeLen = *cstLen;
   auto *ctxt = builder.getContext();
   auto charTy = fir::CharacterType::get(ctxt, kind, typeLen);
-  llvm::SmallVector<mlir::Value, 1> lenParams;
+  llvm::SmallVector<mlir::Value> lenParams;
   if (typeLen == fir::CharacterType::unknownLen())
     lenParams.push_back(len);
   auto ref = builder.allocateLocal(loc, charTy, llvm::StringRef{}, llvm::None,
@@ -423,7 +423,7 @@ fir::CharBoxValue Fortran::lower::CharacterExprHelper::createSubstring(
     mlir::emitError(loc, "Incorrect number of bounds in substring");
     return {mlir::Value{}, mlir::Value{}};
   }
-  mlir::SmallVector<mlir::Value, 2> castBounds;
+  mlir::SmallVector<mlir::Value> castBounds;
   // Convert bounds to length type to do safe arithmetic on it.
   for (auto bound : bounds)
     castBounds.push_back(
@@ -485,7 +485,7 @@ mlir::Value Fortran::lower::CharacterExprHelper::createLenTrim(
   auto c = builder.create<fir::LoadOp>(loc, codeAddr);
   auto isBlank =
       builder.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::eq, blank, c);
-  llvm::SmallVector<mlir::Value, 2> results = {isBlank, index};
+  llvm::SmallVector<mlir::Value> results = {isBlank, index};
   builder.create<fir::ResultOp>(loc, results);
   builder.restoreInsertionPoint(insPt);
   // Compute length after iteration (zero if all blanks)

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -61,7 +61,7 @@ Fortran::lower::genRawCharCompare(Fortran::lower::FirOpBuilder &builder,
   auto llen = builder.createConvert(loc, fTy.getInput(2), lhsLen);
   auto rptr = builder.createConvert(loc, fTy.getInput(1), rhsBuff);
   auto rlen = builder.createConvert(loc, fTy.getInput(3), rhsLen);
-  llvm::SmallVector<mlir::Value, 4> args = {lptr, rptr, llen, rlen};
+  llvm::SmallVector<mlir::Value> args = {lptr, rptr, llen, rlen};
   auto tri = builder.create<fir::CallOp>(loc, beginFunc, args).getResult(0);
   auto zero = builder.createIntegerConstant(loc, tri.getType(), 0);
   return builder.create<mlir::CmpIOp>(loc, cmp, tri, zero);
@@ -96,7 +96,7 @@ void Fortran::lower::genTrim(Fortran::lower::FirOpBuilder &builder,
   auto sourceLine =
       Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(3));
 
-  llvm::SmallVector<mlir::Value, 4> args;
+  llvm::SmallVector<mlir::Value> args;
   args.emplace_back(builder.createConvert(loc, fTy.getInput(0), resultBox));
   args.emplace_back(builder.createConvert(loc, fTy.getInput(1), stringBox));
   args.emplace_back(builder.createConvert(loc, fTy.getInput(2), sourceFile));

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -148,7 +148,7 @@ struct TypeBuilder {
       baseType = genDerivedType(dynamicType->GetDerivedTypeSpec());
     } else {
       // LOGICAL, INTEGER, REAL, COMPLEX, CHARACTER
-      llvm::SmallVector<Fortran::lower::LenParameterTy, 2> params;
+      llvm::SmallVector<Fortran::lower::LenParameterTy> params;
       translateLenParameters(params, category, expr);
       baseType = genFIRType(context, category, dynamicType->kind(), params);
     }
@@ -220,7 +220,7 @@ struct TypeBuilder {
     if (auto *type{ultimate.GetType()}) {
       if (auto *tySpec{type->AsIntrinsic()}) {
         int kind = toInt64(Fortran::common::Clone(tySpec->kind())).value();
-        llvm::SmallVector<Fortran::lower::LenParameterTy, 2> params;
+        llvm::SmallVector<Fortran::lower::LenParameterTy> params;
         translateLenParameters(params, tySpec->category(), ultimate);
         ty = genFIRType(context, tySpec->category(), kind, params);
       } else if (auto *tySpec = type->AsDerived()) {
@@ -379,7 +379,7 @@ struct TypeBuilder {
   /// Stack derived type being processed to avoid infinite loops in case of
   /// recursive derived types. The depth of derived types is expected to be
   /// shallow (<10), so a SmallVector is sufficient.
-  llvm::SmallVector<std::pair<const Fortran::lower::SymbolRef, mlir::Type>, 4>
+  llvm::SmallVector<std::pair<const Fortran::lower::SymbolRef, mlir::Type>>
       derivedTypeInConstruction;
   Fortran::lower::AbstractConverter &converter;
   mlir::MLIRContext *context;

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -360,7 +360,7 @@ static mlir::Value createNewLocal(Fortran::lower::AbstractConverter &converter,
     if (auto arrTy = ty.dyn_cast<fir::SequenceType>()) {
       // elide the constant dimensions before construction
       assert(shape.size() == arrTy.getDimension());
-      llvm::SmallVector<mlir::Value, 8> args;
+      llvm::SmallVector<mlir::Value> args;
       auto typeShape = arrTy.getShape();
       for (unsigned i = 0, end = arrTy.getDimension(); i < end; ++i)
         if (typeShape[i] == fir::SequenceType::getUnknownExtent())
@@ -419,7 +419,7 @@ getAggregateType(Fortran::lower::AbstractConverter &converter,
                  const Fortran::lower::pft::Variable::AggregateStore &st) {
   auto &builder = converter.getFirOpBuilder();
   auto i8Ty = builder.getIntegerType(8);
-  llvm::SmallVector<mlir::Type, 8> members;
+  llvm::SmallVector<mlir::Type> members;
   std::size_t counter = std::get<0>(st.interval);
   for (const auto *mem : st.vars) {
     if (const auto *memDet =
@@ -616,7 +616,7 @@ static mlir::TupleType getTypeOfCommonWithInit(
     const Fortran::semantics::MutableSymbolVector &cmnBlkMems,
     std::size_t commonSize) {
   auto &builder = converter.getFirOpBuilder();
-  llvm::SmallVector<mlir::Type, 8> members;
+  llvm::SmallVector<mlir::Type> members;
   std::size_t counter = 0;
   for (const auto &mem : cmnBlkMems) {
     if (const auto *memDet =
@@ -945,7 +945,7 @@ void Fortran::lower::mapSymbolAttributes(
     if (!boxAlloc)
       boxAlloc = createNewLocal(converter, loc, var, preAlloc);
     // Lower non deferred parameters.
-    llvm::SmallVector<mlir::Value, 2> nonDeferredLenParams;
+    llvm::SmallVector<mlir::Value> nonDeferredLenParams;
     if (sba.isChar()) {
       if (auto len = lowerExplicitCharLen(converter, loc, sba, symMap, stmtCtx))
         nonDeferredLenParams.push_back(len);
@@ -966,9 +966,9 @@ void Fortran::lower::mapSymbolAttributes(
   if (isDummy) {
     auto dummyArg = symMap.lookupSymbol(sym).getAddr();
     if (lowerToBoxValue(sym, dummyArg)) {
-      llvm::SmallVector<mlir::Value, 4> lbounds;
-      llvm::SmallVector<mlir::Value, 4> extents;
-      llvm::SmallVector<mlir::Value, 2> explicitParams;
+      llvm::SmallVector<mlir::Value> lbounds;
+      llvm::SmallVector<mlir::Value> extents;
+      llvm::SmallVector<mlir::Value> explicitParams;
       // Lower lower bounds, explicit type parameters and explicit
       // extents if any.
       if (sba.isChar())
@@ -1156,7 +1156,7 @@ void Fortran::lower::mapSymbolAttributes(
           symMap.addCharSymbol(sym, preAlloc, len);
           return;
         }
-        llvm::SmallVector<mlir::Value, 1> lengths = {len};
+        llvm::SmallVector<mlir::Value> lengths = {len};
         auto local =
             createNewLocal(converter, loc, var, preAlloc, llvm::None, lengths);
         symMap.addCharSymbol(sym, local, len);
@@ -1172,7 +1172,7 @@ void Fortran::lower::mapSymbolAttributes(
           addr = builder.createConvert(loc, castTy, addr);
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shape;
+          llvm::SmallVector<mlir::Value> shape;
           for (auto i : x.shapes)
             shape.push_back(builder.createIntegerConstant(loc, idxTy, i));
           mlir::Value local =
@@ -1182,8 +1182,8 @@ void Fortran::lower::mapSymbolAttributes(
         }
         // If object is an array process the lower bound and extent values by
         // constructing constants and populating the lbounds and extents.
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
         for (auto [fst, snd] : llvm::zip(x.lbounds, x.shapes)) {
           lbounds.emplace_back(builder.createIntegerConstant(loc, idxTy, fst));
           extents.emplace_back(builder.createIntegerConstant(loc, idxTy, snd));
@@ -1214,7 +1214,7 @@ void Fortran::lower::mapSymbolAttributes(
         }
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shapes;
+          llvm::SmallVector<mlir::Value> shapes;
           populateShape(shapes, x.bounds, argBox);
           if (isDummy || isResult) {
             symMap.addSymbolWithShape(sym, addr, shapes, true);
@@ -1228,8 +1228,8 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // if object is an array process the lower bound and extent values
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
         populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
         if (isDummy || isResult) {
           symMap.addSymbolWithBounds(sym, addr, extents, lbounds, true);
@@ -1267,7 +1267,7 @@ void Fortran::lower::mapSymbolAttributes(
 
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shape;
+          llvm::SmallVector<mlir::Value> shape;
           for (auto i : x.shapes)
             shape.push_back(builder.createIntegerConstant(loc, idxTy, i));
           mlir::Value local =
@@ -1277,8 +1277,8 @@ void Fortran::lower::mapSymbolAttributes(
         }
 
         // if object is an array process the lower bound and extent values
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
         // construct constants and populate `bounds`
         for (auto [fst, snd] : llvm::zip(x.lbounds, x.shapes)) {
           lbounds.emplace_back(builder.createIntegerConstant(loc, idxTy, fst));
@@ -1293,7 +1293,7 @@ void Fortran::lower::mapSymbolAttributes(
         // local CHARACTER array with computed bounds
         assert(Fortran::lower::isExplicitShape(sym) ||
                Fortran::semantics::IsAllocatableOrPointer(sym));
-        llvm::SmallVector<mlir::Value, 1> lengths = {len};
+        llvm::SmallVector<mlir::Value> lengths = {len};
         auto local =
             createNewLocal(converter, loc, var, preAlloc, extents, lengths);
         symMap.addCharSymbolWithBounds(sym, local, len, extents, lbounds);
@@ -1326,7 +1326,7 @@ void Fortran::lower::mapSymbolAttributes(
           else
             len = builder.createIntegerConstant(loc, idxTy, sym.size());
         }
-        llvm::SmallVector<mlir::Value, 1> lengths = {len};
+        llvm::SmallVector<mlir::Value> lengths = {len};
 
         // cast to the known constant parts from the declaration
         auto castTy = builder.getRefType(converter.genType(var));
@@ -1335,7 +1335,7 @@ void Fortran::lower::mapSymbolAttributes(
 
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shape;
+          llvm::SmallVector<mlir::Value> shape;
           for (auto i : x.shapes)
             shape.push_back(builder.createIntegerConstant(loc, idxTy, i));
           if (isDummy || isResult) {
@@ -1350,8 +1350,8 @@ void Fortran::lower::mapSymbolAttributes(
         }
 
         // if object is an array process the lower bound and extent values
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
 
         // construct constants and populate `bounds`
         for (auto [fst, snd] : llvm::zip(x.lbounds, x.shapes)) {
@@ -1402,7 +1402,7 @@ void Fortran::lower::mapSymbolAttributes(
           addr = builder.createConvert(loc, castTy, addr);
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shape;
+          llvm::SmallVector<mlir::Value> shape;
           populateShape(shape, x.bounds, argBox);
           if (isDummy || isResult) {
             symMap.addCharSymbolWithShape(sym, addr, len, shape, true);
@@ -1414,8 +1414,8 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // if object is an array process the lower bound and extent values
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
         populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
         if (isDummy || isResult) {
           symMap.addCharSymbolWithBounds(sym, addr, len, extents, lbounds,
@@ -1467,7 +1467,7 @@ void Fortran::lower::mapSymbolAttributes(
           else
             len = builder.createIntegerConstant(loc, idxTy, sym.size());
         }
-        llvm::SmallVector<mlir::Value, 1> lengths = {len};
+        llvm::SmallVector<mlir::Value> lengths = {len};
 
         // cast to the known constant parts from the declaration
         auto castTy = builder.getRefType(converter.genType(var));
@@ -1475,7 +1475,7 @@ void Fortran::lower::mapSymbolAttributes(
           addr = builder.createConvert(loc, castTy, addr);
         if (x.lboundAllOnes()) {
           // if lower bounds are all ones, build simple shaped object
-          llvm::SmallVector<mlir::Value, 8> shape;
+          llvm::SmallVector<mlir::Value> shape;
           populateShape(shape, x.bounds, argBox);
           if (isDummy || isResult) {
             symMap.addCharSymbolWithShape(sym, addr, len, shape, true);
@@ -1488,8 +1488,8 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // Process the lower bound and extent values.
-        llvm::SmallVector<mlir::Value, 8> extents;
-        llvm::SmallVector<mlir::Value, 8> lbounds;
+        llvm::SmallVector<mlir::Value> extents;
+        llvm::SmallVector<mlir::Value> lbounds;
         populateLBoundsExtents(lbounds, extents, x.bounds, argBox);
         if (isDummy || isResult) {
           symMap.addCharSymbolWithBounds(sym, addr, len, extents, lbounds,

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -219,7 +219,7 @@ Fortran::lower::FirOpBuilder::createStringLitOp(mlir::Location loc,
   mlir::NamedAttribute dataAttr(valTag, strAttr);
   auto sizeTag = mlir::Identifier::get(fir::StringLitOp::size(), getContext());
   mlir::NamedAttribute sizeAttr(sizeTag, getI64IntegerAttr(data.size()));
-  llvm::SmallVector<mlir::NamedAttribute, 2> attrs{dataAttr, sizeAttr};
+  llvm::SmallVector<mlir::NamedAttribute> attrs{dataAttr, sizeAttr};
   return create<fir::StringLitOp>(loc, llvm::ArrayRef<mlir::Type>{type},
                                   llvm::None, attrs);
 }
@@ -233,7 +233,7 @@ Fortran::lower::FirOpBuilder::consShape(mlir::Location loc,
   }
   auto shapeType =
       fir::ShapeShiftType::get(getContext(), arr.getExtents().size());
-  SmallVector<mlir::Value, 8> shapeArgs;
+  SmallVector<mlir::Value> shapeArgs;
   auto idxTy = getIndexType();
   for (auto [lbnd, ext] : llvm::zip(arr.getLBounds(), arr.getExtents())) {
     auto lb = createConvert(loc, idxTy, lbnd);
@@ -267,7 +267,7 @@ mlir::Value Fortran::lower::FirOpBuilder::createSlice(
     // If there is no slicing by triple notation, then take the whole array.
     auto fullShape = [&](const llvm::ArrayRef<mlir::Value> lbounds,
                          llvm::ArrayRef<mlir::Value> extents) -> mlir::Value {
-      llvm::SmallVector<mlir::Value, 8> trips;
+      llvm::SmallVector<mlir::Value> trips;
       auto idxTy = getIndexType();
       auto one = createIntegerConstant(loc, idxTy, 1);
       auto sliceTy = fir::SliceType::get(getContext(), extents.size());
@@ -295,7 +295,7 @@ mlir::Value Fortran::lower::FirOpBuilder::createSlice(
           return fullShape(box.getLBounds(), box.getExtents());
         },
         [&](const fir::BoxValue &box) {
-          llvm::SmallVector<mlir::Value, 4> extents;
+          llvm::SmallVector<mlir::Value> extents;
           Fortran::lower::readExtents(*this, loc, box, extents);
           return fullShape(box.getLBounds(), extents);
         },
@@ -328,7 +328,7 @@ Fortran::lower::FirOpBuilder::createBox(mlir::Location loc,
           return create<fir::EmboxOp>(loc, boxTy, itemAddr, s);
 
         mlir::Value emptySlice;
-        llvm::SmallVector<mlir::Value, 1> lenParams{box.getLen()};
+        llvm::SmallVector<mlir::Value> lenParams{box.getLen()};
         return create<fir::EmboxOp>(loc, boxTy, itemAddr, s, emptySlice,
                                     lenParams);
       },
@@ -336,7 +336,7 @@ Fortran::lower::FirOpBuilder::createBox(mlir::Location loc,
         if (Fortran::lower::CharacterExprHelper::hasConstantLengthInType(exv))
           return create<fir::EmboxOp>(loc, boxTy, itemAddr);
         mlir::Value emptyShape, emptySlice;
-        llvm::SmallVector<mlir::Value, 1> lenParams{box.getLen()};
+        llvm::SmallVector<mlir::Value> lenParams{box.getLen()};
         return create<fir::EmboxOp>(loc, boxTy, itemAddr, emptyShape,
                                     emptySlice, lenParams);
       },

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -258,7 +258,7 @@ genOutputItemList(Fortran::lower::AbstractConverter &converter,
     auto argType = outputFunc.getType().getInput(1);
     assert((isFormatted || argType.isa<fir::BoxType>()) &&
            "expect descriptor for unformatted IO runtime");
-    llvm::SmallVector<mlir::Value, 3> outputFuncArgs = {cookie};
+    llvm::SmallVector<mlir::Value> outputFuncArgs = {cookie};
     Fortran::lower::CharacterExprHelper helper{builder, loc};
     if (argType.isa<fir::BoxType>()) {
       auto exv = converter.genExprAddr(expr, stmtCtx, loc);
@@ -354,7 +354,7 @@ static void genInputItemList(Fortran::lower::AbstractConverter &converter,
     if (argType.isa<fir::BoxType>())
       itemAddr = builder.createBox(loc, itemBox);
     itemAddr = builder.createConvert(loc, argType, itemAddr);
-    llvm::SmallVector<mlir::Value, 8> inputFuncArgs = {cookie, itemAddr};
+    llvm::SmallVector<mlir::Value> inputFuncArgs = {cookie, itemAddr};
     if (argType.isa<fir::BoxType>()) {
       // do nothing
     } else if (charHelper.isCharacterScalar(itemTy)) {
@@ -452,7 +452,7 @@ static void genIoLoop(Fortran::lower::AbstractConverter &converter,
       builder.create<mlir::AddIOp>(loc, inductionResult0, iterWhileOp.step());
   auto inductionResult = builder.create<mlir::SelectOp>(
       loc, iterateResult, inductionResult1, inductionResult0);
-  llvm::SmallVector<mlir::Value, 2> results = {inductionResult, iterateResult};
+  llvm::SmallVector<mlir::Value> results = {inductionResult, iterateResult};
   builder.create<fir::ResultOp>(loc, results);
   ok = iterWhileOp.getResult(1);
   builder.setInsertionPointAfter(iterWhileOp);
@@ -581,7 +581,7 @@ mlir::Value genIntIOOption(Fortran::lower::AbstractConverter &converter,
   auto expr = fir::getBase(converter.genExprValue(
       Fortran::semantics::GetExpr(spec.v), stmtCtx, loc));
   auto val = builder.createConvert(loc, ioFuncTy.getInput(1), expr);
-  llvm::SmallVector<mlir::Value, 4> ioArgs = {cookie, val};
+  llvm::SmallVector<mlir::Value> ioArgs = {cookie, val};
   return builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 }
 
@@ -596,8 +596,8 @@ mlir::Value genCharIOOption(Fortran::lower::AbstractConverter &converter,
   mlir::FunctionType ioFuncTy = ioFunc.getType();
   auto tup = lowerStringLit(converter, loc, spec, ioFuncTy.getInput(1),
                             ioFuncTy.getInput(2));
-  llvm::SmallVector<mlir::Value, 4> ioArgs = {cookie, std::get<0>(tup),
-                                              std::get<1>(tup)};
+  llvm::SmallVector<mlir::Value> ioArgs = {cookie, std::get<0>(tup),
+                                           std::get<1>(tup)};
   return builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 }
 
@@ -621,8 +621,8 @@ mlir::Value genIOOption<Fortran::parser::FileNameExpr>(
   mlir::FunctionType ioFuncTy = ioFunc.getType();
   auto tup = lowerStringLit(converter, loc, spec, ioFuncTy.getInput(1),
                             ioFuncTy.getInput(2));
-  llvm::SmallVector<mlir::Value, 4> ioArgs{cookie, std::get<0>(tup),
-                                           std::get<1>(tup)};
+  llvm::SmallVector<mlir::Value> ioArgs{cookie, std::get<0>(tup),
+                                        std::get<1>(tup)};
   return builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 }
 
@@ -682,8 +682,8 @@ mlir::Value genIOOption<Fortran::parser::ConnectSpec::CharExpr>(
   auto tup = lowerStringLit(
       converter, loc, std::get<Fortran::parser::ScalarDefaultCharExpr>(spec.t),
       ioFuncTy.getInput(1), ioFuncTy.getInput(2));
-  llvm::SmallVector<mlir::Value, 4> ioArgs = {cookie, std::get<0>(tup),
-                                              std::get<1>(tup)};
+  llvm::SmallVector<mlir::Value> ioArgs = {cookie, std::get<0>(tup),
+                                           std::get<1>(tup)};
   return builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 }
 
@@ -747,8 +747,8 @@ mlir::Value genIOOption<Fortran::parser::IoControlSpec::CharExpr>(
   auto tup = lowerStringLit(
       converter, loc, std::get<Fortran::parser::ScalarDefaultCharExpr>(spec.t),
       ioFuncTy.getInput(1), ioFuncTy.getInput(2));
-  llvm::SmallVector<mlir::Value, 4> ioArgs = {cookie, std::get<0>(tup),
-                                              std::get<1>(tup)};
+  llvm::SmallVector<mlir::Value> ioArgs = {cookie, std::get<0>(tup),
+                                           std::get<1>(tup)};
   return builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 }
 
@@ -875,13 +875,12 @@ genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
     return builder.create<mlir::ConstantOp>(
         loc, builder.getIntegerAttr(boolType, specifierIsPresent));
   };
-  llvm::SmallVector<mlir::Value, 8> ioArgs = {
-      cookie,
-      boolValue(csi.ioStatExpr != nullptr),
-      boolValue(csi.hasErr),
-      boolValue(csi.hasEnd),
-      boolValue(csi.hasEor),
-      boolValue(csi.ioMsgExpr != nullptr)};
+  llvm::SmallVector<mlir::Value> ioArgs = {cookie,
+                                           boolValue(csi.ioStatExpr != nullptr),
+                                           boolValue(csi.hasErr),
+                                           boolValue(csi.hasEnd),
+                                           boolValue(csi.hasEor),
+                                           boolValue(csi.ioMsgExpr != nullptr)};
   builder.create<fir::CallOp>(loc, enableHandlers, ioArgs);
 }
 
@@ -1043,8 +1042,8 @@ lowerReferenceAsStringSelect(
   auto *block = startBlock->splitBlock(builder.getInsertionPoint());
   builder.setInsertionPointToEnd(block);
 
-  llvm::SmallVector<int64_t, 4> indexList;
-  llvm::SmallVector<mlir::Block *, 4> blockList;
+  llvm::SmallVector<int64_t> indexList;
+  llvm::SmallVector<mlir::Block *> blockList;
 
   auto symbol = GetLastSymbol(&expr);
   Fortran::lower::pft::LabelSet labels;
@@ -1078,7 +1077,7 @@ lowerReferenceAsStringSelect(
 
     // Pass the format string reference and the string length out of the select
     // statement.
-    llvm::SmallVector<mlir::Value, 8> args = {stringRef, stringLen};
+    llvm::SmallVector<mlir::Value> args = {stringRef, stringLen};
     builder.create<mlir::BranchOp>(loc, endBlock, args);
 
     // Add block to the list of cases and make a new one.
@@ -1267,7 +1266,7 @@ Fortran::lower::genOpenStatement(Fortran::lower::AbstractConverter &converter,
   auto &builder = converter.getFirOpBuilder();
   Fortran::lower::StatementContext stmtCtx;
   mlir::FuncOp beginFunc;
-  llvm::SmallVector<mlir::Value, 4> beginArgs;
+  llvm::SmallVector<mlir::Value> beginArgs;
   auto loc = converter.getCurrentLocation();
   if (hasMem<Fortran::parser::FileUnitNumber>(stmt)) {
     beginFunc = getIORuntimeFunc<mkIOKey(BeginOpenUnit)>(loc, builder);
@@ -1317,7 +1316,7 @@ Fortran::lower::genWaitStatement(Fortran::lower::AbstractConverter &converter,
   auto unit = fir::getBase(converter.genExprValue(
       getExpr<Fortran::parser::FileUnitNumber>(stmt), stmtCtx, loc));
   auto un = builder.createConvert(loc, beginFuncTy.getInput(0), unit);
-  llvm::SmallVector<mlir::Value, 4> args{un};
+  llvm::SmallVector<mlir::Value> args{un};
   if (hasId) {
     auto id = fir::getBase(converter.genExprValue(
         getExpr<Fortran::parser::IdExpr>(stmt), stmtCtx, loc));
@@ -1533,7 +1532,7 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter,
   mlir::FunctionType ioFuncTy = ioFunc.getType();
 
   // Append BeginXyz call arguments.  File name and line number are always last.
-  llvm::SmallVector<mlir::Value, 8> ioArgs;
+  llvm::SmallVector<mlir::Value> ioArgs;
   genBeginCallArguments<hasIOCtrl>(ioArgs, converter, loc, stmt, ioFuncTy,
                                    isFormatted, isList, isIntern, isOtherIntern,
                                    isAsynch, isNml, descRef, stmtCtx);
@@ -1640,7 +1639,7 @@ mlir::Value genInquireSpec<Fortran::parser::InquireSpec::CharVar>(
   const auto *varExpr = Fortran::semantics::GetExpr(
       std::get<Fortran::parser::ScalarDefaultCharVariable>(var.t));
   auto str = converter.genExprAddr(varExpr, stmtCtx, loc);
-  llvm::SmallVector<mlir::Value, 8> args = {
+  llvm::SmallVector<mlir::Value> args = {
       builder.createConvert(loc, specFuncTy.getInput(0), cookie),
       builder.createIntegerConstant(
           loc, specFuncTy.getInput(1),
@@ -1677,7 +1676,7 @@ mlir::Value genInquireSpec<Fortran::parser::InquireSpec::IntVar>(
   auto bitWidth = eleTy.cast<mlir::IntegerType>().getWidth();
   auto idxTy = builder.getIndexType();
   auto kind = builder.createIntegerConstant(loc, idxTy, bitWidth / 8);
-  llvm::SmallVector<mlir::Value, 8> args = {
+  llvm::SmallVector<mlir::Value> args = {
       builder.createConvert(loc, specFuncTy.getInput(0), cookie),
       builder.createIntegerConstant(
           loc, specFuncTy.getInput(1),
@@ -1710,7 +1709,7 @@ mlir::Value genInquireSpec<Fortran::parser::InquireSpec::LogVar>(
           std::get<Fortran::parser::Scalar<
               Fortran::parser::Logical<Fortran::parser::Variable>>>(var.t)),
       stmtCtx, loc));
-  llvm::SmallVector<mlir::Value, 8> args = {
+  llvm::SmallVector<mlir::Value> args = {
       builder.createConvert(loc, specFuncTy.getInput(0), cookie)};
   if (pendId)
     args.push_back(builder.createConvert(loc, specFuncTy.getInput(1), idExpr));
@@ -1769,7 +1768,7 @@ mlir::Value Fortran::lower::genInquireStatement(
   auto loc = converter.getCurrentLocation();
   mlir::FuncOp beginFunc;
   ConditionSpecInfo csi;
-  llvm::SmallVector<mlir::Value, 8> beginArgs;
+  llvm::SmallVector<mlir::Value> beginArgs;
   const auto *list =
       std::get_if<std::list<Fortran::parser::InquireSpec>>(&stmt.u);
   auto exprPair = getInquireFileExpr(list);

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -21,7 +21,7 @@
 
 // recursively build the vector of module scopes
 static void moduleNames(const Fortran::semantics::Scope &scope,
-                        llvm::SmallVector<llvm::StringRef, 2> &result) {
+                        llvm::SmallVector<llvm::StringRef> &result) {
   if (scope.kind() == Fortran::semantics::Scope::Kind::Global) {
     return;
   }
@@ -31,10 +31,10 @@ static void moduleNames(const Fortran::semantics::Scope &scope,
       result.emplace_back(toStringRef(symbol->name()));
 }
 
-static llvm::SmallVector<llvm::StringRef, 2>
+static llvm::SmallVector<llvm::StringRef>
 moduleNames(const Fortran::semantics::Symbol &symbol) {
   const auto &scope = symbol.owner();
-  llvm::SmallVector<llvm::StringRef, 2> result;
+  llvm::SmallVector<llvm::StringRef> result;
   moduleNames(scope, result);
   return result;
 }
@@ -133,7 +133,7 @@ std::string Fortran::lower::mangle::mangleName(
   auto symbolName = toStringRef(ultimateSymbol.name());
   auto modNames = moduleNames(ultimateSymbol);
   auto optHost = hostName(ultimateSymbol);
-  llvm::SmallVector<std::int64_t, 4> kinds;
+  llvm::SmallVector<std::int64_t> kinds;
   for (const auto &param :
        Fortran::semantics::OrderParameterDeclarations(ultimateSymbol)) {
     const auto &paramDetails =

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -452,7 +452,7 @@ private:
       lower::pft::EvaluationList::iterator ifConstructIt;
       parser::Label ifTargetLabel;
     };
-    llvm::SmallVector<T, 8> ifExpansionStack;
+    llvm::SmallVector<T> ifExpansionStack;
     auto &evaluationList = *evaluationListStack.back();
     for (auto it = evaluationList.begin(), end = evaluationList.end();
          it != end; ++it) {
@@ -1220,7 +1220,7 @@ struct SymbolDependenceDepth {
       return;
     scopeAnlyzedForAliases.insert(&scope);
     Fortran::lower::IntervalSet intervals;
-    llvm::DenseMap<std::size_t, llvm::SmallVector<const semantics::Symbol *, 8>>
+    llvm::DenseMap<std::size_t, llvm::SmallVector<const semantics::Symbol *>>
         aliasSets;
     llvm::DenseMap<std::size_t, const semantics::Symbol *> setIsGlobal;
 

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -49,7 +49,7 @@ void Fortran::lower::genStopStatement(
   auto &builder = converter.getFirOpBuilder();
   auto loc = converter.getCurrentLocation();
   Fortran::lower::StatementContext stmtCtx;
-  llvm::SmallVector<mlir::Value, 8> operands;
+  llvm::SmallVector<mlir::Value> operands;
   mlir::FuncOp callee;
   mlir::FunctionType calleeType;
   // First operand is stop code (zero if absent)
@@ -213,9 +213,9 @@ void Fortran::lower::genDateAndTime(Fortran::lower::FirOpBuilder &builder,
   mlir::Value zoneLen;
   splitArg(zone, zoneBuffer, zoneLen);
 
-  llvm::SmallVector<mlir::Value, 8> args{dateBuffer, timeBuffer, zoneBuffer,
-                                         dateLen,    timeLen,    zoneLen};
-  llvm::SmallVector<mlir::Value, 8> operands;
+  llvm::SmallVector<mlir::Value> args{dateBuffer, timeBuffer, zoneBuffer,
+                                      dateLen,    timeLen,    zoneLen};
+  llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
     operands.emplace_back(builder.createConvert(loc, snd, fst));
   builder.create<fir::CallOp>(loc, callee, operands);

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -293,7 +293,7 @@ private:
     symbolMapStack.back().try_emplace(&*sym, box);
   }
 
-  llvm::SmallVector<llvm::DenseMap<const semantics::Symbol *, SymbolBox>, 4>
+  llvm::SmallVector<llvm::DenseMap<const semantics::Symbol *, SymbolBox>>
       symbolMapStack;
 };
 

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -181,9 +181,9 @@ public:
     auto fnTy = callOp.getFunctionType();
     auto loc = callOp.getLoc();
     rewriter->setInsertionPoint(callOp);
-    llvm::SmallVector<mlir::Type, 8> newResTys;
-    llvm::SmallVector<mlir::Type, 8> newInTys;
-    llvm::SmallVector<mlir::Value, 8> newOpers;
+    llvm::SmallVector<mlir::Type> newResTys;
+    llvm::SmallVector<mlir::Type> newInTys;
+    llvm::SmallVector<mlir::Value> newOpers;
 
     // If the call is indirect, the first argument must still be the function
     // to call.
@@ -217,8 +217,8 @@ public:
                        fnTy.getResults().end());
     }
 
-    llvm::SmallVector<mlir::Type, 8> trailingInTys;
-    llvm::SmallVector<mlir::Value, 8> trailingOpers;
+    llvm::SmallVector<mlir::Type> trailingInTys;
+    llvm::SmallVector<mlir::Value> trailingOpers;
     for (auto e : llvm::enumerate(
              llvm::zip(fnTy.getInputs().drop_front(dropFront),
                        callOp.getOperands().drop_front(dropFront)))) {
@@ -323,8 +323,8 @@ public:
   void convertAddrOp(AddrOfOp addrOp) {
     rewriter->setInsertionPoint(addrOp);
     auto addrTy = addrOp.getType().cast<mlir::FunctionType>();
-    llvm::SmallVector<mlir::Type, 8> newResTys;
-    llvm::SmallVector<mlir::Type, 8> newInTys;
+    llvm::SmallVector<mlir::Type> newResTys;
+    llvm::SmallVector<mlir::Type> newInTys;
     for (mlir::Type ty : addrTy.getResults()) {
       llvm::TypeSwitch<mlir::Type>(ty)
           .Case<fir::ComplexType>([&](fir::ComplexType ty) {
@@ -335,7 +335,7 @@ public:
           })
           .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
     }
-    llvm::SmallVector<mlir::Type, 8> trailingInTys;
+    llvm::SmallVector<mlir::Type> trailingInTys;
     for (mlir::Type ty : addrTy.getInputs()) {
       llvm::TypeSwitch<mlir::Type>(ty)
           .Case<BoxCharType>([&](BoxCharType box) {
@@ -406,9 +406,9 @@ public:
     auto funcTy = func.getType().cast<mlir::FunctionType>();
     if (hasPortableSignature(funcTy))
       return;
-    llvm::SmallVector<mlir::Type, 8> newResTys;
-    llvm::SmallVector<mlir::Type, 8> newInTys;
-    llvm::SmallVector<FixupTy, 8> fixups;
+    llvm::SmallVector<mlir::Type> newResTys;
+    llvm::SmallVector<mlir::Type> newInTys;
+    llvm::SmallVector<FixupTy> fixups;
 
     // Convert return value(s)
     for (auto ty : funcTy.getResults())
@@ -428,7 +428,7 @@ public:
           .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
 
     // Convert arguments
-    llvm::SmallVector<mlir::Type, 8> trailingTys;
+    llvm::SmallVector<mlir::Type> trailingTys;
     for (auto e : llvm::enumerate(funcTy.getInputs())) {
       auto ty = e.value();
       unsigned index = e.index();

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -76,9 +76,9 @@ public:
     });
     addConversion([&](mlir::TupleType tuple) {
       LLVM_DEBUG(llvm::dbgs() << "type convert: " << tuple << '\n');
-      llvm::SmallVector<mlir::Type, 8> inMembers;
+      llvm::SmallVector<mlir::Type> inMembers;
       tuple.getFlattenedTypes(inMembers);
-      llvm::SmallVector<mlir::Type, 8> members;
+      llvm::SmallVector<mlir::Type> members;
       for (auto mem : inMembers) {
         // Prevent fir.box from degenerating to a pointer to a descriptor in the
         // context of a tuple type.
@@ -137,7 +137,7 @@ public:
   // addendum defined in descriptor.h.
   mlir::Type convertBoxType(BoxType box, int rank = unknownRank()) {
     // (buffer*, ele-size, rank, type-descriptor, attribute, [dims])
-    SmallVector<mlir::Type, 6> parts;
+    SmallVector<mlir::Type> parts;
     mlir::Type ele = box.getEleTy();
     // remove fir.heap/fir.ref/fir.ptr
     if (auto removeIndirection = fir::dyn_cast_ptrEleTy(ele))
@@ -281,7 +281,7 @@ public:
       return iter->second;
     auto st = mlir::LLVM::LLVMStructType::getIdentified(&getContext(), name);
     identStructCache[name] = st;
-    llvm::SmallVector<mlir::Type, 8> members;
+    llvm::SmallVector<mlir::Type> members;
     for (auto mem : derived.getTypeList()) {
       // Prevent fir.box from degenerating to a pointer to a descriptor in the
       // context of a record type.

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -232,7 +232,7 @@ fir::BoxCharLenOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
 /// Get the result types packed in a tuple tuple
 mlir::Type fir::BoxDimsOp::getTupleType() {
   // note: triple, but 4 is nearest power of 2
-  llvm::SmallVector<mlir::Type, 4> triple{
+  llvm::SmallVector<mlir::Type> triple{
       getResult(0).getType(), getResult(1).getType(), getResult(2).getType()};
   return mlir::TupleType::get(getContext(), triple);
 }
@@ -257,14 +257,14 @@ static void printCallOp(mlir::OpAsmPrinter &p, fir::CallOp &op) {
   p << '(' << op->getOperands().drop_front(isDirect ? 0 : 1) << ')';
   p.printOptionalAttrDict(op->getAttrs(), {fir::CallOp::calleeAttrName()});
   auto resultTypes{op.getResultTypes()};
-  llvm::SmallVector<Type, 8> argTypes(
+  llvm::SmallVector<Type> argTypes(
       llvm::drop_begin(op.getOperandTypes(), isDirect ? 0 : 1));
   p << " : " << FunctionType::get(op.getContext(), argTypes, resultTypes);
 }
 
 static mlir::ParseResult parseCallOp(mlir::OpAsmParser &parser,
                                      mlir::OperationState &result) {
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> operands;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
   if (parser.parseOperandList(operands))
     return mlir::failure();
 
@@ -343,7 +343,7 @@ static void printCmpfOp(OpAsmPrinter &p, CmpfOp op) { printCmpOp(p, op); }
 template <typename OPTY>
 static mlir::ParseResult parseCmpOp(mlir::OpAsmParser &parser,
                                     mlir::OperationState &result) {
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 2> ops;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> ops;
   mlir::NamedAttrList attrs;
   mlir::Attribute predicateNameAttr;
   mlir::Type type;
@@ -458,10 +458,10 @@ static mlir::ParseResult parseCoordinateCustom(mlir::OpAsmParser &parser,
   mlir::OpAsmParser::OperandType memref;
   if (parser.parseOperand(memref) || parser.parseComma())
     return mlir::failure();
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> coorOperands;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> coorOperands;
   if (parser.parseOperandList(coorOperands))
     return mlir::failure();
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 16> allOperands;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> allOperands;
   allOperands.push_back(memref);
   allOperands.append(coorOperands.begin(), coorOperands.end());
   mlir::FunctionType funcTy;
@@ -802,7 +802,7 @@ static mlir::ParseResult parseIterWhileOp(mlir::OpAsmParser &parser,
     return mlir::failure();
 
   // Parse the initial iteration arguments.
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> regionArgs;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> regionArgs;
   auto prependCount = false;
 
   // Induction variable.
@@ -810,8 +810,8 @@ static mlir::ParseResult parseIterWhileOp(mlir::OpAsmParser &parser,
   regionArgs.push_back(iterateVar);
 
   if (succeeded(parser.parseOptionalKeyword("iter_args"))) {
-    llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> operands;
-    llvm::SmallVector<mlir::Type, 4> regionTypes;
+    llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
+    llvm::SmallVector<mlir::Type> regionTypes;
     // Parse assignment list and results type list.
     if (parser.parseAssignmentList(regionArgs, operands) ||
         parser.parseArrowTypeList(regionTypes))
@@ -832,7 +832,7 @@ static mlir::ParseResult parseIterWhileOp(mlir::OpAsmParser &parser,
       result.addTypes(resTypes);
     }
   } else if (succeeded(parser.parseOptionalArrow())) {
-    llvm::SmallVector<mlir::Type, 4> typeList;
+    llvm::SmallVector<mlir::Type> typeList;
     if (parser.parseLParen() || parser.parseTypeList(typeList) ||
         parser.parseRParen())
       return failure();
@@ -849,7 +849,7 @@ static mlir::ParseResult parseIterWhileOp(mlir::OpAsmParser &parser,
   if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
     return mlir::failure();
 
-  llvm::SmallVector<mlir::Type, 4> argTypes;
+  llvm::SmallVector<mlir::Type> argTypes;
   // Induction variable (hidden)
   if (prependCount)
     result.addAttribute(IterWhileOp::finalValueAttrName(),
@@ -1054,8 +1054,8 @@ static mlir::ParseResult parseDoLoopOp(mlir::OpAsmParser &parser,
                         builder.getUnitAttr());
 
   // Parse the optional initial iteration arguments.
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 4> regionArgs, operands;
-  llvm::SmallVector<mlir::Type, 4> argTypes;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> regionArgs, operands;
+  llvm::SmallVector<mlir::Type> argTypes;
   auto prependCount = false;
   regionArgs.push_back(inductionVariable);
 
@@ -1339,7 +1339,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&... additionalArgs) {
+                        AdditionalArgs &&...additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();
@@ -1437,16 +1437,16 @@ static mlir::ParseResult parseSelectCase(mlir::OpAsmParser &parser,
   if (parseSelector(parser, result, selector, type))
     return mlir::failure();
 
-  llvm::SmallVector<mlir::Attribute, 8> attrs;
-  llvm::SmallVector<mlir::OpAsmParser::OperandType, 8> opers;
-  llvm::SmallVector<mlir::Block *, 8> dests;
-  llvm::SmallVector<llvm::SmallVector<mlir::Value, 8>, 8> destArgs;
-  llvm::SmallVector<int32_t, 8> argOffs;
+  llvm::SmallVector<mlir::Attribute> attrs;
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> opers;
+  llvm::SmallVector<mlir::Block *> dests;
+  llvm::SmallVector<llvm::SmallVector<mlir::Value>> destArgs;
+  llvm::SmallVector<int32_t> argOffs;
   int32_t offSize = 0;
   while (true) {
     mlir::Attribute attr;
     mlir::Block *dest;
-    llvm::SmallVector<mlir::Value, 8> destArg;
+    llvm::SmallVector<mlir::Value> destArg;
     mlir::NamedAttrList temp;
     if (parser.parseAttribute(attr, "a", temp) || isValidCaseAttr(attr) ||
         parser.parseComma())
@@ -1485,7 +1485,7 @@ static mlir::ParseResult parseSelectCase(mlir::OpAsmParser &parser,
                       parser.getBuilder().getArrayAttr(attrs));
   if (parser.resolveOperands(opers, type, result.operands))
     return mlir::failure();
-  llvm::SmallVector<int32_t, 8> targOffs;
+  llvm::SmallVector<int32_t> targOffs;
   int32_t toffSize = 0;
   const auto count = dests.size();
   for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {
@@ -1523,7 +1523,7 @@ void fir::SelectCaseOp::build(mlir::OpBuilder &builder,
                               llvm::ArrayRef<mlir::NamedAttribute> attributes) {
   result.addOperands(selector);
   result.addAttribute(getCasesAttr(), builder.getArrayAttr(compareAttrs));
-  llvm::SmallVector<int32_t, 8> operOffs;
+  llvm::SmallVector<int32_t> operOffs;
   int32_t operSize = 0;
   for (auto attr : compareAttrs) {
     if (attr.isa<fir::ClosedIntervalAttr>()) {
@@ -1544,7 +1544,7 @@ void fir::SelectCaseOp::build(mlir::OpBuilder &builder,
   for (auto d : destinations)
     result.addSuccessors(d);
   const auto opCount = destOperands.size();
-  llvm::SmallVector<int32_t, 8> argOffs;
+  llvm::SmallVector<int32_t> argOffs;
   int32_t sumArgs = 0;
   for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {
     if (i < opCount) {
@@ -1574,7 +1574,7 @@ void fir::SelectCaseOp::build(mlir::OpBuilder &builder,
                               llvm::ArrayRef<mlir::Block *> destinations,
                               llvm::ArrayRef<mlir::ValueRange> destOperands,
                               llvm::ArrayRef<mlir::NamedAttribute> attributes) {
-  llvm::SmallVector<mlir::ValueRange, 16> cmpOpers;
+  llvm::SmallVector<mlir::ValueRange> cmpOpers;
   auto iter = cmpOpList.begin();
   for (auto &attr : compareAttrs) {
     if (attr.isa<fir::ClosedIntervalAttr>()) {
@@ -1663,13 +1663,13 @@ static ParseResult parseSelectType(OpAsmParser &parser,
   if (parseSelector(parser, result, selector, type))
     return mlir::failure();
 
-  llvm::SmallVector<mlir::Attribute, 8> attrs;
-  llvm::SmallVector<mlir::Block *, 8> dests;
-  llvm::SmallVector<llvm::SmallVector<mlir::Value, 8>, 8> destArgs;
+  llvm::SmallVector<mlir::Attribute> attrs;
+  llvm::SmallVector<mlir::Block *> dests;
+  llvm::SmallVector<llvm::SmallVector<mlir::Value>> destArgs;
   while (true) {
     mlir::Attribute attr;
     mlir::Block *dest;
-    llvm::SmallVector<mlir::Value, 8> destArg;
+    llvm::SmallVector<mlir::Value> destArg;
     mlir::NamedAttrList temp;
     if (parser.parseAttribute(attr, "a", temp) || parser.parseComma() ||
         parser.parseSuccessorAndUseList(dest, destArg))
@@ -1685,7 +1685,7 @@ static ParseResult parseSelectType(OpAsmParser &parser,
   auto &bld = parser.getBuilder();
   result.addAttribute(fir::SelectTypeOp::getCasesAttr(),
                       bld.getArrayAttr(attrs));
-  llvm::SmallVector<int32_t, 8> argOffs;
+  llvm::SmallVector<int32_t> argOffs;
   int32_t offSize = 0;
   const auto count = dests.size();
   for (std::remove_const_t<decltype(count)> i = 0; i != count; ++i) {

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -43,7 +43,7 @@ static std::string doModulesHost(llvm::ArrayRef<llvm::StringRef> mods,
   return result;
 }
 
-inline llvm::SmallVector<llvm::StringRef, 2>
+inline llvm::SmallVector<llvm::StringRef>
 convertToStringRef(llvm::ArrayRef<std::string> from) {
   return {from.begin(), from.end()};
 }
@@ -214,10 +214,10 @@ llvm::StringRef fir::NameUniquer::doProgramEntry() {
 std::pair<fir::NameUniquer::NameKind, fir::NameUniquer::DeconstructedName>
 fir::NameUniquer::deconstruct(llvm::StringRef uniq) {
   if (uniq.startswith("_Q")) {
-    llvm::SmallVector<std::string, 4> modules;
+    llvm::SmallVector<std::string> modules;
     llvm::Optional<std::string> host;
     std::string name;
-    llvm::SmallVector<std::int64_t, 8> kinds;
+    llvm::SmallVector<std::int64_t> kinds;
     NameKind nk = NameKind::NOT_UNIQUED;
     for (std::size_t i = 2, end{uniq.size()}; i != end;) {
       switch (uniq[i]) {

--- a/flang/lib/Optimizer/Transforms/AffineDemotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffineDemotion.cpp
@@ -36,7 +36,7 @@ public:
 
   LogicalResult matchAndRewrite(mlir::AffineLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    SmallVector<Value, 8> indices(op.getMapOperands());
+    SmallVector<Value> indices(op.getMapOperands());
     auto maybeExpandedMap =
         expandAffineMap(rewriter, op.getLoc(), op.getAffineMap(), indices);
     if (!maybeExpandedMap)
@@ -57,7 +57,7 @@ public:
 
   LogicalResult matchAndRewrite(mlir::AffineStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    SmallVector<Value, 8> indices(op.getMapOperands());
+    SmallVector<Value> indices(op.getMapOperands());
     auto maybeExpandedMap =
         expandAffineMap(rewriter, op.getLoc(), op.getAffineMap(), indices);
     if (!maybeExpandedMap)
@@ -104,7 +104,7 @@ public:
 
 mlir::Type convertMemRef(mlir::MemRefType type) {
   return fir::SequenceType::get(
-      SmallVector<int64_t, 8>(type.getShape().begin(), type.getShape().end()),
+      SmallVector<int64_t>(type.getShape().begin(), type.getShape().end()),
       type.getElementType());
 }
 

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -249,7 +249,7 @@ private:
     }
   }
 
-  llvm::SmallVector<mlir::Value, 8> affineArgs;
+  llvm::SmallVector<mlir::Value> affineArgs;
   llvm::Optional<mlir::IntegerSet> integerSet;
   mlir::Value firCondition;
   unsigned symCount{0u};
@@ -386,7 +386,7 @@ createAffineOps(mlir::Value arrayRef, mlir::PatternRewriter &rewriter) {
   auto acoOp = arrayRef.getDefiningOp<ArrayCoorOp>();
   auto affineMap =
       createArrayIndexAffineMap(acoOp.indices().size(), acoOp.getContext());
-  SmallVector<mlir::Value, 4> indexArgs;
+  SmallVector<mlir::Value> indexArgs;
   indexArgs.append(acoOp.indices().begin(), acoOp.indices().end());
 
   populateIndexArgs(acoOp, indexArgs, rewriter);

--- a/flang/lib/Optimizer/Transforms/CSE.cpp
+++ b/flang/lib/Optimizer/Transforms/CSE.cpp
@@ -91,11 +91,11 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
       return false;
     // Compare operands.
     if (lhs->hasTrait<mlir::OpTrait::IsCommutative>()) {
-      SmallVector<void *, 8> lops;
+      SmallVector<void *> lops;
       for (auto lod : lhs->getOperands())
         lops.push_back(lod.getAsOpaquePointer());
       llvm::sort(lops.begin(), lops.end());
-      SmallVector<void *, 8> rops;
+      SmallVector<void *> rops;
       for (auto rod : rhs->getOperands())
         rops.push_back(rod.getAsOpaquePointer());
       llvm::sort(rops.begin(), rops.end());

--- a/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
+++ b/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
@@ -35,9 +35,7 @@ static llvm::cl::opt<bool> disableControlFlowLowering(
                    "dialect operations to more primitive operations"),
     llvm::cl::init(false), llvm::cl::Hidden);
 
-using SmallVecResult = llvm::SmallVector<mlir::Value, 4>;
 using OperandTy = llvm::ArrayRef<mlir::Value>;
-using AttributeTy = llvm::ArrayRef<mlir::NamedAttribute>;
 using namespace fir;
 
 namespace {

--- a/flang/lib/Optimizer/Transforms/MemDataFlowOpt.cpp
+++ b/flang/lib/Optimizer/Transforms/MemDataFlowOpt.cpp
@@ -43,7 +43,7 @@ public:
   // store and a load.
   llvm::Optional<WriteOp> findStoreToForward(ReadOp loadOp,
                                              std::vector<WriteOp> &&storeOps) {
-    llvm::SmallVector<WriteOp, 8> candidateSet;
+    llvm::SmallVector<WriteOp> candidateSet;
 
     for (auto &storeOp : storeOps)
       if (domInfo->dominates(storeOp, loadOp))

--- a/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
+++ b/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
@@ -86,7 +86,7 @@ public:
       iters = rewriter.create<mlir::SelectOp>(loc, cond, one, iters);
     }
 
-    llvm::SmallVector<mlir::Value, 8> loopOperands;
+    llvm::SmallVector<mlir::Value> loopOperands;
     loopOperands.push_back(low);
     auto operands = loop.getIterOperands();
     loopOperands.append(operands.begin(), operands.end());
@@ -106,7 +106,7 @@ public:
     mlir::Value itersMinusOne =
         rewriter.create<mlir::SubIOp>(loc, itersLeft, one);
 
-    llvm::SmallVector<mlir::Value, 8> loopCarried;
+    llvm::SmallVector<mlir::Value> loopCarried;
     loopCarried.push_back(steppedIndex);
     auto begin = loop.finalValue() ? std::next(terminator->operand_begin())
                                    : terminator->operand_begin();
@@ -234,7 +234,7 @@ public:
     mlir::Value stepped = rewriter.create<mlir::AddIOp>(loc, iv, step);
     assert(stepped && "must be a Value");
 
-    llvm::SmallVector<mlir::Value, 8> loopCarried;
+    llvm::SmallVector<mlir::Value> loopCarried;
     loopCarried.push_back(stepped);
     auto begin = whileOp.finalValue() ? std::next(terminator->operand_begin())
                                       : terminator->operand_begin();
@@ -250,7 +250,7 @@ public:
 
     // The initial values of loop-carried values is obtained from the operands
     // of the loop operation.
-    llvm::SmallVector<mlir::Value, 8> destOperands;
+    llvm::SmallVector<mlir::Value> destOperands;
     destOperands.push_back(lowerBound);
     auto iterOperands = whileOp.getIterOperands();
     destOperands.append(iterOperands.begin(), iterOperands.end());

--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -30,10 +30,10 @@ struct DeconstructedName {
   }
 
 private:
-  llvm::SmallVector<std::string, 2> modules;
+  llvm::SmallVector<std::string> modules;
   llvm::Optional<std::string> host;
   std::string name;
-  llvm::SmallVector<std::int64_t, 4> kinds;
+  llvm::SmallVector<std::int64_t> kinds;
 };
 
 void validateDeconstructedName(


### PR DESCRIPTION
Modify 80+% of existing SmallVector declarations that have initial size
allocations to instead use default size allocations.  The default iniitial
size is currently 64 bytes, so after overhead of 16 bytes, a vector of
8-byte integers or pointers will get an initial default allocation of
6 elements.

Cases that remain include:
 - exact allocations
 - small allocations (default too large) in high volume persistent data structures
 - large allocations (default too small)