### PR TITLE
Cherry pick latest runtime fixes from LLVM

### DIFF
--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -48,6 +48,7 @@ add_flang_library(FortranRuntime PARTIAL_SOURCES_INTENDED
   memory.cpp
   misc-intrinsic.cpp
   numeric.cpp
+  random.cpp
   reduction.cpp
   stat.cpp
   stop.cpp

--- a/flang/runtime/buffer.h
+++ b/flang/runtime/buffer.h
@@ -73,7 +73,7 @@ public:
         start_ = 0;
       }
     }
-    while (FrameLength() < bytes) {
+    if (FrameLength() < bytes) {
       auto next{start_ + length_};
       RUNTIME_CHECK(handler, next < size_);
       auto minBytes{bytes - FrameLength()};
@@ -81,10 +81,7 @@ public:
       auto got{Store().Read(
           fileOffset_ + length_, buffer_ + next, minBytes, maxBytes, handler)};
       length_ += got;
-      RUNTIME_CHECK(handler, length_ < size_);
-      if (got < minBytes) {
-        break; // error or EOF & program can handle it
-      }
+      RUNTIME_CHECK(handler, length_ <= size_);
     }
     return FrameLength();
   }

--- a/flang/runtime/descriptor-io.h
+++ b/flang/runtime/descriptor-io.h
@@ -220,7 +220,9 @@ static bool DescriptorIO(IoStatementState &io, const Descriptor &descriptor) {
     return false;
   }
   if constexpr (DIR == Direction::Input) {
-    io.BeginReadingRecord();
+    if (!io.BeginReadingRecord()) {
+      return false;
+    }
   }
   if (auto *unf{io.get_if<UnformattedIoStatementState<DIR>>()}) {
     std::size_t elementBytes{descriptor.ElementBytes()};

--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -310,7 +310,7 @@ Cookie IONAME(BeginEndfile)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
   ExternalFileUnit &unit{ExternalFileUnit::LookUpOrCreateAnonymous(
-      unitNumber, Direction::Output, true /*formatted*/, terminator)};
+      unitNumber, Direction::Output, false /*formatted*/, terminator)};
   return &unit.BeginIoStatement<ExternalMiscIoStatementState>(
       unit, ExternalMiscIoStatementState::Endfile, sourceFile, sourceLine);
 }
@@ -319,7 +319,7 @@ Cookie IONAME(BeginRewind)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
   ExternalFileUnit &unit{ExternalFileUnit::LookUpOrCreateAnonymous(
-      unitNumber, Direction::Input, true /*formatted*/, terminator)};
+      unitNumber, Direction::Input, false /*formatted*/, terminator)};
   return &unit.BeginIoStatement<ExternalMiscIoStatementState>(
       unit, ExternalMiscIoStatementState::Rewind, sourceFile, sourceLine);
 }

