### PR TITLE
Enable usage of runtime shapes in array expressions

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -96,21 +96,13 @@ void createMaskedArrayAssignment(AbstractConverter &converter,
                                  Fortran::lower::MaskExpr &masks,
                                  SymMap &symMap, StatementContext &stmtCtx);
 
-/// Create an array temporary.
-/// When lowering an array expression, it may be necessary to allocate temporary
-/// space for a ephemeral array value to be stored.
-fir::AllocMemOp
-createSomeArrayTemp(AbstractConverter &converter,
-                    const evaluate::Expr<evaluate::SomeType> &expr,
-                    SymMap &symMap, StatementContext &stmtCtx);
-
 /// Lower an array expression with "parallel" semantics. Such a rhs expression
-/// is fully evaluated prior to being assigned back to the destination array.
+/// is fully evaluated prior to being assigned back to a temporary array.
 fir::ExtendedValue
-createSomeNewArrayValue(AbstractConverter &converter, fir::ArrayLoadOp dst,
-                        const std::optional<evaluate::Shape> &shape,
-                        const evaluate::Expr<evaluate::SomeType> &expr,
-                        SymMap &symMap, StatementContext &stmtCtx);
+createSomeArrayTempValue(AbstractConverter &converter,
+                         const std::optional<evaluate::Shape> &shape,
+                         const evaluate::Expr<evaluate::SomeType> &expr,
+                         SymMap &symMap, StatementContext &stmtCtx);
 
 /// Lower an array expression to a value of type box.
 fir::ExtendedValue

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -288,8 +288,8 @@ mlir::Value readLowerBound(FirOpBuilder &, mlir::Location,
                            mlir::Value defaultValue);
 
 /// Read extents from an BoxValue into \p result.
-void readExtents(FirOpBuilder &, mlir::Location, const fir::BoxValue &,
-                 llvm::SmallVectorImpl<mlir::Value> &result);
+llvm::SmallVector<mlir::Value> readExtents(FirOpBuilder &, mlir::Location,
+                                           const fir::BoxValue &);
 
 //===--------------------------------------------------------------------===//
 // String literal helper helpers

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -67,10 +67,10 @@ subroutine sub(a)
   ! CHECK-DAG: %[[five:.*]] = constant 5 : i64
   ! CHECK-DAG: %[[two:.*]] = constant 2 : i64
   ! CHECK-DAG: %[[three:.*]] = constant 3 : index
-  ! CHECK: %[[allocmem:.*]] = fir.allocmem !fir.array<3x!fir.char<1>>
-  ! CHECK: %[[shape3:.*]] = fir.shape %[[three]] :
   ! CHECK: %[[shape:.*]] = fir.shape %[[ten]] :
   ! CHECK: %[[slice:.*]] = fir.slice %[[one]], %[[five]], %[[two]] :
+  ! CHECK: %[[allocmem:.*]] = fir.allocmem !fir.array<3x!fir.char<1>>
+  ! CHECK: %[[shape3:.*]] = fir.shape %[[three]] :
   ! CHECK: fir.array_coor %{{.*}}(%[[shape]]) [%[[slice]]] %
   ! CHECK: fir.embox %[[allocmem]](%[[shape3]]) : (!fir.heap<!fir.array<3x!fir.char<1>>>, !fir.shape<1>) -> !fir.box<!fir.array<3x!fir.char<1>>>
   print *, "a = ", a(1:5:2)

--- a/flang/test/Lower/array-expression-slice-2.f90
+++ b/flang/test/Lower/array-expression-slice-2.f90
@@ -44,9 +44,9 @@ program main
   print *, A
   ! CHECK: %[[A:.*]] = fir.address_of(@_QEa)
   ! CHECK: %[[shape10:.*]] = fir.shape %c10
+  ! CHECK: %[[slice:.*]] = fir.slice %
   ! CHECK: %[[mem:.*]] = fir.allocmem !fir.array<3xi32>
   ! CHECK: %[[shape:.*]] = fir.shape %c3
-  ! CHECK: %[[slice:.*]] = fir.slice %
   ! CHECK: fir.array_coor %[[A]](%[[shape10]]) [%[[slice]]] %
   ! CHECK: fir.array_coor %[[mem]](%[[shape]]) %
   print*, A(1:3:1)

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -272,10 +272,10 @@ subroutine test12(a,b,c,d,n,m)
   ! CHECK: %[[A:.*]] = fir.array_load %arg0(%[[sha]])
   ! CHECK: %[[shb:.*]] = fir.shape %
   ! CHECK: %[[B:.*]] = fir.array_load %arg1(%[[shb]])
