### PR TITLE
Add  tests for spacing and rrspacing and fix macro expansion of forced names

### DIFF
--- a/flang/lib/Lower/NumericRuntime.cpp
+++ b/flang/lib/Lower/NumericRuntime.cpp
@@ -25,7 +25,7 @@ using namespace Fortran::runtime;
 
 /// Placeholder for real*10 version of RRSpacing Intrinsic
 struct ForcedRRSpacing10 {
-  static constexpr const char *name = QuoteKey(RTNAME(RRSpacing10));
+  static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing10));
   static constexpr Fortran::lower::FuncTypeBuilderFunc getTypeModel() {
     return [](mlir::MLIRContext *ctx) {
       auto ty = mlir::FloatType::getF80(ctx);
@@ -36,7 +36,7 @@ struct ForcedRRSpacing10 {
 
 /// Placeholder for real*16 version of RRSpacing Intrinsic
 struct ForcedRRSpacing16 {
-  static constexpr const char *name = QuoteKey(RTNAME(RRSpacing16));
+  static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing16));
   static constexpr Fortran::lower::FuncTypeBuilderFunc getTypeModel() {
     return [](mlir::MLIRContext *ctx) {
       auto ty = mlir::FloatType::getF128(ctx);
@@ -47,7 +47,7 @@ struct ForcedRRSpacing16 {
 
 /// Placeholder for real*10 version of Spacing Intrinsic
 struct ForcedSpacing10 {
-  static constexpr const char *name = QuoteKey(RTNAME(Spacing10));
+  static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing10));
   static constexpr Fortran::lower::FuncTypeBuilderFunc getTypeModel() {
     return [](mlir::MLIRContext *ctx) {
       auto ty = mlir::FloatType::getF80(ctx);
@@ -58,7 +58,7 @@ struct ForcedSpacing10 {
 
 /// Placeholder for real*16 version of Spacing Intrinsic
 struct ForcedSpacing16 {
-  static constexpr const char *name = QuoteKey(RTNAME(Spacing16));
+  static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing16));
   static constexpr Fortran::lower::FuncTypeBuilderFunc getTypeModel() {
     return [](mlir::MLIRContext *ctx) {
       auto ty = mlir::FloatType::getF128(ctx);

--- a/flang/lib/Lower/RTBuilder.h
+++ b/flang/lib/Lower/RTBuilder.h
@@ -319,6 +319,7 @@ struct RuntimeTableEntry<RuntimeTableKey<KT>, RuntimeIdentifier<Cs...>> {
 #undef E
 #define E(L, I) (I < sizeof(L) / sizeof(*L) ? L[I] : 0)
 #define QuoteKey(X) #X
+#define ExpandAndQuoteKey(X) QuoteKey(X)
 #define MacroExpandKey(X)                                                      \
   E(X, 0), E(X, 1), E(X, 2), E(X, 3), E(X, 4), E(X, 5), E(X, 6), E(X, 7),      \
       E(X, 8), E(X, 9), E(X, 10), E(X, 11), E(X, 12), E(X, 13), E(X, 14),      \

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -451,6 +451,16 @@ real*4 function rrspacing_test(x)
 !CHECK %{{.*}} = fir.call @_FortranARRSpacing4(%[[a1]]) : (f32) -> f32
 end function
 
+! RRSPACING
+! CHECK-LABEL: rrspacing_test2
+! CHECK-SAME: [[x:[^:]+]]: !fir.ref<f128>) -> f128
+real*16 function rrspacing_test2(x)
+  real*16 :: x
+  rrspacing_test2 = spacing(x)
+!CHECK %[[a1:.*]] = fir.load %[[x]] : !fir.ref<f128>
+!CHECK %{{.*}} = fir.call @_FortranARRSpacing16(%[[a1]]) : (f128) -> f128
+end function
+
 ! SCAN 
 ! CHECK-LABEL: func @_QPscan_test(%
 ! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
@@ -521,6 +531,16 @@ real*4 function spacing_test(x)
   spacing_test = spacing(x)
 !CHECK %[[a1:.*]] = fir.load %[[x]] : !fir.ref<f32>
 !CHECK %{{.*}} = fir.call @_FortranASpacing4(%[[a1]]) : (f32) -> f32
+end function
+
+! SPACING
+! CHECK-LABEL: spacing_test2
+! CHECK-SAME: [[x:[^:]+]]: !fir.ref<f80>) -> f80
+real*10 function spacing_test2(x)
+  real*10 :: x
+  spacing_test2 = spacing(x)
+!CHECK %[[a1:.*]] = fir.load %[[x]] : !fir.ref<f80>
+!CHECK %{{.*}} = fir.call @_FortranASpacing10(%[[a1]]) : (f80) -> f80
 end function
 
 ! SQRT


### PR DESCRIPTION
Add tests for the forced lowering of the real*10 and real*16 versions of the spacing and rrspacing intrinsics. Also, fix macro expansion on these names (introduced in PR #738) 