### PR TITLE
Embox array slices in IO item list instead of making copies

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -90,7 +90,11 @@ public:
   // Expressions
   //===--------------------------------------------------------------------===//
 
-  /// Generate the address of the location holding the expression, someExpr
+  /// Generate the address of the location holding the expression, someExpr.
+  /// If SomeExpr is a Designator that is not compile time contiguous, the
+  /// address returned is the one of a contiguous temporary storage holding the
+  /// expression value. The clean-up for this temporary is added to the
+  /// StatementContext.
   virtual fir::ExtendedValue genExprAddr(const SomeExpr &, StatementContext &,
                                          mlir::Location *loc = nullptr) = 0;
   /// Generate the address of the location holding the expression, someExpr
@@ -109,6 +113,12 @@ public:
                                   mlir::Location loc) {
     return genExprValue(*someExpr, stmtCtx, &loc);
   }
+
+  /// Generate or get a fir.box describing the expression. If SomeExpr is
+  /// a Designator, the fir.box describes an entity over the Designator base
+  /// storage without making a temporary.
+  virtual mlir::Value genExprBox(const SomeExpr &, StatementContext &,
+                                 mlir::Location) = 0;
 
   /// Generate the address of the box describing the variable designated
   /// by the expression. The expression must be an allocatable or pointer

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -104,7 +104,8 @@ createSomeArrayTempValue(AbstractConverter &converter,
                          const evaluate::Expr<evaluate::SomeType> &expr,
                          SymMap &symMap, StatementContext &stmtCtx);
 
-/// Lower an array expression to a value of type box.
+/// Lower an array expression to a value of type box. The expression must be a
+/// variable.
 fir::ExtendedValue
 createSomeArrayBox(AbstractConverter &converter,
                    const evaluate::Expr<evaluate::SomeType> &expr,

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -298,6 +298,14 @@ public:
                     const Fortran::lower::SomeExpr &expr) override final {
     return createSomeMutableBox(loc, *this, expr, localSymbols);
   }
+  mlir::Value genExprBox(const Fortran::lower::SomeExpr &expr,
+                         Fortran::lower::StatementContext &context,
+                         mlir::Location loc) override final {
+    if (expr.Rank() > 0 && Fortran::evaluate::IsVariable(expr))
+      return fir::getBase(
+          createSomeArrayBox(*this, expr, localSymbols, context));
+    return builder->createBox(loc, genExprAddr(expr, context, &loc));
+  }
 
   Fortran::evaluate::FoldingContext &getFoldingContext() override final {
     return foldingContext;

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -3302,12 +3302,15 @@ public:
                   // Normalize `e` by subtracting the declared lbound.
                   mlir::Value ivAdj =
                       builder.create<mlir::SubIOp>(loc, idxTy, iv, lb);
-                  // Add lbound adjusted value of `e` to the iteration vector.
-                  pc = [=](IterSpace iters) {
-                    IterationSpace newIters = currentPC(iters);
-                    newIters.insertIndexValue(dim, ivAdj);
-                    return newIters;
-                  };
+                  // Add lbound adjusted value of `e` to the iteration vector
+                  // (except when creating a box because the iteration vector is
+                  // empty).
+                  if (!isBoxValue())
+                    pc = [=](IterSpace iters) {
+                      IterationSpace newIters = currentPC(iters);
+                      newIters.insertIndexValue(dim, ivAdj);
+                      return newIters;
+                    };
                 }
               }},
           sub.value().u);
