### PR TITLE
Implements an element-by-element assignment for "vanilla struct" like

### DIFF
--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -224,7 +224,7 @@ public:
     return 0;
   }
   /// Is this a character entity ?
-  bool isCharacter() const { return getEleTy().isa<fir::CharacterType>(); };
+  bool isCharacter() const { return fir::isa_char(getEleTy()); };
   /// Is this a derived type entity ?
   bool isDerived() const { return getEleTy().isa<fir::RecordType>(); };
 
@@ -363,9 +363,6 @@ protected:
   MutableProperties mutableProperties;
 };
 
-/// Used for triple notation (array slices)
-using RangeBoxValue = std::tuple<mlir::Value, mlir::Value, mlir::Value>;
-
 class ExtendedValue;
 
 /// Get the base value of an extended value. Every type of extended value has a
@@ -385,6 +382,9 @@ ExtendedValue substBase(const ExtendedValue &exv, mlir::Value base);
 
 /// Is the extended value `exv` an array?
 bool isArray(const ExtendedValue &exv);
+
+/// Get the type parameters for `exv`.
+llvm::ArrayRef<mlir::Value> getTypeParams(const ExtendedValue &exv);
 
 /// An extended value is a box of values pertaining to a discrete entity. It is
 /// used in lowering to track all the runtime values related to an entity. For
@@ -412,7 +412,7 @@ public:
           type = refType.getEleTy();
         if (auto seqType = type.template dyn_cast<fir::SequenceType>())
           type = seqType.getEleTy();
-        if (type.template isa<fir::CharacterType>())
+        if (fir::isa_char(type))
           fir::emitFatalError(b->getLoc(),
                               "character buffer should be in CharBoxValue");
       }

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -109,6 +109,17 @@ inline bool isa_complex(mlir::Type t) {
   return t.isa<fir::ComplexType>() || t.isa<mlir::ComplexType>();
 }
 
