### PR TITLE
Correct the mapping of symbols in statement functions

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1508,6 +1508,20 @@ public:
       // scalars, so just pass the box with the address.
       symMap.addSymbol(*arg, gen(*expr));
     }
+
+    // Explicitly map statement function host associated symbols to their
+    // parent scope lowered symbol box.
+    for (const Fortran::semantics::SymbolRef &sym :
+         Fortran::evaluate::CollectSymbols(*details.stmtFunction())) {
+      if (const auto *details =
+              sym->detailsIf<Fortran::semantics::HostAssocDetails>()) {
+        if (!symMap.lookupSymbol(*sym)) {
+          symMap.addSymbol(
+              *sym, symMap.lookupSymbol(details->symbol()).toExtendedValue());
+        }
+      }
+    }
+
     auto result = genval(details.stmtFunction().value());
     LLVM_DEBUG(llvm::dbgs() << "stmt-function: " << result << '\n');
     symMap.popScope();


### PR DESCRIPTION
Explicitly map host associated symbols statement functions to their parent scope lowered symbol box.

This patch is per the suggestions by Jean in https://github.com/flang-compiler/f18-llvm-project/pull/646#discussion_r605638653. In a following patch I hope to remove "host association following" in symbol map lookups and "force" in "bindSymbol".

I see that there are tests in flang/test/Lower/statement-function.f90. Please suggest if more cases should be tested.
