### PR TITLE
ALL/ANY fir lowering

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1203,6 +1203,7 @@ IntrinsicLibrary::genAll(mlir::Type resultType,
   return Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox)
       .match(
           [&](const fir::ArrayBoxValue &box) -> fir::ExtendedValue {
+            addCleanUpForTemp(loc, box.getAddr());
             return box;
           },
           [&](const auto &) -> fir::ExtendedValue {
@@ -1274,6 +1275,7 @@ IntrinsicLibrary::genAny(mlir::Type resultType,
   return Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox)
       .match(
           [&](const fir::ArrayBoxValue &box) -> fir::ExtendedValue {
+            addCleanUpForTemp(loc, box.getAddr());
             return box;
           },
           [&](const auto &) -> fir::ExtendedValue {

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -65,14 +65,15 @@ subroutine all_test2(mask, d, rslt)
   logical :: mask(:,:)
   integer :: d
   logical :: rslt(:)
-! CHECK-DAG:  %[[c0:.*]] = constant 0 : index
 ! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
 ! CHECK-DAG:  %[[a1:.*]] = fir.load %[[arg1:.*]] : !fir.ref<i32>
 ! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0:.*]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK-DAG:  %[[a7:.*]] = fir.convert %[[arg0:.*]]: (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.box<none>
   rslt = all(mask, d)
 ! CHECK:  %[[r1:.*]] = fir.call @_FortranAAllDim(%[[a6:.*]], %[[a7:.*]], %[[a1:.*]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
-! CHECK-DAG:  %[[r2:.*]]:3 = fir.box_dims %[[arg2:.*]] %[[c0:.*]] : (!fir.box<!fir.array<?x!fir.logical<4>>>, index) -> (index, index, index)
+! CHECK-DAG:  %[[a10:.*]] = fir.load %[[a0:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
+! CHECK-DAG:  %[[a12:.*]] = fir.box_addr %[[a10:.*]] : (!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>) -> !fir.heap<!fir.array<?x!fir.logical<4>>>
+! CHECK-DAG  fir.freemem %[[a12:.*]] : !fir.heap<!fir.array<?x!fir.logical<4>>>
 end subroutine
 
 ! ALLOCATED
@@ -122,14 +123,15 @@ subroutine any_test2(mask, d, rslt)
   logical :: mask(:,:)
   integer :: d
   logical :: rslt(:)
-! CHECK-DAG:  %[[c0:.*]] = constant 0 : index
 ! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
 ! CHECK-DAG:  %[[a1:.*]] = fir.load %[[arg1:.*]] : !fir.ref<i32>
 ! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0:.*]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK-DAG:  %[[a7:.*]] = fir.convert %[[arg0:.*]]: (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.box<none>
   rslt = any(mask, d)
 ! CHECK:  %[[r1:.*]] = fir.call @_FortranAAnyDim(%[[a6:.*]], %[[a7:.*]], %[[a1:.*]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
-! CHECK-DAG:  %[[r2:.*]]:3 = fir.box_dims %[[arg2:.*]] %[[c0:.*]] : (!fir.box<!fir.array<?x!fir.logical<4>>>, index) -> (index, index, index)
+! CHECK-DAG:  %[[a10:.*]] = fir.load %[[a0:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
+! CHECK-DAG:  %[[a12:.*]] = fir.box_addr %[[a10:.*]] : (!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>) -> !fir.heap<!fir.array<?x!fir.logical<4>>>
+! CHECK-DAG  fir.freemem %[[a12:.*]] : !fir.heap<!fir.array<?x!fir.logical<4>>>
 end subroutine
 
 ! ASSOCIATED

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -56,6 +56,25 @@ logical function all_test(mask)
 ! CHECK:  %[[a3:.*]] = fir.call @_FortranAAll(%[[a1]], %{{.*}}, %{{.*}}, %[[a2]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i1
 end function all_test 
 
+! ALL
+! CHECK-LABEL: all_test2
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<i32>
+! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>
+subroutine all_test2(mask, d, rslt)
+  logical :: mask(:,:)
+  integer :: d
+  logical :: rslt(:)
+! CHECK-DAG:  %[[c0:.*]] = constant 0 : index
+! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
+! CHECK-DAG:  %[[a1:.*]] = fir.load %[[arg1:.*]] : !fir.ref<i32>
+! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0:.*]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG:  %[[a7:.*]] = fir.convert %[[arg0:.*]]: (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.box<none>
+  rslt = all(mask, d)
+! CHECK:  %[[r1:.*]] = fir.call @_FortranAAllDim(%[[a6:.*]], %[[a7:.*]], %[[a1:.*]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
+! CHECK-DAG:  %[[r2:.*]]:3 = fir.box_dims %[[arg2:.*]] %[[c0:.*]] : (!fir.box<!fir.array<?x!fir.logical<4>>>, index) -> (index, index, index)
+end subroutine
+
 ! ALLOCATED
 ! CHECK-LABEL: allocated_test
 ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>,
@@ -93,6 +112,25 @@ logical function any_test(mask)
   any_test = any(mask)
 ! CHECK:  %[[a3:.*]] = fir.call @_FortranAAny(%[[a1]], %{{.*}},  %{{.*}}, %[[a2]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i1
 end function any_test 
+
+! ANY
+! CHECK-LABEL: any_test2
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<i32>
+! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>
+subroutine any_test2(mask, d, rslt)
+  logical :: mask(:,:)
+  integer :: d
+  logical :: rslt(:)
+! CHECK-DAG:  %[[c0:.*]] = constant 0 : index
+! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
+! CHECK-DAG:  %[[a1:.*]] = fir.load %[[arg1:.*]] : !fir.ref<i32>
+! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0:.*]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG:  %[[a7:.*]] = fir.convert %[[arg0:.*]]: (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.box<none>
+  rslt = any(mask, d)
+! CHECK:  %[[r1:.*]] = fir.call @_FortranAAnyDim(%[[a6:.*]], %[[a7:.*]], %[[a1:.*]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none
+! CHECK-DAG:  %[[r2:.*]]:3 = fir.box_dims %[[arg2:.*]] %[[c0:.*]] : (!fir.box<!fir.array<?x!fir.logical<4>>>, index) -> (index, index, index)
+end subroutine
 
 ! ASSOCIATED
 ! CHECK-LABEL: associated_test

--- a/flang/test/Lower/transformational-intrinsics.f90
+++ b/flang/test/Lower/transformational-intrinsics.f90
@@ -6,8 +6,6 @@
 ! tested here is that transformational intrinsics are lowered correctly
 ! regardless of the context they appear into.
 
-! TODO: enable when adding ALL intrinsic lowering tat is used for these tests
-! XFAIL: true
 
 
 module test2


### PR DESCRIPTION
Incorporate more comments from PR #733 (i.e., put back cleanup code). Enable transformational-intrinsics tests. Add all/any regression tests for the result descriptor case.