### PR TITLE
Fix assumed shape bounds read in array expressions

### DIFF
--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -439,5 +439,17 @@ subroutine test_column_and_row_order(x)
   x = 42
 end subroutine
 
+! CHECK-LABEL: func @_QPtest_assigning_to_assumed_shape_slices(
+! CHECK-SAME:  %[[x:.*]]: !fir.box<!fir.array<?xi32>>
+subroutine test_assigning_to_assumed_shape_slices(x)
+  integer :: x(:)
+  ! CHECK: %[[slice:.*]] = fir.array_load %[[x]] [%{{.*}}] : (!fir.box<!fir.array<?xi32>>, !fir.slice<1>) -> !fir.array<?xi32>
+  ! CHECK: fir.box_dims %[[x]], %c0{{.*}} : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+  ! CHECK: %[[loop:.*]] = fir.do_loop %[[idx:.*]] = %c0{{.*}} to %{{.*}} step %c1{{.*}} iter_args(%[[dest:.*]] = %[[slice]]) -> (!fir.array<?xi32>) {
+    ! CHECK: %[[res:.*]] = fir.array_update %[[dest]], %c42{{.*}}, %[[idx]] : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
+    ! CHECK: fir.result %[[res]] : !fir.array<?xi32>
+  ! CHECK: fir.array_merge_store %[[slice]], %[[loop]] to %[[x]] : !fir.box<!fir.array<?xi32>>
+  x(::2) = 42
+end subroutine
 
 ! CHECK: func private @_QPbar(


### PR DESCRIPTION
`box.getExtents()` should not be called on `fir::BoxValue` (that for instance holds non contiguous assumed shape arrays), instead the extents must be read from the fir.box if needed. This lead to read after array bounds in lowering and compiler crashes.

- Use readExtent/readLowerBound  that do the same job and handle all Extended values.
- Add a simple test that uses `getUBound` code path with a `fir::BoxValue`.