### PR TITLE
Keep bind(C) mangling as an attribute

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -244,6 +244,10 @@ public:
   /// procedure.
   bool isIndirectCall() const;
 
+  /// Return the procedure symbol if this is a call to a user defined
+  /// procedure.
+  const Fortran::semantics::Symbol *getProcedureSymbol() const;
+
   /// Helpers to place the lowered arguments at the right place once they
   /// have been lowered.
   void placeInput(const PassedEntity &passedEntity, mlir::Value arg);
@@ -296,6 +300,10 @@ public:
   /// On the callee side it does not matter whether the procedure is
   /// called through pointers or not.
   bool isIndirectCall() const { return false; }
+
+  /// Return the procedure symbol if this is a call to a user defined
+  /// procedure.
+  const Fortran::semantics::Symbol *getProcedureSymbol() const;
 
   /// Add mlir::FuncOp entry block and map fir block arguments to Fortran dummy
   /// argument symbols.

--- a/flang/include/flang/Lower/Mangler.h
+++ b/flang/include/flang/Lower/Mangler.h
@@ -45,7 +45,12 @@ class DerivedTypeSpec;
 namespace lower::mangle {
 
 /// Convert a front-end Symbol to an internal name.
-std::string mangleName(const semantics::Symbol &);
+/// If \p keepExternalInScope is true, the mangling of external symbols
+/// retains the scope of the symbol declaring externals. Otherwise,
+/// external symbols are mangled outside of any scope. Keeping the scope is
+/// useful in attributes where all the Fortran context is to be maintained.
+std::string mangleName(const semantics::Symbol &,
+                       bool keepExternalInScope = false);
 
 /// Convert a derived type instance to an internal name.
 std::string mangleName(const semantics::DerivedTypeSpec &);

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -65,6 +65,8 @@ constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
 constexpr llvm::StringRef getOptionalAttrName() { return "fir.optional"; }
 /// Attribute to mark Fortran entities with the TARGET attribute.
 constexpr llvm::StringRef getTargetAttrName() { return "fir.target"; }
+/// Attribute to keep track of Fortran scoping information for a symbol.
+constexpr llvm::StringRef getSymbolAttrName() { return "fir.sym_name"; }
 
 /// Tell if \p value is:
 ///   - a function argument that has attribute \p attributeName

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -66,7 +66,8 @@ findInterfaceIfSeperateMP(const Fortran::semantics::Symbol &symbol) {
 // Mangle the name of `symbol` to make it unique within FIR's symbol table using
 // the FIR name mangler, `mangler`
 std::string
-Fortran::lower::mangle::mangleName(const Fortran::semantics::Symbol &symbol) {
+Fortran::lower::mangle::mangleName(const Fortran::semantics::Symbol &symbol,
+                                   bool keepExternalInScope) {
   // Resolve host and module association before mangling
   const auto &ultimateSymbol = symbol.GetUltimate();
   auto symbolName = toStringRef(ultimateSymbol.name());
@@ -78,7 +79,8 @@ Fortran::lower::mangle::mangleName(const Fortran::semantics::Symbol &symbol) {
           },
           [&](const Fortran::semantics::SubprogramDetails &) {
             // Mangle external procedure without any scope prefix.
-            if (Fortran::semantics::IsExternal(ultimateSymbol))
+            if (!keepExternalInScope &&
+                Fortran::semantics::IsExternal(ultimateSymbol))
               return fir::NameUniquer::doProcedure(llvm::None, llvm::None,
                                                    symbolName);
             // Separate module subprograms must be mangled according to the

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -125,13 +125,18 @@ program test
 ! CHECK: }
 end program
 
-! CHECK-LABEL: func @omp_get_num_threads() -> f32 {
+! CHECK-LABEL: func @omp_get_num_threads() -> f32 attributes {fir.sym_name = "_QPomp_get_num_threads"} {
 function omp_get_num_threads() bind(c)
 ! CHECK: }
 end function
 
-! CHECK-LABEL: func @get_threads() -> f32 {
+! CHECK-LABEL: func @get_threads() -> f32 attributes {fir.sym_name = "_QPomp_get_num_threads_1"} {
 function omp_get_num_threads_1() bind(c, name ="get_threads")
+! CHECK: }
+end function
+
+! CHECK-LABEL: func @bEtA() -> f32 attributes {fir.sym_name = "_QPalpha"} {
+function alpha() bind(c, name =" bEtA ")
 ! CHECK: }
 end function
 


### PR DESCRIPTION
Keep the Fortran symbol context as an attribute for BIND(C) symbol, to keep the bijective property of MLIR symbols to Fortran source.
Also cover the trailing and leading space constraint of BIND(C) that I found while looking more closely at the standard.