### PR TITLE
Cherry-picking runtime changes from llvm main

### DIFF
--- a/flang/include/flang/Evaluate/real.h
+++ b/flang/include/flang/Evaluate/real.h
@@ -80,6 +80,7 @@ public:
   constexpr bool IsInfinite() const {
     return Exponent() == maxExponent && GetSignificand().IsZero();
   }
+  constexpr bool IsFinite() const { return Exponent() != maxExponent; }
   constexpr bool IsZero() const {
     return Exponent() == 0 && GetSignificand().IsZero();
   }

--- a/flang/lib/Evaluate/fold-logical.cpp
+++ b/flang/lib/Evaluate/fold-logical.cpp
@@ -89,9 +89,9 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldIntrinsicFunction(
             [&fptr](const Scalar<LargestInt> &i, const Scalar<LargestInt> &j) {
               return Scalar<T>{std::invoke(fptr, i, j)};
             }));
-  } else if (name == "isnan") {
+  } else if (name == "isnan" || name == "__builtin_ieee_is_nan") {
     // A warning about an invalid argument is discarded from converting
-    // the argument of isnan().
+    // the argument of isnan() / IEEE_IS_NAN().
     auto restorer{context.messages().DiscardMessages()};
     using DefaultReal = Type<TypeCategory::Real, 4>;
     return FoldElementalIntrinsic<T, DefaultReal>(context, std::move(funcRef),

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -772,6 +772,12 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
             {"back", AnyLogical, Rank::elemental, Optionality::optional},
             DefaultingKIND},
         KINDInt},
+    {"__builtin_ieee_is_nan", {{"a", AnyFloating}}, DefaultLogical},
+    {"__builtin_ieee_selected_real_kind", // alias for selected_real_kind
+        {{"p", AnyInt, Rank::scalar},
+            {"r", AnyInt, Rank::scalar, Optionality::optional},
+            {"radix", AnyInt, Rank::scalar, Optionality::optional}},
+        DefaultInt, Rank::scalar, IntrinsicClass::transformationalFunction},
     {"__builtin_ieee_support_datatype",
         {{"x", AnyReal, Rank::elemental, Optionality::optional}},
         DefaultLogical},

--- a/flang/module/__fortran_builtins.f90
+++ b/flang/module/__fortran_builtins.f90
@@ -32,6 +32,8 @@ module __Fortran_builtins
 
   procedure(type(__builtin_c_ptr)) :: __builtin_c_loc
 
+  intrinsic :: __builtin_ieee_is_nan
+  intrinsic :: __builtin_ieee_selected_real_kind
   intrinsic :: __builtin_ieee_support_datatype, &
     __builtin_ieee_support_denormal, __builtin_ieee_support_divide, &
     __builtin_ieee_support_inf, __builtin_ieee_support_io, &

--- a/flang/module/ieee_arithmetic.f90
+++ b/flang/module/ieee_arithmetic.f90
@@ -10,6 +10,8 @@
 module ieee_arithmetic
 
   use __Fortran_builtins, only: &
+    ieee_is_nan => __builtin_ieee_is_nan, &
+    ieee_selected_real_kind => __builtin_ieee_selected_real_kind, &
     ieee_support_datatype => __builtin_ieee_support_datatype, &
     ieee_support_denormal => __builtin_ieee_support_denormal, &
     ieee_support_divide => __builtin_ieee_support_divide, &
@@ -20,6 +22,8 @@ module ieee_arithmetic
     ieee_support_standard => __builtin_ieee_support_standard, &
     ieee_support_subnormal => __builtin_ieee_support_subnormal, &
     ieee_support_underflow_control => __builtin_ieee_support_underflow_control
+
+  implicit none
 
   type :: ieee_class_type
     private
@@ -64,25 +68,32 @@ module ieee_arithmetic
     module procedure class_ne
     module procedure round_ne
   end interface operator(/=)
+  private :: class_eq, class_ne, round_eq, round_ne
 
   ! See Fortran 2018, 17.10 & 17.11
-  interface ieee_class
-    module procedure ieee_class_a2
-    module procedure ieee_class_a3
-    module procedure ieee_class_a4
-    module procedure ieee_class_a8
-    module procedure ieee_class_a10
-    module procedure ieee_class_a16
-  end interface ieee_class
+  generic :: ieee_class => ieee_class_a2, ieee_class_a3, ieee_class_a4, ieee_class_a8, ieee_class_a10, ieee_class_a16
+  private :: ieee_class_a2, ieee_class_a3, ieee_class_a4, ieee_class_a8, ieee_class_a10, ieee_class_a16
 
-  interface ieee_copy_sign
-    module procedure ieee_copy_sign_a2
-    module procedure ieee_copy_sign_a3
-    module procedure ieee_copy_sign_a4
-    module procedure ieee_copy_sign_a8
-    module procedure ieee_copy_sign_a10
-    module procedure ieee_copy_sign_a16
-  end interface ieee_copy_sign
+  generic :: ieee_copy_sign => ieee_copy_sign_a2, ieee_copy_sign_a3, ieee_copy_sign_a4, ieee_copy_sign_a8, ieee_copy_sign_a10, ieee_copy_sign_a16
+  private :: ieee_copy_sign_a2, ieee_copy_sign_a3, ieee_copy_sign_a4, ieee_copy_sign_a8, ieee_copy_sign_a10, ieee_copy_sign_a16
+
+  generic :: ieee_is_finite => ieee_is_finite_a2, ieee_is_finite_a3, ieee_is_finite_a4, ieee_is_finite_a8, ieee_is_finite_a10, ieee_is_finite_a16
+  private :: ieee_is_finite_a2, ieee_is_finite_a3, ieee_is_finite_a4, ieee_is_finite_a8, ieee_is_finite_a10, ieee_is_finite_a16
+
+  generic :: ieee_rem => &
+    ieee_rem_a2_a2, ieee_rem_a2_a3, ieee_rem_a2_a4, ieee_rem_a2_a8, ieee_rem_a2_a10, ieee_rem_a2_a16, &
+    ieee_rem_a3_a2, ieee_rem_a3_a3, ieee_rem_a3_a4, ieee_rem_a3_a8, ieee_rem_a3_a10, ieee_rem_a3_a16, &
+    ieee_rem_a4_a2, ieee_rem_a4_a3, ieee_rem_a4_a4, ieee_rem_a4_a8, ieee_rem_a4_a10, ieee_rem_a4_a16, &
+    ieee_rem_a8_a2, ieee_rem_a8_a3, ieee_rem_a8_a4, ieee_rem_a8_a8, ieee_rem_a8_a10, ieee_rem_a8_a16, &
+    ieee_rem_a10_a2, ieee_rem_a10_a3, ieee_rem_a10_a4, ieee_rem_a10_a8, ieee_rem_a10_a10, ieee_rem_a10_a16, &
+    ieee_rem_a16_a2, ieee_rem_a16_a3, ieee_rem_a16_a4, ieee_rem_a16_a8, ieee_rem_a16_a10, ieee_rem_a16_a16
+  private :: &
+    ieee_rem_a2_a2, ieee_rem_a2_a3, ieee_rem_a2_a4, ieee_rem_a2_a8, ieee_rem_a2_a10, ieee_rem_a2_a16, &
+    ieee_rem_a3_a2, ieee_rem_a3_a3, ieee_rem_a3_a4, ieee_rem_a3_a8, ieee_rem_a3_a10, ieee_rem_a3_a16, &
+    ieee_rem_a4_a2, ieee_rem_a4_a3, ieee_rem_a4_a4, ieee_rem_a4_a8, ieee_rem_a4_a10, ieee_rem_a4_a16, &
+    ieee_rem_a8_a2, ieee_rem_a8_a3, ieee_rem_a8_a4, ieee_rem_a8_a8, ieee_rem_a8_a10, ieee_rem_a8_a16, &
+    ieee_rem_a10_a2, ieee_rem_a10_a3, ieee_rem_a10_a4, ieee_rem_a10_a8, ieee_rem_a10_a10, ieee_rem_a10_a16, &
+    ieee_rem_a16_a2, ieee_rem_a16_a3, ieee_rem_a16_a4, ieee_rem_a16_a8, ieee_rem_a16_a10, ieee_rem_a16_a16
 
   generic :: ieee_support_rounding => ieee_support_rounding_, &
     ieee_support_rounding_2, ieee_support_rounding_3, &
@@ -201,6 +212,72 @@ module ieee_arithmetic
   _COPYSIGN(10,16,80)
   _COPYSIGN(16,16,128)
 #undef _COPYSIGN
+
+#define _IS_FINITE(KIND) \
+  elemental function ieee_is_finite_a##KIND(x) result(res); \
+    real(kind=KIND), intent(in) :: x; \
+    logical :: res; \
+    type(ieee_class_type) :: classification; \
+    classification = ieee_class(x); \
+    res = classification == ieee_negative_zero .or. classification == ieee_positive_zero \
+     .or. classification == ieee_negative_denormal .or. classification == ieee_positive_denormal \
+     .or. classification == ieee_negative_normal .or. classification == ieee_positive_normal; \
+  end function
+  _IS_FINITE(2)
+  _IS_FINITE(3)
+  _IS_FINITE(4)
+  _IS_FINITE(8)
+  _IS_FINITE(10)
+  _IS_FINITE(16)
+#undef _IS_FINITE
+
+! TODO: handle edge cases from 17.11.31
+#define _REM(XKIND,YKIND) \
+  elemental function ieee_rem_a##XKIND##_a##YKIND(x, y) result(res); \
+    real(kind=XKIND), intent(in) :: x; \
+    real(kind=YKIND), intent(in) :: y; \
+    integer, parameter :: rkind = max(XKIND, YKIND); \
+    real(kind=rkind) :: res, tmp; \
+    tmp = anint(real(x, kind=rkind) / y); \
+    res = x - y * tmp; \
+  end function
+  _REM(2,2)
+  _REM(2,3)
+  _REM(2,4)
+  _REM(2,8)
+  _REM(2,10)
+  _REM(2,16)
+  _REM(3,2)
+  _REM(3,3)
+  _REM(3,4)
+  _REM(3,8)
+  _REM(3,10)
+  _REM(3,16)
+  _REM(4,2)
+  _REM(4,3)
+  _REM(4,4)
+  _REM(4,8)
+  _REM(4,10)
+  _REM(4,16)
+  _REM(8,2)
+  _REM(8,3)
+  _REM(8,4)
+  _REM(8,8)
+  _REM(8,10)
+  _REM(8,16)
+  _REM(10,2)
+  _REM(10,3)
+  _REM(10,4)
+  _REM(10,8)
+  _REM(10,10)
+  _REM(10,16)
+  _REM(16,2)
+  _REM(16,3)
+  _REM(16,4)
+  _REM(16,8)
+  _REM(16,10)
+  _REM(16,16)
+#undef _REM
 
   pure logical function ieee_support_rounding_(round_type)
     type(ieee_round_type), intent(in) :: round_type

--- a/flang/runtime/buffer.h
+++ b/flang/runtime/buffer.h
@@ -27,7 +27,24 @@ void LeftShiftBufferCircularly(char *, std::size_t bytes, std::size_t shift);
 // preserve read data that may be reused by means of Tn/TLn edit descriptors
 // without needing to position the file (which may not always be possible,
 // e.g. a socket) and a general desire to reduce system call counts.
