### PR TITLE
Fix the type mismatches found in testing for std.subi.

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1523,11 +1523,9 @@ public:
       if (arg.passBy == PassBy::Value) {
         auto *argVal = genval(*expr).getUnboxed();
         if (!argVal)
-          mlir::emitError(
-              loc,
-              "Lowering internal error: passing non trivial value by value");
-        else
-          caller.placeInput(arg, *argVal);
+          fir::emitFatalError(
+              loc, "internal error: passing non trivial value by value");
+        caller.placeInput(arg, *argVal);
         continue;
       }
 
@@ -1559,10 +1557,9 @@ public:
               // and after the call to a contiguous character argument.
               TODO(loc, "lowering actual arguments descriptor to boxchar");
             },
-            [&](const auto &x) {
-              mlir::emitError(loc, "Lowering internal error: actual "
-                                   "argument is not a character");
-              return mlir::Value{};
+            [&](const auto &) -> mlir::Value {
+              fir::emitFatalError(
+                  loc, "internal error: actual argument is not a character");
             });
         caller.placeInput(arg, boxChar);
       } else if (arg.passBy == PassBy::Box) {

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -221,7 +221,8 @@ subroutine len_test(i, c)
   integer :: i
   character(*) :: c
   ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1
-  ! CHECK: %[[x:.*]] = fir.convert %[[c]]#1 : (index) -> i32
+  ! CHECK: %[[xx:.*]] = fir.convert %[[c]]#1 : (index) -> i64
+  ! CHECK: %[[x:.*]] = fir.convert %[[xx]] : (i64) -> i32
   ! CHECK: fir.store %[[x]] to %arg0
   i = len(c)
 end subroutine


### PR DESCRIPTION
Changes the lowering of descriptor inquiry to return a 64-bit integer
rather than an index. It appears that Ev::Expr is assuming these have
INTEGER_8 type. It's not clear if this should be target-dependent.