### PR TITLE
Remove code which follows host association

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -69,8 +69,10 @@ public:
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
 
-  /// Bind the symbol to an mlir value.
-  virtual void bindSymbol(const SymbolRef sym, mlir::Value val) = 0;
+  /// Binds the symbol to an mlir value and returns true if the symbol has no
+  /// existing binding. If there is an existing binding this function does
+  /// nothing and returns false.
+  virtual bool bindSymbol(const SymbolRef sym, mlir::Value val) = 0;
 
   /// Get the label set associated with a symbol.
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -237,11 +237,12 @@ public:
     return lookupSymbol(sym).getAddr();
   }
 
-  // TODO: Consider returning a vlue when the FIXME below is fixed.
-  void bindSymbol(Fortran::lower::SymbolRef sym,
+  bool bindSymbol(Fortran::lower::SymbolRef sym,
                   mlir::Value val) override final {
-    // FIXME: removed forced when symbol lookup stop following host association.
-    addSymbol(sym, val, /*forced=*/true);
+    if (lookupSymbol(sym))
+      return false;
+    addSymbol(sym, val);
+    return true;
   }
 
   bool lookupLabelSet(Fortran::lower::SymbolRef sym,

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -60,7 +60,11 @@ static void createBodyOfOp(Op &op, Fortran::lower::AbstractConverter &converter,
   // uses of the induction variable should use this mlir value.
   if (arg) {
     firOpBuilder.createBlock(&op.getRegion(), {}, {converter.genType(*arg)});
-    converter.bindSymbol(*arg, op.getRegion().front().getArgument(0));
+    [[maybe_unused]] bool success =
+        converter.bindSymbol(*arg, op.getRegion().front().getArgument(0));
+    assert(
+        success &&
+        "Existing binding prevents setting MLIR value for the index variable");
   } else {
     firOpBuilder.createBlock(&op.getRegion());
   }

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -188,12 +188,6 @@ Fortran::lower::SymMap::lookupSymbol(Fortran::semantics::SymbolRef sym) {
     if (iter != jmap->end())
       return iter->second;
   }
-  // FIXME BUG: How does this know that the caller is expecting the host
-  // associated symbol?
-  // Follow host association
-  if (const auto *details =
-          sym->detailsIf<Fortran::semantics::HostAssocDetails>())
-    return lookupSymbol(details->symbol());
   return SymbolBox::None{};
 }
 


### PR DESCRIPTION
This was previously necessary for variables in statement functions
and in do concurrent, OpenMP/OpenACC regions. These usages were
updated to follow the host association if necessary in the following PRs.
https://github.com/flang-compiler/f18-llvm-project/pull/748
https://github.com/flang-compiler/f18-llvm-project/pull/745

Also removed the usage of force binding which was previously required
due to always following host association.