### PR TITLE
Lower substring of `evaluate::StaticDataObject` of kind 1

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -999,9 +999,16 @@ public:
     auto baseString = std::visit(
         Fortran::common::visitors{
             [&](const Fortran::evaluate::DataRef &x) { return gen(x); },
-            [&](const Fortran::evaluate::StaticDataObject::Pointer &)
+            [&](const Fortran::evaluate::StaticDataObject::Pointer &p)
                 -> fir::ExtendedValue {
-              TODO(getLoc(), "StaticDataObject::Pointer substring");
+              if (auto str = p->AsString())
+                return Fortran::lower::createStringLiteral(builder, getLoc(),
+                                                           *str);
+              // TODO: convert StaticDataObject to Constant<T> and use normal
+              // constant path. Beware that StaticDataObject data() takes into
+              // account build machine endianness.
+              TODO(getLoc(),
+                   "StaticDataObject::Pointer substring with kind > 1");
             },
         },
         s.parent());

--- a/flang/test/Lower/character-substrings.f90
+++ b/flang/test/Lower/character-substrings.f90
@@ -1,0 +1,30 @@
+! Test character substring lowering
+! RUN: bbc %s -o - -emit-fir | FileCheck %s
+
+! Test substring lower where the parent is a scalar-char-literal-constant
+! CHECK-LABEL: func @_QPfoo(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<i64>)
+subroutine foo(i, j)
+  integer(8) :: i, j
+  call bar("abcHello World!dfg"(i:j))
+  ! CHECK: %[[baseAddr:.*]] = fir.address_of(@[[fooGlobalLiteral:.*]]) : !fir.ref<!fir.char<1,18>>
+  ! CHECK-DAG: %[[i64:.*]] = fir.load %[[arg0]] : !fir.ref<i64>
+  ! CHECK-DAG: %[[j64:.*]] = fir.load %[[arg1]] : !fir.ref<i64>
+  ! CHECK-DAG: %[[i:.*]] = fir.convert %[[i64]] : (i64) -> index
+  ! CHECK-DAG: %[[j:.*]] = fir.convert %[[j64]] : (i64) -> index
+  ! CHECK-DAG: %[[startIdx:.*]] = subi %[[i]], %c1{{.*}} : index
+  ! CHECK-DAG: %[[charArrayView:.*]] = fir.convert %[[baseAddr]] : (!fir.ref<!fir.char<1,18>>) -> !fir.ref<!fir.array<18x!fir.char<1>>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[charArrayView]], %[[startIdx]] : (!fir.ref<!fir.array<18x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[substringBase:.*]] = fir.convert %[[coor]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[boundsDiff:.*]] = subi %[[j]], %[[i]] : index
+  ! CHECK: %[[len:.*]] = addi %[[boundsDiff]], %c1 : index
+  ! CHECK: %[[slt:.*]] = cmpi slt, %[[len]], %c0{{.*}} : index
+  ! CHECK: %[[safeLen:.*]] = select %[[slt]], %c0{{.*}}, %[[len]] : index
+  ! CHECK: %[[substring:.*]] = fir.emboxchar %[[substringBase]], %[[safeLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPbar(%[[substring]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+
+! CHECK: fir.global linkonce @[[fooGlobalLiteral]] constant : !fir.char<1,18>
+  ! CHECK: fir.string_lit "abcHello World!dfg"(18) : !fir.char<1,18>


### PR DESCRIPTION
Implement a small TODO. The non kind 1 is left TODO because it is less trivial and non properly testable right now.