### PR TITLE
Create allocas for OpenMP temp variables inside the region

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -124,7 +124,8 @@ public:
                               llvm::StringRef name = {},
                               mlir::ValueRange shape = {},
                               mlir::ValueRange lenParams = {},
-                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
+                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {},
+                              bool isPinned = false);
 
   /// Create an unnamed and untracked temporary on the stack.
   mlir::Value createTemporary(mlir::Location loc, mlir::Type type,

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -399,8 +399,15 @@ private:
     // FIXME: should return fir::ExtendedValue
     if (auto v = lookupSymbol(sym))
       return v.getAddr();
-    auto newVal = builder->createTemporary(loc, genType(sym),
-                                           toStringRef(sym.name()), shape);
+    // OpenMP: Sometimes the OpenMP standard requires that variables,
+    // like indices of sequential loops, in a parallel region are
+    // privatised. These privatised variables should be placed inside
+    // the region and not in the entry block.
+    bool isPinned =
+        sym.test(Fortran::semantics::Symbol::Flag::OmpPrivate) &&
+        sym.test(Fortran::semantics::Symbol::Flag::OmpPreDetermined);
+    auto newVal = builder->createTemporary(
+        loc, genType(sym), toStringRef(sym.name()), shape, {}, {}, isPinned);
     addSymbol(sym, newVal);
     return newVal;
   }

--- a/flang/test/Lower/OpenMP/omp-seqloop.f90
+++ b/flang/test/Lower/OpenMP/omp-seqloop.f90
@@ -1,0 +1,23 @@
+! This test checks lowering of OpenMP DO Directive(Worksharing).
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+!FIRDialect: func @_QQmain()
+program wsloop
+        integer :: i
+
+!FIRDialect:  omp.parallel {
+        !$OMP PARALLEL
+!FIRDialect:    %[[PRIVATE_INDX:.*]] = fir.alloca i32 {name = "i"}
+!FIRDialect:    %[[FINAL_INDX:.*]] = fir.do_loop %[[INDX:.*]] = {{.*}} {
+        do i=1, 9
+        print*, i
+        end do
+!FIRDialect:    }
+!FIRDialect:    %[[FINAL_INDX_CVT:.*]] = fir.convert %[[FINAL_INDX]] : (index) -> i32
+!FIRDialect:    fir.store %[[FINAL_INDX_CVT]] to %[[PRIVATE_INDX]] : !fir.ref<i32>
+!FIRDialect:    omp.terminator
+!FIRDialect:  }
+        !$OMP END PARALLEL
+end


### PR DESCRIPTION
The OpenMP standard requires that variables, like indices of sequential loops, in a parallel region are privatised. These privatised variables should be placed inside the region and not in the entry block.  Extended the createTemporary function with an isPinned argument to facilitate this.