@@ -3377,7 +3380,7 @@ public:
                     .getResult()
               : builder
                     .create<fir::EmboxOp>(loc, boxTy, memref, shape, slice,
-                                          /*lenParams=*/llvm::None)
+                                          fir::getTypeParams(extMemref))
                     .getResult();
       return [=](IterSpace) -> ExtValue { return fir::BoxValue(embox); };
     }

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -52,6 +52,7 @@ llvm::SmallVector<mlir::Value> fir::getTypeParams(const ExtendedValue &exv) {
   auto baseTy = fir::getBase(exv).getType();
   if (auto t = fir::dyn_cast_ptrEleTy(baseTy))
     baseTy = t;
+  baseTy = fir::unwrapSequenceType(baseTy);
   if (!fir::hasDynamicSize(baseTy))
     return {}; // type has constant size, no type parameters needed
   [[maybe_unused]] auto loc = fir::getBase(exv).getLoc();

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -66,12 +66,10 @@ subroutine sub(a)
   ! CHECK-DAG: %[[one:.*]] = constant 1 : i64
   ! CHECK-DAG: %[[five:.*]] = constant 5 : i64
   ! CHECK-DAG: %[[two:.*]] = constant 2 : i64
-  ! CHECK-DAG: %[[three:.*]] = constant 3 : index
-  ! CHECK: %[[shape:.*]] = fir.shape %[[ten]] :
-  ! CHECK: %[[slice:.*]] = fir.slice %[[one]], %[[five]], %[[two]] :
-  ! CHECK: %[[allocmem:.*]] = fir.allocmem !fir.array<3x!fir.char<1>>
-  ! CHECK: %[[shape3:.*]] = fir.shape %[[three]] :
-  ! CHECK: fir.array_coor %{{.*}}(%[[shape]]) [%[[slice]]] %
-  ! CHECK: fir.embox %[[allocmem]](%[[shape3]]) : (!fir.heap<!fir.array<3x!fir.char<1>>>, !fir.shape<1>) -> !fir.box<!fir.array<3x!fir.char<1>>>
+  ! CHECK: %[[unboxchar:.*]]:2 = fir.unboxchar
+  ! CHECK: %[[a_addr:.*]] = fir.convert %[[unboxchar]]#0 :
+  ! CHECK-DAG: %[[shape10:.*]] = fir.shape %[[ten]] :
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %[[one]], %[[five]], %[[two]] :
+  ! CHECK: fir.embox %[[a_addr]](%[[shape10]]) [%[[slice]]] : (!fir.ref<!fir.array<10x!fir.char<1>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?x!fir.char<1>>>
   print *, "a = ", a(1:5:2)
 end subroutine sub

--- a/flang/test/Lower/array-expression-slice-2.f90
+++ b/flang/test/Lower/array-expression-slice-2.f90
@@ -43,12 +43,9 @@ program main
   A(3) = 3
   print *, A
   ! CHECK: %[[A:.*]] = fir.address_of(@_QEa)
-  ! CHECK: %[[shape10:.*]] = fir.shape %c10
+  ! CHECK: %[[shape:.*]] = fir.shape %c10
   ! CHECK: %[[slice:.*]] = fir.slice %
-  ! CHECK: %[[mem:.*]] = fir.allocmem !fir.array<3xi32>
-  ! CHECK: %[[shape:.*]] = fir.shape %c3
-  ! CHECK: fir.array_coor %[[A]](%[[shape10]]) [%[[slice]]] %
-  ! CHECK: fir.array_coor %[[mem]](%[[shape]]) %
+  ! CHECK: fir.embox %[[A]](%[[shape]]) [%[[slice]]] :
   print*, A(1:3:1)
   call s
   call i

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -25,3 +25,25 @@ subroutine pass_assumed_len_char_array(carray)
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[descriptor]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
   print *, carray
 end
+
+! CHECK-LABEL: func @_QPpass_array_slice_read
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>
+subroutine pass_array_slice_read(x)
+  real :: x(:)
+  read(5, *) x(101:200:2) 
+  ! CHECK: %[[slice:.*]] = fir.slice %c101{{.*}}, %c200{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[box:.*]] = fir.rebox %[[x]] [%[[slice]]] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[box_cast:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioInputDescriptor(%{{.*}}, %[[box_cast]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+end 
+
+! CHECK-LABEL: func @_QPpass_array_slice_write
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>
+subroutine pass_array_slice_write(x)
+  real :: x(:)
+  write(1, rec=1) x(101:200:2) 
+  ! CHECK: %[[slice:.*]] = fir.slice %c101{{.*}}, %c200{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[box:.*]] = fir.rebox %[[x]] [%[[slice]]] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[box_cast:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[box_cast]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+end 


### PR DESCRIPTION
The IO used `genExprAddr` that creates contiguous copies for non contiguous
entities (array slices and assumed shapes). This is semantically wrong in IO
input since the actual variable was not modified as it should. This is also
wasting resources in IO output since the IO runtime support non
contiguous descriptors, so there is no need to create a temp and making
a copy.

- Add `AbstractConverter::genExprBox` that creates a `fir.box` describing an
expression without making a temporary if the expression is a designator. It
uses `createSomeArrayBox` on array expressions.

- Modifies the IO input/output list code to use `genExprBox` when the IO item
must be passed through a descriptors (which is the case for arrays).

- Update `genarr(ArrayRef)` `isBoxValue` case ~~to support assumed shape array base (using
fir.rebox) and~~ [edit: done in #778 ] to pass the length to EmboxOp when this is needed.

- ~~Update all the lit tests that were depending on IO making a copy of
array slices/ expecting an order for fir.slice/fir.shape creation.~~ [edit: no change here eventually].

- ~~Fix fir.embox codegen with slices (we had mentioned the potential issue a while ago, but it was not visible because of the copies. Lower bounds of slice must shift the base address instead of being stored as the descriptor lower bounds).~~ [edit: done in #754]