### PR TITLE
Array constructor

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -69,6 +69,9 @@ public:
   /// Get the mlir instance of a symbol.
   virtual mlir::Value getSymbolAddress(SymbolRef sym) = 0;
 
+  /// Get the binding of an implied do variable by name.
+  virtual mlir::Value impliedDoBinding(llvm::StringRef name) = 0;
+
   /// Copy the binding of src to target symbol.
   virtual void copySymbolBinding(SymbolRef src, SymbolRef target) = 0;
 

--- a/flang/include/flang/Lower/CharacterExpr.h
+++ b/flang/include/flang/Lower/CharacterExpr.h
@@ -171,6 +171,12 @@ private:
   mlir::Location loc;
 };
 
+// FIXME: Move these to Optimizer
+mlir::FuncOp getLlvmMemcpy(FirOpBuilder &builder);
+mlir::FuncOp getLlvmMemmove(FirOpBuilder &builder);
+mlir::FuncOp getLlvmMemset(FirOpBuilder &builder);
+mlir::FuncOp getRealloc(FirOpBuilder &builder);
+
 } // namespace Fortran::lower
 
 #endif // FORTRAN_LOWER_CHARACTEREXPR_H

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -238,6 +238,13 @@ public:
     return lookupSymbol(sym).getAddr();
   }
 
+  mlir::Value impliedDoBinding(llvm::StringRef name) override final {
+    auto val = localSymbols.lookupImpliedDo(name);
+    if (!val)
+      fir::emitFatalError(toLocation(), "ac-do-variable has no binding");
+    return val;
+  }
+
   void copySymbolBinding(Fortran::lower::SymbolRef src,
                          Fortran::lower::SymbolRef target) override final {
     localSymbols.addSymbol(target, lookupSymbol(src).toExtendedValue());

--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -289,8 +289,21 @@ mlir::Value Fortran::lower::CharacterExprHelper::getCharBoxBuffer(
   return buff;
 }
 
+/// Get the LLVM intrinsic for `memcpy`. Use the 64 bit version.
+mlir::FuncOp
+Fortran::lower::getLlvmMemcpy(Fortran::lower::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
+                                        builder.getI1Type()};
+  auto memcpyTy =
+      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.memcpy.p0i8.p0i8.i64", memcpyTy);
+}
+
 /// Get the LLVM intrinsic for `memmove`. Use the 64 bit version.
-static mlir::FuncOp getLlvmMemmove(Fortran::lower::FirOpBuilder &builder) {
+mlir::FuncOp
+Fortran::lower::getLlvmMemmove(Fortran::lower::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
                                         builder.getI1Type()};
@@ -298,6 +311,28 @@ static mlir::FuncOp getLlvmMemmove(Fortran::lower::FirOpBuilder &builder) {
       mlir::FunctionType::get(builder.getContext(), args, llvm::None);
   return builder.addNamedFunction(builder.getUnknownLoc(),
                                   "llvm.memmove.p0i8.p0i8.i64", memmoveTy);
+}
+
+/// Get the LLVM intrinsic for `memset`. Use the 64 bit version.
+mlir::FuncOp
+Fortran::lower::getLlvmMemset(Fortran::lower::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
+                                        builder.getI1Type()};
+  auto memsetTy =
+      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.memset.p0i8.p0i8.i64", memsetTy);
+}
+
+/// Get the standard `realloc` function.
+mlir::FuncOp
+Fortran::lower::getRealloc(Fortran::lower::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, builder.getI64Type()};
+  auto reallocTy = mlir::FunctionType::get(builder.getContext(), args, {ptrTy});
+  return builder.addNamedFunction(builder.getUnknownLoc(), "realloc",
+                                  reallocTy);
 }
 
 /// Create a loop to copy `count` characters from `src` to `dest`. Note that the

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -207,6 +207,14 @@ Fortran::lower::SymMap::lookupSymbol(Fortran::semantics::SymbolRef sym) {
   return SymbolBox::None{};
 }
 
