### PR TITLE
Lowering of array expressions on arrays of CHARACTERs.

### DIFF
--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -51,11 +51,6 @@ public:
   void createAssign(const fir::ExtendedValue &lhs,
                     const fir::ExtendedValue &rhs);
 
-  /// Lower an assignment where the buffer and LEN parameter are known and do
-  /// not need to be unboxed.
-  void createAssign(mlir::Value lptr, mlir::Value llen, mlir::Value rptr,
-                    mlir::Value rlen);
-
   /// Create lhs // rhs in temp obtained with fir.alloca
   fir::CharBoxValue createConcatenate(const fir::CharBoxValue &lhs,
                                       const fir::CharBoxValue &rhs);

--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -113,7 +113,7 @@ public:
   /// Create a slot for a local on the stack. Besides the variable's type and
   /// shape, it may be given name or target attributes.
   mlir::Value allocateLocal(mlir::Location loc, mlir::Type ty,
-                            llvm::StringRef nm,
+                            llvm::StringRef uniqName, llvm::StringRef name,
                             llvm::ArrayRef<mlir::Value> shape,
                             llvm::ArrayRef<mlir::Value> lenParams,
                             bool asTarget = false);

--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -384,7 +384,7 @@ ExtendedValue substBase(const ExtendedValue &exv, mlir::Value base);
 bool isArray(const ExtendedValue &exv);
 
 /// Get the type parameters for `exv`.
-llvm::ArrayRef<mlir::Value> getTypeParams(const ExtendedValue &exv);
+llvm::SmallVector<mlir::Value> getTypeParams(const ExtendedValue &exv);
 
 /// An extended value is a box of values pertaining to a discrete entity. It is
 /// used in lowering to track all the runtime values related to an entity. For

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -35,34 +35,6 @@ class fir_SimpleOp<string mnemonic, list<OpTrait> traits>
   }];
 }
 
-// Base builder for allocate operations
-def fir_AllocateOpBuilder : OpBuilderDAG<(ins
-    "mlir::Type":$inType,
-    CArg<"mlir::ValueRange", "{}">:$lenParams,
-    CArg<"mlir::ValueRange", "{}">:$sizes,
-    CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes),
-  [{
-    $_state.addTypes(getRefTy(inType));
-    $_state.addAttribute("in_type", TypeAttr::get(inType));
-    $_state.addOperands(sizes);
-    $_state.addAttributes(attributes);
-  }]>;
-
-def fir_NamedAllocateOpBuilder : OpBuilderDAG<(ins
-    "mlir::Type":$inType,
-    "llvm::StringRef":$name,
-    CArg<"mlir::ValueRange", "{}">:$lenParams,
-    CArg<"mlir::ValueRange","{}">:$sizes,
-    CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes),
-  [{
-    $_state.addTypes(getRefTy(inType));
-    $_state.addAttribute("in_type", TypeAttr::get(inType));
-    if (!name.empty())
-      $_state.addAttribute("name", $_builder.getStringAttr(name));
-    $_state.addOperands(sizes);
-    $_state.addAttributes(attributes);
-  }]>;
-
 def fir_OneResultOpBuilder : OpBuilderDAG<(ins
     "mlir::Type":$resultType,
     "mlir::ValueRange":$operands,
@@ -86,134 +58,12 @@ class fir_SimpleOneResultOp<string mnemonic, list<OpTrait> traits = []> :
   let builders = [fir_OneResultOpBuilder];
 }
 
-class fir_TwoBuilders<OpBuilderDAG b1, OpBuilderDAG b2> {
-  list<OpBuilderDAG> builders = [b1, b2];
-}
-
-class fir_AllocatableBaseOp<string mnemonic, list<OpTrait> traits = []> :
-    fir_Op<mnemonic, traits>, Results<(outs fir_Type:$res)> {
-  let arguments = (ins
-    OptionalAttr<StrAttr>:$name,
-    OptionalAttr<BoolAttr>:$target
-  );
-}
-
-class fir_AllocatableOp<string mnemonic, Resource resource,
-      list<OpTrait> traits = []> :
-    fir_AllocatableBaseOp<mnemonic,
-	!listconcat(traits, [MemoryEffects<[MemAlloc<resource>]>])>,
-    fir_TwoBuilders<fir_AllocateOpBuilder, fir_NamedAllocateOpBuilder>,
-    Arguments<(ins TypeAttr:$in_type, Variadic<AnyIntegerType>:$args)> {
-
-  let parser = [{
-    mlir::Type intype;
-    if (parser.parseType(intype))
-      return mlir::failure();
-    auto &builder = parser.getBuilder();
-    result.addAttribute(inType(), mlir::TypeAttr::get(intype));
-    llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
-    llvm::SmallVector<mlir::Type> typeVec;
-    bool hasOperands = false;
-    if (!parser.parseOptionalLParen()) {
-      // parse the LEN params of the derived type. (<params> : <types>)
-      if (parser.parseOperandList(operands,
-                                  mlir::OpAsmParser::Delimiter::None) ||
-          parser.parseColonTypeList(typeVec) ||
-          parser.parseRParen())
-        return mlir::failure();
-      auto lens = builder.getI32IntegerAttr(operands.size());
-      result.addAttribute(lenpName(), lens);
-      hasOperands = true;
-    }
-    if (!parser.parseOptionalComma()) {
-      // parse size to scale by, vector of n dimensions of type index
-      auto opSize = operands.size();
-      if (parser.parseOperandList(operands, mlir::OpAsmParser::Delimiter::None))
-        return mlir::failure();
-      for (auto i = opSize, end = operands.size(); i != end; ++i)
-        typeVec.push_back(builder.getIndexType());
-      hasOperands = true;
-    }
-    if (hasOperands &&
-        parser.resolveOperands(operands, typeVec, parser.getNameLoc(),
-                               result.operands))
-      return mlir::failure();
-    mlir::Type restype = wrapResultType(intype);
-    if (!restype) {
-      parser.emitError(parser.getNameLoc(), "invalid allocate type: ")
-          << intype;
-      return mlir::failure();
-    }
-    if (parser.parseOptionalAttrDict(result.attributes) ||
-        parser.addTypeToList(restype, result.types))
-      return mlir::failure();
-    return mlir::success();
-  }];
-
-  let printer = [{
-    p << getOperationName() << ' ' << (*this)->getAttr(inType());
-    if (hasLenParams()) {
-      // print the LEN parameters to a derived type in parens
-      p << '(' << getLenParams() << " : " << getLenParams().getTypes() << ')';
-    }
-    // print the shape of the allocation (if any); all must be index type
-    for (auto sh : getShapeOperands()) {
-      p << ", ";
-      p.printOperand(sh);
-    }
-    p.printOptionalAttrDict((*this)->getAttrs(), {inType(), lenpName()});
-  }];
-
-  string extraAllocClassDeclaration = [{
-    static constexpr llvm::StringRef inType() { return "in_type"; }
-    static constexpr llvm::StringRef lenpName() { return "len_param_count"; }
-    mlir::Type getAllocatedType();
-
-    bool hasLenParams() { return bool{(*this)->getAttr(lenpName())}; }
-    bool hasShapeOperands() { return numShapeOperands() > 0; }
-
-    unsigned numLenParams() {
-      if (auto val = (*this)->getAttrOfType<mlir::IntegerAttr>(lenpName()))
-        return val.getInt();
-      return 0;
-    }
-
-    operand_range getLenParams() {
-      return {operand_begin(), operand_begin() + numLenParams()};
-    }
-
-    unsigned numShapeOperands() {
-      return operand_end() - operand_begin() + numLenParams();
-    }
-
-    operand_range getShapeOperands() {
-      return {operand_begin() + numLenParams(), operand_end()};
-    }
-
-    static mlir::Type getRefTy(mlir::Type ty);
-
-    /// Get the input type of the allocation
-    mlir::Type getInType() {
-      return (*this)->getAttrOfType<mlir::TypeAttr>(inType()).getValue();
-    }
-  }];
-
-  // Verify checks common to all allocation operations
-  string allocVerify = [{
-    llvm::SmallVector<llvm::StringRef> visited;
-    if (verifyInType(getInType(), visited, numShapeOperands()))
-      return emitOpError("invalid type for allocation");
-    if (verifyRecordLenParams(getInType(), numLenParams()))
-      return emitOpError("LEN params do not correspond to type");
-  }];
-}
-
 //===----------------------------------------------------------------------===//
 // Memory SSA operations
 //===----------------------------------------------------------------------===//
 
