### PR TITLE
[NFC][CMake] Cleanup work.

### DIFF
--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -26,6 +26,7 @@ add_flang_library(FortranLower
   DEPENDS
   FIRDialect
   FIRSupport
+  FIRTransforms
   ${dialect_libs}
   omp_gen
   acc_gen
@@ -33,6 +34,7 @@ add_flang_library(FortranLower
   LINK_LIBS
   FIRDialect
   FIRSupport
+  FIRTransforms
   ${dialect_libs}
   FortranCommon
   FortranParser

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -24,13 +24,15 @@ add_flang_library(FortranLower
   SymbolMap.cpp
 
   DEPENDS
-  FIROptimizer
+  FIRDialect
+  FIRSupport
   ${dialect_libs}
   omp_gen
   acc_gen
 
   LINK_LIBS
-  FIROptimizer
+  FIRDialect
+  FIRSupport
   ${dialect_libs}
   FortranCommon
   FortranParser

--- a/flang/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/Analysis/CMakeLists.txt
@@ -1,0 +1,11 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_flang_library(FIRAnalysis
+  IteratedDominanceFrontier.cpp
+
+  DEPENDS
+  ${dialect_libs}
+
+  LINK_LIBS
+  ${dialect_libs}
+)

--- a/flang/lib/Optimizer/CMakeLists.txt
+++ b/flang/lib/Optimizer/CMakeLists.txt
@@ -1,52 +1,5 @@
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-
-add_flang_library(FIROptimizer
-  Dialect/FIRAttr.cpp
-  Dialect/FIRDialect.cpp
-  Dialect/FIROps.cpp
-  Dialect/FIRType.cpp
-
-  Support/FIRContext.cpp
-  Support/InitFIR.cpp
-  Support/InternalNames.cpp
-  Support/KindMapping.cpp
-
-  Analysis/IteratedDominanceFrontier.cpp
-
-  CodeGen/CGOps.cpp
-  CodeGen/CodeGen.cpp
-  CodeGen/PreCGRewrite.cpp
-  CodeGen/Target.cpp
-  CodeGen/TargetRewrite.cpp
-
-  Transforms/AffineDemotion.cpp
-  Transforms/AffinePromotion.cpp
-  Transforms/ArrayValueCopy.cpp
-  Transforms/ControlFlowConverter.cpp
-  Transforms/CSE.cpp
-  Transforms/FirLoopResultOpt.cpp
-  Transforms/Inliner.cpp
-  Transforms/MemDataFlowOpt.cpp
-  Transforms/MemToReg.cpp
-  Transforms/RewriteLoop.cpp
-
-  DEPENDS
-  FIROpsIncGen
-  FIROptCodeGenPassIncGen
-  FIROptTransformsPassIncGen
-  CGOpsIncGen
-  RewritePatternsIncGen
-  ${dialect_libs}
-
-  LINK_LIBS
-  ${dialect_libs}
-  MLIRAffineToStandard
-  MLIROpenMPToLLVM
-  MLIRTargetLLVMIR
-  MLIRTargetLLVMIRModuleTranslation
-
-  LINK_COMPONENTS
-  AsmParser
-  AsmPrinter
-  Remarks
-)
+add_subdirectory(Analysis)
+add_subdirectory(CodeGen)
+add_subdirectory(Dialect)
+add_subdirectory(Support)
+add_subdirectory(Transforms)

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+add_flang_library(FIRCodeGen
+  CGOps.cpp
+  CodeGen.cpp
+  PreCGRewrite.cpp
+  Target.cpp
+  TargetRewrite.cpp
+
+  DEPENDS
+  FIRDialect
+  FIRSupport
+  FIROptCodeGenPassIncGen
+  CGOpsIncGen
+
+  LINK_LIBS
+  FIRSupport
+  MLIROpenMPToLLVM
+  MLIRTargetLLVMIR
+  MLIRTargetLLVMIRModuleTranslation
+
+  LINK_COMPONENTS
+  AsmParser
+  AsmPrinter
+  Remarks
+)

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -13,6 +13,7 @@ add_flang_library(FIRCodeGen
   CGOpsIncGen
 
   LINK_LIBS
+  FIRDialect
   FIRSupport
   MLIROpenMPToLLVM
   MLIRTargetLLVMIR

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -4,10 +4,17 @@ add_flang_library(FIRDialect
   FIRDialect.cpp
   FIROps.cpp
   FIRType.cpp
+  Inliner.cpp
 
   DEPENDS
   FIRSupport
   FIROpsIncGen
+
+  LINK_LIBS
+  FIRSupport
+  MLIROpenMPToLLVM
+  MLIRTargetLLVMIR
+  MLIRTargetLLVMIRModuleTranslation
 
   LINK_COMPONENTS
   AsmParser

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+add_flang_library(FIRDialect
+  FIRAttr.cpp
+  FIRDialect.cpp
+  FIROps.cpp
+  FIRType.cpp
+
+  DEPENDS
+  FIRSupport
+  FIROpsIncGen
+
+  LINK_COMPONENTS
+  AsmParser
+  AsmPrinter
+  Remarks
+)

--- a/flang/lib/Optimizer/Dialect/Inliner.cpp
+++ b/flang/lib/Optimizer/Dialect/Inliner.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "flang/Optimizer/Dialect/FIRDialect.h"
-#include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Transforms/Passes.h"
-#include "mlir/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 
 static llvm::cl::opt<bool>

--- a/flang/lib/Optimizer/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Support/CMakeLists.txt
@@ -1,0 +1,14 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_flang_library(FIRSupport
+  FIRContext.cpp
+  InitFIR.cpp
+  InternalNames.cpp
+  KindMapping.cpp
+
+  DEPENDS
+  ${dialect_libs}
+
+  LINK_LIBS
+  ${dialect_libs}
+)

--- a/flang/lib/Optimizer/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Support/CMakeLists.txt
@@ -11,4 +11,7 @@ add_flang_library(FIRSupport
 
   LINK_LIBS
   ${dialect_libs}
+  MLIROpenMPToLLVM
+  MLIRTargetLLVMIR
+  MLIRTargetLLVMIRModuleTranslation
 )

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+add_flang_library(FIRTransforms
+  AffineDemotion.cpp
+  AffinePromotion.cpp
+  ArrayValueCopy.cpp
+  ControlFlowConverter.cpp
+  CSE.cpp
+  FirLoopResultOpt.cpp
+  Inliner.cpp
+  MemDataFlowOpt.cpp
+  MemToReg.cpp
+  RewriteLoop.cpp
+
+  DEPENDS
+  FIRAnalysis
+  FIRDialect
+  FIRSupport
+  FIROptTransformsPassIncGen
+  RewritePatternsIncGen
+
+  LINK_LIBS
+  MLIRAffineToStandard
+)

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -6,7 +6,6 @@ add_flang_library(FIRTransforms
   ControlFlowConverter.cpp
   CSE.cpp
   FirLoopResultOpt.cpp
-  Inliner.cpp
   MemDataFlowOpt.cpp
   MemToReg.cpp
   RewriteLoop.cpp
@@ -19,5 +18,7 @@ add_flang_library(FIRTransforms
   RewritePatternsIncGen
 
   LINK_LIBS
+  FIRAnalysis
+  FIRDialect
   MLIRAffineToStandard
 )

--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -10,7 +10,11 @@ add_flang_tool(bbc bbc.cpp)
 llvm_update_compile_flags(bbc)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 target_link_libraries(bbc PRIVATE
-  FIROptimizer
+  FIRDialect
+  FIRAnalysis
+  FIRSupport
+  FIRTransforms
+  FIRCodeGen
   ${dialect_libs}
   MLIRLLVMIR
   MLIRAffineToStandard

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -3,7 +3,11 @@ llvm_update_compile_flags(fir-opt)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 target_link_libraries(fir-opt PRIVATE
-  FIROptimizer
+  FIRDialect
+  FIRAnalysis
+  FIRSupport
+  FIRTransforms
+  FIRCodeGen
   ${dialect_libs}
   MLIRIR
   MLIRLLVMIR

--- a/flang/tools/tco/CMakeLists.txt
+++ b/flang/tools/tco/CMakeLists.txt
@@ -10,7 +10,11 @@ add_flang_tool(tco tco.cpp)
 llvm_update_compile_flags(tco)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 target_link_libraries(tco PRIVATE
-  FIROptimizer
+  FIRCodeGen
+  FIRDialect
+  FIRAnalysis
+  FIRSupport
+  FIRTransforms
   ${dialect_libs}
   MLIRIR
   MLIRLLVMIR

--- a/flang/unittests/Lower/CMakeLists.txt
+++ b/flang/unittests/Lower/CMakeLists.txt
@@ -1,7 +1,8 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 set(LIBS
-  FIROptimizer
+  FIRDialect
+  FIRSupport
   MLIRLLVMIR
   ${dialect_libs}
 )
@@ -13,4 +14,5 @@ add_flang_unittest(FlangLoweringOpenMPTests
 )
 target_link_libraries(FlangLoweringOpenMPTests
   PRIVATE
-  ${LIBS})
+  ${LIBS}
+)

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -1,7 +1,8 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 set(LIBS
-  FIROptimizer
+  FIRDialect
+  FIRSupport
   ${dialect_libs}
 )
 


### PR DESCRIPTION
Partition libFIROptimizer into smaller libraries that reflect the
structure.