+mlir::Value
+Fortran::lower::SymMap::lookupImpliedDo(Fortran::lower::SymMap::AcDoVar var) {
+  for (auto [marker, binding] : llvm::reverse(impliedDoStack))
+    if (var == marker)
+      return binding;
+  return {};
+}
+
 llvm::raw_ostream &
 Fortran::lower::operator<<(llvm::raw_ostream &os,
                            const Fortran::lower::SymbolBox &symBox) {

--- a/flang/test/Lower/array-constructor-2.f90
+++ b/flang/test/Lower/array-constructor-2.f90
@@ -29,23 +29,23 @@ subroutine test2(a, b)
   !  Look for the 5 store patterns
   ! CHECK: %[[tmp:.*]] = fir.allocmem !fir.array<5xf32>
   ! CHECK: %[[val:.*]] = fir.call @_QPf(%[[b]]) : (!fir.ref<f32>) -> f32
-  ! CHECK: %[[loc:.*]] = fir.coordinate_of %[[tmp]], %c{{.*}} : (!fir.heap<!fir.array<5xf32>>, index) -> !fir.ref<f32>
+  ! CHECK: %[[loc:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.heap<!fir.array<5xf32>>, index) -> !fir.ref<f32>
   ! CHECK: fir.store %[[val]] to %[[loc]] : !fir.ref<f32>
   ! CHECK: fir.call @_QPf(%{{.*}}) : (!fir.ref<f32>) -> f32
-  ! CHECK: fir.coordinate_of %[[tmp]], %c{{.*}} : (!fir.heap<!fir.array<5xf32>>, index) -> !fir.ref<f32>
+  ! CHECK: fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.heap<!fir.array<5xf32>>, index) -> !fir.ref<f32>
   ! CHECK: fir.store
   ! CHECK: fir.call @_QPf(
-  ! CHECK: fir.coordinate_of %[[tmp]], %c
+  ! CHECK: fir.coordinate_of %
   ! CHECK: fir.store
   ! CHECK: fir.call @_QPf(
-  ! CHECK: fir.coordinate_of %[[tmp]], %c
+  ! CHECK: fir.coordinate_of %
   ! CHECK: fir.store
   ! CHECK: fir.call @_QPf(
-  ! CHECK: fir.coordinate_of %[[tmp]], %c
+  ! CHECK: fir.coordinate_of %
   ! CHECK: fir.store
 
   !  After the ctor done, loop to copy result to `a`
-  ! CHECK-DAG: fir.array_coor %[[tmp]](%
+  ! CHECK-DAG: fir.array_coor %[[tmp:.*]](%
   ! CHECK-DAG: %[[ai:.*]] = fir.array_coor %[[a]](%
   ! CHECK: fir.store %{{.*}} to %[[ai]] : !fir.ref<f32>
   ! CHECK: fir.freemem %[[tmp]] : !fir.heap<!fir.array<5xf32>>
@@ -71,8 +71,30 @@ subroutine test3(a)
   end interface
 
   ! CHECK: fir.call @_QPtest3b
+  ! CHECK: %{{.*}}:3 = fir.box_dims %{{.*}}, %{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %{{.*}} = fir.box_addr %{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[tmp:.*]] = fir.allocmem f32, %c32
   call test3b(b)
-  !a = (/ b, test3c() /)
+  ! CHECK: %[[hp1:.*]] = fir.allocmem !fir.array<?xf32>, %{{.*}} {uniq_name = ".array.expr"}
+  ! CHECK-DAG: %[[rep:.*]] = fir.convert %{{.*}} : (!fir.heap<f32>) -> !fir.ref<i8>
+  ! CHECK-DAG: %[[res:.*]] = fir.convert %{{.*}} : (index) -> i64
+  ! CHECK: %{{.*}} = fir.call @realloc(%[[rep]], %[[res]]) : (!fir.ref<i8>, i64) -> !fir.ref<i8>
+  ! CHECK: fir.call @llvm.memcpy.p0i8.p0i8.i64(%{{.*}}, %{{.*}}, %{{.*}}, %false{{.*}}) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK: fir.call @_QPtest3c
+  ! CHECK: fir.save_result
+  ! CHECK: %[[tmp2:.*]] = fir.allocmem !fir.array<?xf32>, %{{.*}}#1 {uniq_name = ".array.expr"}
+  ! CHECK: fir.call @realloc
+  ! CHECK: fir.call @llvm.memcpy.p0i8.p0i8.i64(%
+  ! CHECK: fir.array_coor %[[tmp:.*]](%{{.*}}) %{{.*}} : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+  ! CHECK-NEXT: fir.load
+  ! CHECK-NEXT: fir.array_coor %arg0 %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK-NEXT: fir.store
+  ! CHECK: fir.freemem %[[tmp]]
+  ! CHECK: fir.freemem %[[tmp2]]
+  ! CHECK: %[[alli:.*]] = fir.box_addr %{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: fir.freemem %[[alli]]
+  ! CHECK: fir.freemem %[[hp1]]
+  a = (/ b, test3c() /)
 end subroutine test3
 
 ! CHECK-LABEL: func @_QPtest4(
@@ -81,9 +103,66 @@ subroutine test4(a, b, n1, m1)
   real :: b(:,:)
   integer, external :: f1, f2, f3
 
-  ! Dynamic array ctor with dynamic extent using implied do loops.
-  !a = [ ((b(i,j), j=f1(i),f2(n1),f3(m1+i)), i=1,n1,m1) ]
+  !  Dynamic array ctor with dynamic extent using implied do loops.
+  ! CHECK-DAG: fir.alloca index {uniq_name = ".buff.pos"}
+  ! CHECK-DAG: fir.alloca index {uniq_name = ".buff.size"}
+  ! CHECK-DAG: %[[c32:.*]] = constant 32 : index
+  ! CHECK: fir.allocmem f32, %[[c32]]
+  ! CHECK: fir.call @_QPf1(%{{.*}}) : (!fir.ref<i32>) -> i32
+  ! CHECK: fir.call @_QPf2(%arg2) : (!fir.ref<i32>) -> i32
+  ! CHECK: fir.call @_QPf3(%{{.*}}) : (!fir.ref<i32>) -> i32
+  ! CHECK: %[[q:.*]] = fir.coordinate_of %arg1, %{{.*}}, %{{.*}} : (!fir.box<!fir.array<?x?xf32>>, i64, i64) -> !fir.ref<f32>
+  ! CHECK: %[[q2:.*]] = fir.load %[[q]] : !fir.ref<f32>
+  ! CHECK: fir.store %[[q2]] to %{{.*}} : !fir.ref<f32>
+  ! CHECK: fir.call @llvm.memcpy.p0i8.p0i8.i64(%
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xf32>>
+  ! CHECK-NEXT: return
+  a = [ ((b(i,j), j=f1(i),f2(n1),f3(m1+i)), i=1,n1,m1) ]
 end subroutine test4
+
+! CHECK-LABEL: func @_QPtest5(
+! CHECK-SAME: %[[a:[^:]*]]: !fir.box<!fir.array<?xf32>>,
+! CHECK-SAME: %[[array2:[^:]*]]: !fir.ref<!fir.array<2xf32>>)
+subroutine test5(a, array2)
+  real :: a(:)
+  real, parameter :: const_array1(2) = [ 1.0, 2.0 ]
+  real :: array2(2)
+
+  !  Array ctor with runtime element values and constant extents.
+  !  Concatenation of array values of constant extent.
+  ! CHECK: %[[res:.*]] = fir.allocmem !fir.array<4xf32>
+  ! CHECK: fir.address_of(@_QQro.2xr4.057a7f5ab69cb695657046b18832c330) : !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[tmp1:.*]] = fir.allocmem !fir.array<2xf32>
+  ! CHECK: fir.call @llvm.memcpy.p0i8.p0i8.i64(%{{.*}}, %{{.*}}, %{{.*}}, %false{{.*}}) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK: %[[tmp2:.*]] = fir.allocmem !fir.array<2xf32>
+  ! CHECK: = fir.array_coor %[[array2]](%{{.*}}) %{{.*}} : (!fir.ref<!fir.array<2xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+  ! CHECK: = fir.array_coor %[[tmp2]](%{{.*}}) %{{.*}} : (!fir.heap<!fir.array<2xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+  ! CHECK: fir.call @llvm.memcpy.p0i8.p0i8.i64(%{{.*}}, %{{.*}}, %{{.*}}, %false{{.*}}) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK: = fir.array_coor %{{.*}}(%{{.*}}) %{{.*}} : (!fir.heap<!fir.array<4xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+  ! CHECK: = fir.array_coor %[[a]] %{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK-DAG: fir.freemem %{{.*}} : !fir.heap<!fir.array<4xf32>>
+  ! CHECK-DAG: fir.freemem %[[tmp2]] : !fir.heap<!fir.array<2xf32>>
+  ! CHECK-DAG: fir.freemem %[[tmp1]] : !fir.heap<!fir.array<2xf32>>
+  ! CHECK: return
+  a = [ const_array1, array2 ]
+end subroutine test5
+
+! CHECK-LABEL: func @_QPtest6(
+subroutine test6(c, d, e)
+  character(5) :: c(3)
+  character(5) :: d, e
+  ! CHECK: = fir.allocmem !fir.array<2x!fir.char<1,5>>
+  ! CHECK: %[[a:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.heap<!fir.array<2x!fir.char<1,5>>>, index) -> !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[b:.*]] = fir.convert %{{.*}}#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[v:.*]] = fir.load %[[b]] : !fir.ref<!fir.char<1,5>>
+  ! CHECK-NEXT: fir.store %[[v]] to %{{.*}} : !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[a:.*]] = fir.array_coor %{{.*}}(%{{.*}}) %{{.*}} : (!fir.heap<!fir.array<2x!fir.char<1,5>>>, !fir.shape<1>, index) -> !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[b:.*]] = fir.array_coor %{{.*}}(%{{.*}}) %{{.*}} : (!fir.ref<!fir.array<3x!fir.char<1,5>>>, !fir.shape<1>, index) -> !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[v:.*]] = fir.load %[[a]] : !fir.ref<!fir.char<1,5>>
+  ! CHECK-NEXT: fir.store %[[v]] to %[[b]] : !fir.ref<!fir.char<1,5>>
+  ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<2x!fir.char<1,5>>>
+  c = (/ d, e /)
+end subroutine test6
 
 ! CHECK: fir.global internal @_QQro.3xr4.6e55f044605a4991f15fd4505d83faf4 constant : !fir.array<3xf32>
 ! CHECK: constant 1.0


### PR DESCRIPTION
This is part two of lowering array constructors and it handles the
dynamic length cases. It is not always possible to know the length of
the final vector produced by the array constructor without actually
building the constructed value.

  - Handle dynamice lengths.
  - Support the ac-implied-do form in ac-value-list.
  - Add support of CHARACTER arrays.