-template <typename STORE> class FileFrame {
+//
+// Possible scenario with a tiny 32-byte buffer after a ReadFrame or
+// WriteFrame with a file offset of 103 to access "DEF":
+//
+//    fileOffset_ 100 --+  +-+ frame of interest (103:105)
+//   file:  ............ABCDEFGHIJKLMNOPQRSTUVWXYZ....
+// buffer: [NOPQRSTUVWXYZ......ABCDEFGHIJKLM]   (size_ == 32)
+//                             |  +-- frame_ == 3
+//                             +----- start_ == 19, length_ == 26
+//
+// The buffer holds length_ == 26 bytes from file offsets 100:125.
+// Those 26 bytes "wrap around" the end of the circular buffer,
+// so file offsets 100:112 map to buffer offsets 19:31 ("A..M") and
+//    file offsets 113:125 map to buffer offsets  0:12 ("N..Z")
+// The 3-byte frame of file offsets 103:105 is contiguous in the buffer
+// at buffer offset (start_ + frame_) == 22 ("DEF").
+
+template <typename STORE, std::size_t minBuffer = 65536> class FileFrame {
 public:
   using FileOffset = std::int64_t;
 
@@ -50,28 +67,17 @@ public:
       FileOffset at, std::size_t bytes, IoErrorHandler &handler) {
     Flush(handler);
     Reallocate(bytes, handler);
-    if (at < fileOffset_ || at > fileOffset_ + length_) {
+    std::int64_t newFrame{at - fileOffset_};
+    if (newFrame < 0 || newFrame > length_) {
       Reset(at);
+    } else {
+      frame_ = newFrame;
     }
-    frame_ = at - fileOffset_;
+    RUNTIME_CHECK(handler, at == fileOffset_ + frame_);
     if (static_cast<std::int64_t>(start_ + frame_ + bytes) > size_) {
       DiscardLeadingBytes(frame_, handler);
-      if (static_cast<std::int64_t>(start_ + bytes) > size_) {
-        // Frame would wrap around; shift current data (if any) to force
-        // contiguity.
-        RUNTIME_CHECK(handler, length_ < size_);
-        if (start_ + length_ <= size_) {
-          // [......abcde..] -> [abcde........]
-          std::memmove(buffer_, buffer_ + start_, length_);
-        } else {
-          // [cde........ab] -> [abcde........]
-          auto n{start_ + length_ - size_}; // 3 for cde
-          RUNTIME_CHECK(handler, length_ >= n);
-          std::memmove(buffer_ + n, buffer_ + start_, length_ - n); // cdeab
-          LeftShiftBufferCircularly(buffer_, length_, n); // abcde
-        }
-        start_ = 0;
-      }
+      MakeDataContiguous(handler, bytes);
+      RUNTIME_CHECK(handler, at == fileOffset_ + frame_);
     }
     if (FrameLength() < bytes) {
       auto next{start_ + length_};
@@ -87,32 +93,38 @@ public:
   }
 
   void WriteFrame(FileOffset at, std::size_t bytes, IoErrorHandler &handler) {
-    if (!dirty_ || at < fileOffset_ || at > fileOffset_ + length_ ||
-        start_ + (at - fileOffset_) + static_cast<std::int64_t>(bytes) >
-            size_) {
+    Reallocate(bytes, handler);
+    std::int64_t newFrame{at - fileOffset_};
+    if (!dirty_ || newFrame < 0 || newFrame > length_) {
       Flush(handler);
       Reset(at);
-      Reallocate(bytes, handler);
+    } else if (start_ + newFrame + static_cast<std::int64_t>(bytes) > size_) {
+      // Flush leading data before "at", retain from "at" onward
+      Flush(handler, length_ - newFrame);
+      MakeDataContiguous(handler, bytes);
+    } else {
+      frame_ = newFrame;
     }
+    RUNTIME_CHECK(handler, at == fileOffset_ + frame_);
     dirty_ = true;
-    frame_ = at - fileOffset_;
     length_ = std::max<std::int64_t>(length_, frame_ + bytes);
   }
 
-  void Flush(IoErrorHandler &handler) {
+  void Flush(IoErrorHandler &handler, std::int64_t keep = 0) {
     if (dirty_) {
-      while (length_ > 0) {
-        std::size_t chunk{std::min<std::size_t>(length_, size_ - start_)};
+      while (length_ > keep) {
+        std::size_t chunk{
+            std::min<std::size_t>(length_ - keep, size_ - start_)};
         std::size_t put{
             Store().Write(fileOffset_, buffer_ + start_, chunk, handler)};
-        length_ -= put;
-        start_ += put;
-        fileOffset_ += put;
+        DiscardLeadingBytes(put, handler);
         if (put < chunk) {
           break;
         }
       }
-      Reset(fileOffset_);
+      if (length_ == 0) {
+        Reset(fileOffset_);
+      }
     }
   }
 
@@ -159,7 +171,24 @@ private:
     fileOffset_ += n;
   }
 
-  static constexpr std::size_t minBuffer{64 << 10};
+  void MakeDataContiguous(IoErrorHandler &handler, std::size_t bytes) {
+    if (static_cast<std::int64_t>(start_ + bytes) > size_) {
+      // Frame would wrap around; shift current data (if any) to force
+      // contiguity.
+      RUNTIME_CHECK(handler, length_ < size_);
+      if (start_ + length_ <= size_) {
+        // [......abcde..] -> [abcde........]
+        std::memmove(buffer_, buffer_ + start_, length_);
+      } else {
+        // [cde........ab] -> [abcde........]
+        auto n{start_ + length_ - size_}; // 3 for cde
+        RUNTIME_CHECK(handler, length_ >= n);
+        std::memmove(buffer_ + n, buffer_ + start_, length_ - n); // cdeab
+        LeftShiftBufferCircularly(buffer_, length_, n); // abcde
+      }
+      start_ = 0;
+    }
+  }
 
   char *buffer_{nullptr};
   std::int64_t size_{0}; // current allocated buffer size

--- a/flang/runtime/io-api.h
+++ b/flang/runtime/io-api.h
@@ -22,14 +22,12 @@ class NamelistGroup;
 } // namespace Fortran::runtime
 
 namespace Fortran::runtime::io {
+
 class IoStatementState;
 using Cookie = IoStatementState *;
 using ExternalUnit = int;
 using AsynchronousId = int;
 static constexpr ExternalUnit DefaultUnit{-1}; // READ(*), WRITE(*), PRINT
-} // namespace Fortran::runtime::io
-
-namespace Fortran::runtime::io {
 
 // INQUIRE specifiers are encoded as simple base-26 packings of
 // the spellings of their keywords.
@@ -325,5 +323,4 @@ enum Iostat IONAME(EndIoStatement)(Cookie);
 
 } // extern "C"
 } // namespace Fortran::runtime::io
-
 #endif

--- a/flang/runtime/io-error.cpp
+++ b/flang/runtime/io-error.cpp
@@ -23,7 +23,7 @@ void IoErrorHandler::SignalError(int iostatOrErrno, const char *msg, ...) {
       ioStat_ = IostatEnd;
     }
   } else if (iostatOrErrno == IostatEor && (flags_ & hasEor)) {
-    if (!ioStat_ == IostatOk || ioStat_ < IostatEor) {
+    if (ioStat_ == IostatOk || ioStat_ < IostatEor) {
       ioStat_ = IostatEor; // least priority
     }
   } else if (iostatOrErrno != IostatOk) {

--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -508,6 +508,38 @@ CppTypeFor<TypeCategory::Real, 16> RTNAME(Fraction16)(
 }
 #endif
 
+bool RTNAME(IsFinite4)(CppTypeFor<TypeCategory::Real, 4> x) {
+  return std::isfinite(x);
+}
+bool RTNAME(IsFinite8)(CppTypeFor<TypeCategory::Real, 8> x) {
+  return std::isfinite(x);
+}
+#if LONG_DOUBLE == 80
+bool RTNAME(IsFinite10)(CppTypeFor<TypeCategory::Real, 10> x) {
+  return std::isfinite(x);
+}
+#elif LONG_DOUBLE == 128
+bool RTNAME(IsFinite16)(CppTypeFor<TypeCategory::Real, 16> x) {
+  return std::isfinite(x);
+}
+#endif
+
+bool RTNAME(IsNaN4)(CppTypeFor<TypeCategory::Real, 4> x) {
+  return std::isnan(x);
+}
+bool RTNAME(IsNaN8)(CppTypeFor<TypeCategory::Real, 8> x) {
+  return std::isnan(x);
+}
+#if LONG_DOUBLE == 80
+bool RTNAME(IsNaN10)(CppTypeFor<TypeCategory::Real, 10> x) {
+  return std::isnan(x);
+}
+#elif LONG_DOUBLE == 128
+bool RTNAME(IsNaN16)(CppTypeFor<TypeCategory::Real, 16> x) {
+  return std::isnan(x);
+}
+#endif
+
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(ModInteger1)(
     CppTypeFor<TypeCategory::Integer, 1> x,
     CppTypeFor<TypeCategory::Integer, 1> p) {

--- a/flang/runtime/numeric.h
+++ b/flang/runtime/numeric.h
@@ -206,6 +206,12 @@ CppTypeFor<TypeCategory::Real, 10> RTNAME(Fraction10)(
 CppTypeFor<TypeCategory::Real, 16> RTNAME(Fraction16)(
     CppTypeFor<TypeCategory::Real, 16>);
 
+// ISNAN / IEEE_IS_NAN
+bool RTNAME(IsNaN4)(CppTypeFor<TypeCategory::Real, 4>);
+bool RTNAME(IsNaN8)(CppTypeFor<TypeCategory::Real, 8>);
+bool RTNAME(IsNaN10)(CppTypeFor<TypeCategory::Real, 10>);
+bool RTNAME(IsNaN16)(CppTypeFor<TypeCategory::Real, 16>);
+
 // MOD & MODULO
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(ModInteger1)(
     CppTypeFor<TypeCategory::Integer, 1>, CppTypeFor<TypeCategory::Integer, 1>);

--- a/flang/runtime/reduction.cpp
+++ b/flang/runtime/reduction.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Implements ALL, ANY, COUNT, MAXLOC, MAXVAL, MINLOC, MINVAL, PRODUCT, and SUM
-// for all required operand types and shapes and (for MAXLOC & MINLOC) kinds of
-// results.
+// Implements ALL, ANY, COUNT, FINDLOC, IPARITY, MAXLOC, MAXVAL, MINLOC, MINVAL,
+// PARITY, PRODUCT, and SUM for all required operand types and shapes and,
+// for FINDLOC, MAXLOC, & MINLOC, kinds of results.
 //
 // * Real and complex SUM reductions attempt to reduce floating-point
 //   cancellation on intermediate results by adding up partial sums
@@ -16,7 +16,7 @@
 // * Partial reductions (i.e., those with DIM= arguments that are not
 //   required to be 1 by the rank of the argument) return arrays that
 //   are dynamically allocated in a caller-supplied descriptor.
-// * Total reductions (i.e., no DIM= argument) with MAXLOC & MINLOC
+// * Total reductions (i.e., no DIM= argument) with FINDLOC, MAXLOC, & MINLOC
 //   return integer vectors of some kind, not scalars; a caller-supplied
 //   descriptor is used
 // * Character-valued reductions (MAXVAL & MINVAL) return arbitrary
@@ -46,8 +46,8 @@ namespace Fortran::runtime {
 // member function that copies a final result into its destination.
 
 // Total reduction of the array argument to a scalar (or to a vector in the
-// cases of MAXLOC & MINLOC).  These are the cases without DIM= or cases
-// where the argument has rank 1 and DIM=, if present, must be 1.
+// cases of FINDLOC, MAXLOC, & MINLOC).  These are the cases without DIM= or
+// cases where the argument has rank 1 and DIM=, if present, must be 1.
 template <typename TYPE, typename ACCUMULATOR>
 inline void DoTotalReduction(const Descriptor &x, int dim,
     const Descriptor *mask, ACCUMULATOR &accumulator, const char *intrinsic,
@@ -122,8 +122,7 @@ inline void GetExpandedSubscripts(SubscriptValue at[],
 
 template <typename TYPE, typename ACCUMULATOR>
 inline void ReduceDimToScalar(const Descriptor &x, int zeroBasedDim,
-    SubscriptValue subscripts[], TYPE *result) {
-  ACCUMULATOR accumulator{x};
+    SubscriptValue subscripts[], TYPE *result, ACCUMULATOR &accumulator) {
   SubscriptValue xAt[maxRank];
   GetExpandedSubscripts(xAt, x, zeroBasedDim, subscripts);
   const auto &dim{x.GetDimension(zeroBasedDim)};
@@ -143,8 +142,8 @@ inline void ReduceDimToScalar(const Descriptor &x, int zeroBasedDim,
 
 template <typename TYPE, typename ACCUMULATOR>
 inline void ReduceDimMaskToScalar(const Descriptor &x, int zeroBasedDim,
-    SubscriptValue subscripts[], const Descriptor &mask, TYPE *result) {
-  ACCUMULATOR accumulator{x};
+    SubscriptValue subscripts[], const Descriptor &mask, TYPE *result,
+    ACCUMULATOR &accumulator) {
   SubscriptValue xAt[maxRank], maskAt[maxRank];
   GetExpandedSubscripts(xAt, x, zeroBasedDim, subscripts);
   GetExpandedSubscripts(maskAt, mask, zeroBasedDim, subscripts);
@@ -201,7 +200,8 @@ static void CreatePartialReductionResult(Descriptor &result,
 
 template <typename ACCUMULATOR, TypeCategory CAT, int KIND>
 inline void PartialReduction(Descriptor &result, const Descriptor &x, int dim,
-    const Descriptor *mask, Terminator &terminator, const char *intrinsic) {
+    const Descriptor *mask, Terminator &terminator, const char *intrinsic,
+    ACCUMULATOR &accumulator) {
   CreatePartialReductionResult(
       result, x, dim, terminator, intrinsic, TypeCode{CAT, KIND});
   SubscriptValue at[maxRank];
@@ -213,13 +213,14 @@ inline void PartialReduction(Descriptor &result, const Descriptor &x, int dim,
     SubscriptValue maskAt[maxRank]; // contents unused
     if (mask->rank() > 0) {
       for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
+        accumulator.Reinitialize();
         ReduceDimMaskToScalar<CppType, ACCUMULATOR>(
-            x, dim - 1, at, *mask, result.Element<CppType>(at));
+            x, dim - 1, at, *mask, result.Element<CppType>(at), accumulator);
       }
       return;
     } else if (!IsLogicalElementTrue(*mask, maskAt)) {
       // scalar MASK=.FALSE.
-      ACCUMULATOR accumulator{x};
+      accumulator.Reinitialize();
       for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
         accumulator.GetResult(result.Element<CppType>(at));
       }
@@ -228,10 +229,53 @@ inline void PartialReduction(Descriptor &result, const Descriptor &x, int dim,
   }
   // No MASK= or scalar MASK=.TRUE.
   for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
+    accumulator.Reinitialize();
     ReduceDimToScalar<CppType, ACCUMULATOR>(
-        x, dim - 1, at, result.Element<CppType>(at));
+        x, dim - 1, at, result.Element<CppType>(at), accumulator);
   }
 }
+
+template <template <typename> class ACCUM>
+struct PartialIntegerReductionHelper {
+  template <int KIND> struct Functor {
+    static constexpr int Intermediate{
+        std::max(KIND, 4)}; // use at least "int" for intermediate results
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        const Descriptor *mask, Terminator &terminator,
+        const char *intrinsic) const {
+      using Accumulator =
+          ACCUM<CppTypeFor<TypeCategory::Integer, Intermediate>>;
+      Accumulator accumulator{x};
+      PartialReduction<Accumulator, TypeCategory::Integer, KIND>(
+          result, x, dim, mask, terminator, intrinsic, accumulator);
+    }
+  };
+};
+
+template <template <typename> class INTEGER_ACCUM>
+inline void PartialIntegerReduction(Descriptor &result, const Descriptor &x,
+    int dim, int kind, const Descriptor *mask, const char *intrinsic,
+    Terminator &terminator) {
+  ApplyIntegerKind<
+      PartialIntegerReductionHelper<INTEGER_ACCUM>::template Functor, void>(
+      kind, terminator, result, x, dim, mask, terminator, intrinsic);
+}
+
+template <TypeCategory CAT, template <typename> class ACCUM>
+struct PartialFloatingReductionHelper {
+  template <int KIND> struct Functor {
+    static constexpr int Intermediate{
+        std::max(KIND, 8)}; // use at least "double" for intermediate results
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        const Descriptor *mask, Terminator &terminator,
+        const char *intrinsic) const {
+      using Accumulator = ACCUM<CppTypeFor<TypeCategory::Real, Intermediate>>;
+      Accumulator accumulator{x};
+      PartialReduction<Accumulator, CAT, KIND>(
+          result, x, dim, mask, terminator, intrinsic, accumulator);
+    }
+  };
+};
 
 template <template <typename> class INTEGER_ACCUM,
     template <typename> class REAL_ACCUM,
@@ -244,98 +288,24 @@ inline void TypedPartialNumericReduction(Descriptor &result,
   RUNTIME_CHECK(terminator, catKind.has_value());
   switch (catKind->first) {
   case TypeCategory::Integer:
-    switch (catKind->second) {
-    case 1:
-      PartialReduction<INTEGER_ACCUM<CppTypeFor<TypeCategory::Integer, 4>>,
-          TypeCategory::Integer, 1>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-    case 2:
-      PartialReduction<INTEGER_ACCUM<CppTypeFor<TypeCategory::Integer, 4>>,
-          TypeCategory::Integer, 2>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-    case 4:
-      PartialReduction<INTEGER_ACCUM<CppTypeFor<TypeCategory::Integer, 4>>,
-          TypeCategory::Integer, 4>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-    case 8:
-      PartialReduction<INTEGER_ACCUM<CppTypeFor<TypeCategory::Integer, 8>>,
-          TypeCategory::Integer, 8>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-#ifdef __SIZEOF_INT128__
-    case 16:
-      PartialReduction<INTEGER_ACCUM<CppTypeFor<TypeCategory::Integer, 16>>,
-          TypeCategory::Integer, 16>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-#endif
-    }
+    PartialIntegerReduction<INTEGER_ACCUM>(
+        result, x, dim, catKind->second, mask, intrinsic, terminator);
     break;
   case TypeCategory::Real:
-    switch (catKind->second) {
-#if 0 // TODO
-    case 2:
-    case 3:
-#endif
-    case 4:
-      PartialReduction<REAL_ACCUM<CppTypeFor<TypeCategory::Real, 8>>,
-          TypeCategory::Real, 4>(result, x, dim, mask, terminator, intrinsic);
-      return;
-    case 8:
-      PartialReduction<REAL_ACCUM<CppTypeFor<TypeCategory::Real, 8>>,
-          TypeCategory::Real, 8>(result, x, dim, mask, terminator, intrinsic);
-      return;
-#if LONG_DOUBLE == 80
-    case 10:
-      PartialReduction<REAL_ACCUM<CppTypeFor<TypeCategory::Real, 10>>,
-          TypeCategory::Real, 10>(result, x, dim, mask, terminator, intrinsic);
-      return;
-#elif LONG_DOUBLE == 128
-    case 16:
-      PartialReduction<REAL_ACCUM<CppTypeFor<TypeCategory::Real, 16>>,
-          TypeCategory::Real, 16>(result, x, dim, mask, terminator, intrinsic);
-      return;
-#endif
-    }
+    ApplyFloatingPointKind<PartialFloatingReductionHelper<TypeCategory::Real,
+                               REAL_ACCUM>::template Functor,
+        void>(catKind->second, terminator, result, x, dim, mask, terminator,
+        intrinsic);
     break;
   case TypeCategory::Complex:
-    switch (catKind->second) {
-#if 0 // TODO
-    case 2:
-    case 3:
-#endif
-    case 4:
-      PartialReduction<COMPLEX_ACCUM<CppTypeFor<TypeCategory::Real, 8>>,
-          TypeCategory::Complex, 4>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-    case 8:
-      PartialReduction<COMPLEX_ACCUM<CppTypeFor<TypeCategory::Real, 8>>,
-          TypeCategory::Complex, 8>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-#if LONG_DOUBLE == 80
-    case 10:
-      PartialReduction<COMPLEX_ACCUM<CppTypeFor<TypeCategory::Real, 10>>,
-          TypeCategory::Complex, 10>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-#elif LONG_DOUBLE == 128
-    case 16:
-      PartialReduction<COMPLEX_ACCUM<CppTypeFor<TypeCategory::Real, 16>>,
-          TypeCategory::Complex, 16>(
-          result, x, dim, mask, terminator, intrinsic);
-      return;
-#endif
-    }
+    ApplyFloatingPointKind<PartialFloatingReductionHelper<TypeCategory::Complex,
+                               COMPLEX_ACCUM>::template Functor,
+        void>(catKind->second, terminator, result, x, dim, mask, terminator,
+        intrinsic);
     break;
   default:
-    break;
+    terminator.Crash("%s: invalid type code %d", intrinsic, x.type().raw());
   }
-  terminator.Crash("%s: invalid type code %d", intrinsic, x.type().raw());
 }
 
 // SUM()
@@ -343,6 +313,7 @@ inline void TypedPartialNumericReduction(Descriptor &result,
 template <typename INTERMEDIATE> class IntegerSumAccumulator {
 public:
   explicit IntegerSumAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { sum_ = 0; }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     *p = static_cast<A>(sum_);
   }
@@ -359,6 +330,7 @@ private:
 template <typename INTERMEDIATE> class RealSumAccumulator {
 public:
   explicit RealSumAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { positives_ = negatives_ = inOrder_ = 0; }
   template <typename A> A Result() const {
     auto sum{static_cast<A>(positives_ + negatives_)};
     return std::isfinite(sum) ? sum : static_cast<A>(inOrder_);
@@ -390,6 +362,10 @@ private:
 template <typename PART> class ComplexSumAccumulator {
 public:
   explicit ComplexSumAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() {
+    reals_.Reinitialize();
+    imaginaries_.Reinitialize();
+  }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     using ResultPart = typename A::value_type;
     *p = {reals_.template Result<ResultPart>(),
@@ -505,6 +481,7 @@ template <typename INTERMEDIATE> class NonComplexProductAccumulator {
 public:
   explicit NonComplexProductAccumulator(const Descriptor &array)
       : array_{array} {}
+  void Reinitialize() { product_ = 1; }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     *p = static_cast<A>(product_);
   }
@@ -521,6 +498,7 @@ private:
 template <typename PART> class ComplexProductAccumulator {
 public:
   explicit ComplexProductAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { product_ = std::complex<PART>{1, 0}; }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     using ResultPart = typename A::value_type;
     *p = {static_cast<ResultPart>(product_.real()),
@@ -645,14 +623,77 @@ void RTNAME(ProductDim)(Descriptor &result, const Descriptor &x, int dim,
 }
 } // extern "C"
 
-// MAXLOC and MINLOC
+// IPARITY()
+
+template <typename INTERMEDIATE> class IntegerXorAccumulator {
+public:
+  explicit IntegerXorAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { xor_ = 0; }
+  template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
+    *p = static_cast<A>(xor_);
+  }
+  template <typename A> bool AccumulateAt(const SubscriptValue at[]) {
+    xor_ ^= *array_.Element<A>(at);
+    return true;
+  }
+
+private:
+  const Descriptor &array_;
+  INTERMEDIATE xor_{0};
+};
+
+extern "C" {
+CppTypeFor<TypeCategory::Integer, 1> RTNAME(IParity1)(const Descriptor &x,
+    const char *source, int line, int dim, const Descriptor *mask) {
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+      IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
+      "IPARITY");
+}
+CppTypeFor<TypeCategory::Integer, 2> RTNAME(IParity2)(const Descriptor &x,
+    const char *source, int line, int dim, const Descriptor *mask) {
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+      IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
+      "IPARITY");
+}
+CppTypeFor<TypeCategory::Integer, 4> RTNAME(IParity4)(const Descriptor &x,
+    const char *source, int line, int dim, const Descriptor *mask) {
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+      IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
+      "IPARITY");
+}
+CppTypeFor<TypeCategory::Integer, 8> RTNAME(IParity8)(const Descriptor &x,
+    const char *source, int line, int dim, const Descriptor *mask) {
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+      IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x},
+      "IPARITY");
+}
+#ifdef __SIZEOF_INT128__
+CppTypeFor<TypeCategory::Integer, 16> RTNAME(IParity16)(const Descriptor &x,
+    const char *source, int line, int dim, const Descriptor *mask) {
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
+      mask, IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
+      "IPARITY");
+}
+#endif
+void RTNAME(IParityDim)(Descriptor &result, const Descriptor &x, int dim,
+    const char *source, int line, const Descriptor *mask) {
+  Terminator terminator{source, line};
+  auto catKind{x.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator,
+      catKind.has_value() && catKind->first == TypeCategory::Integer);
+  PartialIntegerReduction<IntegerXorAccumulator>(
+      result, x, dim, catKind->second, mask, "IPARITY", terminator);
+}
+}
+
+// MAXLOC & MINLOC
 
 template <typename T, bool IS_MAX, bool BACK> struct NumericCompare {
   using Type = T;
   explicit NumericCompare(std::size_t /*elemLen; ignored*/) {}
-  bool operator()(const T &value, const T &previous) {
-    if (BACK && value == previous) {
-      return true;
+  bool operator()(const T &value, const T &previous) const {
+    if (value == previous) {
+      return BACK;
     } else if constexpr (IS_MAX) {
       return value > previous;
     } else {
@@ -666,10 +707,10 @@ public:
   using Type = T;
   explicit CharacterCompare(std::size_t elemLen)
       : chars_{elemLen / sizeof(T)} {}
-  bool operator()(const T &value, const T &previous) {
+  bool operator()(const T &value, const T &previous) const {
     int cmp{CharacterScalarCompare<T>(&value, &previous, chars_, chars_)};
-    if (BACK && cmp == 0) {
-      return true;
+    if (cmp == 0) {
+      return BACK;
     } else if constexpr (IS_MAX) {
       return cmp > 0;
     } else {
@@ -686,10 +727,14 @@ public:
   using Type = typename COMPARE::Type;
   ExtremumLocAccumulator(const Descriptor &array, std::size_t chars = 0)
       : array_{array}, argRank_{array.rank()}, compare_{array.ElementBytes()} {
+    Reinitialize();
+  }
+  void Reinitialize() {
     // per standard: result indices are all zero if no data
     for (int j{0}; j < argRank_; ++j) {
       extremumLoc_[j] = 0;
     }
+    previous_ = nullptr;
   }
   int argRank() const { return argRank_; }
   template <typename A> void GetResult(A *p, int zeroBasedDim = -1) {
@@ -720,38 +765,23 @@ private:
   COMPARE compare_;
 };
 
-template <typename COMPARE, typename CPPTYPE>
-static void DoMaxOrMinLocHelper(const char *intrinsic, Descriptor &result,
+template <typename ACCUMULATOR> struct LocationResultHelper {
+  template <int KIND> struct Functor {
+    void operator()(ACCUMULATOR &accumulator, const Descriptor &result) const {
+      accumulator.GetResult(
+          result.OffsetElement<CppTypeFor<TypeCategory::Integer, KIND>>());
+    }
+  };
+};
+
+template <typename ACCUMULATOR, typename CPPTYPE>
+static void LocationHelper(const char *intrinsic, Descriptor &result,
     const Descriptor &x, int kind, const Descriptor *mask,
     Terminator &terminator) {
-  ExtremumLocAccumulator<COMPARE> accumulator{x};
+  ACCUMULATOR accumulator{x};
   DoTotalReduction<CPPTYPE>(x, 0, mask, accumulator, intrinsic, terminator);
-  switch (kind) {
-  case 1:
-    accumulator.GetResult(
-        result.OffsetElement<CppTypeFor<TypeCategory::Integer, 1>>());
-    break;
-  case 2:
-    accumulator.GetResult(
-        result.OffsetElement<CppTypeFor<TypeCategory::Integer, 2>>());
-    break;
-  case 4:
-    accumulator.GetResult(
-        result.OffsetElement<CppTypeFor<TypeCategory::Integer, 4>>());
-    break;
-  case 8:
-    accumulator.GetResult(
-        result.OffsetElement<CppTypeFor<TypeCategory::Integer, 8>>());
-    break;
-#ifdef __SIZEOF_INT128__
-  case 16:
-    accumulator.GetResult(
-        result.OffsetElement<CppTypeFor<TypeCategory::Integer, 16>>());
-    break;
-#endif
-  default:
-    terminator.Crash("%s: bad KIND=%d", intrinsic, kind);
-  }
+  ApplyIntegerKind<LocationResultHelper<ACCUMULATOR>::template Functor, void>(
+      kind, terminator, accumulator, result);
 }
 
 template <TypeCategory CAT, int KIND, bool IS_MAX,
@@ -762,13 +792,24 @@ inline void DoMaxOrMinLoc(const char *intrinsic, Descriptor &result,
   using CppType = CppTypeFor<CAT, KIND>;
   Terminator terminator{source, line};
   if (back) {
-    DoMaxOrMinLocHelper<COMPARE<CppType, IS_MAX, true>, CppType>(
-        intrinsic, result, x, kind, mask, terminator);
+    LocationHelper<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, true>>,
+        CppType>(intrinsic, result, x, kind, mask, terminator);
   } else {
-    DoMaxOrMinLocHelper<COMPARE<CppType, IS_MAX, false>, CppType>(
-        intrinsic, result, x, kind, mask, terminator);
+    LocationHelper<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, false>>,
+        CppType>(intrinsic, result, x, kind, mask, terminator);
   }
 }
+
+template <TypeCategory CAT, bool IS_MAX> struct TypedMaxOrMinLocHelper {
+  template <int KIND> struct Functor {
+    void operator()(const char *intrinsic, Descriptor &result,
+        const Descriptor &x, int kind, const char *source, int line,
+        const Descriptor *mask, bool back) const {
+      DoMaxOrMinLoc<TypeCategory::Integer, KIND, IS_MAX, NumericCompare>(
+          intrinsic, result, x, kind, source, line, mask, back);
+    }
+  };
+};
 
 template <bool IS_MAX>
 inline void TypedMaxOrMinLoc(const char *intrinsic, Descriptor &result,
@@ -789,76 +830,27 @@ inline void TypedMaxOrMinLoc(const char *intrinsic, Descriptor &result,
   RUNTIME_CHECK(terminator, catKind.has_value());
   switch (catKind->first) {
   case TypeCategory::Integer:
-    switch (catKind->second) {
-    case 1:
-      DoMaxOrMinLoc<TypeCategory::Integer, 1, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 2:
-      DoMaxOrMinLoc<TypeCategory::Integer, 2, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 4:
-      DoMaxOrMinLoc<TypeCategory::Integer, 4, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 8:
-      DoMaxOrMinLoc<TypeCategory::Integer, 8, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-#ifdef __SIZEOF_INT128__
-    case 16:
-      DoMaxOrMinLoc<TypeCategory::Integer, 16, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-#endif
-    }
+    ApplyIntegerKind<
+        TypedMaxOrMinLocHelper<TypeCategory::Integer, IS_MAX>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, source,
+        line, mask, back);
     break;
   case TypeCategory::Real:
-    switch (catKind->second) {
-    // TODO: REAL(2 & 3)
-    case 4:
-      DoMaxOrMinLoc<TypeCategory::Real, 4, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 8:
-      DoMaxOrMinLoc<TypeCategory::Real, 8, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-#if LONG_DOUBLE == 80
-    case 10:
-      DoMaxOrMinLoc<TypeCategory::Real, 10, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-#elif LONG_DOUBLE == 128
-    case 16:
-      DoMaxOrMinLoc<TypeCategory::Real, 16, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-#endif
-    }
+    ApplyFloatingPointKind<
+        TypedMaxOrMinLocHelper<TypeCategory::Real, IS_MAX>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, source,
+        line, mask, back);
     break;
   case TypeCategory::Character:
-    switch (catKind->second) {
-    case 1:
-      DoMaxOrMinLoc<TypeCategory::Character, 1, IS_MAX, CharacterCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 2:
-      DoMaxOrMinLoc<TypeCategory::Character, 2, IS_MAX, CharacterCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    case 4:
-      DoMaxOrMinLoc<TypeCategory::Character, 4, IS_MAX, CharacterCompare>(
-          intrinsic, result, x, kind, source, line, mask, back);
-      return;
-    }
+    ApplyCharacterKind<TypedMaxOrMinLocHelper<TypeCategory::Character,
+                           IS_MAX>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, source,
+        line, mask, back);
     break;
   default:
-    break;
+    terminator.Crash(
+        "%s: Bad data type code (%d) for array", intrinsic, x.type().raw());
   }
-  terminator.Crash(
-      "%s: Bad data type code (%d) for array", intrinsic, x.type().raw());
 }
 
 extern "C" {
@@ -874,38 +866,28 @@ void RTNAME(Minloc)(Descriptor &result, const Descriptor &x, int kind,
 
 // MAXLOC/MINLOC with DIM=
 
+template <typename ACCUMULATOR> struct PartialLocationHelper {
+  template <int KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        const Descriptor *mask, Terminator &terminator, const char *intrinsic,
+        ACCUMULATOR &accumulator) const {
+      PartialReduction<ACCUMULATOR, TypeCategory::Integer, KIND>(
+          result, x, dim, mask, terminator, intrinsic, accumulator);
+    }
+  };
+};
+
 template <TypeCategory CAT, int KIND, bool IS_MAX,
     template <typename, bool, bool> class COMPARE, bool BACK>
 static void DoPartialMaxOrMinLocDirection(const char *intrinsic,
     Descriptor &result, const Descriptor &x, int kind, int dim,
     const Descriptor *mask, Terminator &terminator) {
   using CppType = CppTypeFor<CAT, KIND>;
-  switch (kind) {
-  case 1:
-    PartialReduction<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>,
-        TypeCategory::Integer, 1>(result, x, dim, mask, terminator, intrinsic);
-    break;
-  case 2:
-    PartialReduction<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>,
-        TypeCategory::Integer, 2>(result, x, dim, mask, terminator, intrinsic);
-    break;
-  case 4:
-    PartialReduction<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>,
-        TypeCategory::Integer, 4>(result, x, dim, mask, terminator, intrinsic);
-    break;
-  case 8:
-    PartialReduction<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>,
-        TypeCategory::Integer, 8>(result, x, dim, mask, terminator, intrinsic);
-    break;
-#ifdef __SIZEOF_INT128__
-  case 16:
-    PartialReduction<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>,
-        TypeCategory::Integer, 16>(result, x, dim, mask, terminator, intrinsic);
-    break;
-#endif
-  default:
-    terminator.Crash("%s: bad KIND=%d", intrinsic, kind);
-  }
+  using Accumulator = ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>;
+  Accumulator accumulator{x};
+  ApplyIntegerKind<PartialLocationHelper<Accumulator>::template Functor, void>(
+      kind, terminator, result, x, dim, mask, terminator, intrinsic,
+      accumulator);
 }
 
 template <TypeCategory CAT, int KIND, bool IS_MAX,
@@ -922,6 +904,19 @@ inline void DoPartialMaxOrMinLoc(const char *intrinsic, Descriptor &result,
   }
 }
 
+template <TypeCategory CAT, bool IS_MAX,
+    template <typename, bool, bool> class COMPARE>
+struct DoPartialMaxOrMinLocHelper {
+  template <int KIND> struct Functor {
+    void operator()(const char *intrinsic, Descriptor &result,
+        const Descriptor &x, int kind, int dim, const Descriptor *mask,
+        bool back, Terminator &terminator) const {
+      DoPartialMaxOrMinLoc<CAT, KIND, IS_MAX, COMPARE>(
+          intrinsic, result, x, kind, dim, mask, back, terminator);
+    }
+  };
+};
+
 template <bool IS_MAX>
 inline void TypedPartialMaxOrMinLoc(const char *intrinsic, Descriptor &result,
     const Descriptor &x, int kind, int dim, const char *source, int line,
@@ -932,79 +927,27 @@ inline void TypedPartialMaxOrMinLoc(const char *intrinsic, Descriptor &result,
   RUNTIME_CHECK(terminator, catKind.has_value());
   switch (catKind->first) {
   case TypeCategory::Integer:
-    switch (catKind->second) {
-    case 1:
-      DoPartialMaxOrMinLoc<TypeCategory::Integer, 1, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 2:
-      DoPartialMaxOrMinLoc<TypeCategory::Integer, 2, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 4:
-      DoPartialMaxOrMinLoc<TypeCategory::Integer, 4, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 8:
-      DoPartialMaxOrMinLoc<TypeCategory::Integer, 8, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-#ifdef __SIZEOF_INT128__
-    case 16:
-      DoPartialMaxOrMinLoc<TypeCategory::Integer, 16, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-#endif
-    }
+    ApplyIntegerKind<DoPartialMaxOrMinLocHelper<TypeCategory::Integer, IS_MAX,
+                         NumericCompare>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, dim,
+        mask, back, terminator);
     break;
   case TypeCategory::Real:
-    switch (catKind->second) {
-    // TODO: REAL(2 & 3)
-    case 4:
-      DoPartialMaxOrMinLoc<TypeCategory::Real, 4, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 8:
-      DoPartialMaxOrMinLoc<TypeCategory::Real, 8, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-#if LONG_DOUBLE == 80
-    case 10:
-      DoPartialMaxOrMinLoc<TypeCategory::Real, 10, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-#elif LONG_DOUBLE == 128
-    case 16:
-      DoPartialMaxOrMinLoc<TypeCategory::Real, 16, IS_MAX, NumericCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-#endif
-    }
+    ApplyFloatingPointKind<DoPartialMaxOrMinLocHelper<TypeCategory::Real,
+                               IS_MAX, NumericCompare>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, dim,
+        mask, back, terminator);
     break;
   case TypeCategory::Character:
-    switch (catKind->second) {
-    case 1:
-      DoPartialMaxOrMinLoc<TypeCategory::Character, 1, IS_MAX,
-          CharacterCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 2:
-      DoPartialMaxOrMinLoc<TypeCategory::Character, 2, IS_MAX,
-          CharacterCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    case 4:
-      DoPartialMaxOrMinLoc<TypeCategory::Character, 4, IS_MAX,
-          CharacterCompare>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
-      return;
-    }
+    ApplyCharacterKind<DoPartialMaxOrMinLocHelper<TypeCategory::Character,
+                           IS_MAX, CharacterCompare>::template Functor,
+        void>(catKind->second, terminator, intrinsic, result, x, kind, dim,
+        mask, back, terminator);
     break;
   default:
-    break;
+    terminator.Crash(
+        "%s: Bad data type code (%d) for array", intrinsic, x.type().raw());
   }
-  terminator.Crash(
-      "%s: Bad data type code (%d) for array", intrinsic, x.type().raw());
 }
 
 extern "C" {
@@ -1017,6 +960,329 @@ void RTNAME(MinlocDim)(Descriptor &result, const Descriptor &x, int kind,
     int dim, const char *source, int line, const Descriptor *mask, bool back) {
   TypedPartialMaxOrMinLoc<false>(
       "MINLOC", result, x, kind, dim, source, line, mask, back);
+}
+} // extern "C"
+
+// FINDLOC
+
+template <TypeCategory CAT1, int KIND1, TypeCategory CAT2, int KIND2>
+struct Equality {
+  using Type1 = CppTypeFor<CAT1, KIND1>;
+  using Type2 = CppTypeFor<CAT2, KIND2>;
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    return *array.Element<Type1>(at) == *target.OffsetElement<Type2>();
+  }
+};
+
+template <int KIND1, int KIND2>
+struct Equality<TypeCategory::Complex, KIND1, TypeCategory::Complex, KIND2> {
+  using Type1 = CppTypeFor<TypeCategory::Complex, KIND1>;
+  using Type2 = CppTypeFor<TypeCategory::Complex, KIND2>;
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    const Type1 &xz{*array.Element<Type1>(at)};
+    const Type2 &tz{*target.OffsetElement<Type2>()};
+    return xz.real() == tz.real() && xz.imag() == tz.imag();
+  }
+};
+
+template <int KIND1, TypeCategory CAT2, int KIND2>
+struct Equality<TypeCategory::Complex, KIND1, CAT2, KIND2> {
+  using Type1 = CppTypeFor<TypeCategory::Complex, KIND1>;
+  using Type2 = CppTypeFor<CAT2, KIND2>;
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    const Type1 &z{*array.Element<Type1>(at)};
+    return z.imag() == 0 && z.real() == *target.OffsetElement<Type2>();
+  }
+};
+
+template <TypeCategory CAT1, int KIND1, int KIND2>
+struct Equality<CAT1, KIND1, TypeCategory::Complex, KIND2> {
+  using Type1 = CppTypeFor<CAT1, KIND1>;
+  using Type2 = CppTypeFor<TypeCategory::Complex, KIND2>;
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    const Type2 &z{*target.OffsetElement<Type2>()};
+    return *array.Element<Type1>(at) == z.real() && z.imag() == 0;
+  }
+};
+
+template <int KIND> struct CharacterEquality {
+  using Type = CppTypeFor<TypeCategory::Character, KIND>;
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    return CharacterScalarCompare<Type>(array.Element<Type>(at),
+               target.OffsetElement<Type>(),
+               array.ElementBytes() / static_cast<unsigned>(KIND),
+               target.ElementBytes() / static_cast<unsigned>(KIND)) == 0;
+  }
+};
+
+struct LogicalEquivalence {
+  bool operator()(const Descriptor &array, const SubscriptValue at[],
+      const Descriptor &target) const {
+    return IsLogicalElementTrue(array, at) ==
+        IsLogicalElementTrue(target, at /*ignored*/);
+  }
+};
+
+template <typename EQUALITY> class LocationAccumulator {
+public:
+  LocationAccumulator(
+      const Descriptor &array, const Descriptor &target, bool back)
+      : array_{array}, target_{target}, back_{back} {
+    Reinitialize();
+  }
+  void Reinitialize() {
+    // per standard: result indices are all zero if no data
+    for (int j{0}; j < rank_; ++j) {
+      location_[j] = 0;
+    }
+  }
+  template <typename A> void GetResult(A *p, int zeroBasedDim = -1) {
+    if (zeroBasedDim >= 0) {
+      *p = location_[zeroBasedDim];
+    } else {
+      for (int j{0}; j < rank_; ++j) {
+        p[j] = location_[j];
+      }
+    }
+  }
+  template <typename IGNORED> bool AccumulateAt(const SubscriptValue at[]) {
+    if (equality_(array_, at, target_)) {
+      for (int j{0}; j < rank_; ++j) {
+        location_[j] = at[j];
+      }
+      return back_;
+    } else {
+      return true;
+    }
+  }
+
+private:
+  const Descriptor &array_;
+  const Descriptor &target_;
+  const bool back_{false};
+  const int rank_{array_.rank()};
+  SubscriptValue location_[maxRank];
+  const EQUALITY equality_{};
+};
+
+template <TypeCategory XCAT, int XKIND, TypeCategory TARGET_CAT>
+struct TotalNumericFindlocHelper {
+  template <int TARGET_KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x,
+        const Descriptor &target, int kind, int dim, const Descriptor *mask,
+        bool back, Terminator &terminator) const {
+      using Eq = Equality<XCAT, XKIND, TARGET_CAT, TARGET_KIND>;
+      using Accumulator = LocationAccumulator<Eq>;
+      Accumulator accumulator{x, target, back};
+      DoTotalReduction<void>(x, dim, mask, accumulator, "FINDLOC", terminator);
+      ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor,
+          void>(kind, terminator, accumulator, result);
+    }
+  };
+};
+
+template <TypeCategory CAT,
+    template <TypeCategory XCAT, int XKIND, TypeCategory TARGET_CAT>
+    class HELPER>
+struct NumericFindlocHelper {
+  template <int KIND> struct Functor {
+    void operator()(TypeCategory targetCat, int targetKind, Descriptor &result,
+        const Descriptor &x, const Descriptor &target, int kind, int dim,
+        const Descriptor *mask, bool back, Terminator &terminator) const {
+      switch (targetCat) {
+      case TypeCategory::Integer:
+        ApplyIntegerKind<
+            HELPER<CAT, KIND, TypeCategory::Integer>::template Functor, void>(
+            targetKind, terminator, result, x, target, kind, dim, mask, back,
+            terminator);
+        break;
+      case TypeCategory::Real:
+        ApplyFloatingPointKind<
+            HELPER<CAT, KIND, TypeCategory::Real>::template Functor, void>(
+            targetKind, terminator, result, x, target, kind, dim, mask, back,
+            terminator);
+        break;
+      case TypeCategory::Complex:
+        ApplyFloatingPointKind<
+            HELPER<CAT, KIND, TypeCategory::Complex>::template Functor, void>(
+            targetKind, terminator, result, x, target, kind, dim, mask, back,
+            terminator);
+        break;
+      default:
+        terminator.Crash(
+            "FINDLOC: bad target category %d for array category %d",
+            static_cast<int>(targetCat), static_cast<int>(CAT));
+      }
+    }
+  };
+};
+
+template <int KIND> struct CharacterFindlocHelper {
+  void operator()(Descriptor &result, const Descriptor &x,
+      const Descriptor &target, int kind, const Descriptor *mask, bool back,
+      Terminator &terminator) {
+    using Accumulator = LocationAccumulator<CharacterEquality<KIND>>;
+    Accumulator accumulator{x, target, back};
+    DoTotalReduction<void>(x, 0, mask, accumulator, "FINDLOC", terminator);
+    ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor, void>(
+        kind, terminator, accumulator, result);
+  }
+};
+
+static void LogicalFindlocHelper(Descriptor &result, const Descriptor &x,
+    const Descriptor &target, int kind, const Descriptor *mask, bool back,
+    Terminator &terminator) {
+  using Accumulator = LocationAccumulator<LogicalEquivalence>;
+  Accumulator accumulator{x, target, back};
+  DoTotalReduction<void>(x, 0, mask, accumulator, "FINDLOC", terminator);
+  ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor, void>(
+      kind, terminator, accumulator, result);
+}
+
+extern "C" {
+void RTNAME(Findloc)(Descriptor &result, const Descriptor &x,
+    const Descriptor &target, int kind, const char *source, int line,
+    const Descriptor *mask, bool back) {
+  int rank{x.rank()};
+  SubscriptValue extent[1]{rank};
+  result.Establish(TypeCategory::Integer, kind, nullptr, 1, extent,
+      CFI_attribute_allocatable);
+  result.GetDimension(0).SetBounds(1, extent[0]);
+  Terminator terminator{source, line};
+  if (int stat{result.Allocate()}) {
+    terminator.Crash(
+        "FINDLOC: could not allocate memory for result; STAT=%d", stat);
+  }
+  CheckIntegerKind(terminator, kind, "FINDLOC");
+  auto xType{x.type().GetCategoryAndKind()};
+  auto targetType{target.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator, xType.has_value() && targetType.has_value());
+  switch (xType->first) {
+  case TypeCategory::Integer:
+    ApplyIntegerKind<NumericFindlocHelper<TypeCategory::Integer,
+                         TotalNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, 0, mask, back, terminator);
+    break;
+  case TypeCategory::Real:
+    ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Real,
+                               TotalNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, 0, mask, back, terminator);
+    break;
+  case TypeCategory::Complex:
+    ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Complex,
+                               TotalNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, 0, mask, back, terminator);
+    break;
+  case TypeCategory::Character:
+    RUNTIME_CHECK(terminator,
+        targetType->first == TypeCategory::Character &&
+            targetType->second == xType->second);
+    ApplyCharacterKind<CharacterFindlocHelper, void>(xType->second, terminator,
+        result, x, target, kind, mask, back, terminator);
+    break;
+  case TypeCategory::Logical:
+    RUNTIME_CHECK(terminator, targetType->first == TypeCategory::Logical);
+    LogicalFindlocHelper(result, x, target, kind, mask, back, terminator);
+    break;
+  default:
+    terminator.Crash(
+        "FINDLOC: Bad data type code (%d) for array", x.type().raw());
+  }
+}
+} // extern "C"
+
+// FINDLOC with DIM=
+
+template <TypeCategory XCAT, int XKIND, TypeCategory TARGET_CAT>
+struct PartialNumericFindlocHelper {
+  template <int TARGET_KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x,
+        const Descriptor &target, int kind, int dim, const Descriptor *mask,
+        bool back, Terminator &terminator) const {
+      using Eq = Equality<XCAT, XKIND, TARGET_CAT, TARGET_KIND>;
+      using Accumulator = LocationAccumulator<Eq>;
+      Accumulator accumulator{x, target, back};
+      ApplyIntegerKind<PartialLocationHelper<Accumulator>::template Functor,
+          void>(kind, terminator, result, x, dim, mask, terminator, "FINDLOC",
+          accumulator);
+    }
+  };
+};
+
+template <int KIND> struct PartialCharacterFindlocHelper {
+  void operator()(Descriptor &result, const Descriptor &x,
+      const Descriptor &target, int kind, int dim, const Descriptor *mask,
+      bool back, Terminator &terminator) {
+    using Accumulator = LocationAccumulator<CharacterEquality<KIND>>;
+    Accumulator accumulator{x, target, back};
+    ApplyIntegerKind<PartialLocationHelper<Accumulator>::template Functor,
+        void>(kind, terminator, result, x, dim, mask, terminator, "FINDLOC",
+        accumulator);
+  }
+};
+
+static void PartialLogicalFindlocHelper(Descriptor &result, const Descriptor &x,
+    const Descriptor &target, int kind, int dim, const Descriptor *mask,
+    bool back, Terminator &terminator) {
+  using Accumulator = LocationAccumulator<LogicalEquivalence>;
+  Accumulator accumulator{x, target, back};
+  ApplyIntegerKind<PartialLocationHelper<Accumulator>::template Functor, void>(
+      kind, terminator, result, x, dim, mask, terminator, "FINDLOC",
+      accumulator);
+}
+
+extern "C" {
+void RTNAME(FindlocDim)(Descriptor &result, const Descriptor &x,
+    const Descriptor &target, int kind, int dim, const char *source, int line,
+    const Descriptor *mask, bool back) {
+  Terminator terminator{source, line};
+  CheckIntegerKind(terminator, kind, "FINDLOC");
+  auto xType{x.type().GetCategoryAndKind()};
+  auto targetType{target.type().GetCategoryAndKind()};
+  RUNTIME_CHECK(terminator, xType.has_value() && targetType.has_value());
+  switch (xType->first) {
+  case TypeCategory::Integer:
+    ApplyIntegerKind<NumericFindlocHelper<TypeCategory::Integer,
+                         PartialNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, dim, mask, back, terminator);
+    break;
+  case TypeCategory::Real:
+    ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Real,
+                               PartialNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, dim, mask, back, terminator);
+    break;
+  case TypeCategory::Complex:
+    ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Complex,
+                               PartialNumericFindlocHelper>::template Functor,
+        void>(xType->second, terminator, targetType->first, targetType->second,
+        result, x, target, kind, dim, mask, back, terminator);
+    break;
+  case TypeCategory::Character:
+    RUNTIME_CHECK(terminator,
+        targetType->first == TypeCategory::Character &&
+            targetType->second == xType->second);
+    ApplyCharacterKind<PartialCharacterFindlocHelper, void>(xType->second,
+        terminator, result, x, target, kind, dim, mask, back, terminator);
+    break;
+  case TypeCategory::Logical:
+    RUNTIME_CHECK(terminator, targetType->first == TypeCategory::Logical);
+    PartialLogicalFindlocHelper(
+        result, x, target, kind, dim, mask, back, terminator);
+    break;
+  default:
+    terminator.Crash(
+        "FINDLOC: Bad data type code (%d) for array", x.type().raw());
+  }
 }
 } // extern "C"
 
