### PR TITLE
Place induction variables in column major order

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2103,9 +2103,9 @@ public:
     fir::DoLoopOp inner;
     auto innerArg = destination.getResult();
     mlir::Value outerRes;
-    llvm::SmallVector<mlir::Value> ivars;
-    auto insPt = builder.saveInsertionPoint();
     const auto loopDepth = loopUppers.size();
+    llvm::SmallVector<mlir::Value> ivars(loopDepth);
+    auto insPt = builder.saveInsertionPoint();
     assert(loopDepth > 0);
     for (auto i : llvm::enumerate(llvm::reverse(loopUppers))) {
       if (i.index() > 0) {
@@ -2116,7 +2116,9 @@ public:
           loc, zero, i.value(), one, /*unordered=*/false,
           /*finalCount=*/false, mlir::ValueRange{innerArg});
       innerArg = loop.getRegionIterArgs().front();
-      ivars.push_back(loop.getInductionVar());
+      // Store induction vars in column major order, which is what FIR array ops
+      // expect.
+      ivars[loopDepth - 1 - i.index()] = loop.getInductionVar();
       if (!outerRes)
         outerRes = loop.getResult(0);
       if (!inner)

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -426,4 +426,18 @@ subroutine test18
   row_i => array(i, :)
 end subroutine test18
 
+! CHECK-LABEL: func @_QPtest_column_and_row_order(
+subroutine test_column_and_row_order(x)
+  real :: x(2,3)
+  ! CHECK-DAG: %[[c2:.*]] = fir.convert %c2{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[number_of_rows:.*]] = subi %[[c2]], %c1{{.*}} : index
+  ! CHECK-DAG: %[[c3:.*]] = fir.convert %c3{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[number_of_columns:.*]] = subi %[[c3]], %c1{{.*}} : index
+  ! CHECK: fir.do_loop %[[column:.*]] = %c0{{.*}} to %[[number_of_columns]]
+  ! CHECK: fir.do_loop %[[row:.*]] = %c0{{.*}} to %[[number_of_rows]]
+  ! CHECK: = fir.array_update %{{.*}}, %{{.*}}, %[[row]], %[[column]] : (!fir.array<2x3xf32>, f32, index, index) -> !fir.array<2x3xf32>
+  x = 42
+end subroutine
+
+
 ! CHECK: func private @_QPbar(


### PR DESCRIPTION
Fixes #729.
The issue came from bad order of induction variables in array expressions loops. This was a generic problem, probably not caught because most of the multiple dimension regressions tests have the same extents.
The order of the loops was OK, but the comment about it not OK.

Note that the issue was exposed in #729 because lowering is making a copy of the array slice for the IO runtime call. It should not. It should instead create a descriptor for the array slice. For output IO, that is just a perf issue, for input IO, that is wrong. I am working on a fix for that in a different PR since that is a different issue.