### PR TITLE
[NFC] Explicitly map host associated symbols (do concurrent, OpenMP/OpenACC)

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -69,6 +69,9 @@ public:
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
 
+  /// Copy the binding of src to target symbol.
+  virtual void copySymbolBinding(SymbolRef src, SymbolRef target) = 0;
+
   /// Bind the symbol to an mlir value.
   virtual void bindSymbol(const SymbolRef sym, mlir::Value val) = 0;
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -78,6 +78,7 @@ struct IncrementLoopInfo {
   const Fortran::semantics::SomeExpr *maskExpr = nullptr;
   bool isUnordered; // do concurrent, forall
   llvm::SmallVector<const Fortran::semantics::Symbol *> localInitSymList;
+  llvm::SmallVector<const Fortran::semantics::Symbol *> sharedSymList;
   mlir::Value loopVariable = nullptr;
   mlir::Value stepValue = nullptr; // possible uses in multiple blocks
 
@@ -234,6 +235,11 @@ public:
 
   mlir::Value getSymbolAddress(Fortran::lower::SymbolRef sym) override final {
     return lookupSymbol(sym).getAddr();
+  }
+
+  void copySymbolBinding(Fortran::lower::SymbolRef src,
+                         Fortran::lower::SymbolRef target) override final {
+    localSymbols.addSymbol(target, lookupSymbol(src).toExtendedValue());
   }
 
   // TODO: Consider returning a vlue when the FIXME below is fixed.
@@ -750,6 +756,10 @@ private:
               std::get_if<Fortran::parser::LocalitySpec::LocalInit>(&x.u))
         for (const auto &x : localInitList->v)
           info.localInitSymList.push_back(x.symbol);
+      if (const auto *sharedList =
+              std::get_if<Fortran::parser::LocalitySpec::Shared>(&x.u))
+        for (const auto &x : sharedList->v)
+          info.sharedSymList.push_back(x.symbol);
       if (std::get_if<Fortran::parser::LocalitySpec::Local>(&x.u))
         TODO(toLocation(), "do concurrent locality specs not implemented");
     }
@@ -870,7 +880,8 @@ private:
         return builder->createRealConstant(loc, controlType, 1u);
       return builder->createIntegerConstant(loc, controlType, 1); // step
     };
-    auto genLocalInitAssignments = [&](IncrementLoopInfo &info) {
+    auto handleLocalitySpec = [&](IncrementLoopInfo &info) {
+      // Generate Local Init Assignments
       for (const auto *sym : info.localInitSymList) {
         const auto *hostDetails =
             sym->detailsIf<Fortran::semantics::HostAssocDetails>();
@@ -879,6 +890,14 @@ private:
             hostDetails->symbol();
         TODO(loc, "do concurrent locality specs not implemented");
         // assign sym = hostSym
+      }
+      // Handle shared locality spec
+      for (const auto *sym : info.sharedSymList) {
+        const auto *hostDetails =
+            sym->detailsIf<Fortran::semantics::HostAssocDetails>();
+        assert(hostDetails && "missing shared variable host variable");
+        const Fortran::semantics::Symbol &hostSym = hostDetails->symbol();
+        copySymbolBinding(hostSym, *sym);
       }
     };
     for (auto &info : incrementLoopNestInfo) {
@@ -905,7 +924,7 @@ private:
                                                  /*withElseRegion=*/false);
           builder->setInsertionPointToStart(&ifOp.thenRegion().front());
         }
-        genLocalInitAssignments(info);
+        handleLocalitySpec(info);
         continue;
       }
 
@@ -957,7 +976,7 @@ private:
       if (!info.localInitSymList.empty()) {
         auto insertPt = builder->saveInsertionPoint();
         builder->setInsertionPointToStart(info.bodyBlock);
-        genLocalInitAssignments(info);
+        handleLocalitySpec(info);
         builder->restoreInsertionPoint(insertPt);
       }
     }

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -35,20 +35,29 @@ getDesignatorNameIfDataRef(const Fortran::parser::Designator &designator) {
 static void genObjectList(const Fortran::parser::AccObjectList &objectList,
                           Fortran::lower::AbstractConverter &converter,
                           SmallVectorImpl<mlir::Value> &operands) {
+  auto addOperands = [&](Fortran::lower::SymbolRef sym) {
+    const auto variable = converter.getSymbolAddress(sym);
+    // TODO: Might need revisiting to handle for non-shared clauses
+    if (variable) {
+      operands.push_back(variable);
+    } else {
+      if (const auto *details =
+              sym->detailsIf<Fortran::semantics::HostAssocDetails>())
+        operands.push_back(converter.getSymbolAddress(details->symbol()));
+    }
+  };
   for (const auto &accObject : objectList.v) {
-    std::visit(
-        Fortran::common::visitors{
-            [&](const Fortran::parser::Designator &designator) {
-              if (const auto *name = getDesignatorNameIfDataRef(designator)) {
-                const auto variable = converter.getSymbolAddress(*name->symbol);
-                operands.push_back(variable);
-              }
-            },
-            [&](const Fortran::parser::Name &name) {
-              const auto variable = converter.getSymbolAddress(*name.symbol);
-              operands.push_back(variable);
-            }},
-        accObject.u);
+    std::visit(Fortran::common::visitors{
+                   [&](const Fortran::parser::Designator &designator) {
+                     if (const auto *name =
+                             getDesignatorNameIfDataRef(designator)) {
+                       addOperands(*name->symbol);
+                     }
+                   },
+                   [&](const Fortran::parser::Name &name) {
+                     addOperands(*name.symbol);
+                   }},
+               accObject.u);
   }
 }
 


### PR DESCRIPTION
Explicitly map host associated symbols in DoConcurrent with shared locality-spec, clauses in OpenMP/OpenACC. The mapping of host-assoc symbols is set to their parent SymbolBox. This is achieved through a new interface function in the AbstractConverter.

Note:
A previous patch corrected this mapping for statement functions.
In a following patch I hope to remove "host association following" in symbol map lookups and "force" in "bindSymbol".