@@ -1043,7 +1309,11 @@ template <TypeCategory CAT, int KIND, bool IS_MAXVAL>
 class NumericExtremumAccumulator {
 public:
   using Type = CppTypeFor<CAT, KIND>;
-  NumericExtremumAccumulator(const Descriptor &array) : array_{array} {}
+  explicit NumericExtremumAccumulator(const Descriptor &array)
+      : array_{array} {}
+  void Reinitialize() {
+    extremum_ = MaxOrMinIdentity<CAT, KIND, IS_MAXVAL>::Value();
+  }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     *p = extremum_;
   }
@@ -1092,10 +1362,23 @@ static void DoMaxOrMin(Descriptor &result, const Descriptor &x, int dim,
     accumulator.GetResult(result.OffsetElement<Type>());
   } else {
     // Partial reduction
-    PartialReduction<ACCUMULATOR<CAT, KIND, IS_MAXVAL>, CAT, KIND>(
-        result, x, dim, mask, terminator, intrinsic);
+    using Accumulator = ACCUMULATOR<CAT, KIND, IS_MAXVAL>;
+    Accumulator accumulator{x};
+    PartialReduction<Accumulator, CAT, KIND>(
+        result, x, dim, mask, terminator, intrinsic, accumulator);
   }
 }
+
+template <TypeCategory CAT, bool IS_MAXVAL> struct MaxOrMinHelper {
+  template <int KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        const Descriptor *mask, const char *intrinsic,
+        Terminator &terminator) const {
+      DoMaxOrMin<CAT, KIND, IS_MAXVAL, NumericExtremumAccumulator>(
+          result, x, dim, mask, intrinsic, terminator);
+    }
+  };
+};
 
 template <bool IS_MAXVAL>
 inline void NumericMaxOrMin(Descriptor &result, const Descriptor &x, int dim,
@@ -1106,72 +1389,28 @@ inline void NumericMaxOrMin(Descriptor &result, const Descriptor &x, int dim,
   RUNTIME_CHECK(terminator, type);
   switch (type->first) {
   case TypeCategory::Integer:
-    switch (type->second) {
-    case 1:
-      DoMaxOrMin<TypeCategory::Integer, 1, IS_MAXVAL,
-          NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-    case 2:
-      DoMaxOrMin<TypeCategory::Integer, 2, IS_MAXVAL,
-          NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-    case 4:
-      DoMaxOrMin<TypeCategory::Integer, 4, IS_MAXVAL,
-          NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-    case 8:
-      DoMaxOrMin<TypeCategory::Integer, 8, IS_MAXVAL,
-          NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-#ifdef __SIZEOF_INT128__
-    case 16:
-      DoMaxOrMin<TypeCategory::Integer, 16, IS_MAXVAL,
-          NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-#endif
-    }
+    ApplyIntegerKind<
+        MaxOrMinHelper<TypeCategory::Integer, IS_MAXVAL>::template Functor,
+        void>(
+        type->second, terminator, result, x, dim, mask, intrinsic, terminator);
     break;
   case TypeCategory::Real:
-    switch (type->second) {
-    // TODO: REAL(2 & 3)
-    case 4:
-      DoMaxOrMin<TypeCategory::Real, 4, IS_MAXVAL, NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-    case 8:
-      DoMaxOrMin<TypeCategory::Real, 8, IS_MAXVAL, NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-#if LONG_DOUBLE == 80
-    case 10:
-      DoMaxOrMin<TypeCategory::Real, 10, IS_MAXVAL, NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-#elif LONG_DOUBLE == 128
-    case 16:
-      DoMaxOrMin<TypeCategory::Real, 16, IS_MAXVAL, NumericExtremumAccumulator>(
-          result, x, dim, mask, intrinsic, terminator);
-      return;
-#endif
-    }
+    ApplyFloatingPointKind<
+        MaxOrMinHelper<TypeCategory::Real, IS_MAXVAL>::template Functor, void>(
+        type->second, terminator, result, x, dim, mask, intrinsic, terminator);
     break;
   default:
-    break;
+    terminator.Crash("%s: bad type code %d", intrinsic, x.type().raw());
   }
-  terminator.Crash("%s: bad type code %d", intrinsic, x.type().raw());
 }
 
 template <TypeCategory, int KIND, bool IS_MAXVAL>
 class CharacterExtremumAccumulator {
 public:
   using Type = CppTypeFor<TypeCategory::Character, KIND>;
-  CharacterExtremumAccumulator(const Descriptor &array)
+  explicit CharacterExtremumAccumulator(const Descriptor &array)
       : array_{array}, charLen_{array_.ElementBytes() / KIND} {}
+  void Reinitialize() { extremum_ = nullptr; }
   template <typename A> void GetResult(A *p, int /*zeroBasedDim*/ = -1) const {
     static_assert(std::is_same_v<A, Type>);
     if (extremum_) {
@@ -1202,6 +1441,18 @@ private:
   const Type *extremum_{nullptr};
 };
 
+template <bool IS_MAXVAL> struct CharacterMaxOrMinHelper {
+  template <int KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        const Descriptor *mask, const char *intrinsic,
+        Terminator &terminator) const {
+      DoMaxOrMin<TypeCategory::Character, KIND, IS_MAXVAL,
+          CharacterExtremumAccumulator>(
+          result, x, dim, mask, intrinsic, terminator);
+    }
+  };
+};
+
 template <bool IS_MAXVAL>
 inline void CharacterMaxOrMin(Descriptor &result, const Descriptor &x, int dim,
     const char *source, int line, const Descriptor *mask,
@@ -1209,25 +1460,9 @@ inline void CharacterMaxOrMin(Descriptor &result, const Descriptor &x, int dim,
   Terminator terminator{source, line};
   auto type{x.type().GetCategoryAndKind()};
   RUNTIME_CHECK(terminator, type && type->first == TypeCategory::Character);
-  switch (type->second) {
-  case 1:
-    DoMaxOrMin<TypeCategory::Character, 1, IS_MAXVAL,
-        CharacterExtremumAccumulator>(
-        result, x, dim, mask, intrinsic, terminator);
-    break;
-  case 2:
-    DoMaxOrMin<TypeCategory::Character, 2, IS_MAXVAL,
-        CharacterExtremumAccumulator>(
-        result, x, dim, mask, intrinsic, terminator);
-    break;
-  case 4:
-    DoMaxOrMin<TypeCategory::Character, 4, IS_MAXVAL,
-        CharacterExtremumAccumulator>(
-        result, x, dim, mask, intrinsic, terminator);
-    break;
-  default:
-    terminator.Crash("%s: bad character kind %d", intrinsic, type->second);
-  }
+  ApplyCharacterKind<CharacterMaxOrMinHelper<IS_MAXVAL>::template Functor,
+      void>(
+      type->second, terminator, result, x, dim, mask, intrinsic, terminator);
 }
 
 extern "C" {
@@ -1368,20 +1603,24 @@ void RTNAME(MinvalDim)(Descriptor &result, const Descriptor &x, int dim,
 
 } // extern "C"
 
-// ALL, ANY, & COUNT
+// ALL, ANY, COUNT, & PARITY
 
-template <bool IS_ALL> class LogicalAccumulator {
+enum class LogicalReduction { All, Any, Parity };
+
+template <LogicalReduction REDUCTION> class LogicalAccumulator {
 public:
   using Type = bool;
   explicit LogicalAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { result_ = REDUCTION == LogicalReduction::All; }
   bool Result() const { return result_; }
   bool Accumulate(bool x) {
-    if (x == IS_ALL) {
-      return true;
-    } else {
+    if constexpr (REDUCTION == LogicalReduction::Parity) {
+      result_ = result_ != x;
+    } else if (x != (REDUCTION == LogicalReduction::All)) {
       result_ = x;
       return false;
     }
+    return true;
   }
   template <typename IGNORED = void>
   bool AccumulateAt(const SubscriptValue at[]) {
@@ -1390,7 +1629,7 @@ public:
 
 private:
   const Descriptor &array_;
-  bool result_{IS_ALL};
+  bool result_{REDUCTION == LogicalReduction::All};
 };
 
 template <typename ACCUMULATOR>
@@ -1428,43 +1667,33 @@ inline auto ReduceLogicalDimToScalar(const Descriptor &x, int zeroBasedDim,
   return accumulator.Result();
 }
 
-template <bool IS_ALL, int KIND>
-inline void ReduceLogicalDimension(Descriptor &result, const Descriptor &x,
-    int dim, Terminator &terminator, const char *intrinsic) {
-  // Standard requires result to have same LOGICAL kind as argument.
-  CreatePartialReductionResult(result, x, dim, terminator, intrinsic, x.type());
-  SubscriptValue at[maxRank];
-  result.GetLowerBounds(at);
-  INTERNAL_CHECK(at[0] == 1);
-  using CppType = CppTypeFor<TypeCategory::Logical, KIND>;
-  for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
-    *result.Element<CppType>(at) =
-        ReduceLogicalDimToScalar<LogicalAccumulator<IS_ALL>>(x, dim - 1, at);
-  }
-}
+template <LogicalReduction REDUCTION> struct LogicalReduceHelper {
+  template <int KIND> struct Functor {
+    void operator()(Descriptor &result, const Descriptor &x, int dim,
+        Terminator &terminator, const char *intrinsic) const {
+      // Standard requires result to have same LOGICAL kind as argument.
+      CreatePartialReductionResult(
+          result, x, dim, terminator, intrinsic, x.type());
+      SubscriptValue at[maxRank];
+      result.GetLowerBounds(at);
+      INTERNAL_CHECK(at[0] == 1);
+      using CppType = CppTypeFor<TypeCategory::Logical, KIND>;
+      for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
+        *result.Element<CppType>(at) =
+            ReduceLogicalDimToScalar<LogicalAccumulator<REDUCTION>>(
+                x, dim - 1, at);
+      }
+    }
+  };
+};
 
-template <bool IS_ALL>
+template <LogicalReduction REDUCTION>
 inline void DoReduceLogicalDimension(Descriptor &result, const Descriptor &x,
     int dim, Terminator &terminator, const char *intrinsic) {
   auto catKind{x.type().GetCategoryAndKind()};
   RUNTIME_CHECK(terminator, catKind && catKind->first == TypeCategory::Logical);
-  switch (catKind->second) {
-  case 1:
-    ReduceLogicalDimension<IS_ALL, 1>(result, x, dim, terminator, intrinsic);
-    break;
-  case 2:
-    ReduceLogicalDimension<IS_ALL, 2>(result, x, dim, terminator, intrinsic);
-    break;
-  case 4:
-    ReduceLogicalDimension<IS_ALL, 4>(result, x, dim, terminator, intrinsic);
-    break;
-  case 8:
-    ReduceLogicalDimension<IS_ALL, 8>(result, x, dim, terminator, intrinsic);
-    break;
-  default:
-    terminator.Crash(
-        "%s: bad argument type LOGICAL(%d)", intrinsic, catKind->second);
-  }
+  ApplyLogicalKind<LogicalReduceHelper<REDUCTION>::template Functor, void>(
+      catKind->second, terminator, result, x, dim, terminator, intrinsic);
 }
 
 // COUNT
@@ -1473,6 +1702,7 @@ class CountAccumulator {
 public:
   using Type = std::int64_t;
   explicit CountAccumulator(const Descriptor &array) : array_{array} {}
+  void Reinitialize() { result_ = 0; }
   Type Result() const { return result_; }
   template <typename IGNORED = void>
   bool AccumulateAt(const SubscriptValue at[]) {
@@ -1487,41 +1717,44 @@ private:
   Type result_{0};
 };
 
-template <int KIND>
-inline void CountDimension(
-    Descriptor &result, const Descriptor &x, int dim, Terminator &terminator) {
-  CreatePartialReductionResult(result, x, dim, terminator, "COUNT",
-      TypeCode{TypeCategory::Integer, KIND});
-  SubscriptValue at[maxRank];
-  result.GetLowerBounds(at);
-  INTERNAL_CHECK(at[0] == 1);
-  using CppType = CppTypeFor<TypeCategory::Integer, KIND>;
-  for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
-    *result.Element<CppType>(at) =
-        ReduceLogicalDimToScalar<CountAccumulator>(x, dim - 1, at);
+template <int KIND> struct CountDimension {
+  void operator()(Descriptor &result, const Descriptor &x, int dim,
+      Terminator &terminator) const {
+    CreatePartialReductionResult(result, x, dim, terminator, "COUNT",
+        TypeCode{TypeCategory::Integer, KIND});
+    SubscriptValue at[maxRank];
+    result.GetLowerBounds(at);
+    INTERNAL_CHECK(at[0] == 1);
+    using CppType = CppTypeFor<TypeCategory::Integer, KIND>;
+    for (auto n{result.Elements()}; n-- > 0; result.IncrementSubscripts(at)) {
+      *result.Element<CppType>(at) =
+          ReduceLogicalDimToScalar<CountAccumulator>(x, dim - 1, at);
+    }
   }
-}
+};
 
 extern "C" {
 
 bool RTNAME(All)(const Descriptor &x, const char *source, int line, int dim) {
-  return GetTotalLogicalReduction(
-      x, source, line, dim, LogicalAccumulator<true>{x}, "ALL");
+  return GetTotalLogicalReduction(x, source, line, dim,
+      LogicalAccumulator<LogicalReduction::All>{x}, "ALL");
 }
 void RTNAME(AllDim)(Descriptor &result, const Descriptor &x, int dim,
     const char *source, int line) {
   Terminator terminator{source, line};
-  DoReduceLogicalDimension<true>(result, x, dim, terminator, "ALL");
+  DoReduceLogicalDimension<LogicalReduction::All>(
+      result, x, dim, terminator, "ALL");
 }
 
 bool RTNAME(Any)(const Descriptor &x, const char *source, int line, int dim) {
-  return GetTotalLogicalReduction(
-      x, source, line, dim, LogicalAccumulator<false>{x}, "ANY");
+  return GetTotalLogicalReduction(x, source, line, dim,
+      LogicalAccumulator<LogicalReduction::Any>{x}, "ANY");
 }
 void RTNAME(AnyDim)(Descriptor &result, const Descriptor &x, int dim,
     const char *source, int line) {
   Terminator terminator{source, line};
-  DoReduceLogicalDimension<false>(result, x, dim, terminator, "ANY");
+  DoReduceLogicalDimension<LogicalReduction::Any>(
+      result, x, dim, terminator, "ANY");
 }
 
 std::int64_t RTNAME(Count)(
@@ -1529,30 +1762,24 @@ std::int64_t RTNAME(Count)(
   return GetTotalLogicalReduction(
       x, source, line, dim, CountAccumulator{x}, "COUNT");
 }
+
 void RTNAME(CountDim)(Descriptor &result, const Descriptor &x, int dim,
     int kind, const char *source, int line) {
   Terminator terminator{source, line};
-  switch (kind) {
-  case 1:
-    CountDimension<1>(result, x, dim, terminator);
-    break;
-  case 2:
-    CountDimension<2>(result, x, dim, terminator);
-    break;
-  case 4:
-    CountDimension<4>(result, x, dim, terminator);
-    break;
-  case 8:
-    CountDimension<8>(result, x, dim, terminator);
-    break;
-#ifdef __SIZEOF_INT128__
-  case 16:
-    CountDimension<16>(result, x, dim, terminator);
-    break;
-#endif
-  default:
-    terminator.Crash("COUNT: bad KIND=%d", kind);
-  }
+  ApplyIntegerKind<CountDimension, void>(
+      kind, terminator, result, x, dim, terminator);
+}
+
+bool RTNAME(Parity)(
+    const Descriptor &x, const char *source, int line, int dim) {
+  return GetTotalLogicalReduction(x, source, line, dim,
+      LogicalAccumulator<LogicalReduction::Parity>{x}, "PARITY");
+}
+void RTNAME(ParityDim)(Descriptor &result, const Descriptor &x, int dim,
+    const char *source, int line) {
+  Terminator terminator{source, line};
+  DoReduceLogicalDimension<LogicalReduction::Parity>(
+      result, x, dim, terminator, "PARITY");
 }
 
 } // extern "C"

--- a/flang/runtime/reduction.h
+++ b/flang/runtime/reduction.h
@@ -24,8 +24,8 @@ namespace Fortran::runtime {
 extern "C" {
 
 // Reductions that are known to return scalars have per-type entry
-// points.  These cover the casse that either have no DIM=
-// argument, or have an argument rank of 1.  Pass 0 for no DIM=
+// points.  These cover the cases that either have no DIM=
+// argument or have an argument rank of 1.  Pass 0 for no DIM=
 // or the value of the DIM= argument so that it may be checked.
 // The data type in the descriptor is checked against the expected
 // return type.
@@ -144,20 +144,42 @@ void RTNAME(CppProductComplex16)(std::complex<long double> &,
 void RTNAME(ProductDim)(Descriptor &result, const Descriptor &array, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
 
-// MAXLOC and MINLOC
+// IPARITY()
+std::int8_t RTNAME(IParity1)(const Descriptor &, const char *source, int line,
+    int dim = 0, const Descriptor *mask = nullptr);
+std::int16_t RTNAME(IParity2)(const Descriptor &, const char *source, int line,
+    int dim = 0, const Descriptor *mask = nullptr);
+std::int32_t RTNAME(IParity4)(const Descriptor &, const char *source, int line,
+    int dim = 0, const Descriptor *mask = nullptr);
+std::int64_t RTNAME(IParity8)(const Descriptor &, const char *source, int line,
+    int dim = 0, const Descriptor *mask = nullptr);
+#ifdef __SIZEOF_INT128__
+common::int128_t RTNAME(IParity16)(const Descriptor &, const char *source,
+    int line, int dim = 0, const Descriptor *mask = nullptr);
+#endif
+void RTNAME(IParityDim)(Descriptor &result, const Descriptor &array, int dim,
+    const char *source, int line, const Descriptor *mask = nullptr);
+
+// FINDLOC, MAXLOC, & MINLOC
 // These return allocated arrays in the supplied descriptor.
 // The default value for KIND= should be the default INTEGER in effect at
 // compilation time.
-void RTNAME(Maxloc)(Descriptor &, const Descriptor &, int kind,
+void RTNAME(Findloc)(Descriptor &, const Descriptor &x,
+    const Descriptor &target, int kind, const char *source, int line,
+    const Descriptor *mask = nullptr, bool back = false);
+void RTNAME(FindlocDim)(Descriptor &, const Descriptor &x,
+    const Descriptor &target, int kind, int dim, const char *source, int line,
+    const Descriptor *mask = nullptr, bool back = false);
+void RTNAME(Maxloc)(Descriptor &, const Descriptor &x, int kind,
     const char *source, int line, const Descriptor *mask = nullptr,
     bool back = false);
-void RTNAME(MaxlocDim)(Descriptor &, const Descriptor &, int kind, int dim,
+void RTNAME(MaxlocDim)(Descriptor &, const Descriptor &x, int kind, int dim,
     const char *source, int line, const Descriptor *mask = nullptr,
     bool back = false);
-void RTNAME(Minloc)(Descriptor &, const Descriptor &, int kind,
+void RTNAME(Minloc)(Descriptor &, const Descriptor &x, int kind,
     const char *source, int line, const Descriptor *mask = nullptr,
     bool back = false);
-void RTNAME(MinlocDim)(Descriptor &, const Descriptor &, int kind, int dim,
+void RTNAME(MinlocDim)(Descriptor &, const Descriptor &x, int kind, int dim,
     const char *source, int line, const Descriptor *mask = nullptr,
     bool back = false);
 
@@ -221,7 +243,7 @@ void RTNAME(MaxvalDim)(Descriptor &, const Descriptor &, int dim,
 void RTNAME(MinvalDim)(Descriptor &, const Descriptor &, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
 
-// ALL, ANY, & COUNT logical reductions
+// ALL, ANY, COUNT, & PARITY logical reductions
 bool RTNAME(All)(const Descriptor &, const char *source, int line, int dim = 0);
 void RTNAME(AllDim)(Descriptor &result, const Descriptor &, int dim,
     const char *source, int line);
@@ -231,6 +253,10 @@ void RTNAME(AnyDim)(Descriptor &result, const Descriptor &, int dim,
 std::int64_t RTNAME(Count)(
     const Descriptor &, const char *source, int line, int dim = 0);
 void RTNAME(CountDim)(Descriptor &result, const Descriptor &, int dim, int kind,
+    const char *source, int line);
+bool RTNAME(Parity)(
+    const Descriptor &, const char *source, int line, int dim = 0);
+void RTNAME(ParityDim)(Descriptor &result, const Descriptor &, int dim,
     const char *source, int line);
 
 } // extern "C"

--- a/flang/runtime/terminator.h
+++ b/flang/runtime/terminator.h
@@ -24,6 +24,10 @@ public:
   Terminator(const Terminator &) = default;
   explicit Terminator(const char *sourceFileName, int sourceLine = 0)
       : sourceFileName_{sourceFileName}, sourceLine_{sourceLine} {}
+
+  const char *sourceFileName() const { return sourceFileName_; }
+  int sourceLine() const { return sourceLine_; }
+
   void SetLocation(const char *sourceFileName = nullptr, int sourceLine = 0) {
     sourceFileName_ = sourceFileName;
     sourceLine_ = sourceLine;

--- a/flang/unittests/Runtime/CMakeLists.txt
+++ b/flang/unittests/Runtime/CMakeLists.txt
@@ -80,3 +80,7 @@ target_link_libraries(character-test
 )
 
 add_test(NAME CharacterTest COMMAND character-test)
+add_flang_nongtest_unittest(buffer
+  RuntimeTesting
+  FortranRuntime
+)

--- a/flang/unittests/Runtime/buffer.cpp
+++ b/flang/unittests/Runtime/buffer.cpp
@@ -1,0 +1,115 @@
+#include "../../runtime/buffer.h"
+#include "testing.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+static constexpr std::size_t tinyBuffer{32};
+using FileOffset = std::int64_t;
+using namespace Fortran::runtime;
+using namespace Fortran::runtime::io;
+
+class Store : public FileFrame<Store, tinyBuffer> {
+public:
+  explicit Store(std::size_t bytes = 65536) : bytes_{bytes} {
+    data_.reset(new char[bytes]);
+    std::memset(&data_[0], 0, bytes);
+  }
+  std::size_t bytes() const { return bytes_; }
+  void set_enforceSequence(bool yes = true) { enforceSequence_ = yes; }
+  void set_expect(FileOffset to) { expect_ = to; }
+
+  std::size_t Read(FileOffset at, char *to, std::size_t minBytes,
+      std::size_t maxBytes, IoErrorHandler &handler) {
+    if (enforceSequence_ && at != expect_) {
+      handler.SignalError("Read(%d,%d,%d) not at expected %d",
+          static_cast<int>(at), static_cast<int>(minBytes),
+          static_cast<int>(maxBytes), static_cast<int>(expect_));
+    } else if (at < 0 || at + minBytes > bytes_) {
+      handler.SignalError("Read(%d,%d,%d) is out of bounds",
+          static_cast<int>(at), static_cast<int>(minBytes),
+          static_cast<int>(maxBytes));
+    }
+    auto result{std::min(maxBytes, bytes_ - at)};
+    std::memcpy(to, &data_[at], result);
+    expect_ = at + result;
+    return result;
+  }
+  std::size_t Write(FileOffset at, const char *from, std::size_t bytes,
+      IoErrorHandler &handler) {
+    if (enforceSequence_ && at != expect_) {
+      handler.SignalError("Write(%d,%d) not at expected %d",
+          static_cast<int>(at), static_cast<int>(bytes),
+          static_cast<int>(expect_));
+    } else if (at < 0 || at + bytes > bytes_) {
+      handler.SignalError("Write(%d,%d) is out of bounds", static_cast<int>(at),
+          static_cast<int>(bytes));
+    }
+    std::memcpy(&data_[at], from, bytes);
+    expect_ = at + bytes;
+    return bytes;
+  }
+
+private:
+  std::size_t bytes_;
+  std::unique_ptr<char[]> data_;
+  bool enforceSequence_{false};
+  FileOffset expect_{0};
+};
+
+inline int ChunkSize(int j, int most) {
+  // 31, 1, 29, 3, 27, ...
+  j %= tinyBuffer;
+  auto chunk{
+      static_cast<int>(((j % 2) ? j : (tinyBuffer - 1 - j)) % tinyBuffer)};
+  return std::min(chunk, most);
+}
+
+inline int ValueFor(int at) { return (at ^ (at >> 8)) & 0xff; }
+
+int main() {
+  StartTests();
+  Terminator terminator{__FILE__, __LINE__};
+  IoErrorHandler handler{terminator};
+  Store store;
+  store.set_enforceSequence(true);
+  const auto bytes{static_cast<FileOffset>(store.bytes())};
+  // Fill with an assortment of chunks
+  int at{0}, j{0};
+  while (at < bytes) {
+    auto chunk{ChunkSize(j, static_cast<int>(bytes - at))};
+    store.WriteFrame(at, chunk, handler);
+    char *to{store.Frame()};
+    for (int k{0}; k < chunk; ++k) {
+      to[k] = ValueFor(at + k);
+    }
+    at += chunk;
+    ++j;
+  }
+  store.Flush(handler);
+  // Validate
+  store.set_expect(0);
+  at = 0;
+  while (at < bytes) {
+    auto chunk{ChunkSize(j, static_cast<int>(bytes - at))};
+    std::size_t frame{store.ReadFrame(at, chunk, handler)};
+    if (frame < static_cast<std::size_t>(chunk)) {
+      Fail() << "Badly-sized ReadFrame at " << at << ", chunk=" << chunk
+             << ", got " << frame << '\n';
+      break;
+    }
+    const char *from{store.Frame()};
+    for (int k{0}; k < chunk; ++k) {
+      auto expect{static_cast<char>(ValueFor(at + k))};
+      if (from[k] != expect) {
+        Fail() << "At " << at << '+' << k << '(' << (at + k) << "), read "
+               << (from[k] & 0xff) << ", expected " << static_cast<int>(expect)
+               << '\n';
+      }
+    }
+    at += chunk;
+    ++j;
+  }
+  return EndTests();
+}

--- a/flang/unittests/RuntimeGTest/Numeric.cpp
+++ b/flang/unittests/RuntimeGTest/Numeric.cpp
@@ -79,6 +79,12 @@ TEST(Numeric, Fraction) {
       std::isnan(RTNAME(Fraction8)(std::numeric_limits<Real<8>>::quiet_NaN())));
 }
 
+TEST(Numeric, IsNaN) {
+  EXPECT_FALSE(RTNAME(IsNaN4)(Real<4>{0}));
+  EXPECT_FALSE(RTNAME(IsNaN8)(std::numeric_limits<Real<8>>::infinity()));
+  EXPECT_TRUE(RTNAME(IsNaN8)(std::numeric_limits<Real<8>>::quiet_NaN()));
+}
+
 TEST(Numeric, Mod) {
   EXPECT_EQ(RTNAME(ModInteger1)(Int<1>{8}, Int<1>(5)), 3);
   EXPECT_EQ(RTNAME(ModInteger4)(Int<4>{-8}, Int<4>(5)), -3);

--- a/flang/unittests/RuntimeGTest/Reduction.cpp
+++ b/flang/unittests/RuntimeGTest/Reduction.cpp
@@ -138,8 +138,8 @@ TEST(Reductions, Character) {
   std::vector<int> shape{2, 3};
   auto array{MakeArray<TypeCategory::Character, 1>(shape,
       std::vector<std::string>{"abc", "def", "ghi", "jkl", "mno", "abc"}, 3)};
-  StaticDescriptor<1> statDesc;
-  Descriptor &res{statDesc.descriptor()};
+  StaticDescriptor<1> statDesc[2];
+  Descriptor &res{statDesc[0].descriptor()};
   RTNAME(MaxvalCharacter)(res, *array, __FILE__, __LINE__);
   EXPECT_EQ(res.rank(), 0);
   EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Character, 1}.raw()));
@@ -202,6 +202,30 @@ TEST(Reductions, Character) {
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 2);
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 3);
   res.Destroy();
+  static const char targetChar[]{"abc"};
+  Descriptor &target{statDesc[1].descriptor()};
+  target.Establish(1, std::strlen(targetChar),
+      const_cast<void *>(static_cast<const void *>(&targetChar)), 0, nullptr,
+      CFI_attribute_pointer);
+  RTNAME(Findloc)
+  (res, *array, target, /*KIND=*/4, __FILE__, __LINE__, nullptr,
+      /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 1);
+  res.Destroy();
+  RTNAME(Findloc)
+  (res, *array, target, /*KIND=*/4, __FILE__, __LINE__, nullptr, /*BACK=*/true);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 3);
+  res.Destroy();
 }
 
 TEST(Reductions, Logical) {
@@ -211,9 +235,10 @@ TEST(Reductions, Logical) {
   ASSERT_EQ(array->ElementBytes(), std::size_t{4});
   EXPECT_EQ(RTNAME(All)(*array, __FILE__, __LINE__), false);
   EXPECT_EQ(RTNAME(Any)(*array, __FILE__, __LINE__), true);
+  EXPECT_EQ(RTNAME(Parity)(*array, __FILE__, __LINE__), false);
   EXPECT_EQ(RTNAME(Count)(*array, __FILE__, __LINE__), 2);
-  StaticDescriptor<2> statDesc;
-  Descriptor &res{statDesc.descriptor()};
+  StaticDescriptor<2> statDesc[2];
+  Descriptor &res{statDesc[0].descriptor()};
   RTNAME(AllDim)(res, *array, /*DIM=*/1, __FILE__, __LINE__);
   EXPECT_EQ(res.rank(), 1);
   EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Logical, 4}.raw()));
@@ -246,6 +271,22 @@ TEST(Reductions, Logical) {
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 1);
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 1);
   res.Destroy();
+  RTNAME(ParityDim)(res, *array, /*DIM=*/1, __FILE__, __LINE__);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Logical, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 0);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 0);
+  res.Destroy();
+  RTNAME(ParityDim)(res, *array, /*DIM=*/2, __FILE__, __LINE__);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Logical, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 1);
+  res.Destroy();
   RTNAME(CountDim)(res, *array, /*DIM=*/1, /*KIND=*/4, __FILE__, __LINE__);
   EXPECT_EQ(res.rank(), 1);
   EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
@@ -261,5 +302,124 @@ TEST(Reductions, Logical) {
   EXPECT_EQ(res.GetDimension(0).Extent(), 2);
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int64_t>(0), 1);
   EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int64_t>(1), 1);
+  res.Destroy();
+  bool boolValue{false};
+  Descriptor &target{statDesc[1].descriptor()};
+  target.Establish(TypeCategory::Logical, 1, static_cast<void *>(&boolValue), 0,
+      nullptr, CFI_attribute_pointer);
+  RTNAME(Findloc)
+  (res, *array, target, /*KIND=*/4, __FILE__, __LINE__, nullptr,
+      /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 1);
+  res.Destroy();
+  boolValue = true;
+  RTNAME(Findloc)
+  (res, *array, target, /*KIND=*/4, __FILE__, __LINE__, nullptr, /*BACK=*/true);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(0), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<std::int32_t>(1), 2);
+  res.Destroy();
+}
+
+TEST(Reductions, FindlocNumeric) {
+  std::vector<int> shape{2, 3};
+  auto realArray{MakeArray<TypeCategory::Real, 8>(shape,
+      std::vector<double>{0.0, -0.0, 1.0, 3.14,
+          std::numeric_limits<double>::quiet_NaN(),
+          std::numeric_limits<double>::infinity()})};
+  ASSERT_EQ(realArray->ElementBytes(), sizeof(double));
+  StaticDescriptor<2> statDesc[2];
+  Descriptor &res{statDesc[0].descriptor()};
+  // Find the first zero
+  Descriptor &target{statDesc[1].descriptor()};
+  double value{0.0};
+  target.Establish(TypeCategory::Real, 8, static_cast<void *>(&value), 0,
+      nullptr, CFI_attribute_pointer);
+  RTNAME(Findloc)
+  (res, *realArray, target, 8, __FILE__, __LINE__, nullptr, /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 1);
+  res.Destroy();
+  // Find last zero (even though it's negative)
+  RTNAME(Findloc)
+  (res, *realArray, target, 8, __FILE__, __LINE__, nullptr, /*BACK=*/true);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 1);
+  res.Destroy();
+  // Find the +Inf
+  value = std::numeric_limits<double>::infinity();
+  RTNAME(Findloc)
+  (res, *realArray, target, 8, __FILE__, __LINE__, nullptr, /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 3);
+  res.Destroy();
+  // Ensure that we can't find a NaN
+  value = std::numeric_limits<double>::quiet_NaN();
+  RTNAME(Findloc)
+  (res, *realArray, target, 8, __FILE__, __LINE__, nullptr, /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 0);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 0);
+  res.Destroy();
+  // Find a value of a distinct type
+  int intValue{1};
+  target.Establish(TypeCategory::Integer, 4, static_cast<void *>(&intValue), 0,
+      nullptr, CFI_attribute_pointer);
+  RTNAME(Findloc)
+  (res, *realArray, target, 8, __FILE__, __LINE__, nullptr, /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 2);
+  res.Destroy();
+  // Partial reductions
+  value = 1.0;
+  target.Establish(TypeCategory::Real, 8, static_cast<void *>(&value), 0,
+      nullptr, CFI_attribute_pointer);
+  RTNAME(FindlocDim)
+  (res, *realArray, target, 8, /*DIM=*/1, __FILE__, __LINE__, nullptr,
+      /*BACK=*/false);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 3);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 0);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 1);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(2), 0);
+  res.Destroy();
+  RTNAME(FindlocDim)
+  (res, *realArray, target, 8, /*DIM=*/2, __FILE__, __LINE__, nullptr,
+      /*BACK=*/true);
+  EXPECT_EQ(res.rank(), 1);
+  EXPECT_EQ(res.type().raw(), (TypeCode{TypeCategory::Integer, 8}.raw()));
+  EXPECT_EQ(res.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(res.GetDimension(0).UpperBound(), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(0), 2);
+  EXPECT_EQ(*res.ZeroBasedIndexedElement<SubscriptValue>(1), 0);
   res.Destroy();
 }