-  ! CHECK: %[[tmp:.*]] = fir.allocmem !fir.array<?xf32>, %{{.*}} {{{.*}}uniq_name = ".array.expr"}
-  ! CHECK: %[[T:.*]] = fir.array_load %[[tmp]](%
   ! CHECK: %[[C:.*]] = fir.array_load %arg2(%
   ! CHECK: %[[D:.*]] = fir.array_load %arg3(%
+  ! CHECK: %[[tmp:.*]] = fir.allocmem !fir.array<?xf32>, %{{.*}} {{{.*}}uniq_name = ".array.expr"}
+  ! CHECK: %[[T:.*]] = fir.array_load %[[tmp]](%
   real, external :: bar
   real :: a(n), b(n), c(m), d(m)
   ! CHECK: %[[LOOP:.*]] = fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %[[T]])
@@ -443,8 +443,8 @@ end subroutine
 ! CHECK-SAME:  %[[x:.*]]: !fir.box<!fir.array<?xi32>>
 subroutine test_assigning_to_assumed_shape_slices(x)
   integer :: x(:)
-  ! CHECK: %[[slice:.*]] = fir.array_load %[[x]] [%{{.*}}] : (!fir.box<!fir.array<?xi32>>, !fir.slice<1>) -> !fir.array<?xi32>
   ! CHECK: fir.box_dims %[[x]], %c0{{.*}} : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+  ! CHECK: %[[slice:.*]] = fir.array_load %[[x]] [%{{.*}}] : (!fir.box<!fir.array<?xi32>>, !fir.slice<1>) -> !fir.array<?xi32>
   ! CHECK: %[[loop:.*]] = fir.do_loop %[[idx:.*]] = %c0{{.*}} to %{{.*}} step %c1{{.*}} iter_args(%[[dest:.*]] = %[[slice]]) -> (!fir.array<?xi32>) {
     ! CHECK: %[[res:.*]] = fir.array_update %[[dest]], %c42{{.*}}, %[[idx]] : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
     ! CHECK: fir.result %[[res]] : !fir.array<?xi32>

--- a/flang/test/Lower/where.f90
+++ b/flang/test/Lower/where.f90
@@ -8,9 +8,9 @@
    ! CHECK-DAG: %[[b:.*]] = fir.address_of(@_QEb) : !fir.ref<!fir.array<10xf32>>
    ! CHECK-DAG: fir.array_load %[[b]](%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
    ! CHECK-DAG: fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+   ! CHECK-DAG: %[[four:.*]] = constant 4.0{{.*}} : f32
    ! CHECK: %[[tvec:.*]] = fir.allocmem !fir.array<10x!fir.logical
    ! CHECK-DAG: fir.array_load %[[tvec]]
-   ! CHECK-DAG: %[[four:.*]] = constant 4.0{{.*}} : f32
    ! CHECK: fir.do_loop
    ! CHECK: fir.cmpf "ogt", %{{.*}}, %[[four]]
    ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[tvec]]
@@ -30,10 +30,10 @@
    ! Test that the basic structure is correct
    where (a > 100.0)
    ! loop with an if
-     ! CHECK: %[[tvec:.*]] = fir.allocmem !fir.array<10x!fir.logical
-     ! CHECK: fir.array_load
      ! CHECK: fir.array_load
      ! CHECK: %[[cst:.*]] = constant 1.0{{.*}}2 : f32
+     ! CHECK: %[[tvec:.*]] = fir.allocmem !fir.array<10x!fir.logical
+     ! CHECK: fir.array_load
      ! CHECK: fir.do_loop
      ! CHECK: fir.cmpf "ogt", %{{.*}}, %[[cst]]
      ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[tvec]]
@@ -50,10 +50,10 @@
      b = 2.0 * a
    elsewhere (a > 50.0)
    ! loop with else if
-     ! CHECK: %[[uvec:.*]] = fir.allocmem !fir.array<10x!fir.logical
-     ! CHECK: fir.array_load
      ! CHECK: fir.array_load
      ! CHECK: %[[cst50:.*]] = constant 5.0{{.*}}1 : f32
+     ! CHECK: %[[uvec:.*]] = fir.allocmem !fir.array<10x!fir.logical
+     ! CHECK: fir.array_load
      ! CHECK: fir.do_loop
      ! CHECK: fir.cmpf "ogt", %{{.*}}, %[[cst50]]
      ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[uvec]]


### PR DESCRIPTION
This change is motivated by the impossibility to use `evaluate::GetShape` on an `ev::Expr` array expression and to allocate a temporary storage for the expression with the resulting shape before evaluating the expression.

For instance, in `1 + foo()` where `foo` returns an array pointer, there is no way to allocate the storage for the expression before evaluating `foo`. Hence, part of this change delays the array temp allocation to after the operand evaluation. `createSomeArrayTemp` and `createSomeNewArrayValue` are merged into a single `createSomeArrayTempValue` function to allow this change.

The other part of this change is to only use the result of `evaluate::GetShape` if it is constant. Otherwise, it may contain references to symbols that are not mapped in the current scoped (e.g., result symbols of called array function ), or for which the value may have changed while evaluating the arguments ( see example in *). To cover the other cases, gather the array operands `fir.array_load` when lowering the operands, and when generating the iteration space, use that to deduce the array expression shape using the array conformity rule of array expressions (note that getExtents cannot always directly be used, array_load with fir.box and slice arguments need special care).

The rational for keeping the GetShape usage is that it can deduce  constant values for the loops bounds in cases where the lowered array operand extents would be more opaque. For instance, transformational intrinsic calls will always appear as dynamic shape (since they are allocated by the runtime), even when some knowledge about the intrinsic can allow deducing a constant shape for the result in certain cases. From a pure correctness point-of view, its usage could be eliminated with the proposed changes.

(*) Example of function for which GetShape is not usable after the call:
```
function foo(n)
  integer :: foo(n)
  foo = 41
  n = n + 10 
end function

n = 10
print *, 1 + foo(n)
```

If GetShape returns `n` symbol for expression extent, it is technically correct before the call, but incorrect afterwards since its value may have changed after the call. Hence, GetShape extents are dangerous to use when they contain symbols that may have been modified in the expression operand evaluation. 