+inline bool isa_char(mlir::Type t) {
+   return t.isa<fir::CharacterType>();
+}
+
+/// Is `t` a trivial intrinsic type? CHARACTER is <em>excluded</em> because it
+/// is a dependent type.
+inline bool isa_trivial(mlir::Type t) {
+  return isa_integer(t) || isa_real(t) || isa_complex(t) ||
+         t.isa<fir::LogicalType>();
+}
+
 inline bool isa_char_string(mlir::Type t) {
   if (auto ct = t.dyn_cast_or_null<fir::CharacterType>())
     return ct.getLen() != fir::CharacterType::singleton();

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -910,7 +910,7 @@ createMutableProperties(Fortran::lower::AbstractConverter &converter,
   if (auto record = eleTy.dyn_cast<fir::RecordType>())
     if (record.getNumLenParams() != 0)
       TODO(loc, "deferred length type parameters.");
-  if (eleTy.isa<fir::CharacterType>() && nonDeferredParams.empty()) {
+  if (fir::isa_char(eleTy) && nonDeferredParams.empty()) {
     auto lenVar = builder.allocateLocal(loc, builder.getCharacterLengthType(),
                                         name + ".len", /*shape=*/llvm::None,
                                         /*lenParams=*/llvm::None);

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -70,8 +70,7 @@ getCompileTimeLength(const fir::CharBoxValue &box) {
 /// Detect the precondition that the value `str` does not reside in memory. Such
 /// values will have a type `!fir.array<...x!fir.char<N>>` or `!fir.char<N>`.
 LLVM_ATTRIBUTE_UNUSED static bool needToMaterialize(mlir::Value str) {
-  return str.getType().isa<fir::SequenceType>() ||
-         str.getType().isa<fir::CharacterType>();
+  return str.getType().isa<fir::SequenceType>() || fir::isa_char(str.getType());
 }
 
 /// Unwrap integer constant from mlir::Value.
@@ -284,7 +283,7 @@ void Fortran::lower::CharacterExprHelper::createStoreCharAt(mlir::Value str,
 mlir::Value Fortran::lower::CharacterExprHelper::getCharBoxBuffer(
     const fir::CharBoxValue &box) {
   auto buff = box.getBuffer();
-  if (buff.getType().isa<fir::CharacterType>()) {
+  if (fir::isa_char(buff.getType())) {
     auto newBuff = builder.create<fir::AllocaOp>(loc, buff.getType());
     builder.create<fir::StoreOp>(loc, buff, newBuff);
     return newBuff;
@@ -558,7 +557,7 @@ Fortran::lower::CharacterExprHelper::createUnboxChar(mlir::Value boxChar) {
 bool Fortran::lower::CharacterExprHelper::isCharacterLiteral(mlir::Type type) {
   if (auto seqType = type.dyn_cast<fir::SequenceType>())
     return (seqType.getShape().size() == 1) &&
-           seqType.getEleTy().isa<fir::CharacterType>();
+           fir::isa_char(seqType.getEleTy());
   return false;
 }
 
@@ -573,7 +572,7 @@ bool Fortran::lower::CharacterExprHelper::isCharacterScalar(mlir::Type type) {
     type = pointedType;
   if (auto seqType = type.dyn_cast<fir::SequenceType>())
     return false;
-  return type.isa<fir::CharacterType>();
+  return fir::isa_char(type);
 }
 
 fir::KindTy

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -192,7 +192,7 @@ genInitialDataTarget(Fortran::lower::AbstractConverter &converter,
     fir::emitFatalError(
         loc, "fir.box must be created with embox in global initializers");
   auto targetEleTy = unwrapElementType(box.getType());
-  if (!targetEleTy.isa<fir::CharacterType>())
+  if (!fir::isa_char(targetEleTy))
     return builder.create<fir::EmboxOp>(loc, boxType, op->getOperands(),
                                         op->getAttrs());
 
@@ -262,7 +262,7 @@ static fir::GlobalOp defineGlobal(Fortran::lower::AbstractConverter &converter,
         TODO(loc, "Derived type / polymorphic global with init lowering");
       }
       auto symTy = converter.genType(var);
-      if (symTy.isa<fir::CharacterType>()) {
+      if (fir::isa_char(symTy)) {
         if (auto chLit = getCharacterLiteralCopy(details->init().value())) {
           auto init = builder.getStringAttr(std::get<std::string>(*chLit));
           global = builder.createGlobal(loc, symTy, globalName, linkage, init,

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -313,9 +313,13 @@ static constexpr IntrinsicHandler handlers[]{
     {"modulo", &I::genModulo},
     {"nint", &I::genNint},
     {"present", &I::genPresent, {{{"a", asInquired}}}, /*isElemental=*/false},
-    {"scan", &I::genScan, {{ {"string", asAddr}, {"set", asAddr},
-                          {"back", asAddr}, {"kind", asValue} }},
-             /*isElemental=*/true},
+    {"scan",
+     &I::genScan,
+     {{{"string", asAddr},
+       {"set", asAddr},
+       {"back", asAddr},
+       {"kind", asValue}}},
+     /*isElemental=*/true},
     {"sign", &I::genSign},
     {"trim", &I::genTrim, {{{"string", asAddr}}}, /*isElemental=*/false},
 };
@@ -1532,7 +1536,7 @@ IntrinsicLibrary::genPresent(mlir::Type,
                                           fir::getBase(args[0]));
 }
 
-// SCAN 
+// SCAN
 fir::ExtendedValue
 IntrinsicLibrary::genScan(mlir::Type resultType,
                           llvm::ArrayRef<fir::ExtendedValue> args) {
@@ -1547,21 +1551,21 @@ IntrinsicLibrary::genScan(mlir::Type resultType,
 
   // Handle optional argument, back
   auto back = isAbsent(args[2])
-              ? builder.create<fir::AbsentOp>(
-              loc, fir::BoxType::get(builder.getNoneType()))
-              : builder.createBox(loc, args[2]); 
+                  ? builder.create<fir::AbsentOp>(
+                        loc, fir::BoxType::get(builder.getNoneType()))
+                  : builder.createBox(loc, args[2]);
 
   // Handle optional argument, kind
-  auto kind = isAbsent(args[3])
-              ? builder.createIntegerConstant(loc, resultType, 
-              builder.getKindMap().defaultIntegerKind()) :
-              fir::getBase(args[3]);
-  
-  // Create result descriptor    
+  auto kind = isAbsent(args[3]) ? builder.createIntegerConstant(
+                                      loc, resultType,
+                                      builder.getKindMap().defaultIntegerKind())
+                                : fir::getBase(args[3]);
+
+  // Create result descriptor
   auto resultMutableBox =
-       Fortran::lower::createTempMutableBox(builder, loc, resultType);
+      Fortran::lower::createTempMutableBox(builder, loc, resultType);
   auto resultIrBox =
-       Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
+      Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
 
   Fortran::lower::genScan(builder, loc, resultIrBox, string, set, back, kind);
 
@@ -1569,10 +1573,10 @@ IntrinsicLibrary::genScan(mlir::Type resultType,
   auto res = Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox);
 
   return res.match(
-        [&](const Fortran::lower::SymbolBox::Intrinsic &box)
-            -> fir::ExtendedValue { 
-            addCleanUpForTemp(loc, box.getAddr());
-            return builder.create<fir::LoadOp>(loc, resultType, box.getAddr());
+      [&](const Fortran::lower::SymbolBox::Intrinsic &box)
+          -> fir::ExtendedValue {
+        addCleanUpForTemp(loc, box.getAddr());
+        return builder.create<fir::LoadOp>(loc, resultType, box.getAddr());
       },
       [&](const auto &) -> fir::ExtendedValue {
         fir::emitFatalError(loc, "unexpected result for SCAN");
@@ -1672,12 +1676,13 @@ static mlir::Value createExtremumCompare(mlir::Location loc,
     }
   } else if (fir::isa_integer(type)) {
     result = builder.create<mlir::CmpIOp>(loc, integerPredicate, left, right);
-  } else if (type.isa<fir::CharacterType>()) {
+  } else if (fir::isa_char(type)) {
     // TODO: ! character min and max is tricky because the result
     // length is the length of the longest argument!
     // So we may need a temp.
+    TODO(loc, "CHARACTER min and max");
   }
-  assert(result);
+  assert(result && "result must be defined");
   return result;
 }
 

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -44,6 +44,15 @@ fir::ExtendedValue fir::substBase(const fir::ExtendedValue &exv,
       [=](const auto &x) { return fir::ExtendedValue(x.clone(base)); });
 }
 
+llvm::ArrayRef<mlir::Value> fir::getTypeParams(const ExtendedValue &exv) {
+  // FIXME: We should be keeping track of the type parameters for a particular
+  // variable binding, but that seems to have been erased.
+  auto *ctx = fir::getBase(exv).getContext();
+  mlir::emitWarning(mlir::UnknownLoc::get(ctx),
+                    "TODO: extended value is missing type parameters");
+  return llvm::None;
+}
+
 bool fir::isArray(const fir::ExtendedValue &exv) {
   return exv.match(
       [](const fir::ArrayBoxValue &) { return true; },

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -1,0 +1,93 @@
+! Test lowering of derived type assignments
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Assignment of simple "struct" with trivial intrinsic members.
+! CHECK-LABEL: func @_QPtest1
+subroutine test1
+  type t
+     integer a
+     integer b
+  end type t
+  type(t) :: t1, t2
+  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {name = "_QFtest1Et1"}
+  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {name = "_QFtest1Et2"}
+  ! CHECK-DAG: %[[a:.*]] = fir.field_index a, !fir.type<_QFtest1Tt{a:i32,b:i32}>
+  ! CHECK: %[[ac:.*]] = fir.coordinate_of %[[t2]], %[[a]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: %[[ld:.*]] = fir.load %[[ac]] : !fir.ref<i32>
+  ! CHECK: %[[ad:.*]] = fir.coordinate_of %[[t1]], %[[a]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: fir.store %[[ld]] to %[[ad]] : !fir.ref<i32>
+  ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QFtest1Tt{a:i32,b:i32}>
+  ! CHECK: %[[bc:.*]] = fir.coordinate_of %[[t2]], %[[b]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: %[[ld:.*]] = fir.load %[[bc]] : !fir.ref<i32>
+  ! CHECK: %[[bd:.*]] = fir.coordinate_of %[[t1]], %[[b]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: fir.store %[[ld]] to %[[bd]] : !fir.ref<i32>
+  t1 = t2
+end subroutine test1
+
+! Test a defined assignment on a simple struct.
+module m2
+  type t
+     integer a
+     integer b
+  end type t
+  interface assignment (=)
+     module procedure t_to_t
+  end interface assignment (=)
+contains
+  ! CHECK-LABEL: func @_QMm2Ptest2
+  subroutine test2
+    type(t) :: t1, t2
+    ! CHECK: fir.call @_QMm2Pt_to_t(%{{.*}}, %{{.*}}) : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>) -> ()
+    t1 = t2
+    ! CHECK: return
+  end subroutine test2
+
+  ! Swap elements on assignment.
+  ! CHECK-LABEL: func @_QMm2Pt_to_t(
+  ! CHECK-SAME: %[[a1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>,
+  ! CHECK-SAME: %[[b1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>) 
+  subroutine t_to_t(a1,b1)
+    type(t), intent(out) :: a1
+    type(t), intent(in) :: b1
+    ! CHECK: %[[a:.*]] = fir.field_index a, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[a1a:.*]] = fir.coordinate_of %[[a1]], %[[a]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+    ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[b1b:.*]] = fir.coordinate_of %[[b1]], %[[b]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+    ! CHECK: %[[v:.*]] = fir.load %[[b1b]] : !fir.ref<i32>
+    ! CHECK: fir.store %[[v]] to %[[a1a]] : !fir.ref<i32>
+    ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[a1b:.*]] = fir.coordinate_of %[[a1]], %[[b]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+    ! CHECK: %[[a:.*]] = fir.field_index a, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[b1a:.*]] = fir.coordinate_of %[[b1]], %[[a]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+    ! CHECK: %[[v:.*]] = fir.load %[[b1a]] : !fir.ref<i32>
+    ! CHECK: fir.store %[[v]] to %[[a1b]] : !fir.ref<i32>
+    a1%a = b1%b
+    a1%b = b1%a
+    ! CHECK: return
+  end subroutine t_to_t
+end module m2
+
+! CHECK-LABEL: func @_QPtest3
+subroutine test3
+  type t
+     character(LEN=20) :: m_c
+     integer :: m_i
+  end type t
+  type(t) :: t1, t2
+  ! CHECK: %[[mc:.*]] = fir.field_index m_c, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
+  ! CHECK: %{{.*}} = fir.coordinate_of %{{.*}}, %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK: fir.do_loop %[[i:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[v:.*]] = fir.load %[[coor]] : !fir.ref<!fir.char<1>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: fir.store %[[v]] to %[[coor]] : !fir.ref<!fir.char<1>>
+  ! CHECK: fir.do_loop %[[i:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[v:.*]] = fir.load %[[coor]] : !fir.ref<!fir.char<1>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: fir.store %[[v]] to %[[coor]] : !fir.ref<!fir.char<1>>
+  ! CHECK: %[[mi:.*]] = fir.field_index m_i, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
+  ! CHECK: = fir.coordinate_of %{{.*}}, %[[mi]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  t1 = t2
+  ! CHECK: return
+end subroutine test3


### PR DESCRIPTION
derived types. This is a first step only.

As a bonus gets rid of the RangeBoxValue and removes code that used it.