### PR DESCRIPTION
This PRs pulls all the latest and missing changes from llvm flang/runtime that where not yet in fir-dev flang/runtime.

Note:
- One of the commit pulls changes in flang/[lib/include]/Evaluate and flang/module. I kept them instead of splitting the commit.
- I copied flang/runtime/io-api.h from llvm main. The fir-dev version was functionally equivalent, but its formatting had diverged.

After this patch, everything from llvm is in fir-dev, but the reverse is not true. 6 files differ in flang/runtime between fir-dev and llvm. They are related to 4 patches in fir-dev that where not upstreamed:

- DATE_AND_TIME partial runtime: https://github.com/flang-compiler/f18-llvm-project/pull/412. Diffs in clock.cpp, clock.h, CMakeLists.txt.
- pgmath.h.inc c complex re-addition in fir-dev (https://github.com/flang-compiler/f18-llvm-project/pull/325). That is related to the C complex removal from our lowering code in https://reviews.llvm.org/D83397. Diffs in pgmath.h.inc.
-  Fortran_main library to allow shared builds (https://github.com/flang-compiler/f18-llvm-project/pull/677). Diffs in Fortran_main.c, CMakeLists.txt.
- A fix for hollerith constants (13f8088f2d88c9d5eee5b81ea59d2ac3134e928c).