### PR TITLE
Squash lowering of maxloc/minloc intrinsic calls commits

### DIFF
--- a/flang/include/flang/Lower/ReductionRuntime.h
+++ b/flang/include/flang/Lower/ReductionRuntime.h
@@ -16,40 +16,59 @@ class ExtendedValue;
 }
 
 namespace Fortran::lower {
-class FirOpBuilder;
+  class FirOpBuilder;
 
-/// Generate call to all runtime routine.
-/// This calls the descriptor based runtime call implementation of the scan
-/// intrinsics.
-void genAllDescriptor(Fortran::lower::FirOpBuilder &builder, 
-                         mlir::Location loc,
-                         mlir::Value resultBox, mlir::Value maskBox,
-                         mlir::Value dim); 
+  /// Generate call to all runtime routine.
+  /// This calls the descriptor based runtime call implementation of the scan
+  /// intrinsics.
+  void genAllDescriptor(Fortran::lower::FirOpBuilder & builder,
+                        mlir::Location loc, mlir::Value resultBox,
+                        mlir::Value maskBox, mlir::Value dim);
 
-/// Generate call to any runtime routine.
-/// This calls the descriptor based runtime call implementation of the scan
-/// intrinsics.
-void genAnyDescriptor(Fortran::lower::FirOpBuilder &builder, 
-                         mlir::Location loc,
-                         mlir::Value resultBox, mlir::Value maskBox,
-                         mlir::Value dim); 
+  /// Generate call to any runtime routine.
+  /// This calls the descriptor based runtime call implementation of the scan
+  /// intrinsics.
+  void genAnyDescriptor(Fortran::lower::FirOpBuilder & builder,
+                        mlir::Location loc, mlir::Value resultBox,
+                        mlir::Value maskBox, mlir::Value dim);
 
-/// Generate call to all runtime routine. This version of all is specialized
-/// for rank 1 mask arguments.
-/// This calls the version that returns a scalar logical value.
-mlir::Value
-genAll(Fortran::lower::FirOpBuilder &builder,
-       mlir::Location loc, mlir::Value maskBox,
-       mlir::Value dim);
+  /// Generate call to all runtime routine. This version of all is specialized
+  /// for rank 1 mask arguments.
+  /// This calls the version that returns a scalar logical value.
+  mlir::Value genAll(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                     mlir::Value maskBox, mlir::Value dim);
 
-/// Generate call to any runtime routine. This version of any is specialized
-/// for rank 1 mask arguments.
-/// This calls the version that returns a scalar logical value.
-mlir::Value
-genAny(Fortran::lower::FirOpBuilder &builder,
-       mlir::Location loc, mlir::Value maskBox,
-       mlir::Value dim);
+  /// Generate call to any runtime routine. This version of any is specialized
+  /// for rank 1 mask arguments.
+  /// This calls the version that returns a scalar logical value.
+  mlir::Value genAny(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                     mlir::Value maskBox, mlir::Value dim);
 
+  /// Generate call to Maxloc intrinsic runtime routine. This is the version
+  /// that does not take a dim argument.
+  void genMaxloc(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                 mlir::Value resultBox, mlir::Value arrayBox,
+                 mlir::Value maskBox, mlir::Value kind, mlir::Value back);
+
+  /// Generate call to Maxloc intrinsic runtime routine. This is the version
+  /// that takes a dim argument.
+  void genMaxlocDim(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                    mlir::Value resultBox, mlir::Value arrayBox,
+                    mlir::Value dim, mlir::Value maskBox, mlir::Value kind,
+                    mlir::Value back);
+
+  /// Generate call to Minloc intrinsic runtime routine. This is the version
+  /// that does not take a dim argument.
+  void genMinloc(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                 mlir::Value resultBox, mlir::Value arrayBox,
+                 mlir::Value maskBox, mlir::Value kind, mlir::Value back);
+
+  /// Generate call to Minloc intrinsic runtime routine. This is the version
+  /// that takes a dim argument.
+  void genMinlocDim(Fortran::lower::FirOpBuilder & builder, mlir::Location loc,
+                    mlir::Value resultBox, mlir::Value arrayBox,
+                    mlir::Value dim, mlir::Value maskBox, mlir::Value kind,
+                    mlir::Value back);
 } // namespace Fortran::lower
 
 #endif // FORTRAN_LOWER_REDUCTIONRUNTIME_H

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -106,6 +106,110 @@ static bool isAbsent(const fir::ExtendedValue &exv) {
   return !fir::getBase(exv);
 }
 
