### PR TITLE
Enable fir.coordinate_of on pointer/heap box

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1857,7 +1857,8 @@ struct CoordinateOpConversion
     auto c0 = genConstantIndex(loc, lowerTy().indexType(), rewriter, 0);
     mlir::Value base = operands[0];
     auto firTy = coor.getBaseType();
-    mlir::Type cpnTy = getReferenceEleTy(firTy);
+    mlir::Type cpnTy = fir::dyn_cast_ptrOrBoxEleTy(firTy);
+    assert(cpnTy && "not a reference type");
     bool columnIsDeferred = false;
     bool hasSubdimension = hasSubDimensions(cpnTy);
 
@@ -2071,19 +2072,6 @@ struct CoordinateOpConversion
     if (ptrEle)
       return (!subEle) && (sz == 1);
     return subEle && (i >= sz);
-  }
-
-  /// Returns the element type of the reference `refTy`.
-  static mlir::Type getReferenceEleTy(mlir::Type refTy) {
-    if (auto boxTy = refTy.dyn_cast<fir::BoxType>())
-      return boxTy.getEleTy();
-    if (auto ptrTy = refTy.dyn_cast<fir::ReferenceType>())
-      return ptrTy.getEleTy();
-    if (auto ptrTy = refTy.dyn_cast<fir::PointerType>())
-      return ptrTy.getEleTy();
-    if (auto ptrTy = refTy.dyn_cast<fir::HeapType>())
-      return ptrTy.getEleTy();
-    llvm_unreachable("not a reference type");
   }
 
   /// return true if all `Value`s in `operands` are not `FieldIndexOp`s

--- a/flang/test/Fir/coordinateof.fir
+++ b/flang/test/Fir/coordinateof.fir
@@ -53,3 +53,12 @@ func @foo4(%a : !fir.ptr<!fir.array<5x15x25xi32>>, %i : i32, %j : i64, %k : inde
   %4 = fir.load %3 : !fir.ref<i32>
   return %4 : i32
 }
+
+// CHECK-LABEL: @foo5
+func @foo5(%box : !fir.box<!fir.ptr<!fir.array<?xi32>>>, %i : index) -> i32 {
+  // similar to foo3 test. Just check that the ptr type is not disturbing codegen.
+  %1 = fir.coordinate_of %box, %i : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+  // CHECK: load i32, i32* %{{.*}}
+  %rv = fir.load %1 : !fir.ref<i32>
+  return %rv : i32
+}


### PR DESCRIPTION
While testing #762 on nag tests, I noticed fir.coordinate did not handled `!fir.box<!fir.[ptr/heap]<...>>`. Fix this.