-def fir_AllocaOp :
-      fir_AllocatableOp<"alloca", AutomaticAllocationScopeResource> {
+def fir_AllocaOp : fir_Op<"alloca", [AttrSizedOperandSegments,
+    MemoryEffects<[MemAlloc<AutomaticAllocationScopeResource>]>]> {
   let summary = "allocate storage for a temporary on the stack given a type";
   let description = [{
     This primitive operation is used to allocate an object on the stack.  A
@@ -275,9 +125,38 @@ def fir_AllocaOp :
     whether the procedure is recursive or not.
   }];
 
+  let arguments = (ins
+    TypeAttr:$in_type,
+    OptionalAttr<StrAttr>:$uniq_name,
+    OptionalAttr<StrAttr>:$bindc_name,
+    Variadic<AnyIntegerType>:$typeparams,
+    Variadic<AnyIntegerType>:$shape
+  );
   let results = (outs fir_ReferenceType);
 
-  let verifier = allocVerify#[{
+  let parser = "return parseAlloca(parser, result);";
+  let printer = "printAlloca(p, *this);";
+
+  let builders = [
+    OpBuilderDAG<(ins "mlir::Type":$in_type, "llvm::StringRef":$uniq_name,
+      "llvm::StringRef":$bindc_name, CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>,
+    OpBuilderDAG<(ins "mlir::Type":$in_type, "llvm::StringRef":$uniq_name,
+      CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>,
+    OpBuilderDAG<(ins "mlir::Type":$in_type,
+      CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>];
+
+  let verifier = [{
+    llvm::SmallVector<llvm::StringRef> visited;
+    if (verifyInType(getInType(), visited, numShapeOperands()))
+      return emitOpError("invalid type for allocation");
+    if (verifyTypeParamCount(getInType(), numLenParams()))
+      return emitOpError("LEN params do not correspond to type");
     mlir::Type outType = getType();
     if (!outType.isa<fir::ReferenceType>())
       return emitOpError("must be a !fir.ref type");
@@ -286,9 +165,108 @@ def fir_AllocaOp :
     return mlir::success();
   }];
 
-  let extraClassDeclaration = extraAllocClassDeclaration#[{
-    static mlir::Type wrapResultType(mlir::Type intype);
+  let extraClassDeclaration = [{
+    mlir::Type getAllocatedType();
+    bool hasLenParams() { return !typeparams().empty(); }
+    bool hasShapeOperands() { return !shape().empty(); }
+    unsigned numLenParams() { return typeparams().size(); }
+    operand_range getLenParams() { return typeparams(); }
+    unsigned numShapeOperands() { return shape().size(); }
+    operand_range getShapeOperands() { return shape(); }
+    static mlir::Type getRefTy(mlir::Type ty);
+    mlir::Type getInType() { return in_type(); }
   }];
+}
+
+def fir_AllocMemOp : fir_Op<"allocmem",
+    [MemoryEffects<[MemAlloc<DefaultResource>]>, AttrSizedOperandSegments]> {
+  let summary = "allocate storage on the heap for an object of a given type";
+
+  let description = [{
+    Creates a heap memory reference suitable for storing a value of the
+    given type, T.  The heap refernce returned has type `!fir.heap<T>`.
+    The memory object is in an undefined state.  `allocmem` operations must
+    be paired with `freemem` operations to avoid memory leaks.
+
+    ```mlir
+      %0 = fir.allocmem !fir.array<10 x f32>
+      fir.freemem %0 : !fir.heap<!fir.array<10 x f32>>
+    ```
+  }];
+
+  let arguments = (ins
+    TypeAttr:$in_type,
+    OptionalAttr<StrAttr>:$uniq_name,
+    OptionalAttr<StrAttr>:$bindc_name,
+    Variadic<AnyIntegerType>:$typeparams,
+    Variadic<AnyIntegerType>:$shape
+  );
+  let results = (outs fir_HeapType);
+
+  let parser = "return parseAllocMem(parser, result);";
+  let printer = "printAllocMem(p, *this);";
+
+  let builders = [
+    OpBuilderDAG<(ins "mlir::Type":$in_type, "llvm::StringRef":$uniq_name,
+      "llvm::StringRef":$bindc_name, CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>,
+    OpBuilderDAG<(ins "mlir::Type":$in_type, "llvm::StringRef":$uniq_name,
+      CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>,
+    OpBuilderDAG<(ins "mlir::Type":$in_type,
+      CArg<"mlir::ValueRange", "{}">:$typeparams,
+      CArg<"mlir::ValueRange", "{}">:$shape,
+      CArg<"llvm::ArrayRef<mlir::NamedAttribute>", "{}">:$attributes)>];
+
+  let verifier = [{
+    llvm::SmallVector<llvm::StringRef> visited;
+    if (verifyInType(getInType(), visited, numShapeOperands()))
+      return emitOpError("invalid type for allocation");
+    if (verifyTypeParamCount(getInType(), numLenParams()))
+      return emitOpError("LEN params do not correspond to type");
+    mlir::Type outType = getType();
+    if (!outType.dyn_cast<fir::HeapType>())
+      return emitOpError("must be a !fir.heap type");
+    if (fir::isa_unknown_size_box(fir::dyn_cast_ptrEleTy(outType)))
+      return emitOpError("cannot allocate !fir.box of unknown rank or type");
+    return mlir::success();
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Type getAllocatedType();
+    bool hasLenParams() { return !typeparams().empty(); }
+    bool hasShapeOperands() { return !shape().empty(); }
+    unsigned numLenParams() { return typeparams().size(); }
+    operand_range getLenParams() { return typeparams(); }
+    unsigned numShapeOperands() { return shape().size(); }
+    operand_range getShapeOperands() { return shape(); }
+    static mlir::Type getRefTy(mlir::Type ty);
+    mlir::Type getInType() { return in_type(); }
+  }];
+}
+
+def fir_FreeMemOp : fir_Op<"freemem", [MemoryEffects<[MemFree]>]> {
+  let summary = "free a heap object";
+
+  let description = [{
+    Deallocates a heap memory reference that was allocated by an `allocmem`.
+    The memory object that is deallocated is placed in an undefined state
+    after `fir.freemem`.  Optimizations may treat the loading of an object
+    in the undefined state as undefined behavior.  This includes aliasing
+    references, such as the result of an `fir.embox`.
+
+    ```mlir
+      %21 = fir.allocmem !fir.type<ZT(p:i32){field:i32}>
+      ...
+      fir.freemem %21 : !fir.heap<!fir.type<ZT>>
+    ```
+  }];
+
+  let arguments = (ins Arg<fir_HeapType, "", [MemFree]>:$heapref);
+
+  let assemblyFormat = "$heapref attr-dict `:` type($heapref)";
 }
 
 def fir_LoadOp : fir_OneResultOp<"load"> {
@@ -413,22 +391,26 @@ def fir_StoreOp : fir_Op<"store", []> {
 }
 
 def fir_SaveResultOp : fir_Op<"save_result", [AttrSizedOperandSegments]> {
-  let summary = "save an array, box, or record function result SSA-value to a memory location";
+  let summary = [{
+    save an array, box, or record function result SSA-value to a memory location
+  }];
 
   let description = [{
     Save the result of a function returning an array, box, or record type value
     into a memory location given the shape and length parameters of the result.
 
-    Function results of type fir.box, fir.array, or fir.rec are abstract values that
-    require a storage to be manipulated on the caller side. This operation allows
-    associating such abstract result to a storage. In later lowering of the function
-    interfaces, this storage might be used to pass the result in memory.
+    Function results of type fir.box, fir.array, or fir.rec are abstract values
+    that require a storage to be manipulated on the caller side. This operation
+    allows associating such abstract result to a storage. In later lowering of
+    the function interfaces, this storage might be used to pass the result in
+    memory.
     
-    For arrays, result, it is required to provide the shape of the result. For character arrays
-    and derived types with length parameters, the length parameter values must be provided.
+    For arrays, result, it is required to provide the shape of the result. For
+    character arrays and derived types with length parameters, the length
+    parameter values must be provided.
 
-    The fir.save_result associated to a function call must immediately follow the call and be
-    in the same block.  
+    The fir.save_result associated to a function call must immediately follow
+    the call and be in the same block.  
 
     ```mlir
       %buffer = fir.alloca fir.array<?xf32>, %c100
@@ -447,15 +429,53 @@ def fir_SaveResultOp : fir_Op<"save_result", [AttrSizedOperandSegments]> {
   let arguments = (ins AnyType:$value,
                    Arg<AnyReferenceLike, "", [MemWrite]>:$memref,
                    Optional<AnyShapeType>:$shape,
-                   Variadic<AnyIntegerType>:$lenParams);
+                   Variadic<AnyIntegerType>:$typeparams);
 
   let assemblyFormat = [{
-    $value `to` $memref (`(` $shape^ `)`)? (`typeparams` $lenParams^)?
+    $value `to` $memref (`(` $shape^ `)`)? (`typeparams` $typeparams^)?
     attr-dict `:` type(operands)
   }];
 
   let verifier = [{ return ::verify(*this); }];
+}
 
+def fir_CharConvertOp : fir_Op<"char_convert", []> {
+  let summary = [{
+    Primitive to convert an entity of type CHARACTER from one KIND to a
+    different KIND.
+  }];
+
+  let description = [{
+    Copy a CHARACTER (must be in memory) of KIND _k1_ to a CHARACTER (also must
+    be in memory) of KIND _k2_ where _k1_ != _k2_ and the buffers do not
+    overlap. This latter restriction is unchecked, as the Fortran language
+    definition eliminates the overlapping in memory case.
+
+    The number of code points copied is specified explicitly as the second
+    argument. The length of the !fir.char type is ignored.
+
+    ```mlir
+      fir.char_convert %1 for %2 to %3 : !fir.ref<!fir.char<1,?>>, i32, !fir.ref<!fir.char<2,20>>
+    ```
+
+    Should future support for encodings other than ASCII be supported, codegen
+    can generate a call to a runtime helper routine which will map the code
+    points from UTF-8 to UCS-2, for example. Such remappings may not always
+    be possible as they may involve the creation of more code points than the
+    `count` limit. These details are left as future to-dos.
+  }];
+
+  let arguments = (ins
+    Arg<AnyReferenceLike, "", [MemRead]>:$from,
+    AnyIntegerType:$count,
+    Arg<AnyReferenceLike, "", [MemWrite]>:$to
+  );
+
+  let assemblyFormat = [{
+    $from `for` $count `to` $to attr-dict `:` type(operands)
+  }];
+
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def fir_UndefOp : fir_OneResultOp<"undefined", [NoSideEffect]> {
@@ -499,59 +519,6 @@ def fir_ZeroOp : fir_OneResultOp<"zero_bits", [NoSideEffect]> {
   let results = (outs AnyType:$intype);
 
   let assemblyFormat = "type($intype) attr-dict";
-}
-
-def fir_AllocMemOp : fir_AllocatableOp<"allocmem", DefaultResource> {
-  let summary = "allocate storage on the heap for an object of a given type";
-
-  let description = [{
-    Creates a heap memory reference suitable for storing a value of the
-    given type, T.  The heap refernce returned has type `!fir.heap<T>`.
-    The memory object is in an undefined state.  `allocmem` operations must
-    be paired with `freemem` operations to avoid memory leaks.
-
-    ```mlir
-      %0 = fir.allocmem !fir.array<10 x f32>
-      fir.freemem %0 : !fir.heap<!fir.array<10 x f32>>
-    ```
-  }];
-
-  let results = (outs fir_HeapType);
-
-  let verifier = allocVerify#[{
-    mlir::Type outType = getType();
-    if (!outType.dyn_cast<fir::HeapType>())
-      return emitOpError("must be a !fir.heap type");
-    if (fir::isa_unknown_size_box(fir::dyn_cast_ptrEleTy(outType)))
-      return emitOpError("cannot allocate !fir.box of unknown rank or type");
-    return mlir::success();
-  }];
-
-  let extraClassDeclaration = extraAllocClassDeclaration#[{
-    static mlir::Type wrapResultType(mlir::Type intype);
-  }];
-}
-
-def fir_FreeMemOp : fir_Op<"freemem", [MemoryEffects<[MemFree]>]> {
-  let summary = "free a heap object";
-
-  let description = [{
-    Deallocates a heap memory reference that was allocated by an `allocmem`.
-    The memory object that is deallocated is placed in an undefined state
-    after `fir.freemem`.  Optimizations may treat the loading of an object
-    in the undefined state as undefined behavior.  This includes aliasing
-    references, such as the result of an `fir.embox`.
-
-    ```mlir
-      %21 = fir.allocmem !fir.type<ZT(p:i32){field:i32}>
-      ...
-      fir.freemem %21 : !fir.heap<!fir.type<ZT>>
-    ```
-  }];
-
-  let arguments = (ins Arg<fir_HeapType, "", [MemFree]>:$heapref);
-
-  let assemblyFormat = "$heapref attr-dict `:` type($heapref)";
 }
 
 //===----------------------------------------------------------------------===//
@@ -701,7 +668,8 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
     p << getOperationName() << ' ';
     p.printOperand(getSelector());
     p << " : " << getSelector().getType() << " [";
-    auto cases = (*this)->getAttrOfType<mlir::ArrayAttr>(getCasesAttr()).getValue();
+    auto cases =
+      (*this)->getAttrOfType<mlir::ArrayAttr>(getCasesAttr()).getValue();
     auto count = getNumConditions();
     for (decltype(count) i = 0; i != count; ++i) {
       if (i)
@@ -715,8 +683,9 @@ class fir_IntegralSwitchTerminatorOp<string mnemonic,
       printSuccessorAtIndex(p, i);
     }
     p << ']';
-    p.printOptionalAttrDict((*this)->getAttrs(), {getCasesAttr(), getCompareOffsetAttr(),
-        getTargetOffsetAttr(), getOperandSegmentSizeAttr()});
+    p.printOptionalAttrDict((*this)->getAttrs(), {getCasesAttr(),
+        getCompareOffsetAttr(), getTargetOffsetAttr(),
+        getOperandSegmentSizeAttr()});
   }];
 
   let verifier = [{
@@ -1058,7 +1027,7 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
         - shape: emboxing an array may require shape information (an array's
           lower bounds and extents may not be known until runtime),
         - slice: an array section can be described with a slice triple,
-        - lenParams: for emboxing a derived type with LEN type parameters,
+        - typeparams: for emboxing a derived type with LEN type parameters,
         - accessMap: unused/experimental.
   }];
 
@@ -1066,7 +1035,7 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
     AnyReferenceLike:$memref,
     Optional<AnyShapeType>:$shape,
     Optional<fir_SliceType>:$slice,
-    Variadic<AnyIntegerType>:$lenParams,
+    Variadic<AnyIntegerType>:$typeparams,
     OptionalAttr<AffineMapAttr>:$accessMap
   );
 
@@ -1076,13 +1045,13 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
     OpBuilderDAG<(ins "llvm::ArrayRef<mlir::Type>":$resultTypes,
       "mlir::Value":$memref, CArg<"mlir::Value", "{}">:$shape,
       CArg<"mlir::Value", "{}">:$slice,
-      CArg<"mlir::ValueRange", "{}">:$lenParams),
+      CArg<"mlir::ValueRange", "{}">:$typeparams),
     [{ return build($_builder, $_state, resultTypes, memref, shape, slice,
-                    lenParams, mlir::AffineMapAttr{}); }]>
+                    typeparams, mlir::AffineMapAttr{}); }]>
   ];
 
   let assemblyFormat = [{
-    $memref (`(` $shape^ `)`)? (`[` $slice^ `]`)? (`typeparams` $lenParams^)?
+    $memref (`(` $shape^ `)`)? (`[` $slice^ `]`)? (`typeparams` $typeparams^)?
       (`map` $accessMap^)? attr-dict `:` functional-type(operands, results)
   }];
 
@@ -1091,8 +1060,8 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
   let extraClassDeclaration = [{
     mlir::Value getShape() { return shape(); }
     mlir::Value getSlice() { return slice(); }
-    bool hasLenParams() { return !lenParams().empty(); }
-    unsigned numLenParams() { return lenParams().size(); }
+    bool hasLenParams() { return !typeparams().empty(); }
+    unsigned numLenParams() { return typeparams().size(); }
   }];
 }
 
@@ -1601,13 +1570,14 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
     Arg<AnyRefOrBox, "", [MemRead]>:$memref,
     Optional<AnyShapeOrShiftType>:$shape,
     Optional<fir_SliceType>:$slice,
-    Variadic<AnyIntegerType>:$lenParams
+    Variadic<AnyIntegerType>:$typeparams
   );
 
   let results = (outs fir_SequenceType);
 
   let assemblyFormat = [{
-    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? (`typeparams` $lenParams^)? attr-dict `:` functional-type(operands, results)
+    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? (`typeparams` $typeparams^)?
+    attr-dict `:` functional-type(operands, results)
   }];
 
   let verifier = [{ return ::verify(*this); }];
@@ -1617,8 +1587,8 @@ def fir_ArrayLoadOp : fir_Op<"array_load", [AttrSizedOperandSegments]> {
   }];
 }
 
-def fir_ArrayFetchOp : fir_Op<"array_fetch", [NoSideEffect]> {
-
+def fir_ArrayFetchOp : fir_Op<"array_fetch", [AttrSizedOperandSegments,
+    NoSideEffect]> {
   let summary = "Fetch the value of an element of an array value";
 
   let description = [{
@@ -1648,20 +1618,22 @@ def fir_ArrayFetchOp : fir_Op<"array_fetch", [NoSideEffect]> {
 
   let arguments = (ins
     fir_SequenceType:$sequence,
-    Variadic<AnyCoordinateType>:$indices
+    Variadic<AnyCoordinateType>:$indices,
+    Variadic<AnyIntegerType>:$typeparams
   );
 
   let results = (outs AnyType:$element);
 
   let assemblyFormat = [{
-    $sequence `,` $indices attr-dict `:` functional-type(operands, results)
+    $sequence `,` $indices (`typeparams` $typeparams^)? attr-dict `:`
+      functional-type(operands, results)
   }];
 
   let verifier = [{
     auto arrTy = sequence().getType().cast<fir::SequenceType>();
     if (indices().size() != arrTy.getDimension())
       return emitOpError("number of indices != dimension of array");
-    if (element().getType() != arrTy.getEleTy())
+    if (adjustedElementType(element().getType()) != arrTy.getEleTy())
       return emitOpError("return type does not match array");
     if (!isa<fir::ArrayLoadOp>(sequence().getDefiningOp()))
       return emitOpError("argument #0 must be result of fir.array_load");
@@ -1669,8 +1641,8 @@ def fir_ArrayFetchOp : fir_Op<"array_fetch", [NoSideEffect]> {
   }];
 }
 
-def fir_ArrayUpdateOp : fir_Op<"array_update", [NoSideEffect]> {
-
+def fir_ArrayUpdateOp : fir_Op<"array_update", [AttrSizedOperandSegments,
+    NoSideEffect]> {
   let summary = "Update the value of an element of an array value";
 
   let description = [{
@@ -1706,18 +1678,20 @@ def fir_ArrayUpdateOp : fir_Op<"array_update", [NoSideEffect]> {
   let arguments = (ins
     fir_SequenceType:$sequence,
     AnyType:$merge,
-    Variadic<AnyCoordinateType>:$indices
+    Variadic<AnyCoordinateType>:$indices,
+    Variadic<AnyIntegerType>:$typeparams
   );
 
   let results = (outs fir_SequenceType);
 
   let assemblyFormat = [{
-    $sequence `,` $merge `,` $indices attr-dict `:` functional-type(operands, results)
+    $sequence `,` $merge `,` $indices (`typeparams` $typeparams^)? attr-dict
+      `:` functional-type(operands, results)
   }];
 
   let verifier = [{
     auto arrTy = sequence().getType().cast<fir::SequenceType>();
-    if (merge().getType() != arrTy.getEleTy())
+    if (adjustedElementType(merge().getType()) != arrTy.getEleTy())
       return emitOpError("merged value does not have element type");
     if (indices().size() != arrTy.getDimension())
       return emitOpError("number of indices != dimension of array");
@@ -1760,10 +1734,14 @@ def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store", [
   let arguments = (ins
     fir_SequenceType:$original,
     fir_SequenceType:$sequence,
-    Arg<AnyRefOrBox, "", [MemWrite]>:$memref
+    Arg<AnyRefOrBox, "", [MemWrite]>:$memref,
+    Variadic<AnyIntegerType>:$typeparams
   );
 
-  let assemblyFormat = "$original `,` $sequence `to` $memref attr-dict `:` type($memref)";
+  let assemblyFormat = [{
+    $original `,` $sequence `to` $memref (`typeparams` $typeparams^)?
+      attr-dict `:` type($memref) (`,` type($typeparams)^)?
+  }];
 
   let verifier = [{
     if (!isa<ArrayLoadOp>(original().getDefiningOp()))
@@ -1808,13 +1786,14 @@ def fir_ArrayCoorOp : fir_Op<"array_coor",
     Optional<AnyShapeOrShiftType>:$shape,
     Optional<fir_SliceType>:$slice,
     Variadic<AnyCoordinateType>:$indices,
-    Variadic<AnyIntegerType>:$lenParams
+    Variadic<AnyIntegerType>:$typeparams
   );
 
   let results = (outs fir_ReferenceType);
 
   let assemblyFormat = [{
-    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? $indices (`typeparams` $lenParams^)? attr-dict `:` functional-type(operands, results)
+    $memref (`(`$shape^`)`)? (`[`$slice^`]`)? $indices (`typeparams`
+      $typeparams^)? attr-dict `:` functional-type(operands, results)
   }];
 
   let verifier = [{ return ::verify(*this); }];
@@ -1919,7 +1898,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
   let arguments = (ins
     StrAttr:$field_id,
     TypeAttr:$on_type,
-    Variadic<AnyIntegerType>:$lenparams
+    Variadic<AnyIntegerType>:$typeparams
   );
 
   let parser = [{
@@ -1957,9 +1936,9 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
       << ", " << (*this)->getAttr(typeAttrName());
     if (getNumOperands()) {
       p << '(';
-      p.printOperands(lenparams());
+      p.printOperands(typeparams());
       auto sep = ") : ";
-      for (auto op : lenparams()) {
+      for (auto op : typeparams()) {
         p << sep;
         if (op)
           p.printType(op.getType());
@@ -2776,6 +2755,20 @@ def fir_StringLitOp : fir_Op<"string_lit", [NoSideEffect]> {
     p.printType(getType());
   }];
 
+  let builders = [
+    OpBuilderDAG<(ins "fir::CharacterType":$in_type,
+      "llvm::StringRef":$value,
+      CArg<"llvm::Optional<int64_t>", "{}">:$len)>,
+    OpBuilderDAG<(ins "fir::CharacterType":$in_type,
+      "llvm::ArrayRef<char>":$xlist,
+      CArg<"llvm::Optional<int64_t>", "{}">:$len)>,
+    OpBuilderDAG<(ins "fir::CharacterType":$in_type,
+      "llvm::ArrayRef<char16_t>":$xlist,
+      CArg<"llvm::Optional<int64_t>", "{}">:$len)>,
+    OpBuilderDAG<(ins "fir::CharacterType":$in_type,
+      "llvm::ArrayRef<char32_t>":$xlist,
+      CArg<"llvm::Optional<int64_t>", "{}">:$len)>];
+
   let verifier = [{
     if (getSize().cast<mlir::IntegerAttr>().getValue().isNegative())
       return emitOpError("size must be non-negative");
@@ -3228,9 +3221,7 @@ def fir_GlobalOp : fir_Op<"global", [IsolatedFromAbove, Symbol]> {
     }
 
     /// The semantic type of the global
-    mlir::Type resultType() {
-      return fir::AllocaOp::wrapResultType(getType());
-    }
+    mlir::Type resultType();
 
     /// Return the initializer attribute if it exists, or a null attribute.
     Attribute getValueOrNull() { return initVal().getValueOr(Attribute()); }

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -109,9 +109,7 @@ inline bool isa_complex(mlir::Type t) {
   return t.isa<fir::ComplexType>() || t.isa<mlir::ComplexType>();
 }
 
-inline bool isa_char(mlir::Type t) {
-   return t.isa<fir::CharacterType>();
-}
+inline bool isa_char(mlir::Type t) { return t.isa<fir::CharacterType>(); }
 
 /// Is `t` a trivial intrinsic type? CHARACTER is <em>excluded</em> because it
 /// is a dependent type.
@@ -130,6 +128,29 @@ inline bool isa_char_string(mlir::Type t) {
 /// It is not possible to deduce the size of a box that describes an entity
 /// of unknown rank or type.
 bool isa_unknown_size_box(mlir::Type t);
+
+/// Returns true iff `t` is a fir.char type and has an unknown length.
+inline bool characterWithDynamicLen(mlir::Type t) {
+  if (auto charTy = t.dyn_cast<fir::CharacterType>())
+    return charTy.hasDynamicLen();
+  return false;
+}
+
+/// Returns true iff `seqTy` has either an unknown shape or a non-constant shape
+/// (where rank > 0).
+inline bool sequenceWithNonConstantShape(fir::SequenceType seqTy) {
+  return seqTy.hasUnknownShape() || !seqTy.hasConstantShape();
+}
+
+/// Returns true iff the type `t` does not have a constant size.
+bool hasDynamicSize(mlir::Type t);
+
+/// If `t` is a SequenceType return its element type, otherwise return `t`.
+inline mlir::Type unwrapSequenceType(mlir::Type t) {
+  if (auto seqTy = t.dyn_cast<fir::SequenceType>())
+    return seqTy.getEleTy();
+  return t;
+}
 
 #ifndef NDEBUG
 // !fir.ptr<X> and !fir.heap<X> where X is !fir.ptr, !fir.heap, or !fir.ref

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -419,7 +419,9 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
     bool hasConstantInterior() const;
 
     // Is the shape of the sequence constant?
-    bool hasConstantShape() const { return getConstantRows() == getDimension(); }
+    bool hasConstantShape() const {
+      return getConstantRows() == getDimension();
+    }
 
     // Does the sequence have unknown shape? (`array<* x T>`)
     bool hasUnknownShape() const { return getShape().empty(); }

--- a/flang/include/flang/Optimizer/Transforms/Factory.h
+++ b/flang/include/flang/Optimizer/Transforms/Factory.h
@@ -1,0 +1,141 @@
+//===-- Optimizer/Transforms/Factory.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Templates to generate more complex code patterns in transformation passes.
+// In transformation passes, front-end information such as is available in
+// lowering is not available.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_TRANSFORMS_FACTORY_H
+#define FORTRAN_OPTIMIZER_TRANSFORMS_FACTORY_H
+
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+
+namespace mlir {
+class Location;
+class Value;
+} // namespace mlir
+
+namespace fir::factory {
+
+/// Generate a character copy with optimized forms.
+///
+/// If the lengths are constant and equal, use load/store rather than a loop.
+/// Otherwise, if the lengths are constant and the input is longer than the
+/// output, generate a loop to move a truncated portion of the source to the
+/// destination. Finally, if the lengths are runtime values or the destination
+/// is longer than the source, move the entire source character and pad the
+/// destination with spaces as needed.
+template <typename B>
+void genCharacterCopy(mlir::Value src, mlir::Value srcLen, mlir::Value dst,
+                      mlir::Value dstLen, B &builder, mlir::Location loc) {
+  auto srcTy =
+      fir::dyn_cast_ptrEleTy(src.getType()).template cast<fir::CharacterType>();
+  auto dstTy =
+      fir::dyn_cast_ptrEleTy(dst.getType()).template cast<fir::CharacterType>();
+  if (!srcLen && !dstLen && srcTy.getFKind() == dstTy.getFKind() &&
+      srcTy.getLen() == dstTy.getLen()) {
+    // same size, so just use load and store
+    auto load = builder.template create<fir::LoadOp>(loc, src);
+    builder.template create<fir::StoreOp>(loc, load, dst);
+    return;
+  }
+  auto zero = builder.template create<mlir::ConstantIndexOp>(loc, 0);
+  auto one = builder.template create<mlir::ConstantIndexOp>(loc, 1);
+  auto toArrayTy = [&](fir::CharacterType ty) {
+    return fir::ReferenceType::get(fir::SequenceType::get(
+        fir::SequenceType::ShapeRef{fir::SequenceType::getUnknownExtent()},
+        fir::CharacterType::getSingleton(ty.getContext(), ty.getFKind())));
+  };
+  auto toEleTy = [&](fir::ReferenceType ty) {
+    auto seqTy = ty.getEleTy().cast<fir::SequenceType>();
+    return seqTy.getEleTy().cast<fir::CharacterType>();
+  };
+  auto toCoorTy = [&](fir::ReferenceType ty) {
+    return fir::ReferenceType::get(toEleTy(ty));
+  };
+  if (!srcLen && !dstLen && srcTy.getLen() >= dstTy.getLen()) {
+    auto upper =
+        builder.template create<mlir::ConstantIndexOp>(loc, dstTy.getLen() - 1);
+    auto loop = builder.template create<fir::DoLoopOp>(loc, zero, upper, one);
+    auto insPt = builder.saveInsertionPoint();
+    builder.setInsertionPointToStart(loop.getBody());
+    auto csrcTy = toArrayTy(srcTy);
+    auto csrc = builder.template create<fir::ConvertOp>(loc, csrcTy, src);
+    auto in = builder.template create<fir::CoordinateOp>(
+        loc, toCoorTy(csrcTy), csrc, loop.getInductionVar());
+    auto load = builder.template create<fir::LoadOp>(loc, in);
+    auto cdstTy = toArrayTy(dstTy);
+    auto cdst = builder.template create<fir::ConvertOp>(loc, cdstTy, dst);
+    auto out = builder.template create<fir::CoordinateOp>(
+        loc, toCoorTy(cdstTy), cdst, loop.getInductionVar());
+    mlir::Value cast =
+        srcTy.getFKind() == dstTy.getFKind()
+            ? load.getResult()
+            : builder
+                  .template create<fir::ConvertOp>(loc, toEleTy(cdstTy), load)
+                  .getResult();
+    builder.template create<fir::StoreOp>(loc, cast, out);
+    builder.restoreInsertionPoint(insPt);
+    return;
+  }
+  auto minusOne = [&](mlir::Value v) -> mlir::Value {
+    return builder.template create<mlir::SubIOp>(
+        loc, builder.template create<fir::ConvertOp>(loc, one.getType(), v),
+        one);
+  };
+  mlir::Value len =
+      dstLen
+          ? minusOne(dstLen)
+          : builder
+                .template create<mlir::ConstantIndexOp>(loc, dstTy.getLen() - 1)
+                .getResult();
+  auto loop = builder.template create<fir::DoLoopOp>(loc, zero, len, one);
+  auto insPt = builder.saveInsertionPoint();
+  builder.setInsertionPointToStart(loop.getBody());
+  mlir::Value slen =
+      srcLen
+          ? builder.template create<fir::ConvertOp>(loc, one.getType(), srcLen)
+                .getResult()
+          : builder.template create<mlir::ConstantIndexOp>(loc, srcTy.getLen())
+                .getResult();
+  auto cond = builder.template create<mlir::CmpIOp>(
+      loc, mlir::CmpIPredicate::slt, loop.getInductionVar(), slen);
+  auto ifOp = builder.template create<fir::IfOp>(loc, cond, /*withElse=*/true);
+  builder.setInsertionPointToStart(&ifOp.thenRegion().front());
+  auto csrcTy = toArrayTy(srcTy);
+  auto csrc = builder.template create<fir::ConvertOp>(loc, csrcTy, src);
+  auto in = builder.template create<fir::CoordinateOp>(
+      loc, toCoorTy(csrcTy), csrc, loop.getInductionVar());
+  auto load = builder.template create<fir::LoadOp>(loc, in);
+  auto cdstTy = toArrayTy(dstTy);
+  auto cdst = builder.template create<fir::ConvertOp>(loc, cdstTy, dst);
+  auto out = builder.template create<fir::CoordinateOp>(
+      loc, toCoorTy(cdstTy), cdst, loop.getInductionVar());
+  mlir::Value cast =
+      srcTy.getFKind() == dstTy.getFKind()
+          ? load.getResult()
+          : builder.template create<fir::ConvertOp>(loc, toEleTy(cdstTy), load)
+                .getResult();
+  builder.template create<fir::StoreOp>(loc, cast, out);
+  builder.setInsertionPointToStart(&ifOp.elseRegion().front());
+  auto space = builder.template create<fir::StringLitOp>(
+      loc, toEleTy(cdstTy), llvm::ArrayRef<char>{' '});
+  auto cdst2 = builder.template create<fir::ConvertOp>(loc, cdstTy, dst);
+  auto out2 = builder.template create<fir::CoordinateOp>(
+      loc, toCoorTy(cdstTy), cdst2, loop.getInductionVar());
+  builder.template create<fir::StoreOp>(loc, space, out2);
+  builder.restoreInsertionPoint(insPt);
+}
+
+} // namespace fir::factory
+
+#endif // FORTRAN_OPTIMIZER_TRANSFORMS_FACTORY_H

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -34,6 +34,7 @@ std::unique_ptr<mlir::Pass> createMemDataFlowOptPass();
 std::unique_ptr<mlir::Pass> createFirToCfgPass();
 std::unique_ptr<mlir::Pass> createArrayValueCopyPass();
 std::unique_ptr<mlir::Pass> createAbstractResultOptPass();
+std::unique_ptr<mlir::Pass> createCharacterConversionPass();
 
 /// A pass to convert the FIR dialect from "Mem-SSA" form to "Reg-SSA" form.
 /// This pass is a port of LLVM's mem2reg pass, but modified for the FIR dialect

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -156,7 +156,26 @@ def AbstractResultOpt : Pass<"abstract-result-opt", "mlir::FuncOp"> {
   let options = [
     Option<"passResultAsBox", "abstract-result-as-box",
            "bool", /*default=*/"false",
-           "Pass fir.array<T> result as fir.box<fir.array<T>> argument instead of fir.ref<fir.array<T>>.">,
+           "Pass fir.array<T> result as fir.box<fir.array<T>> argument instead"
+           " of fir.ref<fir.array<T>>.">
+  ];
+}
+
+def CharacterConversion : Pass<"character-conversion"> {
+  let summary = "Convert CHARACTER entities with different KINDs";
+  let description = [{
+    Translates entities of one CHARACTER KIND to another.
+
+    By default the translation is to naively zero-extend or truncate a code
+    point to fit the destination size.
+  }];
+  let constructor = "::fir::createCharacterConversionPass()";
+  let dependentDialects = [ "fir::FIROpsDialect" ];
+  let options = [
+    Option<"useRuntimeCalls", "use-runtime-calls",
+           "std::string", /*default=*/"std::string{}",
+           "Generate runtime calls to a named set of conversion routines. "
+           "By default, the conversions may produce unexpected results.">
   ];
 }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -919,7 +919,7 @@ private:
       if (info.isStructured()) {
         info.doLoop = builder->create<fir::DoLoopOp>(
             loc, lowerValue, upperValue, info.stepValue, info.isUnordered,
-            /*finalCountValue*/ !info.isUnordered);
+            /*finalCountValue=*/!info.isUnordered);
         builder->setInsertionPointToStart(info.doLoop.getBody());
         // Update the loop variable value, as it may have non-index references.
         auto value = builder->createConvert(loc, genType(info.loopVariableSym),

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -268,7 +268,7 @@ static void addSymbolAttribute(mlir::FuncOp func,
   if (!Fortran::semantics::IsBindCProcedure(sym))
     return;
   auto name =
-      Fortran::lower::mangle::mangleName(sym, /*keepExternalInScope*/ true);
+      Fortran::lower::mangle::mangleName(sym, /*keepExternalInScope=*/true);
   auto strAttr = mlir::StringAttr::get(&mlirContext, name);
   func->setAttr(fir::getSymbolAttrName(), strAttr);
 }

--- a/flang/lib/Lower/CharacterRuntime.cpp
+++ b/flang/lib/Lower/CharacterRuntime.cpp
@@ -67,7 +67,7 @@ Fortran::lower::genRawCharCompare(Fortran::lower::FirOpBuilder &builder,
   }
   auto fTy = beginFunc.getType();
   auto args = Fortran::lower::createArguments(builder, loc, fTy, lhsBuff,
-                                              lhsLen, rhsBuff, rhsLen);
+                                              rhsBuff, lhsLen, rhsLen);
   auto tri = builder.create<fir::CallOp>(loc, beginFunc, args).getResult(0);
   auto zero = builder.createIntegerConstant(loc, tri.getType(), 0);
   return builder.create<mlir::CmpIOp>(loc, cmp, tri, zero);

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -296,6 +296,9 @@ public:
 
   /// Find `symbol` and return its value if it appears in the current mappings.
   SymbolBox lookupSymbol(semantics::SymbolRef sym);
+  SymbolBox lookupSymbol(const semantics::Symbol *sym) {
+    return lookupSymbol(*sym);
+  }
 
   /// Remove all symbols from the map.
   void clear() {

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -98,7 +98,7 @@ public:
     }
     auto xbox = rewriter.create<cg::XEmboxOp>(
         loc, embox.getType(), embox.memref(), shapeOpers, llvm::None,
-        llvm::None, llvm::None, embox.lenParams());
+        llvm::None, llvm::None, embox.typeparams());
     LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
@@ -127,7 +127,7 @@ public:
       }
     auto xbox = rewriter.create<cg::XEmboxOp>(
         loc, embox.getType(), embox.memref(), shapeOpers, shiftOpers,
-        sliceOpers, subcompOpers, embox.lenParams());
+        sliceOpers, subcompOpers, embox.typeparams());
     LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
@@ -221,7 +221,7 @@ public:
       }
     auto xArrCoor = rewriter.create<cg::XArrayCoorOp>(
         loc, arrCoor.getType(), arrCoor.memref(), shapeOpers, shiftOpers,
-        sliceOpers, subcompOpers, arrCoor.indices(), arrCoor.lenParams());
+        sliceOpers, subcompOpers, arrCoor.indices(), arrCoor.typeparams());
     LLVM_DEBUG(llvm::dbgs()
                << "rewriting " << arrCoor << " to " << xArrCoor << '\n');
     rewriter.replaceOp(arrCoor, xArrCoor.getOperation()->getResults());

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -62,38 +62,168 @@ static bool verifyInType(mlir::Type inType,
   return false;
 }
 
-static bool verifyRecordLenParams(mlir::Type inType, unsigned numLenParams) {
-  if (numLenParams > 0) {
-    if (auto rt = inType.dyn_cast<fir::RecordType>())
-      return numLenParams != rt.getNumLenParams();
+static bool verifyTypeParamCount(mlir::Type inType, unsigned numParams) {
+  auto ty = fir::unwrapSequenceType(inType);
+  if (numParams > 0) {
+    if (auto recTy = ty.dyn_cast<fir::RecordType>())
+      return numParams != recTy.getNumLenParams();
+    if (auto chrTy = ty.dyn_cast<fir::CharacterType>())
+      return !(numParams == 1 && chrTy.hasDynamicLen());
     return true;
   }
+  if (auto chrTy = ty.dyn_cast<fir::CharacterType>())
+    return !chrTy.hasConstantLen();
   return false;
+}
+
+// Parser shared by Alloca and Allocmem
+template <typename FN>
+static mlir::ParseResult parseAllocatableOp(FN wrapResultType,
+                                            mlir::OpAsmParser &parser,
+                                            mlir::OperationState &result) {
+  mlir::Type intype;
+  if (parser.parseType(intype))
+    return mlir::failure();
+  auto &builder = parser.getBuilder();
+  result.addAttribute("in_type", mlir::TypeAttr::get(intype));
+  llvm::SmallVector<mlir::OpAsmParser::OperandType> operands;
+  llvm::SmallVector<mlir::Type> typeVec;
+  bool hasOperands = false;
+  std::int32_t typeparamsSize = 0;
+  if (!parser.parseOptionalLParen()) {
+    // parse the LEN params of the derived type. (<params> : <types>)
+    if (parser.parseOperandList(operands, mlir::OpAsmParser::Delimiter::None) ||
+        parser.parseColonTypeList(typeVec) || parser.parseRParen())
+      return mlir::failure();
+    typeparamsSize = operands.size();
+    hasOperands = true;
+  }
+  std::int32_t shapeSize = 0;
+  if (!parser.parseOptionalComma()) {
+    // parse size to scale by, vector of n dimensions of type index
+    if (parser.parseOperandList(operands, mlir::OpAsmParser::Delimiter::None))
+      return mlir::failure();
+    shapeSize = operands.size() - typeparamsSize;
+    auto idxTy = builder.getIndexType();
+    for (std::int32_t i = typeparamsSize, end = operands.size(); i != end; ++i)
+      typeVec.push_back(idxTy);
+    hasOperands = true;
+  }
+  if (hasOperands &&
+      parser.resolveOperands(operands, typeVec, parser.getNameLoc(),
+                             result.operands))
+    return mlir::failure();
+  mlir::Type restype = wrapResultType(intype);
+  if (!restype) {
+    parser.emitError(parser.getNameLoc(), "invalid allocate type: ") << intype;
+    return mlir::failure();
+  }
+  result.addAttribute("operand_segment_sizes",
+                      builder.getI32VectorAttr({typeparamsSize, shapeSize}));
+  if (parser.parseOptionalAttrDict(result.attributes) ||
+      parser.addTypeToList(restype, result.types))
+    return mlir::failure();
+  return mlir::success();
+}
+
+template <typename OP>
+static void printAllocatableOp(mlir::OpAsmPrinter &p, OP &op) {
+  p << op.getOperationName() << ' ' << op.in_type();
+  if (!op.typeparams().empty()) {
+    p << '(' << op.typeparams() << " : " << op.typeparams().getTypes() << ')';
+  }
+  // print the shape of the allocation (if any); all must be index type
+  for (auto sh : op.shape()) {
+    p << ", ";
+    p.printOperand(sh);
+  }
+  p.printOptionalAttrDict(op->getAttrs(), {"in_type", "operand_segment_sizes"});
 }
 
 //===----------------------------------------------------------------------===//
 // AllocaOp
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::AllocaOp::getAllocatedType() {
-  return getType().cast<ReferenceType>().getEleTy();
-}
-
 /// Create a legal memory reference as return type
-mlir::Type fir::AllocaOp::wrapResultType(mlir::Type intype) {
+static mlir::Type wrapAllocaResultType(mlir::Type intype) {
   // FIR semantics: memory references to memory references are disallowed
   if (intype.isa<ReferenceType>())
     return {};
   return ReferenceType::get(intype);
 }
 
+static mlir::ParseResult parseAlloca(mlir::OpAsmParser &parser,
+                                     mlir::OperationState &result) {
+  return parseAllocatableOp(wrapAllocaResultType, parser, result);
+}
+
+static void printAlloca(mlir::OpAsmPrinter &p, fir::AllocaOp &op) {
+  printAllocatableOp(p, op);
+}
+
+mlir::Type fir::AllocaOp::getAllocatedType() {
+  return getType().cast<ReferenceType>().getEleTy();
+}
+
 mlir::Type fir::AllocaOp::getRefTy(mlir::Type ty) {
   return ReferenceType::get(ty);
+}
+
+void fir::AllocaOp::build(mlir::OpBuilder &builder,
+                          mlir::OperationState &result, mlir::Type in_type,
+                          llvm::StringRef uniq_name,
+                          mlir::ValueRange typeparams, mlir::ValueRange shape,
+                          llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  auto nameAttr = builder.getStringAttr(uniq_name);
+  build(builder, result, wrapAllocaResultType(in_type), in_type, nameAttr, {},
+        typeparams, shape);
+  result.addAttributes(attributes);
+}
+
+void fir::AllocaOp::build(mlir::OpBuilder &builder,
+                          mlir::OperationState &result, mlir::Type in_type,
+                          llvm::StringRef uniq_name, llvm::StringRef bindc_name,
+                          mlir::ValueRange typeparams, mlir::ValueRange shape,
+                          llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  auto nameAttr = builder.getStringAttr(uniq_name);
+  auto bindcAttr = builder.getStringAttr(bindc_name);
+  build(builder, result, wrapAllocaResultType(in_type), in_type, nameAttr,
+        bindcAttr, typeparams, shape);
+  result.addAttributes(attributes);
+}
+
+void fir::AllocaOp::build(mlir::OpBuilder &builder,
+                          mlir::OperationState &result, mlir::Type in_type,
+                          mlir::ValueRange typeparams, mlir::ValueRange shape,
+                          llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  build(builder, result, wrapAllocaResultType(in_type), in_type, {}, {},
+        typeparams, shape);
+  result.addAttributes(attributes);
 }
 
 //===----------------------------------------------------------------------===//
 // AllocMemOp
 //===----------------------------------------------------------------------===//
+
+/// Create a legal heap reference as return type
+static mlir::Type wrapAllocMemResultType(mlir::Type intype) {
+  // Fortran semantics: C852 an entity cannot be both ALLOCATABLE and POINTER
+  // 8.5.3 note 1 prohibits ALLOCATABLE procedures as well
+  // FIR semantics: one may not allocate a memory reference value
+  if (intype.isa<ReferenceType>() || intype.isa<HeapType>() ||
+      intype.isa<PointerType>() || intype.isa<FunctionType>())
+    return {};
+  return HeapType::get(intype);
+}
+
+static mlir::ParseResult parseAllocMem(mlir::OpAsmParser &parser,
+                                       mlir::OperationState &result) {
+  return parseAllocatableOp(wrapAllocMemResultType, parser, result);
+}
+
+static void printAllocMem(mlir::OpAsmPrinter &p, fir::AllocMemOp &op) {
+  printAllocatableOp(p, op);
+}
 
 mlir::Type fir::AllocMemOp::getAllocatedType() {
   return getType().cast<HeapType>().getEleTy();
@@ -103,15 +233,37 @@ mlir::Type fir::AllocMemOp::getRefTy(mlir::Type ty) {
   return HeapType::get(ty);
 }
 
-/// Create a legal heap reference as return type
-mlir::Type fir::AllocMemOp::wrapResultType(mlir::Type intype) {
-  // Fortran semantics: C852 an entity cannot be both ALLOCATABLE and POINTER
-  // 8.5.3 note 1 prohibits ALLOCATABLE procedures as well
-  // FIR semantics: one may not allocate a memory reference value
-  if (intype.isa<ReferenceType>() || intype.isa<HeapType>() ||
-      intype.isa<PointerType>() || intype.isa<FunctionType>())
-    return {};
-  return HeapType::get(intype);
+void fir::AllocMemOp::build(mlir::OpBuilder &builder,
+                            mlir::OperationState &result, mlir::Type in_type,
+                            llvm::StringRef uniq_name,
+                            mlir::ValueRange typeparams, mlir::ValueRange shape,
+                            llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  auto nameAttr = builder.getStringAttr(uniq_name);
+  build(builder, result, wrapAllocMemResultType(in_type), in_type, nameAttr, {},
+        typeparams, shape);
+  result.addAttributes(attributes);
+}
+
+void fir::AllocMemOp::build(mlir::OpBuilder &builder,
+                            mlir::OperationState &result, mlir::Type in_type,
+                            llvm::StringRef uniq_name,
+                            llvm::StringRef bindc_name,
+                            mlir::ValueRange typeparams, mlir::ValueRange shape,
+                            llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  auto nameAttr = builder.getStringAttr(uniq_name);
+  auto bindcAttr = builder.getStringAttr(bindc_name);
+  build(builder, result, wrapAllocMemResultType(in_type), in_type, nameAttr,
+        bindcAttr, typeparams, shape);
+  result.addAttributes(attributes);
+}
+
+void fir::AllocMemOp::build(mlir::OpBuilder &builder,
+                            mlir::OperationState &result, mlir::Type in_type,
+                            mlir::ValueRange typeparams, mlir::ValueRange shape,
+                            llvm::ArrayRef<mlir::NamedAttribute> attributes) {
+  build(builder, result, wrapAllocMemResultType(in_type), in_type, {}, {},
+        typeparams, shape);
+  result.addAttributes(attributes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -155,6 +307,19 @@ static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
 //===----------------------------------------------------------------------===//
 // ArrayLoadOp
 //===----------------------------------------------------------------------===//
+
+/// Return the element type, adjusting for reference types (interior to the
+/// array value).
+static mlir::Type adjustedElementType(mlir::Type t) {
+  if (auto ty = t.dyn_cast<fir::ReferenceType>()) {
+    auto eleTy = ty.getEleTy();
+    if (fir::isa_char(eleTy))
+      return eleTy;
+    if (eleTy.isa<fir::RecordType>())
+      return eleTy;
+  }
+  return t;
+}
 
 std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
   if (auto sh = shape())
@@ -298,6 +463,24 @@ static mlir::ParseResult parseCallOp(mlir::OpAsmParser &parser,
   }
   result.addTypes(funcType.getResults());
   result.attributes = attrs;
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
+// CharConvertOp
+//===----------------------------------------------------------------------===//
+
+static mlir::LogicalResult verify(fir::CharConvertOp op) {
+  auto unwrap = [&](mlir::Type t) {
+    t = fir::unwrapSequenceType(fir::dyn_cast_ptrEleTy(t));
+    return t.dyn_cast<fir::CharacterType>();
+  };
+  auto inTy = unwrap(op.from().getType());
+  auto outTy = unwrap(op.to().getType());
+  if (!(inTy && outTy))
+    return op.emitOpError("not a reference to a character");
+  if (inTy.getFKind() == outTy.getFKind())
+    return op.emitOpError("buffers must have different KIND values");
   return mlir::success();
 }
 
@@ -545,7 +728,7 @@ static mlir::LogicalResult verify(fir::EmboxOp op) {
     } else {
       return op.emitOpError("LEN parameters require CHARACTER or derived type");
     }
-    for (auto lp : op.lenParams())
+    for (auto lp : op.typeparams())
       if (!fir::isa_integer(lp.getType()))
         return op.emitOpError("LEN parameters must be integral type");
   }
@@ -569,6 +752,10 @@ void fir::GenTypeDescOp::build(OpBuilder &, OperationState &result,
 //===----------------------------------------------------------------------===//
 // GlobalOp
 //===----------------------------------------------------------------------===//
+
+mlir::Type fir::GlobalOp::resultType() {
+  return wrapAllocaResultType(getType());
+}
 
 static ParseResult parseGlobalOp(OpAsmParser &parser, OperationState &result) {
   // Parse the optional linkage
@@ -1340,7 +1527,7 @@ static mlir::LogicalResult verify(fir::SaveResultOp op) {
         "value operand must be a fir.box, fir.array or fir.type");
 
   if (resultType.isa<fir::BoxType>()) {
-    if (op.shape() || !op.lenParams().empty())
+    if (op.shape() || !op.typeparams().empty())
       return op.emitOpError(
           "must not have shape or length operands if the value is a fir.box");
     return mlir::success();
@@ -1369,15 +1556,15 @@ static mlir::LogicalResult verify(fir::SaveResultOp op) {
   }
 
   if (auto recTy = eleTy.dyn_cast<fir::RecordType>()) {
-    if (recTy.getNumLenParams() != op.lenParams().size())
+    if (recTy.getNumLenParams() != op.typeparams().size())
       op.emitOpError("length parameters number must match with the value type "
                      "length parameters");
   } else if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
-    if (op.lenParams().size() > 1)
+    if (op.typeparams().size() > 1)
       op.emitOpError("no more than one length parameter must be provided for "
                      "character value");
   } else {
-    if (!op.lenParams().empty())
+    if (!op.typeparams().empty())
       op.emitOpError(
           "length parameters must not be provided for this value type");
   }
@@ -1807,6 +1994,69 @@ mlir::Type fir::StoreOp::elementType(mlir::Type refType) {
 bool fir::StringLitOp::isWideValue() {
   auto eleTy = getType().cast<fir::SequenceType>().getEleTy();
   return eleTy.cast<fir::CharacterType>().getFKind() != 1;
+}
+
+static mlir::NamedAttribute
+mkNamedIntegerAttr(mlir::OpBuilder &builder, llvm::StringRef name, int64_t v) {
+  assert(v > 0);
+  return builder.getNamedAttr(
+      name, builder.getIntegerAttr(builder.getIntegerType(64), v));
+}
+
+void fir::StringLitOp::build(mlir::OpBuilder &builder, OperationState &result,
+                             fir::CharacterType in_type, llvm::StringRef val,
+                             llvm::Optional<int64_t> len) {
+  auto valAttr = builder.getNamedAttr(value(), builder.getStringAttr(val));
+  int64_t length = len.hasValue() ? len.getValue() : in_type.getLen();
+  auto lenAttr = mkNamedIntegerAttr(builder, size(), length);
+  result.addAttributes({valAttr, lenAttr});
+  result.addTypes(in_type);
+}
+
+template <typename C>
+static mlir::ArrayAttr convertToArrayAttr(mlir::OpBuilder &builder,
+                                          llvm::ArrayRef<C> xlist) {
+  llvm::SmallVector<mlir::Attribute> attrs;
+  auto ty = builder.getIntegerType(8 * sizeof(C));
+  for (auto ch : xlist)
+    attrs.push_back(builder.getIntegerAttr(ty, ch));
+  return builder.getArrayAttr(attrs);
+}
+
+void fir::StringLitOp::build(mlir::OpBuilder &builder, OperationState &result,
+                             fir::CharacterType in_type,
+                             llvm::ArrayRef<char> vlist,
+                             llvm::Optional<int64_t> len) {
+  auto valAttr =
+      builder.getNamedAttr(xlist(), convertToArrayAttr(builder, vlist));
+  std::int64_t length = len.hasValue() ? len.getValue() : in_type.getLen();
+  auto lenAttr = mkNamedIntegerAttr(builder, size(), length);
+  result.addAttributes({valAttr, lenAttr});
+  result.addTypes(in_type);
+}
+
+void fir::StringLitOp::build(mlir::OpBuilder &builder, OperationState &result,
+                             fir::CharacterType in_type,
+                             llvm::ArrayRef<char16_t> vlist,
+                             llvm::Optional<int64_t> len) {
+  auto valAttr =
+      builder.getNamedAttr(xlist(), convertToArrayAttr(builder, vlist));
+  std::int64_t length = len.hasValue() ? len.getValue() : in_type.getLen();
+  auto lenAttr = mkNamedIntegerAttr(builder, size(), length);
+  result.addAttributes({valAttr, lenAttr});
+  result.addTypes(in_type);
+}
+
+void fir::StringLitOp::build(mlir::OpBuilder &builder, OperationState &result,
+                             fir::CharacterType in_type,
+                             llvm::ArrayRef<char32_t> vlist,
+                             llvm::Optional<int64_t> len) {
+  auto valAttr =
+      builder.getNamedAttr(xlist(), convertToArrayAttr(builder, vlist));
+  std::int64_t length = len.hasValue() ? len.getValue() : in_type.getLen();
+  auto lenAttr = mkNamedIntegerAttr(builder, size(), length);
+  result.addAttributes({valAttr, lenAttr});
+  result.addTypes(in_type);
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -230,6 +230,33 @@ mlir::Type dyn_cast_ptrOrBoxEleTy(mlir::Type t) {
       .Default([](mlir::Type) { return mlir::Type{}; });
 }
 
+static bool hasDynamicSize(fir::RecordType recTy) {
+  for (auto field : recTy.getTypeList()) {
+    if (auto arr = field.second.dyn_cast<fir::SequenceType>()) {
+      if (sequenceWithNonConstantShape(arr))
+        return true;
+    } else if (characterWithDynamicLen(field.second)) {
+      return true;
+    } else if (auto rec = field.second.dyn_cast<fir::RecordType>()) {
+      if (hasDynamicSize(rec))
+        return true;
+    }
+  }
+  return false;
+}
+
+bool hasDynamicSize(mlir::Type t) {
+  if (auto arr = t.dyn_cast<fir::SequenceType>()) {
+    if (sequenceWithNonConstantShape(arr))
+      return true;
+    t = arr.getEleTy();
+  }
+  if (characterWithDynamicLen(t))
+    return true;
+  if (auto rec = t.dyn_cast<fir::RecordType>())
+    return hasDynamicSize(rec);
+  return false;
+}
 } // namespace fir
 
 namespace {

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -101,7 +101,7 @@ public:
     if (mustEmboxResult(result.getType(), options))
       arg = rewriter.create<fir::EmboxOp>(
           loc, argType, buffer, saveResult.shape(), /*slice*/ mlir::Value{},
-          saveResult.lenParams());
+          saveResult.typeparams());
 
     llvm::SmallVector<mlir::Type> newResultTypes;
     if (callOp.callee()) {
@@ -220,7 +220,7 @@ public:
     mlir::OwningRewritePatternList patterns;
     mlir::ConversionTarget target = *context;
     AbstractResultOptions options{passResultAsBox.getValue(),
-                                  /*newArg*/ {}};
+                                  /*newArg=*/{}};
 
     // Convert function type itself if it has an abstract result
     auto funcTy = func.getType().cast<mlir::FunctionType>();

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_flang_library(FIRTransforms
   AffineDemotion.cpp
   AffinePromotion.cpp
   ArrayValueCopy.cpp
+  CharacterConversion.cpp
   ControlFlowConverter.cpp
   CSE.cpp
   FirLoopResultOpt.cpp

--- a/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
@@ -1,0 +1,127 @@
+//===- CharacterConversion.cpp -- convert between character encodings ---*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/FIRContext.h"
+#include "flang/Optimizer/Support/KindMapping.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#define DEBUG_TYPE "flang-character-conversion"
+
+namespace {
+
+// TODO: Future hook to select some set of runtime calls.
+struct CharacterConversionOptions {
+  std::string runtimeName;
+};
+
+class CharacterConvertConversion
+    : public mlir::OpRewritePattern<fir::CharConvertOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(fir::CharConvertOp conv,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto kindMap = fir::getKindMapping(conv->getParentOfType<mlir::ModuleOp>());
+    auto loc = conv.getLoc();
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "running character conversion on " << conv << '\n');
+
+    // Establish a loop that executes count iterations.
+    auto zero = rewriter.create<mlir::ConstantIndexOp>(loc, 0);
+    auto one = rewriter.create<mlir::ConstantIndexOp>(loc, 1);
+    auto idxTy = rewriter.getIndexType();
+    auto castCnt = rewriter.create<fir::ConvertOp>(loc, idxTy, conv.count());
+    auto countm1 = rewriter.create<mlir::SubIOp>(loc, castCnt, one);
+    auto loop = rewriter.create<fir::DoLoopOp>(loc, zero, countm1, one);
+    auto insPt = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPointToStart(loop.getBody());
+
+    // For each code point in the `from` string, convert naively to the `to`
+    // string code point. Conversion is done blindly on size only, not value.
+    auto getCharBits = [&](mlir::Type t) {
+      auto chrTy = fir::unwrapSequenceType(fir::dyn_cast_ptrEleTy(t))
+                       .cast<fir::CharacterType>();
+      return kindMap.getCharacterBitsize(chrTy.getFKind());
+    };
+    auto fromBits = getCharBits(conv.from().getType());
+    auto toBits = getCharBits(conv.to().getType());
+    auto pointerType = [&](unsigned bits) {
+      return fir::ReferenceType::get(fir::SequenceType::get(
+          fir::SequenceType::ShapeRef{fir::SequenceType::getUnknownExtent()},
+          rewriter.getIntegerType(bits)));
+    };
+    auto fromPtrTy = pointerType(fromBits);
+    auto toTy = rewriter.getIntegerType(toBits);
+    auto toPtrTy = pointerType(toBits);
+    auto fromPtr = rewriter.create<fir::ConvertOp>(loc, fromPtrTy, conv.from());
+    auto toPtr = rewriter.create<fir::ConvertOp>(loc, toPtrTy, conv.to());
+    auto getEleTy = [&](unsigned bits) {
+      return fir::ReferenceType::get(rewriter.getIntegerType(bits));
+    };
+    auto fromi = rewriter.create<fir::CoordinateOp>(
+        loc, getEleTy(fromBits), fromPtr,
+        mlir::ValueRange{loop.getInductionVar()});
+    auto toi = rewriter.create<fir::CoordinateOp>(
+        loc, getEleTy(toBits), toPtr, mlir::ValueRange{loop.getInductionVar()});
+    auto load = rewriter.create<fir::LoadOp>(loc, fromi);
+    mlir::Value icast =
+        (fromBits >= toBits)
+            ? rewriter.create<fir::ConvertOp>(loc, toTy, load).getResult()
+            : rewriter.create<mlir::ZeroExtendIOp>(loc, toTy, load).getResult();
+    rewriter.replaceOpWithNewOp<fir::StoreOp>(conv, icast, toi);
+    rewriter.restoreInsertionPoint(insPt);
+    return mlir::success();
+  }
+};
+
+/// Rewrite the `fir.char_convert` op into a loop. This pass must be run only on
+/// fir::CharConvertOp.
+class CharacterConversion
+    : public fir::CharacterConversionBase<CharacterConversion> {
+public:
+  void runOnOperation() override {
+    CharacterConversionOptions clOpts{useRuntimeCalls.getValue()};
+    if (clOpts.runtimeName.empty()) {
+      auto *context = &getContext();
+      auto func = getOperation();
+      mlir::OwningRewritePatternList patterns;
+      patterns.insert<CharacterConvertConversion>(context);
+      mlir::ConversionTarget target(*context);
+      target.addLegalDialect<mlir::AffineDialect, fir::FIROpsDialect,
+                             mlir::StandardOpsDialect>();
+
+      // apply the patterns
+      target.addIllegalOp<fir::CharConvertOp>();
+      if (mlir::failed(mlir::applyPartialConversion(func, target,
+                                                    std::move(patterns)))) {
+        mlir::emitError(mlir::UnknownLoc::get(context),
+                        "error in rewriting character convert op");
+        signalPassFailure();
+      }
+      return;
+    }
+
+    // TODO: some sort of runtime supported conversion?
+    signalPassFailure();
+  }
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> fir::createCharacterConversionPass() {
+  return std::make_unique<CharacterConversion>();
+}

--- a/flang/test/Fir/abstract-results.fir
+++ b/flang/test/Fir/abstract-results.fir
@@ -179,7 +179,7 @@ func private @chararrayfunc(index, index) -> !fir.array<?x!fir.char<1,?>>
 func @call_chararrayfunc() {
   %c100 = constant 100 : index
   %c50 = constant 50 : index
-  %buffer = fir.alloca !fir.array<?x!fir.char<1,?>>, %c100, %c50
+  %buffer = fir.alloca !fir.array<?x!fir.char<1,?>>(%c100 : index), %c50
   %shape = fir.shape %c100 : (index) -> !fir.shape<1>
   %res = fir.call @chararrayfunc(%c100, %c50) : (index, index) -> !fir.array<?x!fir.char<1,?>>
   fir.save_result %res to %buffer(%shape) typeparams %c50 : !fir.array<?x!fir.char<1,?>>, !fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index
@@ -187,13 +187,13 @@ func @call_chararrayfunc() {
 
   // CHECK: %[[c100:.*]] = constant 100 : index
   // CHECK: %[[c50:.*]] = constant 50 : index
-  // CHECK: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>, %[[c100]], %[[c50]]
+  // CHECK: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>(%[[c100]] : index), %[[c50]]
   // CHECK: fir.call @chararrayfunc(%[[buffer]], %[[c100]], %[[c50]]) : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, index, index) -> ()
   // CHECK-NOT: fir.save_result
 
   // CHECK-BOX: %[[c100:.*]] = constant 100 : index
   // CHECK-BOX: %[[c50:.*]] = constant 50 : index
-  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>, %[[c100]], %[[c50]]
+  // CHECK-BOX: %[[buffer:.*]] = fir.alloca !fir.array<?x!fir.char<1,?>>(%[[c100]] : index), %[[c50]]
   // CHECK-BOX: %[[shape:.*]] = fir.shape %[[c100]] : (index) -> !fir.shape<1>
   // CHECK-BOX: %[[box:.*]] = fir.embox %[[buffer]](%[[shape]]) typeparams %[[c50]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
   // CHECK-BOX: fir.call @chararrayfunc(%[[box]], %[[c100]], %[[c50]]) : (!fir.box<!fir.array<?x!fir.char<1,?>>>, index, index) -> ()

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -728,3 +728,12 @@ func @test_save_result(%buffer: !fir.ref<!fir.array<?x!fir.char<1,?>>>) {
   fir.save_result %res to %buffer(%shape) typeparams %c50 : !fir.array<?x!fir.char<1,?>>, !fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index
   return
 }
+
+func @char_convert() {
+  %1 = fir.undefined i32
+  %2 = fir.undefined !fir.ref<!fir.char<1>>
+  %3 = fir.undefined !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  // CHECK: fir.char_convert %{{.*}} for %{{.*}} to %{{.*}} : !fir.ref<!fir.char<1>>, i32, !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  fir.char_convert %2 for %1 to %3 : !fir.ref<!fir.char<1>>, i32, !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  return
+}

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -454,3 +454,47 @@ func @bad_save_result(%buffer : !fir.ref<!fir.array<?xf32>>, %n :index) {
   fir.save_result %res to %buffer(%shape) typeparams %n : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index
   return
 }
+
+// -----
+
+func @ugly_char_convert() {
+  %1 = fir.undefined i32
+  %2 = fir.undefined !fir.ref<!fir.char<1>>
+  %3 = fir.undefined !fir.ref<!fir.array<?x!fir.char<1>>>
+  // expected-error@+1 {{'fir.char_convert' op buffers must have different KIND values}}
+  fir.char_convert %2 for %1 to %3 : !fir.ref<!fir.char<1>>, i32, !fir.ref<!fir.array<?x!fir.char<1>>>
+  return
+}
+
+// -----
+
+func @ugly_char_convert() {
+  %1 = fir.undefined i32
+  %2 = fir.undefined !fir.ref<!fir.char<1>>
+  %3 = fir.undefined !fir.ref<!fir.array<?xf32>>
+  // expected-error@+1 {{'fir.char_convert' op not a reference to a character}}
+  fir.char_convert %2 for %1 to %3 : !fir.ref<!fir.char<1>>, i32, !fir.ref<!fir.array<?xf32>>
+  return
+}
+
+// -----
+
+func @ugly_char_convert() {
+  %1 = fir.undefined i32
+  %2 = fir.undefined !fir.ref<!fir.char<1>>
+  %3 = fir.undefined !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  // expected-error@+1 {{'fir.char_convert' op operand #0 must be any reference, but got 'i32'}}
+  fir.char_convert %1 for %1 to %3 : i32, i32, !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  return
+}
+
+// -----
+
+func @ugly_char_convert() {
+  %1 = fir.undefined i32
+  %2 = fir.undefined !fir.ref<!fir.char<1>>
+  %3 = fir.undefined !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  // expected-error@+1 {{'fir.char_convert' op operand #1 must be any integer, but got '!fir.ref<!fir.char<1>>'}}
+  fir.char_convert %2 for %2 to %3 : !fir.ref<!fir.char<1>>, !fir.ref<!fir.char<1>>, !fir.ref<!fir.array<?x!fir.char<2,?>>>
+  return
+}

--- a/flang/test/Lower/OpenACC/acc-data.f90
+++ b/flang/test/Lower/OpenACC/acc-data.f90
@@ -6,9 +6,9 @@ subroutine acc_data
   real, dimension(10, 10) :: a, b, c
   logical :: ifCondition = .TRUE.
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 
   !$acc data if(.TRUE.) copy(a)
   !$acc end data

--- a/flang/test/Lower/OpenACC/acc-enter-data.f90
+++ b/flang/test/Lower/OpenACC/acc-enter-data.f90
@@ -7,9 +7,9 @@ subroutine acc_enter_data
   real, dimension(10, 10) :: a, b, c
   logical :: ifCondition = .TRUE.
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 
   !$acc enter data create(a)
 !CHECK: acc.enter_data create([[A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}

--- a/flang/test/Lower/OpenACC/acc-exit-data.f90
+++ b/flang/test/Lower/OpenACC/acc-exit-data.f90
@@ -7,9 +7,9 @@ subroutine acc_exit_data
   real, dimension(10, 10) :: a, b, c
   logical :: ifCondition = .TRUE.
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 
   !$acc exit data delete(a)
 !CHECK: acc.exit_data delete([[A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}

--- a/flang/test/Lower/OpenACC/acc-parallel-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel-loop.f90
@@ -21,9 +21,9 @@ subroutine acc_parallel_loop
   integer :: vectorNum = 128
   integer, parameter :: tileSize = 2
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 !CHECK: [[IFCONDITION:%.*]] = fir.address_of(@{{.*}}ifcondition) : !fir.ref<!fir.logical<4>>
 
   !$acc parallel loop

--- a/flang/test/Lower/OpenACC/acc-parallel.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel.f90
@@ -14,9 +14,9 @@ subroutine acc_parallel
   logical :: ifCondition = .TRUE.
   real, dimension(10, 10) :: a, b, c
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 !CHECK: [[IFCONDITION:%.*]] = fir.address_of(@{{.*}}ifcondition) : !fir.ref<!fir.logical<4>>
 
   !$acc parallel

--- a/flang/test/Lower/OpenACC/acc-update.f90
+++ b/flang/test/Lower/OpenACC/acc-update.f90
@@ -7,9 +7,9 @@ subroutine acc_update
   real, dimension(10, 10) :: a, b, c
   logical :: ifCondition = .TRUE.
 
-!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ea"}
-!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Eb"}
-!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {name = "{{.*}}Ec"}
+!CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
+!CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
+!CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
 
   !$acc update host(a)
 !CHECK: acc.update host([[A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}

--- a/flang/test/Lower/OpenMP/omp-flush.f90
+++ b/flang/test/Lower/OpenMP/omp-flush.f90
@@ -13,14 +13,14 @@ program flush
         integer :: a,b,c
 
 !FIRDialect-LABEL:func @_QQmain() {
-!FIRDialect:  %{{.*}} = fir.alloca i32 {name = "{{.*}}Ea"}
-!FIRDialect:  %{{.*}} = fir.alloca i32 {name = "{{.*}}Eb"}
-!FIRDialect:  %{{.*}} = fir.alloca i32 {name = "{{.*}}Ec"}
+!FIRDialect:  %{{.*}} = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ea"}
+!FIRDialect:  %{{.*}} = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eb"}
+!FIRDialect:  %{{.*}} = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ec"}
 
 !LLVMIRDialect-LABEL: llvm.func @_QQmain() {
-!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ea"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Eb"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ec"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ea"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Eb"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect:   %{{.*}} = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ec"} : (i64) -> !llvm.ptr<i32>
 
 !LLVMIR-LABEL: define void @_QQmain() {{.*}} {
 !LLVMIR:   %{{.*}} = alloca i32, i64 1, align 4

--- a/flang/test/Lower/OpenMP/omp-parallel-allocate-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-allocate-clause.f90
@@ -5,17 +5,17 @@
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 
 !FIRDialect: func @_QPallocate_clause(%arg0: !fir.ref<f32>, %arg1: !fir.ref<f32>) {
-!FIRDialect-DAG: %[[A:.*]] = fir.alloca i32 {name = "{{.*}}Ea"}
-!FIRDialect-DAG: %[[B:.*]] = fir.alloca i32 {name = "{{.*}}Eb"}
-!FIRDialect-DAG: %[[C:.*]] = fir.alloca i32 {name = "{{.*}}Ec"}
-!FIRDialect-DAG: %[[D:.*]] = fir.alloca i32 {name = "{{.*}}Ed"}
-!FIRDialect-DAG: %[[E:.*]] = fir.alloca i32 {name = "{{.*}}Ee"}
-!FIRDialect-DAG: %[[F:.*]] = fir.alloca i32 {name = "{{.*}}Ef"}
-!FIRDialect-DAG: %[[G:.*]] = fir.alloca i32 {name = "{{.*}}Eg"}
-!FIRDialect-DAG: %[[H:.*]] = fir.alloca i32 {name = "{{.*}}Eh"}
-!FIRDialect-DAG: %[[X:.*]] = fir.alloca i32 {name = "{{.*}}Ex"}
-!FIRDialect-DAG: %[[Y:.*]] = fir.alloca i32 {name = "{{.*}}Ey"}
-!FIRDialect-DAG: %[[Z:.*]] = fir.alloca i32 {name = "{{.*}}Ez"}
+!FIRDialect-DAG: %[[A:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ea"}
+!FIRDialect-DAG: %[[B:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eb"}
+!FIRDialect-DAG: %[[C:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ec"}
+!FIRDialect-DAG: %[[D:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ed"}
+!FIRDialect-DAG: %[[E:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ee"}
+!FIRDialect-DAG: %[[F:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ef"}
+!FIRDialect-DAG: %[[G:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eg"}
+!FIRDialect-DAG: %[[H:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eh"}
+!FIRDialect-DAG: %[[X:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ex"}
+!FIRDialect-DAG: %[[Y:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ey"}
+!FIRDialect-DAG: %[[Z:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ez"}
 
 subroutine allocate_clause(arg1, arg2)
 use omp_lib

--- a/flang/test/Lower/OpenMP/omp-parallel-copyin-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-copyin-clause.f90
@@ -8,20 +8,20 @@
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
 
 !FIRDialect: func @_QPcopyin_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
-!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {name = "{{.*}}Ealpha"}
-!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {name = "{{.*}}Ebeta"}
-!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {name = "{{.*}}Egama"}
-!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {name = "{{.*}}Ealpha_array"}
+!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
+!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ebeta"}
+!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Egama"}
+!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {{{.*}}uniq_name = "{{.*}}Ealpha_array"}
 !FIRDialect:  omp.parallel copyin(%[[ALPHA]] : !fir.ref<i32>, %[[BETA]] : !fir.ref<i32>, %[[GAMA]] : !fir.ref<i32>, %[[ALPHA_ARRAY]]
 !: !fir.ref<!fir.array<10xi32>>, %[[ARG1]] : !fir.ref<i32>, %[[ARG2]] : !fir.ref<!fir.array<10xi32>>)) {
 !FIRDialect:    omp.terminator
 !FIRDialect:  }
 
 !LLVMDialect: llvm.func @_QPcopyin_clause(%[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>) {
-!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {in_type = !fir.array<10xi32>, name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
+!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {{{.*}}, uniq_name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
 !LLVMIRDialect:  omp.parallel copyin(%[[ALPHA]] : !llvm.ptr<i32>, %[[BETA]] : !llvm.ptr<i32>, %[[GAMA]] : !llvm.ptr<i32>,
 !%[[ALPHA_ARRAY]] : !llvm.ptr<array<10 x i32>>, %[[ARG1]] : !llvm.ptr<i32>, %[[ARG2]] : !llvm.ptr<array<10 x i32>>) {
 !LLVMIRDialect:    omp.terminator

--- a/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause.f90
@@ -8,20 +8,20 @@
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
 
 !FIRDialect: func @_QPfirstprivate_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
-!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {name = "{{.*}}Ealpha"}
-!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {name = "{{.*}}Ebeta"}
-!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {name = "{{.*}}Egama"}
-!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {name = "{{.*}}Ealpha_array"}
+!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
+!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ebeta"}
+!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Egama"}
+!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {{{.*}}uniq_name = "{{.*}}Ealpha_array"}
 !FIRDialect:  omp.parallel firstprivate(%[[ALPHA]] : !fir.ref<i32>, %[[BETA]] : !fir.ref<i32>, %[[GAMA]] : !fir.ref<i32>,
 !%[[ALPHA_ARRAY]] : !fir.ref<!fir.array<10xi32>>, %[[ARG1]] : !fir.ref<i32>, %[[ARG2]] : !fir.ref<!fir.array<10xi32>>)) {
 !FIRDialect:    omp.terminator
 !FIRDialect:  }
 
 !LLVMDialect: llvm.func @_QPfirstprivate_clause(%[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>) {
-!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {in_type = !fir.array<10xi32>, name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
+!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {{{.*}}, uniq_name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
 !LLVMIRDialect:  omp.parallel firstprivate(%[[ALPHA]] : !llvm.ptr<i32>, %[[BETA]] : !llvm.ptr<i32>, %[[GAMA]] : !llvm.ptr<i32>,
 !%[[ALPHA_ARRAY]] : !llvm.ptr<array<10 x i32>>, %[[ARG1]] : !llvm.ptr<i32>, %[[ARG2]] : !llvm.ptr<array<10 x i32>>) {
 !LLVMIRDialect:    omp.terminator

--- a/flang/test/Lower/OpenMP/omp-parallel-if-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-if-clause.f90
@@ -10,7 +10,7 @@
 ! RUN:   tco | FileCheck %s --check-prefix=LLVMIR
 
 !FIRDialect-LABEL: func @_QQmain() {
-!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {name = "{{.*}}Ealpha"}
+!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
 !FIRDialect-DAG: %[[CONSTANT_4:.*]] = constant 4 : i32
 !FIRDialect-DAG: fir.store %[[CONSTANT_4]] to %[[ALPHA]] : !fir.ref<i32>
 !FIRDialect-DAG: %[[CONSTANT_0:.*]] = constant 0 : i32
@@ -23,7 +23,7 @@
 !LLVMIRDialect-LABEL:   llvm.func @_QQmain() {
 !LLVMIRDialect-DAG: %[[CONSTANT_4:.*]] = llvm.mlir.constant(4 : i32) : i32
 !LLVMIRDialect-DAG: %[[CONSTANT_0:.*]] = llvm.mlir.constant(0 : i32) : i32
-!LLVMIRDialect-DAG: %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
 !LLVMIRDialect-DAG: llvm.store %[[CONSTANT_4]], %[[ALPHA]] : !llvm.ptr<i32>
 !LLVMIRDialect-DAG: %[[LD_ALPHA:.*]] = llvm.load %[[ALPHA]] : !llvm.ptr<i32>
 !LLVMIRDialect:     %[[COND:.*]] = llvm.icmp "sle" %[[LD_ALPHA]], %[[CONSTANT_0]] : i32

--- a/flang/test/Lower/OpenMP/omp-parallel-private-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-private-clause.f90
@@ -8,20 +8,20 @@
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
 
 !FIRDialect: func @_QPprivate_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
-!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {name = "{{.*}}Ealpha"}
-!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {name = "{{.*}}Ebeta"}
-!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {name = "{{.*}}Egama"}
-!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {name = "{{.*}}Ealpha_array"}
+!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
+!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ebeta"}
+!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Egama"}
+!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {{{.*}}uniq_name = "{{.*}}Ealpha_array"}
 !FIRDialect-DAG:  omp.parallel private(%[[ALPHA]] : !fir.ref<i32>, %[[BETA]] : !fir.ref<i32>, %[[GAMA]] : !fir.ref<i32>,
 !%[[ALPHA_ARRAY]] : !fir.ref<!fir.array<10xi32>>, %[[ARG1]] : !fir.ref<i32>, %[[ARG2]] : !fir.ref<!fir.array<10xi32>>)) {
 !FIRDialect:    omp.terminator
 !FIRDialect:  }
 
 !LLVMDialect: llvm.func @_QPprivate_clause(%[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>) {
-!LLVMIRDialect-DAG: %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {in_type = !fir.array<10xi32>, name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
+!LLVMIRDialect-DAG: %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {{{.*}}, uniq_name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
 !LLVMIRDialect:  omp.parallel private(%[[ALPHA]] : !llvm.ptr<i32>, %[[BETA]] : !llvm.ptr<i32>, %[[GAMA]] : !llvm.ptr<i32>,
 !%[[ALPHA_ARRAY]] : !llvm.ptr<array<10 x i32>>, %[[ARG1]] : !llvm.ptr<i32>, %[[ARG2]] : !llvm.ptr<array<10 x i32>>) {
 !LLVMIRDialect:    omp.terminator

--- a/flang/test/Lower/OpenMP/omp-parallel-region.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-region.f90
@@ -16,15 +16,15 @@ program parallel
 
         a = 1
         b = 2
-!FIRDialect:  %[[VAR_A:.*]] = fir.alloca i32 {name = "{{.*}}Ea"}
-!FIRDialect:  %[[VAR_B:.*]] = fir.alloca i32 {name = "{{.*}}Eb"}
-!FIRDialect:  %[[VAR_C:.*]] = fir.alloca i32 {name = "{{.*}}Ec"}
-!FIRDialect:  %[[VAR_NUM_THREADS:.*]] = fir.alloca i32 {name = "{{.*}}Enum_threads"}
+!FIRDialect:  %[[VAR_A:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ea"}
+!FIRDialect:  %[[VAR_B:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eb"}
+!FIRDialect:  %[[VAR_C:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ec"}
+!FIRDialect:  %[[VAR_NUM_THREADS:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enum_threads"}
 
-!LLVMIRDialect: %[[VAR_A:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ea"}
-!LLVMIRDialect: %[[VAR_B:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Eb"}
-!LLVMIRDialect: %[[VAR_C:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ec"}
-!LLVMIRDialect: %[[VAR_NUM_THREADS:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Enum_threads"}
+!LLVMIRDialect: %[[VAR_A:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, {{.*}}, uniq_name = "{{.*}}Ea"}
+!LLVMIRDialect: %[[VAR_B:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, {{.*}}, uniq_name = "{{.*}}Eb"}
+!LLVMIRDialect: %[[VAR_C:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, {{.*}}, uniq_name = "{{.*}}Ec"}
+!LLVMIRDialect: %[[VAR_NUM_THREADS:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Enum_threads"}
 
 !LLVMIR: %[[OMP_GLOBAL_THREAD_NUM:.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @{{.*}})
 !LLVMIR: call void @__kmpc_push_num_threads(%struct.ident_t* @{{.*}}, i32 %[[OMP_GLOBAL_THREAD_NUM]], i32 %{{.*}})

--- a/flang/test/Lower/OpenMP/omp-parallel-shared-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-shared-clause.f90
@@ -8,20 +8,20 @@
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
 
 !FIRDialect: func @_QPshared_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
-!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {name = "{{.*}}Ealpha"}
-!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {name = "{{.*}}Ebeta"}
-!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {name = "{{.*}}Egama"}
-!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {name = "{{.*}}Ealpha_array"}
+!FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
+!FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ebeta"}
+!FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Egama"}
+!FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {{{.*}}uniq_name = "{{.*}}Ealpha_array"}
 !FIRDialect:  omp.parallel shared(%[[ALPHA]] : !fir.ref<i32>, %[[BETA]] : !fir.ref<i32>, %[[GAMA]] : !fir.ref<i32>, %[[ALPHA_ARRAY]]
 !: !fir.ref<!fir.array<10xi32>>, %[[ARG1]] : !fir.ref<i32>, %[[ARG2]] : !fir.ref<!fir.array<10xi32>>)) {
 !FIRDialect:    omp.terminator
 !FIRDialect:  }
 
 !LLVMDialect: llvm.func @_QPshared_clause(%[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>) {
-!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {in_type = i32, name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
-!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {in_type = !fir.array<10xi32>, name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
+!LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>
+!LLVMIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = llvm.alloca %{{.*}} x !llvm.array<10 x i32> {{{.*}}, uniq_name = "{{.*}}Ealpha_array"} : (i64) -> !llvm.ptr<array<10 x i32>>
 !LLVMIRDialect:  omp.parallel shared(%[[ALPHA]] : !llvm.ptr<i32>, %[[BETA]] : !llvm.ptr<i32>, %[[GAMA]] : !llvm.ptr<i32>,
 !%[[ALPHA_ARRAY]] : !llvm.ptr<array<10 x i32>>, %[[ARG1]] : !llvm.ptr<i32>, %[[ARG2]] : !llvm.ptr<array<10 x i32>>) {
 !LLVMIRDialect:    omp.terminator

--- a/flang/test/Lower/OpenMP/omp-seqloop.f90
+++ b/flang/test/Lower/OpenMP/omp-seqloop.f90
@@ -9,7 +9,7 @@ program wsloop
 
 !FIRDialect:  omp.parallel {
         !$OMP PARALLEL
-!FIRDialect:    %[[PRIVATE_INDX:.*]] = fir.alloca i32 {name = "i"}
+!FIRDialect:    %[[PRIVATE_INDX:.*]] = fir.alloca i32 {{{.*}}uniq_name = "i"}
 !FIRDialect:    %[[FINAL_INDX:.*]] = fir.do_loop %[[INDX:.*]] = {{.*}} {
         do i=1, 9
         print*, i

--- a/flang/test/Lower/allocatable-caller.f90
+++ b/flang/test/Lower/allocatable-caller.f90
@@ -10,7 +10,7 @@ subroutine test_scalar_call()
   end subroutine
   end interface
   real, allocatable :: x
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFtest_scalar_callEx"}
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {{{.*}}uniq_name = "_QFtest_scalar_callEx"}
   call test_scalar(x)
   ! CHECK: fir.call @_QPtest_scalar(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> ()
 end subroutine
@@ -23,7 +23,7 @@ subroutine test_array_call()
   end subroutine
   end interface
   integer, allocatable :: x(:)
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {name = "_QFtest_array_callEx"}
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {{{.*}}uniq_name = "_QFtest_array_callEx"}
   call test_array(x)
   ! CHECK: fir.call @_QPtest_array(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> ()
 end subroutine
@@ -38,8 +38,8 @@ subroutine test_char_scalar_deferred_call()
   end interface
   character(:), allocatable :: x
   character(10), allocatable :: x2
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFtest_char_scalar_deferred_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFtest_char_scalar_deferred_callEx2"}
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx2"}
   call test_char_scalar_deferred(x)
   ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
   call test_char_scalar_deferred(x2)
@@ -56,8 +56,8 @@ subroutine test_char_scalar_explicit_call()
   end interface
   character(10), allocatable :: x
   character(:), allocatable :: x2
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFtest_char_scalar_explicit_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFtest_char_scalar_explicit_callEx2"}
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx2"}
   call test_char_scalar_explicit(x)
   ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
   call test_char_scalar_explicit(x2)
@@ -75,8 +75,8 @@ subroutine test_char_array_deferred_call()
   end interface
   character(:), allocatable :: x(:)
   character(10), allocatable :: x2(:)
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFtest_char_array_deferred_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFtest_char_array_deferred_callEx2"}
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx2"}
   call test_char_array_deferred(x)
   ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
   call test_char_array_deferred(x2)
@@ -93,8 +93,8 @@ subroutine test_char_array_explicit_call()
   end interface
   character(10), allocatable :: x(:)
   character(:), allocatable :: x2(:)
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFtest_char_array_explicit_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFtest_char_array_explicit_callEx2"}
+  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx"}
+  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx2"}
   call test_char_array_explicit(x)
   ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
   call test_char_array_explicit(x2)

--- a/flang/test/Lower/allocatable-runtime.f90
+++ b/flang/test/Lower/allocatable-runtime.f90
@@ -4,19 +4,19 @@
 ! CHECK-LABEL: _QPfoo
 subroutine foo()
   real, allocatable :: x(:), y(:, :), z
-  ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {name = "_QFfooEx"}
+  ! CHECK: %[[xBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {{{.*}}uniq_name = "_QFfooEx"}
   ! CHECK-DAG: %[[xNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
   ! CHECK-DAG: %[[xNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK: %[[xInitEmbox:.*]] = fir.embox %[[xNullAddr]](%[[xNullShape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
   ! CHECK: fir.store %[[xInitEmbox]] to %[[xBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 
-  ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {name = "_QFfooEy"}
+  ! CHECK: %[[yBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>> {{{.*}}uniq_name = "_QFfooEy"}
   ! CHECK-DAG: %[[yNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x?xf32>>
   ! CHECK-DAG: %[[yNullShape:.*]] = fir.shape %c0{{.*}}, %c0{{.*}} : (index, index) -> !fir.shape<2>
   ! CHECK: %[[yInitEmbox:.*]] = fir.embox %[[yNullAddr]](%[[yNullShape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
   ! CHECK: fir.store %[[yInitEmbox]] to %[[yBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 
-  ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {name = "_QFfooEz"}
+  ! CHECK: %[[zBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {{{.*}}uniq_name = "_QFfooEz"}
   ! CHECK: %[[zNullAddr:.*]] = fir.zero_bits !fir.heap<f32>
   ! CHECK: %[[zInitEmbox:.*]] = fir.embox %[[zNullAddr]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
   ! CHECK: fir.store %[[zInitEmbox]] to %[[zBoxAddr]] : !fir.ref<!fir.box<!fir.heap<f32>>>
@@ -63,12 +63,12 @@ end subroutine
 subroutine char_deferred(n)
   integer :: n
   character(:), allocatable :: scalar, array(:)
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_deferredEscalar"}
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFchar_deferredEscalar"}
   ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_deferredEarray"}
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFchar_deferredEarray"}
   ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
@@ -111,12 +111,12 @@ end subroutine
 subroutine char_explicit_cst(n)
   integer :: n
   character(10), allocatable :: scalar, array(:)
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {name = "_QFchar_explicit_cstEscalar"}
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFchar_explicit_cstEscalar"}
   ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,10>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
 
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {name = "_QFchar_explicit_cstEarray"}
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFchar_explicit_cstEarray"}
   ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,10>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
@@ -136,14 +136,14 @@ subroutine char_explicit_dyn(n, l1, l2)
   integer :: n, l1, l2
   character(l1), allocatable :: scalar
   ! CHECK-DAG: %[[l1:.*]] = fir.load %arg1 : !fir.ref<i32>
-  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {name = "_QFchar_explicit_dynEscalar"}
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFchar_explicit_dynEscalar"}
   ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
   ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %[[l1]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 
   character(l2), allocatable :: array(:)
   ! CHECK-DAG: %[[l2:.*]] = fir.load %arg2 : !fir.ref<i32>
-  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {name = "_QFchar_explicit_dynEarray"}
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFchar_explicit_dynEarray"}
   ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
   ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
   ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %[[l2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, i32) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -5,13 +5,13 @@
 subroutine fooscalar()
   ! Test lowering of local allocatable specification
   real, allocatable :: x
-  ! CHECK: %[[xAddrVar:.*]] = fir.alloca !fir.heap<f32> {name = "_QFfooscalarEx.addr"}
+  ! CHECK: %[[xAddrVar:.*]] = fir.alloca !fir.heap<f32> {{{.*}}uniq_name = "_QFfooscalarEx.addr"}
   ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<f32>
   ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 
   ! Test allocation of local allocatables
   allocate(x)
-  ! CHECK: %[[alloc:.*]] = fir.allocmem f32 {name = "_QFfooscalarEx.alloc"}
+  ! CHECK: %[[alloc:.*]] = fir.allocmem f32 {{{.*}}uniq_name = "_QFfooscalarEx.alloc"}
   ! CHECK: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 
   ! Test reading allocatable bounds and extents
@@ -31,9 +31,9 @@ end subroutine
 subroutine foodim1()
   ! Test lowering of local allocatable specification
   real, allocatable :: x(:)
-  ! CHECK-DAG: %[[xAddrVar:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {name = "_QFfoodim1Ex.addr"}
-  ! CHECK-DAG: %[[xLbVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.lb0"}
-  ! CHECK-DAG: %[[xExtVar:.*]] = fir.alloca index {name = "_QFfoodim1Ex.ext0"}
+  ! CHECK-DAG: %[[xAddrVar:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {{{.*}}uniq_name = "_QFfoodim1Ex.addr"}
+  ! CHECK-DAG: %[[xLbVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFfoodim1Ex.lb0"}
+  ! CHECK-DAG: %[[xExtVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFfoodim1Ex.ext0"}
   ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
   ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
 
@@ -43,7 +43,7 @@ subroutine foodim1()
   ! CHECK-DAG: %[[c100:.*]] = fir.convert %c100_i32 : (i32) -> index
   ! CHECK-DAG: %[[diff:.*]] = subi %[[c100]], %[[c42]] : index
   ! CHECK: %[[extent:.*]] = addi %[[diff]], %c1{{.*}} : index
-  ! CHECK: %[[alloc:.*]] = fir.allocmem !fir.array<?xf32>, %[[extent]] {name = "_QFfoodim1Ex.alloc"}
+  ! CHECK: %[[alloc:.*]] = fir.allocmem !fir.array<?xf32>, %[[extent]] {{{.*}}uniq_name = "_QFfoodim1Ex.alloc"}
   ! CHECK-DAG: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
   ! CHECK-DAG: fir.store %[[extent]] to %[[xExtVar]] : !fir.ref<index>
   ! CHECK-DAG: fir.store %[[c42]] to %[[xLbVar]] : !fir.ref<index>
@@ -65,11 +65,11 @@ end subroutine
 subroutine foodim2()
   ! Test lowering of local allocatable specification
   real, allocatable :: x(:, :)
-  ! CHECK-DAG: fir.alloca !fir.heap<!fir.array<?x?xf32>> {name = "_QFfoodim2Ex.addr"}
-  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.lb0"}
-  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.ext0"}
-  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.lb1"}
-  ! CHECK-DAG: fir.alloca index {name = "_QFfoodim2Ex.ext1"}
+  ! CHECK-DAG: fir.alloca !fir.heap<!fir.array<?x?xf32>> {{{.*}}uniq_name = "_QFfoodim2Ex.addr"}
+  ! CHECK-DAG: fir.alloca index {{{.*}}uniq_name = "_QFfoodim2Ex.lb0"}
+  ! CHECK-DAG: fir.alloca index {{{.*}}uniq_name = "_QFfoodim2Ex.ext0"}
+  ! CHECK-DAG: fir.alloca index {{{.*}}uniq_name = "_QFfoodim2Ex.lb1"}
+  ! CHECK-DAG: fir.alloca index {{{.*}}uniq_name = "_QFfoodim2Ex.ext1"}
 end subroutine
 
 ! test lowering of character allocatables. Focus is placed on the length handling
@@ -77,18 +77,18 @@ end subroutine
 subroutine char_deferred(n)
   integer :: n
   character(:), allocatable :: c
-  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {name = "_QFchar_deferredEc.addr"}
-  ! CHECK-DAG: %[[cLenVar:.*]] = fir.alloca index {name = "_QFchar_deferredEc.len"}
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {{{.*}}uniq_name = "_QFchar_deferredEc.addr"}
+  ! CHECK-DAG: %[[cLenVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFchar_deferredEc.len"}
   allocate(character(10):: c)
   ! CHECK: %[[c10:.]] = fir.convert %c10_i32 : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>, %[[c10]] {name = "_QFchar_deferredEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,?>(%[[c10]] : index) {{{.*}}uniq_name = "_QFchar_deferredEc.alloc"}
   ! CHECK: fir.store %[[c10]] to %[[cLenVar]] : !fir.ref<index>
   deallocate(c)
   ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
   allocate(character(n):: c)
   ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
   ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>, %[[ni]] {name = "_QFchar_deferredEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,?>(%[[ni]] : index) {{{.*}}uniq_name = "_QFchar_deferredEc.alloc"}
   ! CHECK: fir.store %[[ni]] to %[[cLenVar]] : !fir.ref<index>
 
   call bar(c)
@@ -103,18 +103,18 @@ subroutine char_explicit_cst(n)
   integer :: n
   character(10), allocatable :: c
   ! CHECK-DAG: %[[cLen:.*]] = constant 10 : index
-  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,10>> {name = "_QFchar_explicit_cstEc.addr"}
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,10>> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.addr"}
   ! CHECK-NOT: "_QFchar_explicit_cstEc.len"
   allocate(c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   deallocate(c)
   ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,10>>
   allocate(character(n):: c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   deallocate(c)
   ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,10>>
   allocate(character(10):: c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {name = "_QFchar_explicit_cstEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   call bar(c)
   ! CHECK: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
   ! CHECK: %[[cAddrcast:.*]] = fir.convert %[[cAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
@@ -126,21 +126,21 @@ subroutine char_explicit_dyn(l1, l2)
   integer :: l1, l2
   character(l1), allocatable :: c
   ! CHECK-DAG: %[[cLen:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {name = "_QFchar_explicit_dynEc.addr"}
+  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {{{.*}}uniq_name = "_QFchar_explicit_dynEc.addr"}
   ! CHECK-NOT: "_QFchar_explicit_dynEc.len"
   allocate(c)
   ! CHECK: %[[cLenCast1:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast1]] {name = "_QFchar_explicit_dynEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast1]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   deallocate(c)
   ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
   allocate(character(l2):: c)
   ! CHECK: %[[cLenCast2:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast2]] {name = "_QFchar_explicit_dynEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast2]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   deallocate(c)
   ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.char<1,?>>
   allocate(character(10):: c)
   ! CHECK: %[[cLenCast3:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>, %[[cLenCast3]] {name = "_QFchar_explicit_dynEc.alloc"}
+  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast3]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   call bar(c)
   ! CHECK-DAG: %[[cLenCast4:.*]] = fir.convert %[[cLen]] : (i32) -> index
   ! CHECK-DAG: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
@@ -151,7 +151,7 @@ end subroutine
 ! CHECK-LABEL: _QPspecifiers(
 subroutine specifiers
   allocatable jj1(:), jj2(:,:), jj3(:)
-  ! CHECK: [[STAT:%[0-9]+]] = fir.alloca i32 {name = "_QFspecifiersEsss"}
+  ! CHECK: [[STAT:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QFspecifiersEsss"}
   integer sss
   character*30 :: mmm = "None"
   ! CHECK: fir.call @_FortranAAllocatableSetBounds

--- a/flang/test/Lower/alternate-return.f90
+++ b/flang/test/Lower/alternate-return.f90
@@ -39,7 +39,7 @@ end
 
 ! CHECK-LABEL: func @_QPs
 subroutine s(n1, *, n2, *)
-  ! CHECK: [[retval:%[0-9]+]] = fir.alloca index {name = "s"}
+  ! CHECK: [[retval:%[0-9]+]] = fir.alloca index {{{.*}}uniq_name = "s"}
   ! CHECK-COUNT-3: fir.store {{.*}} to [[retval]] : !fir.ref<index>
   if (n1 < n2) return 1
   if (n1 > n2) return 2

--- a/flang/test/Lower/associate-construct.f90
+++ b/flang/test/Lower/associate-construct.f90
@@ -2,7 +2,7 @@
 
 ! CHECK-LABEL: func @_QQmain
 program p
-  ! CHECK: [[N:%[0-9]+]] = fir.alloca i32 {name = "_QEn"}
+  ! CHECK: [[N:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QEn"}
   ! CHECK: [[T:%[0-9]+]] = fir.address_of(@_QEt) : !fir.ref<!fir.array<3xi32>>
   integer :: n, foo, t(3)
   ! CHECK: [[N]]

--- a/flang/test/Lower/assumed-shape-caller.f90
+++ b/flang/test/Lower/assumed-shape-caller.f90
@@ -15,7 +15,7 @@ subroutine foo()
   ! CHECK-DAG: %[[c42:.*]] = constant 42 : index
   ! CHECK-DAG: %[[c55:.*]] = constant 55 : index
   ! CHECK-DAG: %[[c12:.*]] = constant 12 : index
-  ! CHECK-DAG: %[[addr:.*]] = fir.alloca !fir.array<42x55x12xf32> {name = "_QFfooEx"}
+  ! CHECK-DAG: %[[addr:.*]] = fir.alloca !fir.array<42x55x12xf32> {{{.*}}uniq_name = "_QFfooEx"}
 
   call bar(x)
   ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>

--- a/flang/test/Lower/character-concatenation.f90
+++ b/flang/test/Lower/character-concatenation.f90
@@ -13,24 +13,20 @@ subroutine concat_1(a, b)
   ! Concatenation
 
   ! CHECK: %[[len:.*]] = addi %[[a]]#1, %[[b]]#1
-  ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,?>, %[[len]]
+  ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,?>(%[[len]] : index)
 
-  ! CHECK-DAG: %[[c0:.*]] = constant 0
   ! CHECK-DAG: %[[c1:.*]] = constant 1
-  ! CHECK-DAG: %[[count:.*]] = subi %[[a]]#1, %[[c1]]
-  ! CHECK: fir.do_loop %[[index:.*]] = %[[c0]] to %[[count]] step %[[c1]] {
-    ! CHECK: %[[a_cast:.*]] = fir.convert %[[a]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
-    ! CHECK: %[[a_addr:.*]] = fir.coordinate_of %[[a_cast]], %[[index]]
-    ! CHECK-DAG: %[[a_elt:.*]] = fir.load %[[a_addr]]
-    ! CHECK: %[[temp_cast:.*]] = fir.convert %[[temp]]
-    ! CHECK: %[[temp_addr:.*]] = fir.coordinate_of %[[temp_cast]], %[[index]]
-    ! CHECK: fir.store %[[a_elt]] to %[[temp_addr]]
-  ! CHECK: }
+  ! CHECK-DAG: %[[a2:.*]] = fir.convert %[[a]]#1
+  ! CHECK: %[[count:.*]] = muli %[[c1]], %[[a2]]
+  ! CHECK-DAG: constant false
+  ! CHECK-DAG: %[[to:.*]] = fir.convert %[[temp]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK-DAG: %[[from:.*]] = fir.convert %[[a]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[to]], %[[from]], %[[count]], %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
 
   ! CHECK: %[[c1_0:.*]] = constant 1
   ! CHECK: %[[count2:.*]] = subi %[[len]], %[[c1_0]]
   ! CHECK: fir.do_loop %[[index2:.*]] = %[[a]]#1 to %[[count2]] step %[[c1_0]] {
-    ! CHECK: %[[b_index:.*]] = subi %[[index]], %[[a]]#1
+    ! CHECK: %[[b_index:.*]] = subi %[[index2]], %[[a]]#1
     ! CHECK: %[[b_cast:.*]] = fir.convert %[[b]]#0
     ! CHECK: %[[b_addr:.*]] = fir.coordinate_of %[[b_cast]], %[[b_index]]
     ! CHECK-DAG: %[[b_elt:.*]] = fir.load %[[b_addr]]

--- a/flang/test/Lower/character-local-variables.f90
+++ b/flang/test/Lower/character-local-variables.f90
@@ -5,7 +5,7 @@
 ! CHECK-LABEL: func @_QPscalar_cst_len
 subroutine scalar_cst_len()
   character(10) :: c
-  ! CHECK: fir.alloca !fir.char<1,10> {name = "_QFscalar_cst_lenEc"}
+  ! CHECK: fir.alloca !fir.char<1,10> {{{.*}}uniq_name = "_QFscalar_cst_lenEc"}
 end subroutine
 
 ! CHECK-LABEL: func @_QPscalar_dyn_len
@@ -13,14 +13,13 @@ subroutine scalar_dyn_len(l)
   integer :: l
   character(l) :: c
   ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
-  ! CHECK: fir.alloca !fir.char<1,?>, %[[li]] {name = "_QFscalar_dyn_lenEc"}
+  ! CHECK: fir.alloca !fir.char<1,?>(%[[l]] : i32) {{{.*}}uniq_name = "_QFscalar_dyn_lenEc"}
 end subroutine
 
 ! CHECK-LABEL: func @_QPcst_array_cst_len
 subroutine cst_array_cst_len()
   character(10) :: c(20)
-  ! CHECK: fir.alloca !fir.array<20x!fir.char<1,10>> {name = "_QFcst_array_cst_lenEc"}
+  ! CHECK: fir.alloca !fir.array<20x!fir.char<1,10>> {{{.*}}uniq_name = "_QFcst_array_cst_lenEc"}
 end subroutine
 
 ! CHECK-LABEL: func @_QPcst_array_dyn_len
@@ -28,8 +27,7 @@ subroutine cst_array_dyn_len(l)
   integer :: l
   character(l) :: c
   ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
-  ! CHECK: fir.alloca !fir.char<1,?>, %[[li]] {name = "_QFcst_array_dyn_lenEc"}
+  ! CHECK: fir.alloca !fir.char<1,?>(%[[l]] : i32) {{{.*}}uniq_name = "_QFcst_array_dyn_lenEc"}
 end subroutine
 
 ! CHECK-LABEL: func @_QPdyn_array_cst_len
@@ -38,7 +36,7 @@ subroutine dyn_array_cst_len(n)
   character(10) :: c(n)
   ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
   ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
-  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[ni]] {name = "_QFdyn_array_cst_lenEc"}
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[ni]] {{{.*}}uniq_name = "_QFdyn_array_cst_lenEc"}
 end subroutine
 
 ! CHECK: func @_QPdyn_array_dyn_len
@@ -46,8 +44,7 @@ subroutine dyn_array_dyn_len(l, n)
   integer :: l, n
   character(l) :: c(n)
   ! CHECK-DAG: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK-DAG: %[[li:.*]] = fir.convert %[[l]] : (i32) -> index
   ! CHECK-DAG: %[[n:.*]] = fir.load %arg1 : !fir.ref<i32>
-  ! CHECK-DAG: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
-  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>, %[[li]], %[[ni]] {name = "_QFdyn_array_dyn_lenEc"}
+  ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>(%[[l]] : i32), %[[ni]] {{{.*}}uniq_name = "_QFdyn_array_dyn_lenEc"}
 end subroutine

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -9,8 +9,8 @@ subroutine test1
      integer b
   end type t
   type(t) :: t1, t2
-  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {name = "_QFtest1Et1"}
-  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {name = "_QFtest1Et2"}
+  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et1"}
+  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et2"}
   ! CHECK-DAG: %[[a:.*]] = fir.field_index a, !fir.type<_QFtest1Tt{a:i32,b:i32}>
   ! CHECK: %[[ac:.*]] = fir.coordinate_of %[[t2]], %[[a]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
   ! CHECK: %[[ld:.*]] = fir.load %[[ac]] : !fir.ref<i32>
@@ -74,20 +74,24 @@ subroutine test3
      integer :: m_i
   end type t
   type(t) :: t1, t2
+  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et1"}
+  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et2"}
+
   ! CHECK: %[[mc:.*]] = fir.field_index m_c, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
-  ! CHECK: %{{.*}} = fir.coordinate_of %{{.*}}, %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
-  ! CHECK: fir.do_loop %[[i:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-  ! CHECK: %[[v:.*]] = fir.load %[[coor]] : !fir.ref<!fir.char<1>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-  ! CHECK: fir.store %[[v]] to %[[coor]] : !fir.ref<!fir.char<1>>
-  ! CHECK: fir.do_loop %[[i:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-  ! CHECK: %[[v:.*]] = fir.load %[[coor]] : !fir.ref<!fir.char<1>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %[[i]] : (!fir.ref<!fir.array<20x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-  ! CHECK: fir.store %[[v]] to %[[coor]] : !fir.ref<!fir.char<1>>
+  ! CHECK: %[[t2x:.*]] = fir.coordinate_of %[[t2]], %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK: %[[t1x:.*]] = fir.coordinate_of %[[t1]], %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK-DAG: %[[one:.*]] = constant 1
+  ! CHECK: %[[count:.*]] = muli %[[one]], %
+  ! CHECK: constant false
+  ! CHECK: %[[dst:.*]] = fir.convert %[[t1x]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
+  ! CHECK: %[[src:.*]] = fir.convert %[[t2x]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
+  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[dst]], %[[src]], %[[count]], %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+
+
   ! CHECK: %[[mi:.*]] = fir.field_index m_i, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
-  ! CHECK: = fir.coordinate_of %{{.*}}, %[[mi]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: %[[ii:.*]] = fir.load
+  ! CHECK: %[[mip:.*]] = fir.coordinate_of %{{.*}}, %[[mi]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK: fir.store %[[ii]] to %[[mip]] : !fir.ref<i32>
   t1 = t2
   ! CHECK: return
 end subroutine test3

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -6,7 +6,7 @@
 ! CHECK-LABEL: func @_QPfoo(%arg0: () -> ()) -> f32
 real function foo(bar)
   real :: bar, x
-  ! CHECK: %[[x:.*]] = fir.alloca f32 {name = "{{.*}}Ex"}
+  ! CHECK: %[[x:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Ex"}
   x = 42.
   ! CHECK: %[[funccast:.*]] = fir.convert %arg0 : (() -> ()) -> ((!fir.ref<f32>) -> f32)
   ! CHECK: fir.call %[[funccast]](%[[x]]) : (!fir.ref<f32>) -> f32
@@ -43,7 +43,7 @@ end function
 
 ! CHECK-LABEL: func @_QPfoo_sub(%arg0: () -> ())
 subroutine foo_sub(bar_sub)
-  ! CHECK: %[[x:.*]] = fir.alloca f32 {name = "{{.*}}Ex"}
+  ! CHECK: %[[x:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Ex"}
   x = 42.
   ! CHECK: %[[funccast:.*]] = fir.convert %arg0 : (() -> ()) -> ((!fir.ref<f32>) -> ())
   ! CHECK: fir.call %[[funccast]](%[[x]]) : (!fir.ref<f32>)

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -34,8 +34,8 @@ end
 
 ! CHECK-LABEL: func @_QPss(%arg0: !fir.ref<i32>)
 subroutine ss(n1)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Enx"}
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Eny"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   integer n17, n2
   nx = 100
   n1 = nx + 10
@@ -43,34 +43,34 @@ subroutine ss(n1)
 
 ! CHECK-LABEL: func @_QPe1(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>)
 entry e1(n2, n17)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Enx"}
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Eny"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   ny = 200
   n2 = ny + 20
   return
 
 ! CHECK-LABEL: func @_QPe2(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>)
 entry e2(n3, n1)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Enx"}
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Eny"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
 
 ! CHECK-LABEL: func @_QPe3(%arg0: !fir.ref<i32>)
 entry e3(n1)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Enx"}
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Eny"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   n1 = 30
 end
 
 ! CHECK-LABEL: func @_QPjj(%arg0: !fir.ref<i32>) -> i32
 function jj(n1)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Ejj"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ejj"}
   jj = 100
   jj = jj + n1
   return
 
 ! CHECK-LABEL: func @_QPrr(%arg0: !fir.ref<i32>) -> f32
 entry rr(n2)
-  ! CHECK: fir.alloca i32 {name = "{{.*}}Ejj"}
+  ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ejj"}
   rr = 200.0
   rr = rr + n2
 end

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -283,8 +283,8 @@ subroutine ichar_test(c)
   character(1) :: c
   character :: str(10)
   ! CHECK-DAG: %[[unbox:.*]]:2 = fir.unboxchar
-  ! CHECK-DAG: %[[J:.*]] = fir.alloca i32 {name = "{{.*}}Ej"}
-  ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {name = "{{.*}}Estr"}
+  ! CHECK-DAG: %[[J:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ej"}
+  ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {{{.*}}uniq_name = "{{.*}}Estr"}
   ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>>
   ! CHECK: %[[CHAR:.*]] = fir.load %[[BOX]] : !fir.ref<!fir.char<1>>
   ! CHECK: fir.extract_value %[[CHAR]], %c0{{.*}}

--- a/flang/test/Lower/loops.f90
+++ b/flang/test/Lower/loops.f90
@@ -1,17 +1,17 @@
 ! RUN: bbc -emit-fir -o - %s | FileCheck %s
 
 subroutine loop_test
-  ! CHECK-DAG: fir.alloca i16 {name = "i"}
-  ! CHECK-DAG: fir.alloca i8 {name = "k"}
-  ! CHECK-DAG: fir.alloca i8 {name = "j"}
-  ! CHECK-DAG: fir.alloca i8 {name = "i"}
-  ! CHECK-DAG: fir.alloca i32 {name = "k"}
-  ! CHECK-DAG: fir.alloca i32 {name = "j"}
-  ! CHECK-DAG: fir.alloca i32 {name = "i"}
-  ! CHECK-DAG: fir.alloca !fir.array<5x5x5xi32> {name = "{{.*}}Ea"}
-  ! CHECK-DAG: fir.alloca i32 {name = "{{.*}}Ei"}
-  ! CHECK-DAG: fir.alloca i32 {name = "{{.*}}Ej"}
-  ! CHECK-DAG: fir.alloca i32 {name = "{{.*}}Ek"}
+  ! CHECK-DAG: fir.alloca i16 {{{.*}}uniq_name = "i"}
+  ! CHECK-DAG: fir.alloca i8 {{{.*}}uniq_name = "k"}
+  ! CHECK-DAG: fir.alloca i8 {{{.*}}uniq_name = "j"}
+  ! CHECK-DAG: fir.alloca i8 {{{.*}}uniq_name = "i"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "k"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "j"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "i"}
+  ! CHECK-DAG: fir.alloca !fir.array<5x5x5xi32> {{{.*}}uniq_name = "{{.*}}Ea"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ei"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ej"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ek"}
   integer(4) :: a(5,5,5), i, j, k, asum, xsum
 
   i = 100

--- a/flang/test/Lower/pointer-references.f90
+++ b/flang/test/Lower/pointer-references.f90
@@ -28,21 +28,21 @@ subroutine char_ptr(p)
 
   ! CHECK: %[[boxload:.*]] = fir.load %[[arg0]]
   ! CHECK: %[[addr:.*]] = fir.box_addr %[[boxload]]
-  ! CHECK:  fir.do_loop
-  ! CHECK:  fir.do_loop %[[arg1:.*]] = {{.*}} {
-    ! CHECK: %[[castAddr:.*]] = fir.convert %[[addr]] : (!fir.ptr<!fir.char<1,12>>) -> !fir.ref<!fir.array<12x!fir.char<1>>>
-    ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[castAddr]], %[[arg1]] : (!fir.ref<!fir.array<12x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-    ! CHECK: fir.store %{{.*}} to %[[coor]] : !fir.ref<!fir.char<1>>
-  ! CHECK: }
+  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl.68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
+  ! CHECK-DAG: %[[one:.*]] = constant 1
+  ! CHECK-DAG: %[[size:.*]] = fir.convert %{{.*}} : (index) -> i64
+  ! CHECK: %[[count:.*]] = muli %[[one]], %[[size]] : i64
+  ! CHECK: %[[dst:.*]] = fir.convert %[[addr]] : (!fir.ptr<!fir.char<1,12>>) -> !fir.ref<i8>
+  ! CHECK: %[[src:.*]] = fir.convert %[[str]] : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
+  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[dst]], %[[src]], %5, %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
   p = "hello world!"
 
   ! CHECK: %[[boxload2:.*]] = fir.load %[[arg0]]
   ! CHECK: %[[addr2:.*]] = fir.box_addr %[[boxload2]]
-  ! CHECK:  fir.do_loop %[[arg2:.*]] = {{.*}} {
-    ! CHECK: %[[castAddr2:.*]] = fir.convert %[[addr2]] : (!fir.ptr<!fir.char<1,12>>) -> !fir.ref<!fir.array<12x!fir.char<1>>>
-    ! CHECK: %[[coor2:.*]] = fir.coordinate_of %[[castAddr2]], %[[arg2]] : (!fir.ref<!fir.array<12x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-    ! CHECK: fir.load %[[coor2]] : !fir.ref<!fir.char<1>>
-  ! CHECK: }
+  ! CHECK: %[[count:.*]] = muli %{{.*}}, %{{.*}} : i64
+  ! CHECK: %[[dst:.*]] = fir.convert %{{.*}} : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
+  ! CHECK: %[[src:.*]] = fir.convert %[[addr2]] : (!fir.ptr<!fir.char<1,12>>) -> !fir.ref<i8>
+  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[dst]], %[[src]], %[[count]], %{{.*}}) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
   x = p
 end subroutine
 

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -41,9 +41,9 @@ real function test_stmt_1(x, a)
   real :: res1, res2
   func1(arg1) = a + foo(arg1)
   func2(arg2) = func1(arg2) + b
-  ! CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {name = "{{.*}}Eb"}
-  ! CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {name = "{{.*}}Eres1"}
-  ! CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {name = "{{.*}}Eres2"}
+  ! CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eb"}
+  ! CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eres1"}
+  ! CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eres2"}
 
   b = 5
 

--- a/flang/test/Lower/variable.f90
+++ b/flang/test/Lower/variable.f90
@@ -2,11 +2,11 @@
 
 ! CHECK-LABEL: func @_QPs() {
 subroutine s
-  ! CHECK-DAG: fir.alloca !fir.box<!fir.heap<i32>> {name = "{{.*}}Eally"}
+  ! CHECK-DAG: fir.alloca !fir.box<!fir.heap<i32>> {{{.*}}uniq_name = "{{.*}}Eally"}
   integer, allocatable :: ally
-  ! CHECK-DAG: fir.alloca !fir.box<!fir.ptr<i32>> {name = "{{.*}}Epointy"} 
+  ! CHECK-DAG: fir.alloca !fir.box<!fir.ptr<i32>> {{{.*}}uniq_name = "{{.*}}Epointy"} 
   integer, pointer :: pointy
-  ! CHECK-DAG: fir.alloca i32 {fir.target, name = "{{.*}}Ebullseye"}
+  ! CHECK-DAG: fir.alloca i32 {{{.*}}fir.target{{.*}}uniq_name = "{{.*}}Ebullseye"}
   integer, target :: bullseye
   ! CHECK: return
 end subroutine s

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -275,6 +275,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
 
     // simplify the IR
     pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
+    pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
     pm.addPass(mlir::createCanonicalizerPass());
     fir::addCSE(pm);
     pm.addPass(mlir::createInlinerPass());

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -113,6 +113,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
   } else {
     // simplify the IR
     pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
+    pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
     pm.addPass(mlir::createCanonicalizerPass());
     fir::addCSE(pm);
     pm.addPass(mlir::createInlinerPass());


### PR DESCRIPTION
  - Rewrite of the allocation Ops to use advances in MLIR tablegen and
    implement the threading of type parameters
  - Start introducing two names to some Ops. We need a unique name for
    FIR to avoid collisions, but we also want to track raw and/or
    BIND(C) names as well.
  - Add fir.char_convert Op. This Op is intended to capture the
    conversion from one CHARACTER,KIND to another CHARACTER,KIND.
    Implements a naive conversion but should be easy to hook up to
    runtime calls as needed.
  - Standardize to "typeparams" in the IR.
  - Thread typeparams through the array operations.
  - Add new FIR type helpers.
  - Start a FIR "factpry". Transformations will need to create some
    idioms that have been in the bridge to this point. While the bridge
    has access to front-end information, transformations will only have
    access to the IR. We should consider how/if to move some bridge
    idioms fully into the optimizer.
  - Add the character conversion pass. This is meant as a placeholder
    for now, but it can convert ASCII to UCS-{2,4} and vice versa.
  - Rewrite character copy in lowering. Now uses memmove intrinsic to
    copy characters, which is more compact in the IR and does not
    require the use of temporary buffers.
  - Start threading type parameters through expression lowering.
  - Lowering of arrays of memory bound objects (implicit reference
    types). Slight change to the semantics of array values to
    accomodate these types. Implement through array value copy pass.
  - Fix bugs in Expr#Convert, etc.
  - Lowering of Expr#SetLength, #Concat, #Substring, etc.
  - Fix bugs in Tilikum relating to CHARACTERs with type parameters.
  - Undate tests.
  - Add more tests.