### PR TITLE
Improve allocatable/pointer lowering TODOs

### DIFF
--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -227,6 +227,11 @@ public:
   bool isCharacter() const { return getEleTy().isa<fir::CharacterType>(); };
   /// Is this a derived type entity ?
   bool isDerived() const { return getEleTy().isa<fir::RecordType>(); };
+
+  bool isDerivedWithLengthParameters() const {
+    auto record = getEleTy().dyn_cast<fir::RecordType>();
+    return record && record.getNumLenParams() != 0;
+  };
   /// Is this a CLASS(*)/TYPE(*) ?
   bool isUnlimitedPolymorphic() const {
     return getEleTy().isa<mlir::NoneType>();


### PR DESCRIPTION
TODO improvements coming from nag test failures:

- Make derived type TODOs more specific by actually checking for length parameters
  before complaining something needs to be done with length parameters.
- Add a TODO for derived type components. This was failing in a more cryptic internal error: "symbol was not lowered to MutableBoxValue".
- Use TODO marco instead of custom TODOs.
- Use fatal error when something goes wrong instead of continuing.