### PR TITLE
Add calls to specialized versions of scan/verify intrinsics. 

### DIFF
--- a/flang/docs/tutorials/addingIntrinsics.md
+++ b/flang/docs/tutorials/addingIntrinsics.md
@@ -280,7 +280,7 @@ argument to a function called `genTrim` that implements the actual lowering of T
 Pass by value is the default argument passing scheme. If all arguments are passed by value, then you do not need to specify any arguments in this table. If at least one argument is not passed by value, then it is good practice to specify all the arguments. For example, consider the genScan entry:
 ```c++
 {"scan", &I::genScan, {{ {"string", asAddr}, {"set", asAddr}, 
-                         {"back", asAddr}, {"kind", asValue} }}, 
+                         {"back", asValue}, {"kind", asValue} }}, 
                          /*isElemental=*/true}
 ```
 

--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -58,21 +58,39 @@ void genIndexDescriptor(FirOpBuilder &builder, mlir::Location loc,
 void genTrim(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
              mlir::Value resultBox, mlir::Value stringBox);
 
-/// Generate call to verify runtime.
-/// This calls the descriptor based runtime call implementation of the scan or
-/// verify intrinsics.
-void genScanVerify(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
-               mlir::Value resultBox, mlir::Value stringBox,
-               mlir::Value setBox, mlir::Value backBox, mlir::Value kind,
-               bool isScan);
+/// Generate call to scan runtime.
+/// This calls the descriptor based runtime call implementation of the scan
+/// intrinsics.
+void genScanDescriptor(Fortran::lower::FirOpBuilder &builder, 
+                       mlir::Location loc,
+                       mlir::Value resultBox, mlir::Value stringBox,
+                       mlir::Value setBox, mlir::Value backBox, 
+                       mlir::Value kind);
 
-/// Generate call to the scan or verify runtime routine that is specialized on 
+/// Generate call to the scan runtime routine that is specialized on 
 /// \param kind.
 /// The \param kind represents the kind of the elements in the strings.
-mlir::Value genScanVerifyKind(Fortran::lower::FirOpBuilder &builder,
-                         mlir::Location loc, int kind, mlir::Value stringBase,
-                         mlir::Value stringLen, mlir::Value setBase,
-                         mlir::Value setLen, mlir::Value back, bool isScan);
+mlir::Value genScan(Fortran::lower::FirOpBuilder &builder,
+                    mlir::Location loc, int kind, mlir::Value stringBase,
+                    mlir::Value stringLen, mlir::Value setBase,
+                    mlir::Value setLen, mlir::Value back);
+
+/// Generate call to verify runtime.
+/// This calls the descriptor based runtime call implementation of the scan
+/// intrinsics.
+void genVerifyDescriptor(Fortran::lower::FirOpBuilder &builder, 
+                         mlir::Location loc,
+                         mlir::Value resultBox, mlir::Value stringBox,
+                         mlir::Value setBox, mlir::Value backBox, 
+                       mlir::Value kind);
+
+/// Generate call to the verify runtime routine that is specialized on 
+/// \param kind.
+/// The \param kind represents the kind of the elements in the strings.
+mlir::Value genVerify(Fortran::lower::FirOpBuilder &builder,
+                      mlir::Location loc, int kind, mlir::Value stringBase,
+                      mlir::Value stringLen, mlir::Value setBase,
+                      mlir::Value setLen, mlir::Value back);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -60,7 +60,7 @@ void genTrim(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
 
 /// Generate call to verify runtime.
 /// This calls the descriptor based runtime call implementation of the scan or
-/// verify intrinsicis.
+/// verify intrinsics.
 void genScanVerify(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
                mlir::Value resultBox, mlir::Value stringBox,
                mlir::Value setBox, mlir::Value backBox, mlir::Value kind,

--- a/flang/include/flang/Lower/CharacterRuntime.h
+++ b/flang/include/flang/Lower/CharacterRuntime.h
@@ -51,13 +51,6 @@ void genIndexDescriptor(FirOpBuilder &builder, mlir::Location loc,
                         mlir::Value substringBox, mlir::Value backOpt,
                         mlir::Value kind);
 
-/// Generate call to scan runtime.
-/// This calls the descriptor based runtime call implementation of the scan
-/// intrinsic.
-void genScan(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
-             mlir::Value resultBox, mlir::Value stringBox,
-             mlir::Value setBox, mlir::Value backBox, mlir::Value kind);
-
 /// Generate call to trim runtime.
 ///   \p resultBox must be an unallocated allocatable used for the temporary
 ///   result. \p stringBox must be a fir.box describing trim string argument.
@@ -66,11 +59,20 @@ void genTrim(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
              mlir::Value resultBox, mlir::Value stringBox);
 
 /// Generate call to verify runtime.
-/// This calls the descriptor based runtime call implementation of the verify
-/// intrinsic.
-void genVerify(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+/// This calls the descriptor based runtime call implementation of the scan or
+/// verify intrinsicis.
+void genScanVerify(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
                mlir::Value resultBox, mlir::Value stringBox,
-               mlir::Value setBox, mlir::Value backBox, mlir::Value kind);
+               mlir::Value setBox, mlir::Value backBox, mlir::Value kind,
+               bool isScan);
+
+/// Generate call to the scan or verify runtime routine that is specialized on 
+/// \param kind.
+/// The \param kind represents the kind of the elements in the strings.
+mlir::Value genScanVerifyKind(Fortran::lower::FirOpBuilder &builder,
+                         mlir::Location loc, int kind, mlir::Value stringBase,
+                         mlir::Value stringLen, mlir::Value setBase,
+                         mlir::Value setLen, mlir::Value back, bool isScan);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -163,7 +163,6 @@ Fortran::lower::genScanDescriptor(Fortran::lower::FirOpBuilder &builder,
                                   mlir::Location loc, mlir::Value resultBox,
                                   mlir::Value stringBox, mlir::Value setBox,
                                   mlir::Value backBox, mlir::Value kind) {
-
   auto func = getRuntimeFunc<mkRTKey(Scan)>(loc, builder);
   genCharacterSearch(func, builder, loc, resultBox, stringBox, setBox, backBox,
                      kind);
@@ -211,7 +210,6 @@ Fortran::lower::genVerifyDescriptor(Fortran::lower::FirOpBuilder &builder,
                                     mlir::Location loc, mlir::Value resultBox,
                                     mlir::Value stringBox, mlir::Value setBox,
                                     mlir::Value backBox, mlir::Value kind) {
-
   auto func = getRuntimeFunc<mkRTKey(Verify)>(loc, builder);
   genCharacterSearch(func, builder, loc, resultBox, stringBox, 
                                      setBox, backBox, kind);

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -12,7 +12,6 @@
 // module.
 //
 //===----------------------------------------------------------------------===//
-#include "../../runtime/character.h"
 
 #include "flang/Lower/IntrinsicCall.h"
 #include "RTBuilder.h"

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -171,6 +171,7 @@ struct IntrinsicLibrary {
   mlir::Value genSign(mlir::Type, llvm::ArrayRef<mlir::Value>);
   fir::ExtendedValue genTrim(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genVerify(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
+  fir::ExtendedValue genScanVerify(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>, bool isScan);
   /// Implement all conversion functions like DBLE, the first argument is
   /// the value to convert. There may be an additional KIND arguments that
   /// is ignored because this is already reflected in the result type.
@@ -318,14 +319,18 @@ static constexpr IntrinsicHandler handlers[]{
      &I::genScan,
      {{{"string", asAddr},
        {"set", asAddr},
-       {"back", asAddr},
+       {"back", asValue},
        {"kind", asValue}}},
      /*isElemental=*/true},
     {"sign", &I::genSign},
     {"trim", &I::genTrim, {{{"string", asAddr}}}, /*isElemental=*/false},
-    {"verify", &I::genVerify, {{ {"string", asAddr}, {"set", asAddr},
-                          {"back", asAddr}, {"kind", asValue} }},
-               /*isElemental=*/true},
+    {"verify",
+     &I::genVerify,
+     {{{"string", asAddr},
+       {"set", asAddr},
+       {"back", asValue},
+       {"kind", asValue}}},
+     /*isElemental=*/true},
 };
 
 /// To make fir output more readable for debug, one can outline all intrinsic
@@ -1545,46 +1550,7 @@ fir::ExtendedValue
 IntrinsicLibrary::genScan(mlir::Type resultType,
                           llvm::ArrayRef<fir::ExtendedValue> args) {
 
-  assert(args.size() == 4);
-
-  // Handle required string argument
-  auto string = builder.createBox(loc, args[0]);
-
-  // Handle required set argument
-  auto set = builder.createBox(loc, args[1]);
-
-  // Handle optional argument, back
-  auto back = isAbsent(args[2])
-                  ? builder.create<fir::AbsentOp>(
-                        loc, fir::BoxType::get(builder.getNoneType()))
-                  : builder.createBox(loc, args[2]);
-
-  // Handle optional argument, kind
-  auto kind = isAbsent(args[3]) ? builder.createIntegerConstant(
-                                      loc, resultType,
-                                      builder.getKindMap().defaultIntegerKind())
-                                : fir::getBase(args[3]);
-
-  // Create result descriptor
-  auto resultMutableBox =
-      Fortran::lower::createTempMutableBox(builder, loc, resultType);
-  auto resultIrBox =
-      Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
-
-  Fortran::lower::genScan(builder, loc, resultIrBox, string, set, back, kind);
-
-  // Handle cleanup of allocatable result descriptor and return
-  auto res = Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox);
-
-  return res.match(
-      [&](const Fortran::lower::SymbolBox::Intrinsic &box)
-          -> fir::ExtendedValue {
-        addCleanUpForTemp(loc, box.getAddr());
-        return builder.create<fir::LoadOp>(loc, resultType, box.getAddr());
-      },
-      [&](const auto &) -> fir::ExtendedValue {
-        fir::emitFatalError(loc, "unexpected result for SCAN");
-      });
+  return IntrinsicLibrary::genScanVerify(resultType, args, true);
 }
 
 // SIGN
@@ -1693,9 +1659,67 @@ static mlir::Value createExtremumCompare(mlir::Location loc,
 // VERIFY 
 fir::ExtendedValue
 IntrinsicLibrary::genVerify(mlir::Type resultType,
-                            llvm::ArrayRef<fir::ExtendedValue> args) {
+                                llvm::ArrayRef<fir::ExtendedValue> args) {
+
+  return IntrinsicLibrary::genScanVerify(resultType, args, false);
+}
+
+// Process Scan/Verify intrinsic
+fir::ExtendedValue
+IntrinsicLibrary::genScanVerify(mlir::Type resultType,
+                                llvm::ArrayRef<fir::ExtendedValue> args,
+                                bool isScan) {
 
   assert(args.size() == 4);
+
+  if (isAbsent(args[3])) {
+    // Kind not specified, so call scan/verify runtime routine that is 
+    // specialized on the kind of characters in string.
+
+    // Handle required string base arg
+    auto stringBase = fir::getBase(args[0]);
+
+    // Handle required set string base arg
+    auto setBase = fir::getBase(args[1]);
+
+    // Handle kind argument; it is the kind of character in this case
+    auto kind =
+      Fortran::lower::CharacterExprHelper{builder, loc}.getCharacterKind(  
+          stringBase.getType());
+
+    // Get string length argument
+    auto stringLen = fir::getLen(args[0]);   
+
+    // Get set string length argument
+    auto setLen = fir::getLen(args[1]);
+
+    // Handle optional back argument
+    auto back = isAbsent(args[2])
+                ? builder.createIntegerConstant(loc, builder.getI1Type(), 0) 
+                : fir::getBase(args[2]);
+
+    return builder.createConvert(
+        loc, resultType,
+        Fortran::lower::genScanVerifyKind(builder, loc, kind, stringBase, 
+                                          stringLen, setBase, setLen, back,
+                                          isScan));
+  }
+  // else use the runtime descriptor version of scan/verify
+ 
+
+  // Handle optional argument, back
+  auto makeRefThenEmbox = [&](mlir::Value b) {
+    auto logTy = fir::LogicalType::get(
+      builder.getContext(), builder.getKindMap().defaultLogicalKind());
+    auto temp = builder.createTemporary(loc, logTy);
+    auto castb = builder.createConvert(loc, logTy, b);
+    builder.create<fir::StoreOp>(loc, castb, temp);
+    return builder.createBox(loc, temp);
+  };
+  auto back = fir::isUnboxedValue(args[2])
+              ? makeRefThenEmbox(*args[2].getUnboxed())
+              : builder.create<fir::AbsentOp>(
+                loc, fir::BoxType::get(builder.getI1Type()));
 
   // Handle required string argument
   auto string = builder.createBox(loc, args[0]);
@@ -1703,17 +1727,8 @@ IntrinsicLibrary::genVerify(mlir::Type resultType,
   // Handle required set argument
   auto set = builder.createBox(loc, args[1]);
 
-  // Handle optional argument, back
-  auto back = isAbsent(args[2])
-              ? builder.create<fir::AbsentOp>(
-              loc, fir::BoxType::get(builder.getNoneType()))
-              : builder.createBox(loc, args[2]); 
-
-  // Handle optional argument, kind
-  auto kind = isAbsent(args[3])
-              ? builder.createIntegerConstant(loc, resultType, 
-              builder.getKindMap().defaultIntegerKind()) :
-              fir::getBase(args[3]);
+  // Handle kind argument
+  auto kind = fir::getBase(args[3]);
   
   // Create result descriptor    
   auto resultMutableBox =
@@ -1721,7 +1736,8 @@ IntrinsicLibrary::genVerify(mlir::Type resultType,
   auto resultIrBox =
        Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
 
-  Fortran::lower::genVerify(builder, loc, resultIrBox, string, set, back, kind);
+  Fortran::lower::genScanVerify(builder, loc, resultIrBox, string, set, back, 
+                                kind, isScan);
 
   // Handle cleanup of allocatable result descriptor and return
   auto res = Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox);
@@ -1733,7 +1749,7 @@ IntrinsicLibrary::genVerify(mlir::Type resultType,
             return builder.create<fir::LoadOp>(loc, resultType, box.getAddr());
       },
       [&](const auto &) -> fir::ExtendedValue {
-        fir::emitFatalError(loc, "unexpected result for VERIFY");
+        fir::emitFatalError(loc, "unexpected result for SCAN/VERIFY");
       });
 }
 

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -390,14 +390,31 @@ integer function scan_test(s1, s2)
 ! CHECK-DAG: %[[c2:.*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK-DAG: %[[cBox2:.*]] = fir.embox %[[c2]]#0 typeparams %[[c2]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-DAG: %[[cBoxNone2:.*]] = fir.convert %[[cBox2]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-DAG: %[[backBox:.*]] = fir.absent !fir.box<none>
+! CHECK-DAG: %[[backOptBox:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG: %[[backBox:.*]] = fir.convert %[[backOptBox]] : (!fir.box<i1>) -> !fir.box<none>
 ! CHECK-DAG: %[[kindConstant:.*]] = constant 4 : i32
 ! CHECK-DAG: %[[resBox:.*]] = fir.convert %[[tmpBox:.*]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: fir.call @{{.*}}Scan(%[[resBox]], %[[cBoxNone]], %[[cBoxNone2]], %[[backBox]], %[[kindConstant]], {{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
-  scan_test = scan(s1, s2)
+  scan_test = scan(s1, s2, kind=4)
 ! CHECK-DAG: %[[tmpAddr:.*]] = fir.box_addr
 ! CHECK: fir.freemem %[[tmpAddr]] : !fir.heap<i32>
 end function scan_test
+
+! SCAN 
+! CHECK-LABEL: func @_QPscan_test2(%
+! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
+! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+integer function scan_test2(s1, s2)
+  character(*) :: s1, s2
+  ! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[sst:[^:]*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[a1:.*]] = fir.convert %[[st]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK: %[[a2:.*]] = fir.convert %[[st]]#1 : (index) -> i64
+  ! CHECK: %[[a3:.*]] = fir.convert %[[sst]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK: %[[a4:.*]] = fir.convert %[[sst]]#1 : (index) -> i64
+  ! CHECK: = fir.call @_FortranAScan1(%[[a1]], %[[a2]], %[[a3]], %[[a4]], %{{.*}}) : (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
+  scan_test2 = scan(s1, s2, .true.)
+end function scan_test2
 
 ! SIGN
 ! CHECK-LABEL: sign_testi
@@ -462,12 +479,29 @@ integer function verify_test(s1, s2)
 ! CHECK-DAG: %[[c2:.*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK-DAG: %[[cBox2:.*]] = fir.embox %[[c2]]#0 typeparams %[[c2]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-DAG: %[[cBoxNone2:.*]] = fir.convert %[[cBox2]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-DAG: %[[backBox:.*]] = fir.absent !fir.box<none>
+! CHECK-DAG: %[[backOptBox:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG: %[[backBox:.*]] = fir.convert %[[backOptBox]] : (!fir.box<i1>) -> !fir.box<none>
 ! CHECK-DAG: %[[kindConstant:.*]] = constant 4 : i32
 ! CHECK-DAG: %[[resBox:.*]] = fir.convert %[[tmpBox:.*]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: fir.call @{{.*}}Verify(%[[resBox]], %[[cBoxNone]], %[[cBoxNone2]], %[[backBox]], %[[kindConstant]], {{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
-  verify_test = verify(s1, s2)
+  verify_test = verify(s1, s2, kind=4)
 ! CHECK-DAG: %[[tmpAddr:.*]] = fir.box_addr
 ! CHECK: fir.freemem %[[tmpAddr]] : !fir.heap<i32>
 end function verify_test
+
+! VERIFY 
+! CHECK-LABEL: func @_QPverify_test2(%
+! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
+! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+integer function verify_test2(s1, s2)
+  character(*) :: s1, s2
+  ! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[sst:[^:]*]]:2 = fir.unboxchar %[[ss]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[a1:.*]] = fir.convert %[[st]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK: %[[a2:.*]] = fir.convert %[[st]]#1 : (index) -> i64
+  ! CHECK: %[[a3:.*]] = fir.convert %[[sst]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK: %[[a4:.*]] = fir.convert %[[sst]]#1 : (index) -> i64
+  ! CHECK: = fir.call @_FortranAVerify1(%[[a1]], %[[a2]], %[[a3]], %[[a4]], %{{.*}}) : (!fir.ref<i8>, i64, !fir.ref<i8>, i64, i1) -> i64
+  verify_test2 = verify(s1, s2, .true.)
+end function verify_test2
 


### PR DESCRIPTION
Add runtime calls to specialized versions of scan/verify intrinsics. Refactor some code into functions that operate on both scan/verify. Update the "adding intrinsics" tutorial.