--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -894,6 +894,9 @@ bool IONAME(InputUnformattedBlock)(
     Cookie cookie, char *x, std::size_t length, std::size_t elementBytes) {
   IoStatementState &io{*cookie};
   io.BeginReadingRecord();
+  if (io.GetIoErrorHandler().InError()) {
+    return false;
+  }
   if (auto *unf{io.get_if<UnformattedIoStatementState<Direction::Input>>()}) {
     return unf->Receive(x, length, elementBytes);
   }
@@ -1037,7 +1040,7 @@ bool IONAME(InputLogical)(Cookie cookie, bool &truth) {
 
 void IONAME(GetIoMsg)(Cookie cookie, char *msg, std::size_t length) {
   IoErrorHandler &handler{cookie->GetIoErrorHandler()};
-  if (handler.GetIoStat()) { // leave "msg" alone when no error
+  if (handler.InError()) { // leave "msg" alone when no error
     handler.GetIoMsg(msg, length);
   }
 }

--- a/flang/runtime/io-error.cpp
+++ b/flang/runtime/io-error.cpp
@@ -17,20 +17,13 @@
 
 namespace Fortran::runtime::io {
 
-void IoErrorHandler::Begin(const char *sourceFileName, int sourceLine) {
-  flags_ = 0;
-  ioStat_ = 0;
-  ioMsg_.reset();
-  SetLocation(sourceFileName, sourceLine);
-}
-
 void IoErrorHandler::SignalError(int iostatOrErrno, const char *msg, ...) {
   if (iostatOrErrno == IostatEnd && (flags_ & hasEnd)) {
-    if (!ioStat_ || ioStat_ < IostatEnd) {
+    if (ioStat_ == IostatOk || ioStat_ < IostatEnd) {
       ioStat_ = IostatEnd;
     }
   } else if (iostatOrErrno == IostatEor && (flags_ & hasEor)) {
-    if (!ioStat_ || ioStat_ < IostatEor) {
+    if (!ioStat_ == IostatOk || ioStat_ < IostatEor) {
       ioStat_ = IostatEor; // least priority
     }
   } else if (iostatOrErrno != IostatOk) {

--- a/flang/runtime/io-error.h
+++ b/flang/runtime/io-error.h
@@ -27,14 +27,13 @@ class IoErrorHandler : public Terminator {
 public:
   using Terminator::Terminator;
   explicit IoErrorHandler(const Terminator &that) : Terminator{that} {}
-  void Begin(const char *sourceFileName, int sourceLine);
   void HasIoStat() { flags_ |= hasIoStat; }
   void HasErrLabel() { flags_ |= hasErr; }
   void HasEndLabel() { flags_ |= hasEnd; }
   void HasEorLabel() { flags_ |= hasEor; }
   void HasIoMsg() { flags_ |= hasIoMsg; }
 
-  bool InError() const { return ioStat_ != 0; }
+  bool InError() const { return ioStat_ != IostatOk; }
 
   void SignalError(int iostatOrErrno, const char *msg, ...);
   void SignalError(int iostatOrErrno);
@@ -58,7 +57,7 @@ private:
     hasIoMsg = 16, // IOMSG=
   };
   std::uint8_t flags_{0};
-  int ioStat_{0};
+  int ioStat_{IostatOk};
   OwningPtr<char> ioMsg_;
 };
 

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -230,7 +230,7 @@ int NoUnitIoStatementState::EndIoStatement() {
 
 template <Direction DIR> int ExternalIoStatementState<DIR>::EndIoStatement() {
   if constexpr (DIR == Direction::Input) {
-    BeginReadingRecord(); // in case of READ with no data items
+    BeginReadingRecord(); // in case there were no I/O items
     if (!unit().nonAdvancing) {
       FinishReadingRecord();
     }
@@ -310,12 +310,13 @@ void ExternalIoStatementState<DIR>::HandleRelativePosition(std::int64_t n) {
 }
 
 template <Direction DIR>
-void ExternalIoStatementState<DIR>::BeginReadingRecord() {
+bool ExternalIoStatementState<DIR>::BeginReadingRecord() {
   if constexpr (DIR == Direction::Input) {
-    unit().BeginReadingRecord(*this);
+    return unit().BeginReadingRecord(*this);
   } else {
     Crash("ExternalIoStatementState<Direction::Output>::BeginReadingRecord() "
           "called");
+    return false;
   }
 }
 
@@ -384,8 +385,8 @@ MutableModes &IoStatementState::mutableModes() {
       [](auto &x) -> MutableModes & { return x.get().mutableModes(); }, u_);
 }
 
-void IoStatementState::BeginReadingRecord() {
-  std::visit([](auto &x) { return x.get().BeginReadingRecord(); }, u_);
+bool IoStatementState::BeginReadingRecord() {
+  return std::visit([](auto &x) { return x.get().BeginReadingRecord(); }, u_);
 }
 
 IoErrorHandler &IoStatementState::GetIoErrorHandler() const {

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -188,17 +188,12 @@ void OpenStatementState::set_path(const char *path, std::size_t length) {
 }
 
 int OpenStatementState::EndIoStatement() {
-  if (wasExtant_ && status_ && *status_ != OpenStatus::Old) {
-    SignalError("OPEN statement for connected unit may not have STATUS= other "
-                "than 'OLD'");
-  }
   if (path_.get() || wasExtant_ ||
       (status_ && *status_ == OpenStatus::Scratch)) {
-    unit().OpenUnit(status_.value_or(OpenStatus::Unknown), action_, position_,
-        std::move(path_), pathLength_, convert_, *this);
+    unit().OpenUnit(status_, action_, position_, std::move(path_), pathLength_,
+        convert_, *this);
   } else {
-    unit().OpenAnonymousUnit(status_.value_or(OpenStatus::Unknown), action_,
-        position_, convert_, *this);
+    unit().OpenAnonymousUnit(status_, action_, position_, convert_, *this);
   }
   if (access_) {
     if (*access_ != unit().access) {

--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -71,7 +71,7 @@ public:
   IoErrorHandler &GetIoErrorHandler() const;
   ExternalFileUnit *GetExternalFileUnit() const; // null if internal unit
   MutableModes &mutableModes();
-  void BeginReadingRecord();
+  bool BeginReadingRecord();
   void FinishReadingRecord();
   bool Inquire(InquiryKeywordHash, char *, std::size_t);
   bool Inquire(InquiryKeywordHash, bool &);
@@ -139,7 +139,7 @@ struct IoStatementBase : public DefaultFormatControlCallbacks {
   int EndIoStatement();
   std::optional<DataEdit> GetNextDataEdit(IoStatementState &, int = 1);
   ExternalFileUnit *GetExternalFileUnit() const { return nullptr; }
-  void BeginReadingRecord() {}
+  bool BeginReadingRecord() { return true; }
   void FinishReadingRecord() {}
   bool Inquire(InquiryKeywordHash, char *, std::size_t);
   bool Inquire(InquiryKeywordHash, bool &);
@@ -282,7 +282,7 @@ public:
   void BackspaceRecord();
   void HandleRelativePosition(std::int64_t);
   void HandleAbsolutePosition(std::int64_t);
-  void BeginReadingRecord();
+  bool BeginReadingRecord();
   void FinishReadingRecord();
 };
 

--- a/flang/runtime/random.cpp
+++ b/flang/runtime/random.cpp
@@ -1,0 +1,193 @@
+//===-- runtime/random.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Implements the intrinsic subroutines RANDOM_INIT, RANDOM_NUMBER, and
+// RANDOM_SEED.
+
+#include "random.h"
+#include "cpp-type.h"
+#include "descriptor.h"
+#include "lock.h"
+#include "flang/Common/leading-zero-bit-count.h"
+#include "flang/Common/uint128.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <ctime>
+#include <limits>
+#include <memory>
+#include <random>
+
+namespace Fortran::runtime {
+
+// Newer "Minimum standard", recommended by Park, Miller, and Stockmeyer in
+// 1993. Same as C++17 std::minstd_rand, but explicitly instantiated for
+// permanence.
+using Generator =
+    std::linear_congruential_engine<std::uint_fast32_t, 48271, 0, 2147483647>;
+
+using GeneratedWord = typename Generator::result_type;
+static constexpr std::uint64_t range{
+    static_cast<std::uint64_t>(Generator::max() - Generator::min() + 1)};
+static constexpr bool rangeIsPowerOfTwo{(range & (range - 1)) == 0};
+static constexpr int rangeBits{
+    64 - common::LeadingZeroBitCount(range) - !rangeIsPowerOfTwo};
+
+static Lock lock;
+static Generator generator;
+
+template <typename REAL, int PREC>
+inline void Generate(const Descriptor &harvest) {
+  static constexpr std::size_t minBits{
+      std::max<std::size_t>(PREC, 8 * sizeof(GeneratedWord))};
+  using Int = common::HostUnsignedIntType<minBits>;
+  static constexpr std::size_t words{
+      static_cast<std::size_t>(PREC + rangeBits - 1) / rangeBits};
+  std::size_t elements{harvest.Elements()};
+  SubscriptValue at[maxRank];
+  harvest.GetLowerBounds(at);
+  {
+    CriticalSection critical{lock};
+    for (std::size_t j{0}; j < elements; ++j) {
+      Int fraction{generator()};
+      if constexpr (words > 1) {
+        for (std::size_t k{1}; k < words; ++k) {
+          static constexpr Int rangeMask{(Int{1} << rangeBits) - 1};
+          GeneratedWord word{(generator() - generator.min()) & rangeMask};
+          fraction = (fraction << rangeBits) | word;
+        }
+      }
+      fraction >>= words * rangeBits - PREC;
+      *harvest.Element<REAL>(at) =
+          std::ldexp(static_cast<REAL>(fraction), -(PREC + 1));
+      harvest.IncrementSubscripts(at);
+    }
+  }
+}
+
+extern "C" {
+
+void RTNAME(RandomInit)(bool repeatable, bool /*image_distinct*/) {
+  // TODO: multiple images and image_distinct: add image number
+  {
+    CriticalSection critical{lock};
+    if (repeatable) {
+      generator.seed(0);
+    } else {
+      generator.seed(std::time(nullptr));
+    }
+  }
+}
+
+void RTNAME(RandomNumber)(
+    const Descriptor &harvest, const char *source, int line) {
+  Terminator terminator{source, line};
+  auto typeCode{harvest.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator, typeCode && typeCode->first == TypeCategory::Real);
+  int kind{typeCode->second};
+  switch (kind) {
+  // TODO: REAL (2 & 3)
+  case 4:
+    Generate<CppTypeFor<TypeCategory::Real, 4>, 24>(harvest);
+    break;
+  case 8:
+    Generate<CppTypeFor<TypeCategory::Real, 8>, 53>(harvest);
+    break;
+#if LONG_DOUBLE == 80
+  case 10:
+    Generate<CppTypeFor<TypeCategory::Real, 10>, 64>(harvest);
+    break;
+#elif LONG_DOUBLE == 128
+  case 4:
+    Generate<CppTypeFor<TypeCategory::Real, 16>, 113>(harvest);
+    break;
+#endif
+  default:
+    terminator.Crash("RANDOM_NUMBER(): unsupported REAL kind %d", kind);
+  }
+}
+
+void RTNAME(RandomSeedSize)(
+    const Descriptor &size, const char *source, int line) {
+  Terminator terminator{source, line};
+  auto typeCode{size.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator,
+      size.rank() == 0 && typeCode && typeCode->first == TypeCategory::Integer);
+  int kind{typeCode->second};
+  switch (kind) {
+  case 4:
+    *size.OffsetElement<CppTypeFor<TypeCategory::Integer, 4>>() = 1;
+    break;
+  case 8:
+    *size.OffsetElement<CppTypeFor<TypeCategory::Integer, 8>>() = 1;
+    break;
+  default:
+    terminator.Crash("RANDOM_SEED(SIZE=): bad kind %d\n", kind);
+  }
+}
+
+void RTNAME(RandomSeedPut)(
+    const Descriptor &put, const char *source, int line) {
+  Terminator terminator{source, line};
+  auto typeCode{put.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator,
+      put.rank() == 1 && typeCode && typeCode->first == TypeCategory::Integer &&
+          put.GetDimension(0).Extent() >= 1);
+  int kind{typeCode->second};
+  GeneratedWord seed;
+  switch (kind) {
+  case 4:
+    seed = *put.OffsetElement<CppTypeFor<TypeCategory::Integer, 4>>();
+    break;
+  case 8:
+    seed = *put.OffsetElement<CppTypeFor<TypeCategory::Integer, 8>>();
+    break;
+  default:
+    terminator.Crash("RANDOM_SEED(PUT=): bad kind %d\n", kind);
+  }
+  {
+    CriticalSection critical{lock};
+    generator.seed(seed);
+  }
+}
+
+void RTNAME(RandomSeedDefaultPut)() {
+  // TODO: should this be time &/or image dependent?
+  {
+    CriticalSection critical{lock};
+    generator.seed(0);
+  }
+}
+
+void RTNAME(RandomSeedGet)(
+    const Descriptor &got, const char *source, int line) {
+  Terminator terminator{source, line};
+  auto typeCode{got.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator,
+      got.rank() == 1 && typeCode && typeCode->first == TypeCategory::Integer &&
+          got.GetDimension(0).Extent() >= 1);
+  int kind{typeCode->second};
+  GeneratedWord seed;
+  {
+    CriticalSection critical{lock};
+    seed = generator();
+    generator.seed(seed);
+  }
+  switch (kind) {
+  case 4:
+    *got.OffsetElement<CppTypeFor<TypeCategory::Integer, 4>>() = seed;
+    break;
+  case 8:
+    *got.OffsetElement<CppTypeFor<TypeCategory::Integer, 8>>() = seed;
+    break;
+  default:
+    terminator.Crash("RANDOM_SEED(GET=): bad kind %d\n", kind);
+  }
+}
+} // extern "C"
+} // namespace Fortran::runtime

--- a/flang/runtime/random.cpp
+++ b/flang/runtime/random.cpp
@@ -57,7 +57,7 @@ inline void Generate(const Descriptor &harvest) {
       Int fraction{generator()};
       if constexpr (words > 1) {
         for (std::size_t k{1}; k < words; ++k) {
-          static constexpr Int rangeMask{(Int{1} << rangeBits) - 1};
+          static constexpr auto rangeMask{(GeneratedWord{1} << rangeBits) - 1};
           GeneratedWord word{(generator() - generator.min()) & rangeMask};
           fraction = (fraction << rangeBits) | word;
         }

--- a/flang/runtime/random.h
+++ b/flang/runtime/random.h
@@ -1,0 +1,30 @@
+//===-- runtime/random.h --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Intrinsic subroutines RANDOM_INIT, RANDOM_NUMBER, and RANDOM_SEED.
+
+#include "entry-names.h"
+#include <cstdint>
+
+namespace Fortran::runtime {
+class Descriptor;
+extern "C" {
+
+void RTNAME(RandomInit)(bool repeatable, bool image_distinct);
+
+void RTNAME(RandomNumber)(
+    const Descriptor &harvest, const char *source, int line);
+
+// Subroutine RANDOM_SEED can be called with at most one of its optional
+// arguments; they each (plus the default case) map to these entry points.
+void RTNAME(RandomSeedSize)(const Descriptor &, const char *source, int line);
+void RTNAME(RandomSeedPut)(const Descriptor &, const char *source, int line);
+void RTNAME(RandomSeedGet)(const Descriptor &, const char *source, int line);
+void RTNAME(RandomSeedDefaultPut)();
+} // extern "C"
+} // namespace Fortran::runtime

--- a/flang/runtime/type-code.h
+++ b/flang/runtime/type-code.h
@@ -45,7 +45,7 @@ public:
   }
   constexpr bool IsLogical() const {
     return raw_ == CFI_type_Bool ||
-        (raw_ >= CFI_type_int_fast8_t && raw_ <= CFI_type_int_fast64_t);
+        (raw_ >= CFI_type_int_least8_t && raw_ <= CFI_type_int_least64_t);
   }
   constexpr bool IsDerived() const { return raw_ == CFI_type_struct; }
   constexpr bool IsIntrinsic() const { return IsValid() && !IsDerived(); }

--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -77,7 +77,7 @@ public:
   bool Receive(char *, std::size_t, std::size_t elementBytes, IoErrorHandler &);
   std::optional<char32_t> GetCurrentChar(IoErrorHandler &);
   void SetLeftTabLimit();
-  void BeginReadingRecord(IoErrorHandler &);
+  bool BeginReadingRecord(IoErrorHandler &);
   void FinishReadingRecord(IoErrorHandler &);
   bool AdvanceRecord(IoErrorHandler &);
   void BackspaceRecord(IoErrorHandler &);

--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -50,11 +50,11 @@ public:
   static void CloseAll(IoErrorHandler &);
   static void FlushAll(IoErrorHandler &);
 
-  void OpenUnit(OpenStatus, std::optional<Action>, Position,
+  void OpenUnit(std::optional<OpenStatus>, std::optional<Action>, Position,
       OwningPtr<char> &&path, std::size_t pathLength, Convert,
       IoErrorHandler &);
-  void OpenAnonymousUnit(
-      OpenStatus, std::optional<Action>, Position, Convert, IoErrorHandler &);
+  void OpenAnonymousUnit(std::optional<OpenStatus>, std::optional<Action>,
+      Position, Convert, IoErrorHandler &);
   void CloseUnit(CloseStatus, IoErrorHandler &);
   void DestroyClosed();
 

--- a/flang/unittests/RuntimeGTest/Random.cpp
+++ b/flang/unittests/RuntimeGTest/Random.cpp
@@ -1,0 +1,63 @@
+//===-- flang/unittests/RuntimeGTest/Random.cpp -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../../runtime/random.h"
+#include "gtest/gtest.h"
+#include "../../runtime/descriptor.h"
+#include "../../runtime/type-code.h"
+#include <cmath>
+
+using namespace Fortran::runtime;
+
+TEST(RandomNumber, Real4) {
+  StaticDescriptor<1> statDesc;
+  Descriptor &harvest{statDesc.descriptor()};
+  static constexpr int n{10000};
+  float xs[n]{};
+  SubscriptValue extent[1]{n};
+  harvest.Establish(TypeCategory::Real, 4, xs, 1, extent);
+  RTNAME(RandomNumber)(harvest, __FILE__, __LINE__);
+  double sum{0};
+  for (int j{0}; j < n; ++j) {
+    sum += xs[j];
+  }
+  double mean{sum / n};
+  std::fprintf(stderr, "mean of %d random numbers: %g\n", n, mean);
+  EXPECT_GE(mean, 0.95 * 0.5); // mean of uniform dist [0..1] is of course 0.5
+  EXPECT_LE(mean, 1.05 * 0.5);
+  double sumsq{0};
+  for (int j{0}; j < n; ++j) {
+    double diff{xs[j] - mean};
+    sumsq += diff * diff;
+  }
+  double sdev{std::sqrt(sumsq / n)};
+  std::fprintf(stderr, "stddev of %d random numbers: %g\n", n, sdev);
+  double expect{1.0 / std::sqrt(12.0)}; // stddev of uniform dist [0..1]
+  EXPECT_GE(sdev, 0.95 * expect);
+  EXPECT_LT(sdev, 1.05 * expect);
+}
+
+TEST(RandomNumber, RandomSeed) {
+  StaticDescriptor<1> statDesc[2];
+  Descriptor &desc{statDesc[0].descriptor()};
+  std::int32_t n;
+  desc.Establish(TypeCategory::Integer, 4, &n, 0, nullptr);
+  RTNAME(RandomSeedSize)(desc, __FILE__, __LINE__);
+  EXPECT_EQ(n, 1);
+  SubscriptValue extent[1]{1};
+  desc.Establish(TypeCategory::Integer, 4, &n, 1, extent);
+  RTNAME(RandomSeedGet)(desc, __FILE__, __LINE__);
+  Descriptor &harvest{statDesc[1].descriptor()};
+  float x;
+  harvest.Establish(TypeCategory::Real, 4, &x, 1, extent);
+  RTNAME(RandomNumber)(harvest, __FILE__, __LINE__);
+  float got{x};
+  RTNAME(RandomSeedPut)(desc, __FILE__, __LINE__); // n from RandomSeedGet()
+  RTNAME(RandomNumber)(harvest, __FILE__, __LINE__);
+  EXPECT_EQ(x, got);
+}


### PR DESCRIPTION
Get fir runtime up-to-date with LLVM latest runtime:
- Add  RANDOM_NUMBER, RANDOM_SEED, RANDOM_INIT intrinsics
- Various runtime fixes.