### PR TITLE
Support fir.array, fir.box and fir.type function results in FIR

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -412,6 +412,52 @@ def fir_StoreOp : fir_Op<"store", []> {
   }];
 }
 
+def fir_SaveResultOp : fir_Op<"save_result", [AttrSizedOperandSegments]> {
+  let summary = "save an array, box, or record function result SSA-value to a memory location";
+
+  let description = [{
+    Save the result of a function returning an array, box, or record type value
+    into a memory location given the shape and length parameters of the result.
+
+    Function results of type fir.box, fir.array, or fir.rec are abstract values that
+    require a storage to be manipulated on the caller side. This operation allows
+    associating such abstract result to a storage. In later lowering of the function
+    interfaces, this storage might be used to pass the result in memory.
+    
+    For arrays, result, it is required to provide the shape of the result. For character arrays
+    and derived types with length parameters, the length parameter values must be provided.
+
+    The fir.save_result associated to a function call must immediately follow the call and be
+    in the same block.  
+
+    ```mlir
+      %buffer = fir.alloca fir.array<?xf32>, %c100
+      %shape = fir.shape %c100
+      %array_result = fir.call @foo() : () -> fir.array<?xf32>
+      fir.save_result %array_result to %buffer(%shape)
+      %coor = fir.array_coor %buffer%(%shape), %c5
+      %fifth_element = fir.load %coor : f32 
+    ```
+
+    The above fir.save_result allows saving a fir.array function result into
+    a buffer to later access its 5th element.
+
+  }];
+
+  let arguments = (ins AnyType:$value,
+                   Arg<AnyReferenceLike, "", [MemWrite]>:$memref,
+                   Optional<AnyShapeType>:$shape,
+                   Variadic<AnyIntegerType>:$lenParams);
+
+  let assemblyFormat = [{
+    $value `to` $memref (`(` $shape^ `)`)? (`typeparams` $lenParams^)?
+    attr-dict `:` type(operands)
+  }];
+
+  let verifier = [{ return ::verify(*this); }];
+
+}
+
 def fir_UndefOp : fir_OneResultOp<"undefined", [NoSideEffect]> {
   let summary = "explicit undefined value of some type";
   let description = [{

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -33,6 +33,7 @@ std::unique_ptr<mlir::Pass> createFirLoopResultOptPass();
 std::unique_ptr<mlir::Pass> createMemDataFlowOptPass();
 std::unique_ptr<mlir::Pass> createFirToCfgPass();
 std::unique_ptr<mlir::Pass> createArrayValueCopyPass();
+std::unique_ptr<mlir::Pass> createAbstractResultOptPass();
 
 /// A pass to convert the FIR dialect from "Mem-SSA" form to "Reg-SSA" form.
 /// This pass is a port of LLVM's mem2reg pass, but modified for the FIR dialect

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -144,4 +144,20 @@ def ArrayValueCopy : FunctionPass<"array-value-copy"> {
   ];
 }
 
+def AbstractResultOpt : Pass<"abstract-result-opt", "mlir::FuncOp"> {
+  let summary = "Convert fir.array, fir.box and fir.rec function result to function argument";
+  let description = [{
+    This passed is required before code gen to the LLVM IR dialect, including the pre-cg rewrite pass.
+  }];
+  let constructor = "::fir::createAbstractResultOptPass()";
+  let dependentDialects = [
+    "fir::FIROpsDialect", "mlir::StandardOpsDialect"
+  ];
+  let options = [
+    Option<"passResultAsBox", "abstract-result-as-box",
+           "bool", /*default=*/"false",
+           "Pass fir.array<T> result as fir.box<fir.array<T>> argument instead of fir.ref<fir.array<T>>.">,
+  ];
+}
+
 #endif // FORTRAN_OPTIMIZER_TRANSFORMS_FIR_PASSES

--- a/flang/lib/Lower/MaskExpr.h
+++ b/flang/lib/Lower/MaskExpr.h
@@ -20,7 +20,7 @@
 #include <functional>
 
 namespace Fortran::evaluate {
-class SomeType;
+struct SomeType;
 template <typename>
 class Expr;
 } // namespace Fortran::evaluate

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1325,6 +1325,67 @@ static mlir::LogicalResult verify(fir::ResultOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// SaveResultOp
+//===----------------------------------------------------------------------===//
+
+static mlir::LogicalResult verify(fir::SaveResultOp op) {
+  auto resultType = op.value().getType();
+  if (resultType != fir::dyn_cast_ptrEleTy(op.memref().getType()))
+    return op.emitOpError("value type must match memory reference type");
+  if (fir::isa_unknown_size_box(resultType))
+    return op.emitOpError("cannot save !fir.box of unknown rank or type");
+
+  if (!resultType.isa<fir::BoxType, fir::SequenceType, fir::RecordType>())
+    return op.emitOpError(
+        "value operand must be a fir.box, fir.array or fir.type");
+
+  if (resultType.isa<fir::BoxType>()) {
+    if (op.shape() || !op.lenParams().empty())
+      return op.emitOpError(
+          "must not have shape or length operands if the value is a fir.box");
+    return mlir::success();
+  }
+
+  // fir.record or fir.array case.
+  unsigned shapeTyRank = 0;
+  if (auto shapeOp = op.shape()) {
+    auto shapeTy = shapeOp.getType();
+    if (auto s = shapeTy.dyn_cast<fir::ShapeType>())
+      shapeTyRank = s.getRank();
+    else
+      shapeTyRank = shapeTy.cast<fir::ShapeShiftType>().getRank();
+  }
+
+  auto eleTy = resultType;
+  if (auto seqTy = resultType.dyn_cast<fir::SequenceType>()) {
+    if (seqTy.getDimension() != shapeTyRank)
+      op.emitOpError("shape operand must be provided and have the value rank "
+                     "when the value is a fir.array");
+    eleTy = seqTy.getEleTy();
+  } else {
+    if (shapeTyRank != 0)
+      op.emitOpError(
+          "shape operand should only be provided if the value is a fir.array");
+  }
+
+  if (auto recTy = eleTy.dyn_cast<fir::RecordType>()) {
+    if (recTy.getNumLenParams() != op.lenParams().size())
+      op.emitOpError("length parameters number must match with the value type "
+                     "length parameters");
+  } else if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
+    if (op.lenParams().size() > 1)
+      op.emitOpError("no more than one length parameter must be provided for "
+                     "character value");
+  } else {
+    if (!op.lenParams().empty())
+      op.emitOpError(
+          "length parameters must not be provided for this value type");
+  }
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // SelectOp
 //===----------------------------------------------------------------------===//
 

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -1,0 +1,289 @@
+//===- AbstractResult.cpp - Conversion of Abstract Function Result    ---*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#define DEBUG_TYPE "flang-abstract-result-opt"
+
+namespace fir {
+namespace {
+
+struct AbstractResultOptions {
+  // Always pass result as a fir.box argument.
+  bool boxResult = false;
+  // New function block argument for the result if the current FuncOp had
+  // an abstract result.
+  mlir::Value newArg;
+};
+
+static bool mustConvertCallOrFunc(mlir::FunctionType type) {
+  if (type.getNumResults() == 0)
+    return false;
+  auto resultType = type.getResult(0);
+  return resultType.isa<fir::SequenceType, fir::BoxType, fir::RecordType>();
+}
+
+static mlir::Type getResultArgumentType(mlir::Type resultType,
+                                        const AbstractResultOptions &options) {
+  return llvm::TypeSwitch<mlir::Type, mlir::Type>(resultType)
+      .Case<fir::SequenceType, fir::RecordType>(
+          [&](mlir::Type type) -> mlir::Type {
+            if (options.boxResult)
+              return fir::BoxType::get(type);
+            else
+              return fir::ReferenceType::get(type);
+          })
+      .Case<fir::BoxType>([](mlir::Type type) -> mlir::Type {
+        return fir::ReferenceType::get(type);
+      })
+      .Default([](mlir::Type) -> mlir::Type {
+        llvm_unreachable("bad abstract result type");
+      });
+}
+
+static mlir::FunctionType
+getNewFunctionType(mlir::FunctionType funcTy,
+                   const AbstractResultOptions &options) {
+  auto resultType = funcTy.getResult(0);
+  auto argTy = getResultArgumentType(resultType, options);
+  llvm::SmallVector<mlir::Type> newInputTypes = {argTy};
+  newInputTypes.append(funcTy.getInputs().begin(), funcTy.getInputs().end());
+  return mlir::FunctionType::get(funcTy.getContext(), newInputTypes,
+                                 /*resultTypes=*/{});
+}
+
+static bool mustEmboxResult(mlir::Type resultType,
+                            const AbstractResultOptions &options) {
+  return resultType.isa<fir::SequenceType, fir::RecordType>() &&
+         options.boxResult;
+}
+
+class CallOpConversion : public mlir::OpRewritePattern<fir::CallOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  CallOpConversion(mlir::MLIRContext *context, const AbstractResultOptions &opt)
+      : OpRewritePattern(context), options{opt} {}
+  mlir::LogicalResult
+  matchAndRewrite(fir::CallOp callOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto loc = callOp.getLoc();
+    auto result = callOp->getResult(0);
+    if (!result.hasOneUse()) {
+      mlir::emitError(loc,
+                      "calls with abstract result must have exactly one user");
+      return mlir::failure();
+    }
+    auto saveResult =
+        mlir::dyn_cast<fir::SaveResultOp>(result.use_begin().getUser());
+    if (!saveResult) {
+      mlir::emitError(
+          loc, "calls with abstract result must be used in fir.save_result");
+      return mlir::failure();
+    }
+    auto argType = getResultArgumentType(result.getType(), options);
+    auto buffer = saveResult.memref();
+    mlir::Value arg = buffer;
+    if (mustEmboxResult(result.getType(), options))
+      arg = rewriter.create<fir::EmboxOp>(
+          loc, argType, buffer, saveResult.shape(), /*slice*/ mlir::Value{},
+          saveResult.lenParams());
+
+    llvm::SmallVector<mlir::Type> newResultTypes;
+    if (callOp.callee()) {
+      llvm::SmallVector<mlir::Value> newOperands = {arg};
+      newOperands.append(callOp.getOperands().begin(),
+                         callOp.getOperands().end());
+      rewriter.create<fir::CallOp>(loc, callOp.callee().getValue(),
+                                   newResultTypes, newOperands);
+    } else {
+      // Indirect calls.
+      llvm::SmallVector<mlir::Type> newInputTypes = {argType};
+      for (auto operand : callOp.getOperands().drop_front())
+        newInputTypes.push_back(operand.getType());
+      auto funTy = mlir::FunctionType::get(callOp.getContext(), newInputTypes,
+                                           newResultTypes);
+
+      llvm::SmallVector<mlir::Value> newOperands;
+      newOperands.push_back(
+          rewriter.create<fir::ConvertOp>(loc, funTy, callOp.getOperand(0)));
+      newOperands.push_back(arg);
+      newOperands.append(callOp.getOperands().begin() + 1,
+                         callOp.getOperands().end());
+      rewriter.create<fir::CallOp>(loc, mlir::SymbolRefAttr{}, newResultTypes,
+                                   newOperands);
+    }
+    callOp->dropAllReferences();
+    rewriter.eraseOp(callOp);
+    return mlir::success();
+  }
+
+private:
+  const AbstractResultOptions &options;
+};
+
+class SaveResultOpConversion
+    : public mlir::OpRewritePattern<fir::SaveResultOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  SaveResultOpConversion(mlir::MLIRContext *context)
+      : OpRewritePattern(context) {}
+  mlir::LogicalResult
+  matchAndRewrite(fir::SaveResultOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
+class ReturnOpConversion : public mlir::OpRewritePattern<mlir::ReturnOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  ReturnOpConversion(mlir::MLIRContext *context,
+                     const AbstractResultOptions &opt)
+      : OpRewritePattern(context), options{opt} {}
+  mlir::LogicalResult
+  matchAndRewrite(mlir::ReturnOp ret,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.setInsertionPoint(ret);
+    auto returnedValue = ret.getOperand(0);
+    bool replacedStorage = false;
+    if (auto op = returnedValue.getDefiningOp())
+      if (auto load = mlir::dyn_cast<fir::LoadOp>(op)) {
+        auto resultStorage = load.memref();
+        load.memref().replaceAllUsesWith(options.newArg);
+        replacedStorage = true;
+        if (auto alloc = resultStorage.getDefiningOp())
+          if (alloc->use_empty())
+            rewriter.eraseOp(alloc);
+      }
+    // The result storage may have been optimized out by a memory to
+    // register pass, this is possible for fir.box results, or fir.record
+    // with no length parameters. Simply store the result in the result storage.
+    // at the return point.
+    if (!replacedStorage)
+      rewriter.create<fir::StoreOp>(ret.getLoc(), returnedValue,
+                                    options.newArg);
+    rewriter.replaceOpWithNewOp<mlir::ReturnOp>(ret);
+    return mlir::success();
+  }
+
+private:
+  const AbstractResultOptions &options;
+};
+
+class AddrOfOpConversion : public mlir::OpRewritePattern<fir::AddrOfOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  AddrOfOpConversion(mlir::MLIRContext *context,
+                     const AbstractResultOptions &opt)
+      : OpRewritePattern(context), options{opt} {}
+  mlir::LogicalResult
+  matchAndRewrite(fir::AddrOfOp addrOf,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto oldFuncTy = addrOf.getType().cast<mlir::FunctionType>();
+    auto newFuncTy = getNewFunctionType(oldFuncTy, options);
+    auto newAddrOf = rewriter.create<fir::AddrOfOp>(addrOf.getLoc(), newFuncTy,
+                                                    addrOf.symbol());
+    // Rather than converting all op a function pointer might transit through
+    // (e.g calls, stores, loads, converts...), cast new type to the abstract
+    // type. A conversion will be added when calling indirect calls of abstract
+    // types.
+    rewriter.replaceOpWithNewOp<fir::ConvertOp>(addrOf, oldFuncTy, newAddrOf);
+    return mlir::success();
+  }
+
+private:
+  const AbstractResultOptions &options;
+};
+
+class AbstractResultOpt : public fir::AbstractResultOptBase<AbstractResultOpt> {
+public:
+  void runOnOperation() override {
+    auto *context = &getContext();
+    auto func = getOperation();
+    auto loc = func.getLoc();
+    mlir::OwningRewritePatternList patterns;
+    mlir::ConversionTarget target = *context;
+    AbstractResultOptions options{passResultAsBox.getValue(),
+                                  /*newArg*/ {}};
+
+    // Convert function type itself if it has an abstract result
+    auto funcTy = func.getType().cast<mlir::FunctionType>();
+    if (mustConvertCallOrFunc(funcTy)) {
+      func.setType(getNewFunctionType(funcTy, options));
+      unsigned zero = 0;
+      if (!func.empty()) {
+        // Insert new argument
+        mlir::OpBuilder rewriter(context);
+        auto resultType = funcTy.getResult(0);
+        auto argTy = getResultArgumentType(resultType, options);
+        options.newArg = func.front().insertArgument(zero, argTy);
+        if (mustEmboxResult(resultType, options)) {
+          auto bufferType = fir::ReferenceType::get(resultType);
+          rewriter.setInsertionPointToStart(&func.front());
+          options.newArg =
+              rewriter.create<fir::BoxAddrOp>(loc, bufferType, options.newArg);
+        }
+        patterns.insert<ReturnOpConversion>(context, options);
+        target.addDynamicallyLegalOp<mlir::ReturnOp>(
+            [](mlir::ReturnOp ret) { return ret.operands().empty(); });
+      }
+    }
+
+    if (func.empty())
+      return;
+
+    // Convert the calls and, if needed,  the ReturnOp in the function body.
+    target.addLegalDialect<fir::FIROpsDialect, mlir::StandardOpsDialect>();
+    target.addIllegalOp<fir::SaveResultOp>();
+    target.addDynamicallyLegalOp<fir::CallOp>([](fir::CallOp call) {
+      return !mustConvertCallOrFunc(call.getFunctionType());
+    });
+    target.addDynamicallyLegalOp<fir::AddrOfOp>([](fir::AddrOfOp addrOf) {
+      if (auto funTy = addrOf.getType().dyn_cast<mlir::FunctionType>())
+        return !mustConvertCallOrFunc(funTy);
+      return true;
+    });
+    target.addDynamicallyLegalOp<fir::DispatchOp>([](fir::DispatchOp dispatch) {
+      if (dispatch->getNumResults() != 1)
+        return true;
+      auto resultType = dispatch->getResult(0).getType();
+      if (resultType.isa<fir::SequenceType, fir::BoxType, fir::RecordType>()) {
+        mlir::emitError(dispatch.getLoc(),
+                        "TODO: dispatchOp with abstract results");
+        return false;
+      }
+      return true;
+    });
+
+    patterns.insert<CallOpConversion>(context, options);
+    patterns.insert<SaveResultOpConversion>(context);
+    patterns.insert<AddrOfOpConversion>(context, options);
+    if (mlir::failed(
+            mlir::applyPartialConversion(func, target, std::move(patterns)))) {
+      mlir::emitError(func.getLoc(), "error in converting abstract results\n");
+      signalPassFailure();
+    }
+  }
+};
+} // end anonymous namespace
+} // namespace fir
+
+std::unique_ptr<mlir::Pass> fir::createAbstractResultOptPass() {
+  return std::make_unique<AbstractResultOpt>();
+}

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_flang_library(FIRTransforms
+  AbstractResult.cpp
   AffineDemotion.cpp
   AffinePromotion.cpp
   ArrayValueCopy.cpp

--- a/flang/test/Fir/abstract-results.fir
+++ b/flang/test/Fir/abstract-results.fir
@@ -1,0 +1,255 @@
+// Test rewrite of functions that return fir.array<>, fir.type<>, fir.box<> to
+// functions that take an additional argument for the result.
+
+// RUN: fir-opt %s --abstract-result-opt | FileCheck %s
+// RUN: fir-opt %s --abstract-result-opt=abstract-result-as-box | FileCheck %s --check-prefix=CHECK-BOX
+
+// ----------------------- Test declaration rewrite ----------------------------
+
+// CHECK-LABEL:  func private @arrayfunc(!fir.ref<!fir.array<?xf32>>, i32)
+// CHECK-BOX-LABEL:  func private @arrayfunc(!fir.box<!fir.array<?xf32>>, i32)
+func private @arrayfunc(i32) -> !fir.array<?xf32>
+
+// CHECK-LABEL:  func private @derivedfunc(!fir.ref<!fir.type<t{x:f32}>>, f32)
+// CHECK-BOX-LABEL:  func private @derivedfunc(!fir.box<!fir.type<t{x:f32}>>, f32)
+func private @derivedfunc(f32) -> !fir.type<t{x:f32}>
+
+// CHECK-LABEL:  func private @boxfunc(!fir.ref<!fir.box<!fir.heap<f64>>>, i64)
+// CHECK-BOX-LABEL:  func private @boxfunc(!fir.ref<!fir.box<!fir.heap<f64>>>, i64)
+func private @boxfunc(i64) -> !fir.box<!fir.heap<f64>>
+
+
+// ------------------------ Test callee rewrite --------------------------------
+
+// CHECK-LABEL:  func private @arrayfunc_callee(
+// CHECK-SAME: %[[buffer:.*]]: !fir.ref<!fir.array<?xf32>>, %[[n:.*]]: index) {
+// CHECK-BOX-LABEL:  func private @arrayfunc_callee(
+// CHECK-BOX-SAME: %[[box:.*]]: !fir.box<!fir.array<?xf32>>, %[[n:.*]]: index) {
+func private @arrayfunc_callee(%n : index) -> !fir.array<?xf32> {
+  %buffer = fir.alloca !fir.array<?xf32>, %n
+  // Do something with result (res(4) = 42.)
+  %c4 = constant 4 : i64
+  %coor = fir.coordinate_of %buffer, %c4 : (!fir.ref<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  %cst = constant 4.200000e+01 : f32
+  fir.store %cst to %coor : !fir.ref<f32>
+  %res = fir.load %buffer : !fir.ref<!fir.array<?xf32>>
+  return %res : !fir.array<?xf32>
+
+  // CHECK-DAG: %[[coor:.*]] = fir.coordinate_of %[[buffer]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  // CHECK-DAG: fir.store %{{.*}} to %[[coor]] : !fir.ref<f32>
+  // CHECK: return
+
+  // CHECK-BOX: %[[buffer:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  // CHECK-BOX-DAG: %[[coor:.*]] = fir.coordinate_of %[[buffer]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  // CHECK-BOX-DAG: fir.store %{{.*}} to %[[coor]] : !fir.ref<f32>
+  // CHECK-BOX: return
+}
+
+
+// CHECK-LABEL: func @derivedfunc_callee(
+// CHECK-SAME: %[[buffer:.*]]: !fir.ref<!fir.type<t{x:f32}>>, %[[v:.*]]: f32) {
+// CHECK-BOX-LABEL: func @derivedfunc_callee(
+// CHECK-BOX-SAME: %[[box:.*]]: !fir.box<!fir.type<t{x:f32}>>, %[[v:.*]]: f32) {
+func @derivedfunc_callee(%v: f32) -> !fir.type<t{x:f32}> {
+  %buffer = fir.alloca !fir.type<t{x:f32}>
+  %0 = fir.field_index x, !fir.type<t{x:f32}>
+  %1 = fir.coordinate_of %buffer, %0 : (!fir.ref<!fir.type<t{x:f32}>>, !fir.field) -> !fir.ref<f32>
+  fir.store %v to %1 : !fir.ref<f32>
+  %res = fir.load %buffer : !fir.ref<!fir.type<t{x:f32}>>
+  return %res : !fir.type<t{x:f32}>
+
+  // CHECK: %[[coor:.*]] = fir.coordinate_of %[[buffer]], %{{.*}} : (!fir.ref<!fir.type<t{x:f32}>>, !fir.field) -> !fir.ref<f32>
+  // CHECK: fir.store %[[v]] to %[[coor]] : !fir.ref<f32>
+  // CHECK: return
+
+  // CHECK-BOX: %[[buffer:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.type<t{x:f32}>>) -> !fir.ref<!fir.type<t{x:f32}>>
+  // CHECK-BOX: %[[coor:.*]] = fir.coordinate_of %[[buffer]], %{{.*}} : (!fir.ref<!fir.type<t{x:f32}>>, !fir.field) -> !fir.ref<f32>
+  // CHECK-BOX: fir.store %[[v]] to %[[coor]] : !fir.ref<f32>
+  // CHECK-BOX: return
+}
+
+// CHECK-LABEL: func @boxfunc_callee(
+// CHECK-SAME: %[[buffer:.*]]: !fir.ref<!fir.box<!fir.heap<f64>>>) {
+// CHECK-BOX-LABEL: func @boxfunc_callee(
+// CHECK-BOX-SAME: %[[buffer:.*]]: !fir.ref<!fir.box<!fir.heap<f64>>>) {
+func @boxfunc_callee() -> !fir.box<!fir.heap<f64>> {
+  %alloc = fir.allocmem f64
+  %res = fir.embox %alloc : (!fir.heap<f64>) -> !fir.box<!fir.heap<f64>>
+  return %res : !fir.box<!fir.heap<f64>>
+  // CHECK: %[[box:.*]] = fir.embox %{{.*}} : (!fir.heap<f64>) -> !fir.box<!fir.heap<f64>>
+  // CHECK: fir.store %[[box]] to %[[buffer]] : !fir.ref<!fir.box<!fir.heap<f64>>>
+  // CHECK: return
+
+  // CHECK-BOX: %[[box:.*]] = fir.embox %{{.*}} : (!fir.heap<f64>) -> !fir.box<!fir.heap<f64>>
+  // CHECK-BOX: fir.store %[[box]] to %[[buffer]] : !fir.ref<!fir.box<!fir.heap<f64>>>
+  // CHECK-BOX: return
+}
+
+// ------------------------ Test caller rewrite --------------------------------
+
+// CHECK-LABEL: func @call_arrayfunc() {
+// CHECK-BOX-LABEL: func @call_arrayfunc() {
+func @call_arrayfunc() {
+  %c100 = constant 100 : index
+  %buffer = fir.alloca !fir.array<?xf32>, %c100
+  %shape = fir.shape %c100 : (index) -> !fir.shape<1>
+  %res = fir.call @arrayfunc_callee(%c100) : (index) -> !fir.array<?xf32>
+  fir.save_result %res to %buffer(%shape) : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<1>
+  return
+
+  // CHECK: %[[c100:.*]] = constant 100 : index
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.array<?xf32>, %[[c100]]
+  // CHECK: fir.call @arrayfunc_callee(%[[buffer]], %[[c100]]) : (!fir.ref<!fir.array<?xf32>>, index) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[c100:.*]] = constant 100 : index
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.array<?xf32>, %[[c100]]
+  // CHECK-BOX: %[[shape:.*]] = fir.shape %[[c100]] : (index) -> !fir.shape<1>
+  // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  // CHECK-BOX: fir.call @arrayfunc_callee(%[[box]], %[[c100]]) : (!fir.box<!fir.array<?xf32>>, index) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}
+
+// CHECK-LABEL: func @call_derivedfunc() {
+// CHECK-BOX-LABEL: func @call_derivedfunc() {
+func @call_derivedfunc() {
+  %buffer = fir.alloca !fir.type<t{x:f32}>
+  %cst = constant 4.200000e+01 : f32
+  %res = fir.call @derivedfunc_callee(%cst) : (f32) -> !fir.type<t{x:f32}>
+  fir.save_result %res to %buffer : !fir.type<t{x:f32}>, !fir.ref<!fir.type<t{x:f32}>>
+  return
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.type<t{x:f32}>
+  // CHECK: %[[cst:.*]] = constant {{.*}} : f32
+  // CHECK: fir.call @derivedfunc_callee(%[[buffer]], %[[cst]]) : (!fir.ref<!fir.type<t{x:f32}>>, f32) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.type<t{x:f32}>
+  // CHECK-BOX: %[[cst:.*]] = constant {{.*}} : f32
+  // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]] : (!fir.ref<!fir.type<t{x:f32}>>) -> !fir.box<!fir.type<t{x:f32}>>
+  // CHECK-BOX: fir.call @derivedfunc_callee(%[[box]], %[[cst]]) : (!fir.box<!fir.type<t{x:f32}>>, f32) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}
+
+func private @derived_lparams_func() -> !fir.type<t2(l1:i32,l2:i32){x:f32}>
+
+// CHECK-LABEL: func @call_derived_lparams_func(
+// CHECK-SAME: %[[buffer:.*]]: !fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>
+// CHECK-BOX-LABEL: func @call_derived_lparams_func(
+// CHECK-BOX-SAME: %[[buffer:.*]]: !fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>
+func @call_derived_lparams_func(%buffer: !fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>) {
+  %l1 = constant 3 : i32
+  %l2 = constant 5 : i32
+  %res = fir.call @derived_lparams_func() : () -> !fir.type<t2(l1:i32,l2:i32){x:f32}>
+  fir.save_result %res to %buffer typeparams %l1, %l2 : !fir.type<t2(l1:i32,l2:i32){x:f32}>, !fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>, i32, i32
+  return
+
+  // CHECK: %[[l1:.*]] = constant 3 : i32
+  // CHECK: %[[l2:.*]] = constant 5 : i32
+  // CHECK: fir.call @derived_lparams_func(%[[buffer]]) : (!fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[l1:.*]] = constant 3 : i32
+  // CHECK-BOX: %[[l2:.*]] = constant 5 : i32
+  // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]] typeparams %[[l1]], %[[l2]] : (!fir.ref<!fir.type<t2(l1:i32,l2:i32){x:f32}>>, i32, i32) -> !fir.box<!fir.type<t2(l1:i32,l2:i32){x:f32}>>
+  // CHECK-BOX: fir.call @derived_lparams_func(%[[box]]) : (!fir.box<!fir.type<t2(l1:i32,l2:i32){x:f32}>>) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}
+
+// CHECK-LABEL: func @call_boxfunc() {
+// CHECK-BOX-LABEL: func @call_boxfunc() {
+func @call_boxfunc() {
+  %buffer = fir.alloca !fir.box<!fir.heap<f64>>
+  %res = fir.call @boxfunc_callee() : () -> !fir.box<!fir.heap<f64>>
+  fir.save_result %res to %buffer: !fir.box<!fir.heap<f64>>, !fir.ref<!fir.box<!fir.heap<f64>>>
+  return
+
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.box<!fir.heap<f64>>
+  // CHECK: fir.call @boxfunc_callee(%[[buffer]]) : (!fir.ref<!fir.box<!fir.heap<f64>>>) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.box<!fir.heap<f64>>
+  // CHECK-BOX: fir.call @boxfunc_callee(%[[buffer]]) : (!fir.ref<!fir.box<!fir.heap<f64>>>) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}
+
+func private @chararrayfunc(index, index) -> !fir.array<?x!fir.char<1,?>>
+
+// CHECK-LABEL: func @call_chararrayfunc() {
+// CHECK-BOX-LABEL: func @call_chararrayfunc() {
+func @call_chararrayfunc() {
+  %c100 = constant 100 : index
+  %c50 = constant 50 : index
+  %buffer = fir.alloca !fir.array<?x!fir.char<1,?>>, %c100, %c50
+  %shape = fir.shape %c100 : (index) -> !fir.shape<1>
+  %res = fir.call @chararrayfunc(%c100, %c50) : (index, index) -> !fir.array<?x!fir.char<1,?>>
+  fir.save_result %res to %buffer(%shape) typeparams %c50 : !fir.array<?x!fir.char<1,?>>, !fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index
+  return
+
+  // CHECK: %[[c100:.*]] = constant 100 : index
+  // CHECK: %[[c50:.*]] = constant 50 : index
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>, %[[c100]], %[[c50]]
+  // CHECK: fir.call @chararrayfunc(%[[buffer]], %[[c100]], %[[c50]]) : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, index, index) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[c100:.*]] = constant 100 : index
+  // CHECK-BOX: %[[c50:.*]] = constant 50 : index
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>, %[[c100]], %[[c50]]
+  // CHECK-BOX: %[[shape:.*]] = fir.shape %[[c100]] : (index) -> !fir.shape<1>
+  // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) typeparams %[[c50]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  // CHECK-BOX: fir.call @chararrayfunc(%[[box]], %[[c100]], %[[c50]]) : (!fir.box<!fir.array<?x!fir.char<1,?>>>, index, index) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}
+
+// ------------------------ Test fir.address_of rewrite ------------------------
+
+func private @takesfuncarray((i32) -> !fir.array<?xf32>)
+
+// CHECK-LABEL: func @test_address_of() {
+// CHECK-BOX-LABEL: func @test_address_of() {
+func @test_address_of() {
+  %0 = fir.address_of(@arrayfunc) : (i32) -> !fir.array<?xf32>
+  fir.call @takesfuncarray(%0) : ((i32) -> !fir.array<?xf32>) -> ()
+  return
+
+  // CHECK: %[[addrOf:.*]] = fir.address_of(@arrayfunc) : (!fir.ref<!fir.array<?xf32>>, i32) -> ()
+  // CHECK: %[[conv:.*]] = fir.convert %[[addrOf]] : ((!fir.ref<!fir.array<?xf32>>, i32) -> ()) -> ((i32) -> !fir.array<?xf32>)
+  // CHECK: fir.call @takesfuncarray(%[[conv]]) : ((i32) -> !fir.array<?xf32>) -> ()
+
+  // CHECK-BOX: %[[addrOf:.*]] = fir.address_of(@arrayfunc) : (!fir.box<!fir.array<?xf32>>, i32) -> ()
+  // CHECK-BOX: %[[conv:.*]] = fir.convert %[[addrOf]] : ((!fir.box<!fir.array<?xf32>>, i32) -> ()) -> ((i32) -> !fir.array<?xf32>)
+  // CHECK-BOX: fir.call @takesfuncarray(%[[conv]]) : ((i32) -> !fir.array<?xf32>) -> ()
+
+}
+
+// ----------------------- Test indirect calls rewrite ------------------------
+
+// CHECK-LABEL: func @test_indirect_calls(
+// CHECK-SAME: %[[arg0:.*]]: () -> ()) {
+// CHECK-BOX-LABEL: func @test_indirect_calls(
+// CHECK-BOX-SAME: %[[arg0:.*]]: () -> ()) {
+func @test_indirect_calls(%arg0: () -> ()) {
+  %c100 = constant 100 : index
+  %buffer = fir.alloca !fir.array<?xf32>, %c100
+  %shape = fir.shape %c100 : (index) -> !fir.shape<1>
+  %0 = fir.convert %arg0 : (() -> ()) -> ((index) -> !fir.array<?xf32>)
+  %res = fir.call %0(%c100) : (index) -> !fir.array<?xf32>
+  fir.save_result %res to %buffer(%shape) : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<1>
+  return
+
+  // CHECK: %[[c100:.*]] = constant 100 : index
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.array<?xf32>, %[[c100]]
+  // CHECK: %[[shape:.*]] = fir.shape %[[c100]] : (index) -> !fir.shape<1>
+  // CHECK: %[[original_conv:.*]] = fir.convert %[[arg0]] : (() -> ()) -> ((index) -> !fir.array<?xf32>)
+  // CHECK: %[[conv:.*]] = fir.convert %[[original_conv]] : ((index) -> !fir.array<?xf32>) -> ((!fir.ref<!fir.array<?xf32>>, index) -> ())
+  // CHECK: fir.call %[[conv]](%[[buffer]], %c100) : (!fir.ref<!fir.array<?xf32>>, index) -> ()
+  // CHECK-NOT: fir.save_result
+
+  // CHECK-BOX: %[[c100:.*]] = constant 100 : index
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.array<?xf32>, %[[c100]]
+  // CHECK-BOX: %[[shape:.*]] = fir.shape %[[c100]] : (index) -> !fir.shape<1>
+  // CHECK-BOX: %[[original_conv:.*]] = fir.convert %[[arg0]] : (() -> ()) -> ((index) -> !fir.array<?xf32>)
+  // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+  // CHECK-BOX: %[[conv:.*]] = fir.convert %[[original_conv]] : ((index) -> !fir.array<?xf32>) -> ((!fir.box<!fir.array<?xf32>>, index) -> ())
+  // CHECK-BOX: fir.call %[[conv]](%[[box]], %c100) : (!fir.box<!fir.array<?xf32>>, index) -> ()
+  // CHECK-BOX-NOT: fir.save_result
+}

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -54,18 +54,20 @@ func @fa(%a : !fir.ref<!fir.array<100xf32>>) {
 }
 
 // Boxing of a scalar character of dynamic length
-// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8 }* @b1(
-// CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
+// CHECK-LABEL: define void @b1(
+// CHECK-SAME: { i8*, i64, i32, i8, i8, i8, i8 }* %[[res:.*]], i8* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b1(%arg0 : !fir.ref<!fir.char<1,?>>, %arg1 : index) -> !fir.box<!fir.char<1,?>> {
   // CHECK: insertvalue {{.*}} undef, i64 %[[arg1]], 1
   // CHECK: insertvalue {{.*}} i32 20180515, 2
   // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
   %x = fir.embox %arg0 typeparams %arg1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+  // CHECK: store {{.*}}, { i8*, i64, i32, i8, i8, i8, i8 }* %[[res]]
   return %x : !fir.box<!fir.char<1,?>>
 }
 
 // Boxing of a dynamic array of character with static length (5)
-// CHECK-LABEL: define { [5 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b2(
+// CHECK-LABEL: define void @b2(
+// CHECK-SAME: { [5 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[res]],
 // CHECK-SAME: [5 x i8]* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.box<!fir.array<?x!fir.char<1,5>>> {
   %1 = fir.shape %arg1 : (index) -> !fir.shape<1>
@@ -73,12 +75,13 @@ func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.
   // CHECK: insertvalue {{.*}} %{{.*}}, i64 5, 7, 0, 2
   // CHECK: insertvalue {{.*}} [5 x i8]* %[[arg0]], 0
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<?x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<?x!fir.char<1,5>>>
+  // CHECK: store {{.*}}, {{.*}}* %[[res]]
   return %2 : !fir.box<!fir.array<?x!fir.char<1,5>>>
 }
 
 // Boxing of a dynamic array of character of dynamic length
-// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b3(
-// CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]], i64 %[[arg2:.*]])
+// CHECK-LABEL: define void @b3(
+// CHECK-SAME: { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[res:.*]], i8* %[[arg0:.*]], i64 %[[arg1:.*]], i64 %[[arg2:.*]])
 func @b3(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,?>>>, %arg1 : index, %arg2 : index) -> !fir.box<!fir.array<?x!fir.char<1,?>>> {
   %1 = fir.shape %arg2 : (index) -> !fir.shape<1>
   // CHECK: insertvalue {{.*}} i64 %[[arg1]], 1
@@ -87,12 +90,13 @@ func @b3(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,?>>>, %arg1 : index, %arg2 : 
   // CHECK: insertvalue {{.*}} i64 %[[arg1]], 7, 0, 2
   // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
   %2 = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  // CHECK: store {{.*}}, {{.*}}* %[[res]]
   return %2 : !fir.box<!fir.array<?x!fir.char<1,?>>>
 }
 
 // Boxing of a static array of character of dynamic length
-// CHECK-LABEL: define { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* @b4(
-// CHECK-SAME: i8* %[[arg0:.*]], i64 %[[arg1:.*]])
+// CHECK-LABEL: define void @b4(
+// CHECK-SAME: { i8*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[res:.*]], i8* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b4(%arg0 : !fir.ref<!fir.array<7x!fir.char<1,?>>>, %arg1 : index) -> !fir.box<!fir.array<7x!fir.char<1,?>>> {
   %c_7 = constant 7 : index
   %1 = fir.shape %c_7 : (index) -> !fir.shape<1>
@@ -102,6 +106,7 @@ func @b4(%arg0 : !fir.ref<!fir.array<7x!fir.char<1,?>>>, %arg1 : index) -> !fir.
   // CHECK: insertvalue {{.*}} i64 %[[arg1]], 7, 0, 2
   // CHECK: insertvalue {{.*}} i8* %[[arg0]], 0
   %x = fir.embox %arg0(%1) typeparams %arg1 : (!fir.ref<!fir.array<7x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<7x!fir.char<1,?>>>
+  // CHECK: store {{.*}}, {{.*}}* %[[res]]
   return %x : !fir.box<!fir.array<7x!fir.char<1,?>>>
 }
 

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -716,3 +716,15 @@ func @test_rebox(%arg0: !fir.box<!fir.array<?xf32>>) {
   fir.call @bar_rebox_test(%4) : (!fir.box<!fir.array<?x?xf32>>) -> ()
   return
 }
+
+func private @array_func() -> !fir.array<?x!fir.char<1,?>>
+// CHECK-LABEL: @test_save_result(
+func @test_save_result(%buffer: !fir.ref<!fir.array<?x!fir.char<1,?>>>) {
+  %c100 = constant 100 : index
+  %c50 = constant 50 : index
+  %shape = fir.shape %c100 : (index) -> !fir.shape<1>
+  %res = fir.call @array_func() : () -> !fir.array<?x!fir.char<1,?>>
+  // CHECK: fir.save_result %{{.*}} to %{{.*}}(%{{.*}}) typeparams %{{.*}} : !fir.array<?x!fir.char<1,?>>, !fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index
+  fir.save_result %res to %buffer(%shape) typeparams %c50 : !fir.array<?x!fir.char<1,?>>, !fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index
+  return
+}

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -377,3 +377,80 @@ fir.do_loop %i = %c1 to %c10 step %c1 -> index {
 // expected-error@+1 {{'fir.result' op parent of result must have same arity}}
 fir.do_loop %i = %c1 to %c10 step %c1 -> index {
 }
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.array<?xf64>>, %n :index) {
+  %res = fir.call @array_func() : () -> !fir.array<?xf32>
+  %shape = fir.shape %n : (index) -> !fir.shape<1>
+  // expected-error@+1 {{'fir.save_result' op value type must match memory reference type}}
+  fir.save_result %res to %buffer(%shape) : !fir.array<?xf32>, !fir.ref<!fir.array<?xf64>>, !fir.shape<1>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.box<!fir.array<*:f32>>>) {
+  %res = fir.call @array_func() : () -> !fir.box<!fir.array<*:f32>>
+  // expected-error@+1 {{'fir.save_result' op cannot save !fir.box of unknown rank or type}}
+  fir.save_result %res to %buffer : !fir.box<!fir.array<*:f32>>, !fir.ref<!fir.box<!fir.array<*:f32>>>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<f64>) {
+  %res = fir.call @array_func() : () -> f64
+  // expected-error@+1 {{'fir.save_result' op value operand must be a fir.box, fir.array or fir.type}}
+  fir.save_result %res to %buffer : f64, !fir.ref<f64>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.box<!fir.array<?xf32>>>, %n : index) {
+  %res = fir.call @array_func() : () -> !fir.box<!fir.array<?xf32>>
+  %shape = fir.shape %n : (index) -> !fir.shape<1>
+  // expected-error@+1 {{'fir.save_result' op must not have shape or length operands if the value is a fir.box}}
+  fir.save_result %res to %buffer(%shape) : !fir.box<!fir.array<?xf32>>, !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.shape<1>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.array<?xf32>>, %n :index) {
+  %res = fir.call @array_func() : () -> !fir.array<?xf32>
+  %shape = fir.shape %n, %n : (index, index) -> !fir.shape<2>
+  // expected-error@+1 {{'fir.save_result' op shape operand must be provided and have the value rank when the value is a fir.array}}
+  fir.save_result %res to %buffer(%shape) : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<2>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.type<t{x:f32}>>, %n :index) {
+  %res = fir.call @array_func() : () -> !fir.type<t{x:f32}>
+  %shape = fir.shape %n : (index) -> !fir.shape<1>
+  // expected-error@+1 {{'fir.save_result' op shape operand should only be provided if the value is a fir.array}}
+  fir.save_result %res to %buffer(%shape) : !fir.type<t{x:f32}>, !fir.ref<!fir.type<t{x:f32}>>, !fir.shape<1>
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.type<t{x:f32}>>, %n :index) {
+  %res = fir.call @array_func() : () -> !fir.type<t{x:f32}>
+  // expected-error@+1 {{'fir.save_result' op length parameters number must match with the value type length parameters}}
+  fir.save_result %res to %buffer typeparams %n : !fir.type<t{x:f32}>, !fir.ref<!fir.type<t{x:f32}>>, index
+  return
+}
+
+// -----
+
+func @bad_save_result(%buffer : !fir.ref<!fir.array<?xf32>>, %n :index) {
+  %res = fir.call @array_func() : () -> !fir.array<?xf32>
+  %shape = fir.shape %n : (index) -> !fir.shape<1>
+  // expected-error@+1 {{'fir.save_result' op length parameters must not be provided for this value type}}
+  fir.save_result %res to %buffer(%shape) typeparams %n : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index
+  return
+}

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -126,6 +126,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     pm.addPass(mlir::createCanonicalizerPass());
     fir::addCSE(pm);
 
+    pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
     // pm.addPass(fir::createMemToRegPass());
     fir::addCodeGenRewritePass(pm);
     fir::addTargetRewritePass(pm);


### PR DESCRIPTION
This patch goes towards explicit function returns support. It implements the FIR part of it.

- Add fir.save_result operation to associate these abstract results to
  a storage on the caller side (fir.array, fir.box and fir.type storage may be abstract/unknown
  in FIR). This is needed to manipulate the results, and to later
  be able to rewrite the call to a call where the result is passed as an
  argument and where the result storage allocation is done on the caller
  side.

- Add a FIR to FIR pass that rewrites FIR functions and calls that
  involve fir.array, fir.box or fir.type results to functions that takes
  an extra argument for the result. This pass gets rid of
  fir.save_result that has therefore no LLVM codegen.
  This pass handles both rewrites of direct and indirect calls, but
  fir.dispatch rewrite is left as a TODO.
  This pass can pass fir.array and fir.type result as a raw pointer
  or a boxed argument (this is left as a pass option, and both options
  are tested).