### PR TITLE
move command line options

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -22,7 +22,7 @@ def FIRToLLVMLowering : Pass<"fir-to-llvm-ir", "mlir::ModuleOp"> {
     Convert the FIR dialect to the LLVM-IR dialect of MLIR. This conversion
     will also convert ops in the standard and FIRCG dialects.
   }];
-  let constructor = "fir::createFIRToLLVMPass()";
+  let constructor = "::fir::createFIRToLLVMPass()";
   let dependentDialects = [
     "fir::FIROpsDialect", "fir::FIRCodeGenDialect", "mlir::BuiltinDialect",
     "mlir::LLVM::LLVMDialect", "mlir::omp::OpenMPDialect"
@@ -34,7 +34,7 @@ def CodeGenRewrite : Pass<"cg-rewrite", "mlir::ModuleOp"> {
   let description = [{
     Fuse specific subgraphs into single Ops for code generation.
   }];
-  let constructor = "fir::createFirCodeGenRewritePass()";
+  let constructor = "::fir::createFirCodeGenRewritePass()";
   let dependentDialects = [
     "fir::FIROpsDialect", "fir::FIRCodeGenDialect"
   ];
@@ -49,7 +49,7 @@ def TargetRewrite : Pass<"target-rewrite", "mlir::ModuleOp"> {
       Certain abstractions in the FIR dialect need to be rewritten to reflect
       representations that may differ based on the target machine.
   }];
-  let constructor = "fir::createFirTargetRewritePass()";
+  let constructor = "::fir::createFirTargetRewritePass()";
   let dependentDialects = [ "fir::FIROpsDialect" ];
   let options = [
     Option<"noCharacterConversion", "no-character-conversion",

--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -36,8 +36,7 @@ def CodeGenRewrite : Pass<"cg-rewrite", "mlir::ModuleOp"> {
   }];
   let constructor = "fir::createFirCodeGenRewritePass()";
   let dependentDialects = [
-    "fir::FIROpsDialect", "fir::FIRCodeGenDialect", "mlir::BuiltinDialect",
-    "mlir::LLVM::LLVMDialect", "mlir::omp::OpenMPDialect"
+    "fir::FIROpsDialect", "fir::FIRCodeGenDialect"
   ];
   let statistics = [
     Statistic<"numDCE", "num-dce'd", "Number of operations eliminated">
@@ -51,10 +50,7 @@ def TargetRewrite : Pass<"target-rewrite", "mlir::ModuleOp"> {
       representations that may differ based on the target machine.
   }];
   let constructor = "fir::createFirTargetRewritePass()";
-  let dependentDialects = [
-    "fir::FIROpsDialect", "fir::FIRCodeGenDialect", "mlir::BuiltinDialect",
-    "mlir::omp::OpenMPDialect"
-  ];
+  let dependentDialects = [ "fir::FIROpsDialect" ];
   let options = [
     Option<"noCharacterConversion", "no-character-conversion",
            "bool", /*default=*/"false",

--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -15,8 +15,16 @@
       llvm::cl::Hidden)
 
 namespace {
+// Optimizer Passes
+DisableOption(FirCse, "fir-cse", "CSE for FIR dialect");
+
+// CodeGen Passes
+#if !defined(FLANG_EXCLUDE_CODEGEN)
+DisableOption(CodeGenRewrite, "codegen-rewrite", "rewrite FIR for codegen");
+DisableOption(TargetRewrite, "target-rewrite", "rewrite FIR for target");
 DisableOption(FirToLlvmIr, "fir-to-llvmir", "FIR to LLVM-IR dialect");
 DisableOption(LlvmIrToLlvm, "llvm", "conversion to LLVM");
+#endif
 
 // Generic for adding a pass to the pass manager if it is not disabled.
 template <typename F>
@@ -26,10 +34,33 @@ void addPassConditionally(
     pm.addPass(ctor());
 }
 
+template <typename OP, typename F>
+void addNestedPassConditionally(
+    mlir::PassManager &pm, llvm::cl::opt<bool> &disabled, F ctor) {
+  if (!disabled)
+    pm.addNestedPass<OP>(ctor());
+}
+
 } // namespace
 
-#if !defined(FLANG_EXCLUDE_CODEGEN)
 namespace fir {
+
+inline void addCSE(mlir::PassManager &pm) {
+  addNestedPassConditionally<mlir::FuncOp>(
+      pm, disableFirCse, fir::createCSEPass);
+}
+
+#if !defined(FLANG_EXCLUDE_CODEGEN)
+inline void addCodeGenRewritePass(mlir::PassManager &pm) {
+  addPassConditionally(
+      pm, disableCodeGenRewrite, fir::createFirCodeGenRewritePass);
+}
+
+inline void addTargetRewritePass(mlir::PassManager &pm) {
+  addPassConditionally(pm, disableTargetRewrite, []() {
+    return fir::createFirTargetRewritePass(fir::TargetRewriteOptions{});
+  });
+}
 
 inline void addFIRToLLVMPass(mlir::PassManager &pm) {
   addPassConditionally(pm, disableFirToLlvmIr, fir::createFIRToLLVMPass);
@@ -40,7 +71,7 @@ inline void addLLVMDialectToLLVMPass(
   addPassConditionally(pm, disableLlvmIrToLlvm,
       [&]() { return fir::createLLVMDialectToLLVMPass(output); });
 }
-
-} // namespace fir
 #undef FLANG_EXCLUDE_CODEGEN
 #endif
+
+} // namespace fir

--- a/flang/lib/Optimizer/Transforms/CSE.cpp
+++ b/flang/lib/Optimizer/Transforms/CSE.cpp
@@ -37,9 +37,6 @@ static llvm::cl::opt<bool>
     leaveEffects("keep-effects",
                  llvm::cl::desc("disable cleaning up effects attributes"),
                  llvm::cl::init(false), llvm::cl::Hidden);
-static llvm::cl::opt<bool> disableCSE("disable-cse",
-                                      llvm::cl::desc("disable CSE pass"),
-                                      llvm::cl::init(false), llvm::cl::Hidden);
 
 namespace {
 
@@ -293,9 +290,6 @@ void BasicCSE::simplifyRegion(ScopedMapTy &knownValues, DominanceInfo &domInfo,
 }
 
 void BasicCSE::runOnFunction() {
-  if (disableCSE)
-    return;
-
   /// A scoped hash table of defining operations within a function.
   {
     ScopedMapTy knownValues;

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -276,7 +276,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     // simplify the IR
     pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createCSEPass());
+    fir::addCSE(pm);
     pm.addPass(mlir::createInlinerPass());
     pm.addPass(mlir::createCSEPass());
 
@@ -286,7 +286,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     pm.addPass(mlir::createLowerToCFGPass());
 
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createCSEPass());
+    fir::addCSE(pm);
   }
 
   if (mlir::succeeded(pm.run(mlirModule))) {

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -114,7 +114,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     // simplify the IR
     pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createCSEPass());
+    fir::addCSE(pm);
     pm.addPass(mlir::createInlinerPass());
     pm.addPass(mlir::createCSEPass());
 
@@ -124,11 +124,11 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     pm.addPass(mlir::createLowerToCFGPass());
 
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createCSEPass());
+    fir::addCSE(pm);
 
     // pm.addPass(fir::createMemToRegPass());
-    pm.addPass(fir::createFirCodeGenRewritePass());
-    pm.addPass(fir::createFirTargetRewritePass());
+    fir::addCodeGenRewritePass(pm);
+    fir::addTargetRewritePass(pm);
     fir::addFIRToLLVMPass(pm);
     fir::addLLVMDialectToLLVMPass(pm, out.os());
   }


### PR DESCRIPTION
Unlike clang and llvm, command line options in MLIR aren't allowed to appear with the passes. These changes move the command line options for debugging to the tools to hopefully grease the skids for upstreaming.