### PR TITLE
Fixes bug with cleanups being done too late.

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -387,12 +387,13 @@ static void genIoLoop(Fortran::lower::AbstractConverter &converter,
                        ? genControlValue(*control.step)
                        : builder.create<mlir::ConstantIndexOp>(loc, 1);
   auto genItemList = [&](const D &ioImpliedDo) {
+    Fortran::lower::StatementContext loopCtx;
     if constexpr (std::is_same_v<D, Fortran::parser::InputImpliedDo>)
       genInputItemList(converter, cookie, itemList, isFormatted, checkResult,
-                       ok, /*inLoop=*/true, stmtCtx);
+                       ok, /*inLoop=*/true, loopCtx);
     else
       genOutputItemList(converter, cookie, itemList, isFormatted, checkResult,
-                        ok, /*inLoop=*/true, stmtCtx);
+                        ok, /*inLoop=*/true, loopCtx);
   };
   if (!checkResult) {
     // No I/O call result checks - the loop is a fir.do_loop op.
@@ -1560,6 +1561,7 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter,
     genOutputItemList(converter, cookie, stmt.items, isFormatted,
                       csi.hasTransferConditionSpec(), ok,
                       /*inLoop=*/false, stmtCtx);
+  stmtCtx.finalize();
 
   // Generate end statement call/s.
   builder.restoreInsertionPoint(insertPt);


### PR DESCRIPTION
The cleanups were firing after the end of the implied-do loop, when the
expression(s) they were cleaning up were inside the impled-do. That
violates the SSA dominance relation (and would have leaked memory in the
resulting code).