+/// Process calls to Minloc or Maxloc intrinsic functions
+template <typename FN, typename FD>
+static fir::ExtendedValue
+genExtremumloc(FN func, FD funcDim, mlir::Type resultType,
+               Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+               Fortran::lower::StatementContext *stmtCtx, 
+               const char *errMsg, llvm::ArrayRef<fir::ExtendedValue> args) {
+  assert(args.size() == 5);
+
+  // Handle required array argument
+  auto array = builder.createBox(loc, args[0]);
+
+  fir::BoxValue arryTmp = builder.createBox(loc, args[0]);
+  int rank = arryTmp.rank();
+  assert(rank >= 1);
+
+  // Handle optional mask argument
+  auto mask = isAbsent(args[2]) ?
+              builder.create<fir::AbsentOp>( 
+              loc, fir::BoxType::get(builder.getI1Type())) :
+              builder.createBox(loc, args[2]);
+
+  // Handle optional kind argument
+  auto kind = isAbsent(args[3]) ?
+              builder.createIntegerConstant(loc, builder.getIndexType(),
+                                   builder.getKindMap().defaultIntegerKind()) :
+              fir::getBase(args[3]); 
+
+  // Handle optional back argument
+  auto back = isAbsent(args[4]) ?
+              builder.createBool(loc, false) :
+              fir::getBase(args[4]);
+
+  bool absentDim = isAbsent(args[1]);
+
+  if (!absentDim && rank == 1) {
+    // If dim argument is present and the array is rank 1, then the result is
+    // a scalar (since the the result is rank-1 or 0).
+    // Therefore, we use a scalar result descriptor with Min/MaxlocDim().
+    auto dim = fir::getBase(args[1]);
+    // Create mutable fir.box to be passed to the runtime for the result.
+    auto resultMutableBox =
+         Fortran::lower::createTempMutableBox(builder, loc, resultType);
+    auto resultIrBox =
+         Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
+
+    funcDim(builder, loc, resultIrBox, array, dim, mask, kind, back);
+
+    // Handle cleanup of allocatable result descriptor and return
+    auto res = Fortran::lower::genMutableBoxRead(builder, loc, 
+                                                 resultMutableBox);
+    return res.match(
+          [&](const Fortran::lower::SymbolBox::Intrinsic &box)
+              -> fir::ExtendedValue { 
+              // Add cleanup code
+              assert(stmtCtx);
+              auto *bldr = &builder;
+              auto temp = box.getAddr();
+              stmtCtx->attachCleanup([=]() { 
+              bldr->create<fir::FreeMemOp>(loc, temp); });
+              return builder.create<fir::LoadOp>(loc, resultType, temp);
+        },
+        [&](const auto &) -> fir::ExtendedValue {
+          fir::emitFatalError(loc, errMsg);
+        });
+  }
+
+  // Note: The Min/Maxloc cases below have an array result.
+
+  // Create mutable fir.box to be passed to the runtime for the result.
+  auto resultArrayType = builder.getVarLenSeqTy(resultType, absentDim ? 1 :
+                                                rank - 1);
+  auto resultMutableBox =
+       Fortran::lower::createTempMutableBox(builder, loc, resultArrayType);
+  auto resultIrBox =
+       Fortran::lower::getMutableIRBox(builder, loc, resultMutableBox);
+
+  if (absentDim) {
+    // Handle min/maxloc case where there is no dim argument
+    // (calls Min/Maxloc() runtime routine)
+    func(builder, loc, resultIrBox, array, mask, kind, back);
+  } else {
+    // else handle min/maxloc case with dim argument (calls Min/MaxlocDim() 
+    // runtime routine).
+    auto dim = fir::getBase(args[1]);
+    funcDim(builder, loc, resultIrBox, array, dim, mask, kind, back);
+  }
+
+  return Fortran::lower::genMutableBoxRead(builder, loc, resultMutableBox)
+      .match(
+          [&](const fir::ArrayBoxValue &box) -> fir::ExtendedValue {
+            // Add cleanup code
+            assert(stmtCtx);
+            auto *bldr = &builder;
+            auto temp = box.getAddr();
+            stmtCtx->attachCleanup([=]() { 
+            bldr->create<fir::FreeMemOp>(loc, temp); });
+            return box;
+          },
+          [&](const auto &) -> fir::ExtendedValue {
+            fir::emitFatalError(loc, errMsg);
+          });
+}
+
 // TODO error handling -> return a code or directly emit messages ?
 struct IntrinsicLibrary {
 
@@ -168,7 +272,11 @@ struct IntrinsicLibrary {
   mlir::Value genIOr(mlir::Type, llvm::ArrayRef<mlir::Value>);
   fir::ExtendedValue genLen(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genLenTrim(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
+  fir::ExtendedValue genMaxloc(mlir::Type,
+                               llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genMerge(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  fir::ExtendedValue genMinloc(mlir::Type,
+                               llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genMod(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genModulo(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genNint(mlir::Type, llvm::ArrayRef<mlir::Value>);
@@ -328,8 +436,24 @@ static constexpr IntrinsicHandler handlers[]{
     {"len", &I::genLen},
     {"len_trim", &I::genLenTrim},
     {"max", &I::genExtremum<Extremum::Max, ExtremumBehavior::MinMaxss>},
-    {"min", &I::genExtremum<Extremum::Min, ExtremumBehavior::MinMaxss>},
+    {"maxloc",
+     &I::genMaxloc,
+     {{{"array", asAddr},
+       {"dim", asValue},
+       {"mask", asAddr},
+       {"kind", asValue},
+       {"back", asValue}}},
+       /*isElemental=*/false},
     {"merge", &I::genMerge},
+    {"min", &I::genExtremum<Extremum::Min, ExtremumBehavior::MinMaxss>},
+    {"minloc",
+     &I::genMinloc,
+     {{{"array", asAddr},
+       {"dim", asValue},
+       {"mask", asAddr},
+       {"kind", asValue},
+       {"back", asValue}}},
+       /*isElemental=*/false},
     {"mod", &I::genMod},
     {"modulo", &I::genModulo},
     {"nint", &I::genNint},
@@ -1957,6 +2081,26 @@ IntrinsicLibrary::genVerify(mlir::Type resultType,
       [&](const auto &) -> fir::ExtendedValue {
         fir::emitFatalError(loc, "unexpected result for VERIFY");
       });
+}
+
+// MAXLOC
+fir::ExtendedValue
+IntrinsicLibrary::genMaxloc(mlir::Type resultType,
+                            llvm::ArrayRef<fir::ExtendedValue> args) {
+  return genExtremumloc(Fortran::lower::genMaxloc, 
+                        Fortran::lower::genMaxlocDim, 
+                        resultType, builder, loc, stmtCtx, 
+                        "unexpected result for Maxloc", args);
+}
+
+// MINLOC
+fir::ExtendedValue
+IntrinsicLibrary::genMinloc(mlir::Type resultType,
+                            llvm::ArrayRef<fir::ExtendedValue> args) {
+  return genExtremumloc(Fortran::lower::genMinloc, 
+                        Fortran::lower::genMinlocDim, 
+                        resultType, builder, loc, stmtCtx, 
+                        "unexpected result for Minloc", args);
 }
 
 // MIN and MAX

--- a/flang/lib/Lower/ReductionRuntime.cpp
+++ b/flang/lib/Lower/ReductionRuntime.cpp
@@ -19,94 +19,184 @@
 using namespace Fortran::runtime;
 
 /// Generate calls to reduction intrinsics such as All and Any.
-/// These are the descriptor based implementations that take two 
+/// These are the descriptor based implementations that take two
 /// arguments (mask, dim).
 template <typename FN>
-static void
-genRed2Args(FN func, Fortran::lower::FirOpBuilder &builder,
-            mlir::Location loc, mlir::Value resultBox,
-            mlir::Value maskBox, mlir::Value dim) {
+static void genReduction2Args(FN func, Fortran::lower::FirOpBuilder &builder,
+                              mlir::Location loc, mlir::Value resultBox,
+                              mlir::Value maskBox, mlir::Value dim) {
   auto fTy = func.getType();
   auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
   auto sourceLine =
-       Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(4));
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(4));
 
   llvm::SmallVector<mlir::Value> args = {
     builder.createConvert(loc, fTy.getInput(0), resultBox),
     builder.createConvert(loc, fTy.getInput(1), maskBox),
     builder.createConvert(loc, fTy.getInput(2), dim),
     builder.createConvert(loc, fTy.getInput(3), sourceFile),
-    builder.createConvert(loc, fTy.getInput(4), sourceLine) 
+    builder.createConvert(loc, fTy.getInput(4), sourceLine)
   };
-   
+
   builder.create<fir::CallOp>(loc, func, args);
-
 }
+
+/// Generate calls to reduction intrinsics such as Maxloc and Minloc.
+/// These take arguments such as (array, mask, kind, back).
+template <typename FN>
+static void genReduction4Args(FN func, Fortran::lower::FirOpBuilder &builder,
+                              mlir::Location loc, mlir::Value resultBox,
+                              mlir::Value arrayBox, mlir::Value maskBox,
+                              mlir::Value kind, mlir::Value back) {
+  auto fTy = func.getType();
+  auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
+  auto sourceLine =
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(4));
+
+  llvm::SmallVector<mlir::Value> args = {
+    builder.createConvert(loc, fTy.getInput(0), resultBox),
+    builder.createConvert(loc, fTy.getInput(1), arrayBox),
+    builder.createConvert(loc, fTy.getInput(2), kind),
+    builder.createConvert(loc, fTy.getInput(3), sourceFile),
+    builder.createConvert(loc, fTy.getInput(4), sourceLine),
+    builder.createConvert(loc, fTy.getInput(5), maskBox),
+    builder.createConvert(loc, fTy.getInput(6), back)
+  };
+
+  builder.create<fir::CallOp>(loc, func, args);
+}
+
+/// Generate calls to reduction intrinsics such as Maxloc and Minloc.
+/// These take arguments such as (array, dim, mask, kind, back).
+template <typename FN>
+static void genReduction5Args(FN func, Fortran::lower::FirOpBuilder &builder,
+                              mlir::Location loc, mlir::Value resultBox,
+                              mlir::Value arrayBox, mlir::Value dim,
+                              mlir::Value maskBox, mlir::Value kind,
+                              mlir::Value back) {
+  auto fTy = func.getType();
+  auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
+  auto sourceLine =
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(5));
+
+  llvm::SmallVector<mlir::Value> args = {
+    builder.createConvert(loc, fTy.getInput(0), resultBox),
+    builder.createConvert(loc, fTy.getInput(1), arrayBox),
+    builder.createConvert(loc, fTy.getInput(2), kind),
+    builder.createConvert(loc, fTy.getInput(3), dim),
+    builder.createConvert(loc, fTy.getInput(4), sourceFile),
+    builder.createConvert(loc, fTy.getInput(5), sourceLine),
+    builder.createConvert(loc, fTy.getInput(6), maskBox),
+    builder.createConvert(loc, fTy.getInput(7), back)
+  };
+
+  builder.create<fir::CallOp>(loc, func, args);
+}
+
 /// Generate call to all runtime routine.
-/// This calls the descriptor based runtime call implementation of the all 
+/// This calls the descriptor based runtime call implementation of the all
 /// intrinsic.
-void
-Fortran::lower::genAllDescriptor(Fortran::lower::FirOpBuilder &builder, 
-                                 mlir::Location loc,
-                                 mlir::Value resultBox, mlir::Value maskBox,
-                                 mlir::Value dim) {
+void Fortran::lower::genAllDescriptor(Fortran::lower::FirOpBuilder &builder,
+                                      mlir::Location loc, mlir::Value resultBox,
+                                      mlir::Value maskBox, mlir::Value dim) {
   auto allFunc = Fortran::lower::getRuntimeFunc<mkRTKey(AllDim)>(loc, builder);
-  genRed2Args(allFunc, builder, loc, resultBox, maskBox, dim);
+  genReduction2Args(allFunc, builder, loc, resultBox, maskBox, dim);
 }
-
 
 /// Generate call to any runtime routine.
 /// This calls the descriptor based runtime call implementation of the any
 /// intrinsic.
-void
-Fortran::lower::genAnyDescriptor(Fortran::lower::FirOpBuilder &builder, 
-                                 mlir::Location loc,
-                                 mlir::Value resultBox, mlir::Value maskBox,
-                                 mlir::Value dim) {
+void Fortran::lower::genAnyDescriptor(Fortran::lower::FirOpBuilder &builder,
+                                      mlir::Location loc, mlir::Value resultBox,
+                                      mlir::Value maskBox, mlir::Value dim) {
   auto anyFunc = Fortran::lower::getRuntimeFunc<mkRTKey(AnyDim)>(loc, builder);
-  genRed2Args(anyFunc, builder, loc, resultBox, maskBox, dim);
+  genReduction2Args(anyFunc, builder, loc, resultBox, maskBox, dim);
 }
 
 /// Generate call to All intrinsic runtime routine. This routine is
 /// specialized for mask arguments with rank == 1.
-mlir::Value
-Fortran::lower::genAll(Fortran::lower::FirOpBuilder &builder, 
-                       mlir::Location loc, mlir::Value maskBox, 
-                       mlir::Value dim) {
+mlir::Value Fortran::lower::genAll(Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc, mlir::Value maskBox,
+                                   mlir::Value dim) {
   auto allFunc = Fortran::lower::getRuntimeFunc<mkRTKey(All)>(loc, builder);
   auto fTy = allFunc.getType();
   auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
   auto sourceLine =
-       Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(2));
-     
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(2));
+
   llvm::SmallVector<mlir::Value> args = {
     builder.createConvert(loc, fTy.getInput(0), maskBox),
     builder.createConvert(loc, fTy.getInput(1), sourceFile),
-    builder.createConvert(loc, fTy.getInput(2), sourceLine), 
+    builder.createConvert(loc, fTy.getInput(2), sourceLine),
     builder.createConvert(loc, fTy.getInput(3), dim)
   };
-   
+
   return builder.create<fir::CallOp>(loc, allFunc, args).getResult(0);
 }
 
 /// Generate call to Any intrinsic runtime routine. This routine is
 /// specialized for mask arguments with rank == 1.
-mlir::Value
-Fortran::lower::genAny(Fortran::lower::FirOpBuilder &builder, 
-                       mlir::Location loc, mlir::Value maskBox, 
-                       mlir::Value dim) {
+mlir::Value Fortran::lower::genAny(Fortran::lower::FirOpBuilder &builder,
+                                   mlir::Location loc, mlir::Value maskBox,
+                                   mlir::Value dim) {
   auto anyFunc = Fortran::lower::getRuntimeFunc<mkRTKey(Any)>(loc, builder);
   auto fTy = anyFunc.getType();
   auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
   auto sourceLine =
-       Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(2));
-     
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(2));
+
   llvm::SmallVector<mlir::Value> args = {
     builder.createConvert(loc, fTy.getInput(0), maskBox),
     builder.createConvert(loc, fTy.getInput(1), sourceFile),
-    builder.createConvert(loc, fTy.getInput(2), sourceLine), 
+    builder.createConvert(loc, fTy.getInput(2), sourceLine),
     builder.createConvert(loc, fTy.getInput(3), dim)
   };
-   
+
   return builder.create<fir::CallOp>(loc, anyFunc, args).getResult(0);
+}
+
+/// Generate call to Maxloc intrinsic runtime routine. This is the version
+/// that does not take a dim argument.
+void Fortran::lower::genMaxloc(Fortran::lower::FirOpBuilder &builder,
+                               mlir::Location loc, mlir::Value resultBox,
+                               mlir::Value arrayBox, mlir::Value maskBox,
+                               mlir::Value kind, mlir::Value back) {
+  auto func = Fortran::lower::getRuntimeFunc<mkRTKey(Maxloc)>(loc, builder);
+  genReduction4Args(func, builder, loc, resultBox, arrayBox, maskBox, kind,
+                    back);
+}
+
+/// Generate call to Maxloc intrinsic runtime routine. This is the version
+/// that takes a dim argument.
+void Fortran::lower::genMaxlocDim(Fortran::lower::FirOpBuilder &builder,
+                                  mlir::Location loc, mlir::Value resultBox,
+                                  mlir::Value arrayBox, mlir::Value dim,
+                                  mlir::Value maskBox, mlir::Value kind,
+                                  mlir::Value back) {
+  auto func = Fortran::lower::getRuntimeFunc<mkRTKey(MaxlocDim)>(loc, builder);
+  genReduction5Args(func, builder, loc, resultBox, arrayBox, dim, maskBox, kind,
+                    back);
+}
+
+/// Generate call to Minloc intrinsic runtime routine. This is the version
+/// that does not take a dim argument.
+void Fortran::lower::genMinloc(Fortran::lower::FirOpBuilder &builder,
+                               mlir::Location loc, mlir::Value resultBox,
+                               mlir::Value arrayBox, mlir::Value maskBox,
+                               mlir::Value kind, mlir::Value back) {
+  auto func = Fortran::lower::getRuntimeFunc<mkRTKey(Minloc)>(loc, builder);
+  genReduction4Args(func, builder, loc, resultBox, arrayBox, maskBox, kind,
+                    back);
+}
+
+/// Generate call to Minloc intrinsic runtime routine. This is the version
+/// that takes a dim argument.
+void Fortran::lower::genMinlocDim(Fortran::lower::FirOpBuilder &builder,
+                                  mlir::Location loc, mlir::Value resultBox,
+                                  mlir::Value arrayBox, mlir::Value dim,
+                                  mlir::Value maskBox, mlir::Value kind,
+                                  mlir::Value back) {
+  auto func = Fortran::lower::getRuntimeFunc<mkRTKey(MinlocDim)>(loc, builder);
+  genReduction5Args(func, builder, loc, resultBox, arrayBox, dim, maskBox, kind,
+                    back);
 }

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -388,6 +388,92 @@ integer function len_trim_test(c)
   ! CHECK: select %[[iterateResult]]#0, %[[c0]], %[[len]]
 end function
 
+! MAXLOC
+! CHECK-LABEL: maxloc_test
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+subroutine maxloc_test(arr,res)
+  integer :: arr(:)
+  integer :: res(:)
+! CHECK-DAG: %[[c4:.*]] = constant 4 : index
+! CHECK-DAG: %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK-DAG: %[[a1:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG: %[[a6:.*]] = fir.convert %[[a0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG: %[[a7:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+! CHECK-DAG: %[[a8:.*]] = fir.convert %[[c4]] : (index) -> i32
+! CHECK-DAG: %[[a10:.*]] = fir.convert %[[a1]] : (!fir.box<i1>) -> !fir.box<none>
+  res = maxloc(arr)
+! CHECK: %{{.*}} = fir.call @_FortranAMaxloc(%[[a6]], %[[a7]], %[[a8]], %{{.*}}, %{{.*}}, %[[a10]], %false) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> none
+! CHECK-DAG: %[[a12:.*]] = fir.load %[[a0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK-DAG: %[[a14:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK-DAG: fir.freemem %[[a14]] : !fir.heap<!fir.array<?xi32>>
+end subroutine
+
+! MAXLOC
+! CHECK-LABEL: maxloc_test2
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg2:.*]]: !fir.ref<i32>
+subroutine maxloc_test2(arr,res,d)
+  integer :: arr(:) 
+  integer :: res(:)
+  integer :: d
+! CHECK-DAG:  %[[c4:.*]] = constant 4 : index
+! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
+! CHECK-DAG:  %[[a1:.*]] = fir.load %arg2 : !fir.ref<i32>
+! CHECK-DAG:  %[[a2:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG:  %[[a7:.*]] = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+! CHECK-DAG:  %[[a8:.*]] = fir.convert %[[c4]] : (index) -> i32
+! CHECK-DAG:  %[[a10:.*]] = fir.convert %[[a2]] : (!fir.box<i1>) -> !fir.box<none>
+  res = maxloc(arr, dim=d)
+! CHECK:  %{{.*}} = fir.call @_FortranAMaxlocDim(%[[a6]], %[[a7]], %[[a8]], %[[a1]], %{{.*}}, %{{.*}}, %[[a10]], %false) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> none
+! CHECK:  %[[a12:.*]] = fir.load %0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[a13:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[a13]] : !fir.heap<i32>
+end subroutine
+
+! MINLOC
+! CHECK-LABEL: minloc_test
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+subroutine minloc_test(arr,res)
+  integer :: arr(:)
+  integer :: res(:)
+! CHECK-DAG: %[[c4:.*]] = constant 4 : index
+! CHECK-DAG: %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK-DAG: %[[a1:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG: %[[a6:.*]] = fir.convert %[[a0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG: %[[a7:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+! CHECK-DAG: %[[a8:.*]] = fir.convert %[[c4]] : (index) -> i32
+! CHECK-DAG: %[[a10:.*]] = fir.convert %[[a1]] : (!fir.box<i1>) -> !fir.box<none>
+  res = minloc(arr)
+! CHECK: %{{.*}} = fir.call @_FortranAMinloc(%[[a6]], %[[a7]], %[[a8]], %{{.*}}, %{{.*}}, %[[a10]], %false) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> none
+! CHECK-DAG: %[[a12:.*]] = fir.load %[[a0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK-DAG: %[[a14:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK-DAG: fir.freemem %[[a14]] : !fir.heap<!fir.array<?xi32>>
+end subroutine
+
+! MINLOC
+! CHECK-LABEL: minloc_test2
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg2:.*]]: !fir.ref<i32>
+subroutine minloc_test2(arr,res,d)
+  integer :: arr(:) 
+  integer :: res(:)
+  integer :: d
+! CHECK-DAG:  %[[c4:.*]] = constant 4 : index
+! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
+! CHECK-DAG:  %[[a1:.*]] = fir.load %arg2 : !fir.ref<i32>
+! CHECK-DAG:  %[[a2:.*]] = fir.absent !fir.box<i1>
+! CHECK-DAG:  %[[a6:.*]] = fir.convert %[[a0]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK-DAG:  %[[a7:.*]] = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+! CHECK-DAG:  %[[a8:.*]] = fir.convert %[[c4]] : (index) -> i32
+! CHECK-DAG:  %[[a10:.*]] = fir.convert %[[a2]] : (!fir.box<i1>) -> !fir.box<none>
+  res = minloc(arr, dim=d)
+! CHECK:  %{{.*}} = fir.call @_FortranAMinlocDim(%[[a6]], %[[a7]], %[[a8]], %[[a1]], %{{.*}}, %{{.*}}, %[[a10]], %false) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> none
+! CHECK:  %[[a12:.*]] = fir.load %0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[a13:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[a13]] : !fir.heap<i32>
+end subroutine
+
 ! NINT
 ! CHECK-LABEL: nint_test1
 subroutine nint_test1(i, a)


### PR DESCRIPTION
Add lowering of maxloc/minloc intrinsic calls

Fix some spacing

Remove unneeded braces and add a comment

Incorporate comments from code review:
Run clang-format on ReductionRuntime.h. Spell out Reduction in genRed
functions. Use extremum in place of minmax. Add comments.

Incorporate comments. Fix typo and formatting.