### PR TITLE
Lower ALLOCATED, and ASSOCIATED without TARGET argument

### DIFF
--- a/flang/include/flang/Lower/IntrinsicCall.h
+++ b/flang/include/flang/Lower/IntrinsicCall.h
@@ -63,6 +63,9 @@ LowerIntrinsicArgAs
 lowerIntrinsicArgumentAs(mlir::Location, const IntrinsicArgumentLoweringRules &,
                          llvm::StringRef argName);
 
+/// Return place-holder for absent intrinsic arguments.
+fir::ExtendedValue getAbsentIntrinsicArgument();
+
 /// Get SymbolRefAttr of runtime (or wrapper function containing inlined
 // implementation) of an unrestricted intrinsic (defined by its signature
 // and generic name)

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -393,8 +393,9 @@ bool isArray(const ExtendedValue &exv);
 /// indices if it is an array entity.
 class ExtendedValue : public details::matcher<ExtendedValue> {
 public:
-  using VT = std::variant<UnboxedValue, CharBoxValue, ArrayBoxValue,
-                          CharArrayBoxValue, ProcBoxValue, BoxValue>;
+  using VT =
+      std::variant<UnboxedValue, CharBoxValue, ArrayBoxValue, CharArrayBoxValue,
+                   ProcBoxValue, BoxValue, MutableBoxValue>;
 
   ExtendedValue() : box{UnboxedValue{}} {}
   ExtendedValue(const ExtendedValue &) = default;

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1423,7 +1423,7 @@ public:
           Fortran::evaluate::Expr<Fortran::evaluate::SomeType>>(arg);
       if (!expr) {
         // Absent optional.
-        operands.emplace_back(fir::UnboxedValue{});
+        operands.emplace_back(Fortran::lower::getAbsentIntrinsicArgument());
         continue;
       }
       if (!argLowering) {

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1402,7 +1402,7 @@ public:
   lowerIntrinsicArgumentAsInquired(const Fortran::lower::SomeExpr &expr) {
     const auto *sym = Fortran::evaluate::UnwrapWholeSymbolDataRef(expr);
     if (sym && Fortran::semantics::IsAllocatableOrPointer(*sym))
-      return genMutableBoxValue(expr).getAddr();
+      return genMutableBoxValue(expr);
     return gen(expr);
   }
 

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -49,7 +49,7 @@ end subroutine
 ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>,
 ! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 subroutine allocated_test(scalar, array)
-  real, allocatable  :: scalar, array(:) 
+  real, allocatable  :: scalar, array(:)
   ! CHECK: %[[scalar:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
   ! CHECK: %[[addr0:.*]] = fir.box_addr %[[scalar]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
   ! CHECK: %[[addrToInt0:.*]] = fir.convert %[[addr0]]
@@ -68,6 +68,24 @@ subroutine anint_test(a, b)
   real :: a, b
   ! CHECK: fir.call @llvm.round.f32
   b = anint(a)
+end subroutine
+
+! ASSOCIATED
+! CHECK-LABEL: associated_test
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+subroutine associated_test(scalar, array)
+  real, pointer  :: scalar, array(:)
+  ! CHECK: %[[scalar:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[addr0:.*]] = fir.box_addr %[[scalar]] : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  ! CHECK: %[[addrToInt0:.*]] = fir.convert %[[addr0]]
+  ! CHECK: cmpi ne, %[[addrToInt0]], %c0{{.*}}
+  print *, associated(scalar)
+  ! CHECK: %[[array:.*]] = fir.load %[[arg1]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[addr1:.*]] = fir.box_addr %[[array]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[addrToInt1:.*]] = fir.convert %[[addr1]]
+  ! CHECK: cmpi ne, %[[addrToInt1]], %c0{{.*}}
+  print *, associated(array)
 end subroutine
 
 ! DBLE
@@ -112,8 +130,8 @@ subroutine dprod_test (x, y, z)
   z = dprod(x,y)
   ! CHECK-DAG: %[[x:.*]] = fir.load %arg0
   ! CHECK-DAG: %[[y:.*]] = fir.load %arg1
-  ! CHECK-DAG: %[[a:.*]] = fir.convert %[[x]] : (f32) -> f64 
-  ! CHECK-DAG: %[[b:.*]] = fir.convert %[[y]] : (f32) -> f64 
+  ! CHECK-DAG: %[[a:.*]] = fir.convert %[[x]] : (f32) -> f64
+  ! CHECK-DAG: %[[b:.*]] = fir.convert %[[y]] : (f32) -> f64
   ! CHECK: %[[res:.*]] = mulf %[[a]], %[[b]]
   ! CHECK: fir.store %[[res]] to %arg2
 end subroutine
@@ -203,7 +221,7 @@ subroutine ichar_test(c)
   ! CHECK-DAG: %[[unbox:.*]]:2 = fir.unboxchar
   ! CHECK-DAG: %[[J:.*]] = fir.alloca i32 {name = "{{.*}}Ej"}
   ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {name = "{{.*}}Estr"}
-  ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>> 
+  ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>>
   ! CHECK: %[[CHAR:.*]] = fir.load %[[BOX]] : !fir.ref<!fir.char<1>>
   ! CHECK: fir.extract_value %[[CHAR]], %c0{{.*}}
   print *, ichar(c)
@@ -228,7 +246,7 @@ end subroutine ieor_test
 ! INDEX
 ! CHECK-LABEL: func @_QPindex_test(%
 ! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
-! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32 
+! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
 integer function index_test(s1, s2)
   character(*) :: s1, s2
   ! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -44,6 +44,24 @@ subroutine aint_test(a, b)
   b = aint(a)
 end subroutine
 
+! ALLOCATED
+! CHECK-LABEL: allocated_test
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
+subroutine allocated_test(scalar, array)
+  real, allocatable  :: scalar, array(:) 
+  ! CHECK: %[[scalar:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr0:.*]] = fir.box_addr %[[scalar]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: %[[addrToInt0:.*]] = fir.convert %[[addr0]]
+  ! CHECK: cmpi ne, %[[addrToInt0]], %c0{{.*}}
+  print *, allocated(scalar)
+  ! CHECK: %[[array:.*]] = fir.load %[[arg1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[addr1:.*]] = fir.box_addr %[[array]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[addrToInt1:.*]] = fir.convert %[[addr1]]
+  ! CHECK: cmpi ne, %[[addrToInt1]], %c0{{.*}}
+  print *, allocated(array)
+end subroutine
+
 ! ANINT
 ! CHECK-LABEL: anint_test
 subroutine anint_test(a, b)


### PR DESCRIPTION
- Add `fir::MutableBoxValue` to `fir::ExtendedValue` list, this will be needed to deal with allocatable/associated components and help in  the intrinsic lowering interface.
- Add `isAbsent` / `getAbsentIntrinsicArgument` to deal with absent intrinsic argument (note that as opposed to user optional argument, there is no type for a missing optional argument since generic intrinsic interface are derived from their actual argument. So fir.absent cannot be used, and does not make complete sense anyway in this internal compiler interface).
- Lower ALLOCATED
- Lower ASSOCIATED. Left TARGET argument as TODO because I think it will be cleaner to deal with it with runtime using descriptors (there are quite a few case to pay attention to).
