### PR TITLE
Lower allocatable and pointer components

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -141,11 +141,10 @@ static mlir::Type unwrapElementType(mlir::Type type) {
   return type;
 }
 
-/// Helper to create initial-data-target fir.box in a global initializer region.
-static mlir::Value
-genInitialDataTarget(Fortran::lower::AbstractConverter &converter,
-                     mlir::Location loc, mlir::Type boxType,
-                     const Fortran::lower::SomeExpr &initialTarget) {
+/// create initial-data-target fir.box in a global initializer region.
+mlir::Value Fortran::lower::genInitialDataTarget(
+    Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+    mlir::Type boxType, const Fortran::lower::SomeExpr &initialTarget) {
   Fortran::lower::SymMap globalOpSymMap;
   Fortran::lower::AggregateStoreMap storeMap;
   Fortran::lower::StatementContext stmtCtx;
@@ -240,7 +239,8 @@ static fir::GlobalOp defineGlobal(Fortran::lower::AbstractConverter &converter,
     if (details && details->init()) {
       auto expr = *details->init();
       auto init = [&](Fortran::lower::FirOpBuilder &b) {
-        auto box = genInitialDataTarget(converter, loc, symTy, expr);
+        auto box =
+            Fortran::lower::genInitialDataTarget(converter, loc, symTy, expr);
         b.create<fir::HasValueOp>(loc, box);
       };
       global =
@@ -732,8 +732,8 @@ defineCommonBlock(Fortran::lower::AbstractConverter &converter,
           auto initExpr = memDet->init().value();
           auto initVal =
               Fortran::semantics::IsPointer(*mem)
-                  ? genInitialDataTarget(converter, loc,
-                                         converter.genType(*mem), initExpr)
+                  ? Fortran::lower::genInitialDataTarget(
+                        converter, loc, converter.genType(*mem), initExpr)
                   : genInitializerExprValue(converter, loc, initExpr, stmtCtx);
           auto offVal = builder.createIntegerConstant(loc, idxTy, tupIdx);
           auto castVal = builder.createConvert(loc, commonTy.getType(tupIdx),

--- a/flang/lib/Lower/ConvertVariable.h
+++ b/flang/lib/Lower/ConvertVariable.h
@@ -29,6 +29,11 @@ namespace Fortran {
 namespace semantics {
 class Scope;
 }
+namespace evaluate {
+template <typename T>
+class Expr;
+struct SomeType;
+} // namespace evaluate
 namespace lower {
 class AbstractConverter;
 class CallerInterface;
@@ -71,6 +76,13 @@ void mapSymbolAttributes(AbstractConverter &, const pft::Variable &, SymMap &,
 void mapCallInterfaceSymbols(AbstractConverter &,
                              const Fortran::lower::CallerInterface &caller,
                              SymMap &symMap);
+
+/// Create initial-data-target fir.box in a global initializer region.
+/// This handles the local instantiation of the target variable.
+mlir::Value
+genInitialDataTarget(Fortran::lower::AbstractConverter &, mlir::Location,
+                     mlir::Type boxType,
+                     const evaluate::Expr<evaluate::SomeType> &initialTarget);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -60,11 +60,11 @@ static bool isaIntegerType(mlir::Type ty) {
 }
 
 bool verifyRecordMemberType(mlir::Type ty) {
-  return !(ty.isa<BoxType>() || ty.isa<BoxCharType>() ||
-           ty.isa<BoxProcType>() || ty.isa<ShapeType>() ||
-           ty.isa<ShapeShiftType>() || ty.isa<ShiftType>() ||
-           ty.isa<SliceType>() || ty.isa<FieldType>() || ty.isa<LenType>() ||
-           ty.isa<ReferenceType>() || ty.isa<TypeDescType>());
+  return !(ty.isa<BoxCharType>() || ty.isa<BoxProcType>() ||
+           ty.isa<ShapeType>() || ty.isa<ShapeShiftType>() ||
+           ty.isa<ShiftType>() || ty.isa<SliceType>() || ty.isa<FieldType>() ||
+           ty.isa<LenType>() || ty.isa<ReferenceType>() ||
+           ty.isa<TypeDescType>());
 }
 
 bool verifySameLists(llvm::ArrayRef<RecordType::TypePair> a1,

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -1,0 +1,517 @@
+! Test lowering of allocatable components
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module acomp
+  implicit none
+  type t
+    real :: x
+    integer :: i
+  end type
+  interface
+    subroutine takes_real_scalar(x)
+      real :: x
+    end subroutine
+    subroutine takes_char_scalar(x)
+      character(*) :: x
+    end subroutine
+    subroutine takes_derived_scalar(x)
+      import t
+      type(t) :: x
+    end subroutine
+    subroutine takes_real_array(x)
+      real :: x(:)
+    end subroutine
+    subroutine takes_char_array(x)
+      character(*) :: x(:)
+    end subroutine
+    subroutine takes_derived_array(x)
+      import t
+      type(t) :: x(:)
+    end subroutine
+    subroutine takes_real_scalar_pointer(x)
+      real, allocatable :: x
+    end subroutine
+    subroutine takes_real_array_pointer(x)
+      real, allocatable :: x(:)
+    end subroutine
+    subroutine takes_logical(x)
+      logical :: x
+    end subroutine
+  end interface
+
+  type real_a0
+    real, allocatable :: p
+  end type
+  type real_a1
+    real, allocatable :: p(:)
+  end type
+  type cst_char_a0
+    character(10), allocatable :: p
+  end type
+  type cst_char_a1
+    character(10), allocatable :: p(:)
+  end type
+  type def_char_a0
+    character(:), allocatable :: p
+  end type
+  type def_char_a1
+    character(:), allocatable :: p(:)
+  end type
+  type derived_a0
+    type(t), allocatable :: p
+  end type
+  type derived_a1
+    type(t), allocatable :: p(:)
+  end type
+
+  real, target :: real_target, real_array_target(100)
+  character(10), target :: char_target, char_array_target(100)
+
+contains
+
+! -----------------------------------------------------------------------------
+!            Test allocatable component references
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMacompPref_scalar_real_a(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>,
+! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>>,
+! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>)
+subroutine ref_scalar_real_a(a0_0, a1_0, a0_1, a1_1)
+  type(real_a0) :: a0_0, a0_1(100)
+  type(real_a1) :: a1_0, a1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg0]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[load]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]] : (!fir.heap<f32>) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[cast]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(a0_0%p)
+
+  ! CHECK: %[[a0_1_coor:.*]] = fir.coordinate_of %[[arg2]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>>, i64) -> !fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[load]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]] : (!fir.heap<f32>) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[cast]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg1]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %c7{{.*}} : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(a1_0%p(7))
+
+  ! CHECK: %[[a1_1_coor:.*]] = fir.coordinate_of %[[arg3]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, i64) -> !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %c7{{.*}} : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(a1_1(5)%p(7))
+end subroutine
+
+
+! CHECK-LABEL: func @_QMacompPref_array_real_a(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>
+subroutine ref_array_real_a(a1_0, a1_1)
+  type(real_a1) :: a1_0, a1_1(100)
+  ! Currently, base is evaluated twice (issue 772). Skip first eval.
+  ! CHECK:  fir.load %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+  ! CHECK: %[[fld_coor:.*]] = fir.coordinate_of %[[arg0]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[box:.*]] = fir.load %[[fld_coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape_shift %[[dims]]#0, %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c20{{.*}}, %c50{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) [%[[slice]]] : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QPtakes_real_array(%[[embox]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call takes_real_array(a1_0%p(20:50:2))
+
+
+  ! Currently, base is evaluated twice (issue 772). Skip first eval.
+  ! CHECK: fir.load %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[a1_1_coor:.*]] = fir.coordinate_of %[[arg1]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, i64) -> !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+  ! CHECK: %[[fld_coor:.*]] = fir.coordinate_of %[[a1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[box:.*]] = fir.load %[[fld_coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape_shift %[[dims]]#0, %[[dims]]#1 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c20{{.*}}, %c50{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) [%[[slice]]] : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QPtakes_real_array(%[[embox]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call takes_real_array(a1_1(5)%p(20:50:2))
+end subroutine
+
+! CHECK-LABEL: func @_QMacompPref_scalar_cst_char_a
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine ref_scalar_cst_char_a(a0_0, a1_0, a0_1, a1_1)
+  type(cst_char_a0) :: a0_0, a0_1(100)
+  type(cst_char_a1) :: a1_0, a1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a0_1(5)%p)
+
+
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a1_0%p(7))
+
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a1_1(5)%p(7))
+
+end subroutine
+
+! CHECK-LABEL: func @_QMacompPref_scalar_def_char_a
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
+  type(def_char_a0) :: a0_0, a0_1(100)
+  type(def_char_a1) :: a1_0, a1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a0_1(5)%p)
+
+
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a1_0%p(7))
+
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(a1_1(5)%p(7))
+
+end subroutine
+
+! CHECK-LABEL: func @_QMacompPref_scalar_derived
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine ref_scalar_derived(a0_0, a1_0, a0_1, a1_1)
+  type(derived_a0) :: a0_0, a0_1(100)
+  type(derived_a1) :: a1_0, a1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(a0_0%p%x)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(a0_1(5)%p%x)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(a1_0%p(7)%x)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(a1_1(5)%p(7)%x)
+
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test passing allocatable component references as allocatables
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMacompPpass_real_a
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine pass_real_a(a0_0, a1_0, a0_1, a1_1)
+  type(real_a0) :: a0_0, a0_1(100)
+  type(real_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_scalar_pointer(%[[coor]])
+  call takes_real_scalar_pointer(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_scalar_pointer(%[[coor]])
+  call takes_real_scalar_pointer(a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_array_pointer(%[[coor]])
+  call takes_real_array_pointer(a1_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_array_pointer(%[[coor]])
+  call takes_real_array_pointer(a1_1(5)%p)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test usage in intrinsics where pointer aspect matters
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMacompPallocated_p
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine allocated_p(a0_0, a1_0, a0_1, a1_1)
+  type(real_a0) :: a0_0, a0_1(100)
+  type(def_char_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(allocated(a0_0%p))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(allocated(a0_1(5)%p))
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(allocated(a1_0%p))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(allocated(a1_1(5)%p))
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test allocation
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMacompPallocate_real
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine allocate_real(a0_0, a1_0, a0_1, a1_1)
+  type(real_a0) :: a0_0, a0_1(100)
+  type(real_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a1_1(5)%p(100))
+end subroutine
+
+! CHECK-LABEL: func @_QMacompPallocate_cst_char
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine allocate_cst_char(a0_0, a1_0, a0_1, a1_1)
+  type(cst_char_a0) :: a0_0, a0_1(100)
+  type(cst_char_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(a1_1(5)%p(100))
+end subroutine
+
+! CHECK-LABEL: func @_QMacompPallocate_def_char
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine allocate_def_char(a0_0, a1_0, a0_1, a1_1)
+  type(def_char_a0) :: a0_0, a0_1(100)
+  type(def_char_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::a1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::a1_1(5)%p(100))
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test deallocation
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMacompPdeallocate_real
+! CHECK-SAME: (%[[a0_0:.*]]: {{.*}}, %[[a1_0:.*]]: {{.*}}, %[[a0_1:.*]]: {{.*}}, %[[a1_1:.*]]: {{.*}})
+subroutine deallocate_real(a0_0, a1_0, a0_1, a1_1)
+  type(real_a0) :: a0_0, a0_1(100)
+  type(real_a1) :: a1_0, a1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(a0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(a0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(a1_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(a1_1(5)%p)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test a recursive derived type reference
+! -----------------------------------------------------------------------------
+
+! CHECK: func @_QMacompPtest_recursive
+! CHECK-SAME: (%[[x:.*]]: {{.*}})
+subroutine test_recursive(x)
+  type t
+    integer :: i
+    type(t), allocatable :: next
+  end type
+  type(t) :: x
+
+  ! CHECK: %[[fldNext1:.*]] = fir.field_index next
+  ! CHECK: %[[next1:.*]] = fir.coordinate_of %[[x]], %[[fldNext1]]
+  ! CHECK: %[[nextBox1:.*]] = fir.load %[[next1]]
+  ! CHECK: %[[fldNext2:.*]] = fir.field_index next
+  ! CHECK: %[[next2:.*]] = fir.coordinate_of %[[nextBox1]], %[[fldNext2]]
+  ! CHECK: %[[nextBox2:.*]] = fir.load %[[next2]]
+  ! CHECK: %[[fldNext3:.*]] = fir.field_index next
+  ! CHECK: %[[next3:.*]] = fir.coordinate_of %[[nextBox2]], %[[fldNext3]]
+  ! CHECK: %[[nextBox3:.*]] = fir.load %[[next3]]
+  ! CHECK: %[[fldi:.*]] = fir.field_index i
+  ! CHECK: %[[i:.*]] = fir.coordinate_of %[[nextBox3]], %[[fldi]]
+  ! CHECK: %[[nextBox3:.*]] = fir.load %[[i]] : !fir.ref<i32>
+  print *, x%next%next%next%i
+end subroutine
+
+end module

--- a/flang/test/Lower/derived-pointer-components.f90
+++ b/flang/test/Lower/derived-pointer-components.f90
@@ -1,0 +1,730 @@
+! Test lowering of pointer components
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module pcomp
+  implicit none
+  type t
+    real :: x
+    integer :: i
+  end type
+  interface
+    subroutine takes_real_scalar(x)
+      real :: x
+    end subroutine
+    subroutine takes_char_scalar(x)
+      character(*) :: x
+    end subroutine
+    subroutine takes_derived_scalar(x)
+      import t
+      type(t) :: x
+    end subroutine
+    subroutine takes_real_array(x)
+      real :: x(:)
+    end subroutine
+    subroutine takes_char_array(x)
+      character(*) :: x(:)
+    end subroutine
+    subroutine takes_derived_array(x)
+      import t
+      type(t) :: x(:)
+    end subroutine
+    subroutine takes_real_scalar_pointer(x)
+      real, pointer :: x
+    end subroutine
+    subroutine takes_real_array_pointer(x)
+      real, pointer :: x(:)
+    end subroutine
+    subroutine takes_logical(x)
+      logical :: x
+    end subroutine
+  end interface
+
+  type real_p0
+    real, pointer :: p
+  end type
+  type real_p1
+    real, pointer :: p(:)
+  end type
+  type cst_char_p0
+    character(10), pointer :: p
+  end type
+  type cst_char_p1
+    character(10), pointer :: p(:)
+  end type
+  type def_char_p0
+    character(:), pointer :: p
+  end type
+  type def_char_p1
+    character(:), pointer :: p(:)
+  end type
+  type derived_p0
+    type(t), pointer :: p
+  end type
+  type derived_p1
+    type(t), pointer :: p(:)
+  end type
+
+  real, target :: real_target, real_array_target(100)
+  character(10), target :: char_target, char_array_target(100)
+
+contains
+
+! -----------------------------------------------------------------------------
+!            Test pointer component references
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPref_scalar_real_p(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>,
+! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>>,
+! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>)
+subroutine ref_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg0]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[load]] : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]] : (!fir.ptr<f32>) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[cast]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(p0_0%p)
+
+  ! CHECK: %[[p0_1_coor:.*]] = fir.coordinate_of %[[arg2]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>>, i64) -> !fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[load]] : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]] : (!fir.ptr<f32>) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[cast]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg1]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %c7{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(p1_0%p(7))
+
+  ! CHECK: %[[p1_1_coor:.*]] = fir.coordinate_of %[[arg3]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, i64) -> !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %c7{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
+  call takes_real_scalar(p1_1(5)%p(7))
+end subroutine
+
+
+! CHECK-LABEL: func @_QMpcompPref_array_real_p(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>
+subroutine ref_array_real_p(p1_0, p1_1)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! Currently, base is evaluated twice (issue 772). Skip first eval.
+  ! CHECK:  fir.load %{{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK: %[[fld_coor:.*]] = fir.coordinate_of %[[arg0]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[box:.*]] = fir.load %[[fld_coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[shift:.*]] = fir.shift %[[dims]]#0 : (index) -> !fir.shift<1>
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c20{{.*}}, %c50{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[box]](%[[shift]]) [%[[slice]]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.shift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QPtakes_real_array(%[[rebox]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call takes_real_array(p1_0%p(20:50:2))
+
+
+  ! Currently, base is evaluated twice (issue 772). Skip first eval.
+  ! CHECK: fir.load %{{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[p1_1_coor:.*]] = fir.coordinate_of %[[arg1]], %{{.*}} : (!fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, i64) -> !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK: %[[fld_coor:.*]] = fir.coordinate_of %[[p1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[box:.*]] = fir.load %[[fld_coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0_5 : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[shift:.*]] = fir.shift %[[dims]]#0 : (index) -> !fir.shift<1>
+  ! CHECK-DAG: %[[slice:.*]] = fir.slice %c20{{.*}}, %c50{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK: %[[rebox:.*]] = fir.rebox %[[box]](%[[shift]]) [%[[slice]]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.shift<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QPtakes_real_array(%[[rebox]]) : (!fir.box<!fir.array<?xf32>>) -> ()
+  call takes_real_array(p1_1(5)%p(20:50:2))
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPassign_scalar_real
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine assign_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: fir.store {{.*}} to %[[addr]]
+  p0_0%p = 1.
+
+  ! CHECK: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: fir.store {{.*}} to %[[addr]]
+  p0_1(5)%p = 2.
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], {{.*}}
+  ! CHECK: fir.store {{.*}} to %[[addr]]
+  p1_0%p(7) = 3.
+
+  ! CHECK: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], {{.*}}
+  ! CHECK: fir.store {{.*}} to %[[addr]]
+  p1_1(5)%p(7) = 4.
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPref_scalar_cst_char_p
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine ref_scalar_cst_char_p(p0_0, p1_0, p0_1, p1_1)
+  type(cst_char_p0) :: p0_0, p0_1(100)
+  type(cst_char_p1) :: p1_0, p1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p0_1(5)%p)
+
+
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p1_0%p(7))
+
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p1_1(5)%p(7))
+
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPref_scalar_def_char_p
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine ref_scalar_def_char_p(p0_0, p1_0, p0_1, p1_1)
+  type(def_char_p0) :: p0_0, p0_1(100)
+  type(def_char_p1) :: p1_0, p1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p0_1(5)%p)
+
+
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p1_0%p(7))
+
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
+  call takes_char_scalar(p1_1(5)%p(7))
+
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPref_scalar_derived
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine ref_scalar_derived(p0_0, p1_0, p0_1, p1_1)
+  type(derived_p0) :: p0_0, p0_1(100)
+  type(derived_p1) :: p1_0, p1_1(100)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(p0_0%p%x)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(p0_1(5)%p%x)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(p1_0%p(7)%x)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[fldx:.*]] = fir.field_index x
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
+  ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
+  call takes_real_scalar(p1_1(5)%p(7)%x)
+
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test passing pointer component references as pointers
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPpass_real_p
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine pass_real_p(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_scalar_pointer(%[[coor]])
+  call takes_real_scalar_pointer(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_scalar_pointer(%[[coor]])
+  call takes_real_scalar_pointer(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_array_pointer(%[[coor]])
+  call takes_real_array_pointer(p1_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.call @_QPtakes_real_array_pointer(%[[coor]])
+  call takes_real_array_pointer(p1_1(5)%p)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test usage in intrinsics where pointer aspect matters
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPassociated_p
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine associated_p(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(def_char_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(associated(p0_0%p))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(associated(p0_1(5)%p))
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(associated(p1_0%p))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK: fir.box_addr %[[box]]
+  call takes_logical(associated(p1_1(5)%p))
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test pointer assignment of components
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPpassoc_real
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine passoc_real(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p0_0%p => real_target
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p0_1(5)%p => real_target
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p1_0%p => real_array_target
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p1_1(5)%p => real_array_target
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPpassoc_char
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine passoc_char(p0_0, p1_0, p0_1, p1_1)
+  type(cst_char_p0) :: p0_0, p0_1(100)
+  type(def_char_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p0_0%p => char_target
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p0_1(5)%p => char_target
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p1_0%p => char_array_target
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  p1_1(5)%p => char_array_target
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test nullify of components
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPnullify_test
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine nullify_test(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(def_char_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  nullify(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  nullify(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  nullify(p1_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  nullify(p1_1(5)%p)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test allocation
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPallocate_real
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine allocate_real(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p1_1(5)%p(100))
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPallocate_cst_char
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine allocate_cst_char(p0_0, p1_0, p0_1, p1_1)
+  type(cst_char_p0) :: p0_0, p0_1(100)
+  type(cst_char_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(p1_1(5)%p(100))
+end subroutine
+
+! CHECK-LABEL: func @_QMpcompPallocate_def_char
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine allocate_def_char(p0_0, p1_0, p0_1, p1_1)
+  type(def_char_p0) :: p0_0, p0_1(100)
+  type(def_char_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::p1_0%p(100))
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  allocate(character(18)::p1_1(5)%p(100))
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test deallocation
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPdeallocate_real
+! CHECK-SAME: (%[[p0_0:.*]]: {{.*}}, %[[p1_0:.*]]: {{.*}}, %[[p0_1:.*]]: {{.*}}, %[[p1_1:.*]]: {{.*}})
+subroutine deallocate_real(p0_0, p1_0, p0_1, p1_1)
+  type(real_p0) :: p0_0, p0_1(100)
+  type(real_p1) :: p1_0, p1_1(100)
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p0_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(p0_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p0_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(p0_1(5)%p)
+
+  ! CHECK: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(p1_0%p)
+
+  ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[p1_1]], %{{.*}}
+  ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
+  ! CHECK: fir.store {{.*}} to %[[coor]]
+  deallocate(p1_1(5)%p)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test a very long component
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMpcompPvery_long
+! CHECK-SAME: (%[[x:.*]]: {{.*}})
+subroutine very_long(x)
+  type t0
+    real :: f
+  end type
+  type t1
+    type(t0), allocatable :: e(:)
+  end type
+  type t2
+    type(t1) :: d(10)
+  end type
+  type t3
+    type(t2) :: c
+  end type
+  type t4
+    type(t3), pointer :: b
+  end type
+  type t5
+    type(t4) :: a
+  end type
+  type(t5) :: x(:, :, :, :, :)
+
+  ! CHECK: %[[coor0:.*]] = fir.coordinate_of %[[x]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.}}
+  ! CHECK-DAG: %[[flda:.*]] = fir.field_index a
+  ! CHECK-DAG: %[[fldb:.*]] = fir.field_index b
+  ! CHECK: %[[coor1:.*]] = fir.coordinate_of %[[coor0]], %[[flda]], %[[fldb]]
+  ! CHECK: %[[b_box:.*]] = fir.load %[[coor1]]
+  ! CHECK-DAG: %[[fldc:.*]] = fir.field_index c
+  ! CHECK-DAG: %[[fldd:.*]] = fir.field_index d
+  ! CHECK: %[[coor2:.*]] = fir.coordinate_of %[[b_box]], %[[fldc]], %[[fldd]]
+  ! CHECK: %[[coor3:.*]] = fir.coordinate_of %[[coor2]], %c6{{.*}}
+  ! CHECK: %[[flde:.*]] = fir.field_index e
+  ! CHECK: %[[coor4:.*]] = fir.coordinate_of %[[coor3]], %[[flde]]
+  ! CHECK: %[[e_box:.*]] = fir.load %[[coor4]]
+  ! CHECK: %[[coor5:.*]] = fir.coordinate_of %[[e_box]], %c7{{.*}}
+  ! CHECK: %[[fldf:.*]] = fir.field_index f
+  ! CHECK: %[[coor6:.*]] = fir.coordinate_of %[[coor5]], %[[fldf:.*]]
+  ! CHECK: fir.load %[[coor6]] : !fir.ref<f32>
+  print *, x(1,2,3,4,5)%a%b%c%d(6)%e(7)%f
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test a recursive derived type reference
+! -----------------------------------------------------------------------------
+
+! CHECK: func @_QMpcompPtest_recursive
+! CHECK-SAME: (%[[x:.*]]: {{.*}})
+subroutine test_recursive(x)
+  type t
+    integer :: i
+    type(t), pointer :: next
+  end type
+  type(t) :: x
+
+  ! CHECK: %[[fldNext1:.*]] = fir.field_index next
+  ! CHECK: %[[next1:.*]] = fir.coordinate_of %[[x]], %[[fldNext1]]
+  ! CHECK: %[[nextBox1:.*]] = fir.load %[[next1]]
+  ! CHECK: %[[fldNext2:.*]] = fir.field_index next
+  ! CHECK: %[[next2:.*]] = fir.coordinate_of %[[nextBox1]], %[[fldNext2]]
+  ! CHECK: %[[nextBox2:.*]] = fir.load %[[next2]]
+  ! CHECK: %[[fldNext3:.*]] = fir.field_index next
+  ! CHECK: %[[next3:.*]] = fir.coordinate_of %[[nextBox2]], %[[fldNext3]]
+  ! CHECK: %[[nextBox3:.*]] = fir.load %[[next3]]
+  ! CHECK: %[[fldi:.*]] = fir.field_index i
+  ! CHECK: %[[i:.*]] = fir.coordinate_of %[[nextBox3]], %[[fldi]]
+  ! CHECK: %[[nextBox3:.*]] = fir.load %[[i]] : !fir.ref<i32>
+  print *, x%next%next%next%i
+end subroutine
+
+end module
+
+! -----------------------------------------------------------------------------
+!            Test initial data target
+! -----------------------------------------------------------------------------
+
+module pinit
+  use pcomp
+  ! CHECK-LABEL: fir.global {{.*}}@_QMpinitEarp0
+    ! CHECK-DAG: %[[undef:.*]] = fir.undefined
+    ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+    ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEreal_target)
+    ! CHECK: %[[box:.*]] = fir.embox %[[target]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: fir.has_value %[[insert]]
+  type(real_p0) :: arp0 = real_p0(real_target)
+
+  ! CHECK-LABEL: fir.global {{.*}}@_QMpinitEbrp1
+    ! CHECK-DAG: %[[undef:.*]] = fir.undefined
+    ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+    ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEreal_array_target)
+    ! CHECK-DAG: %[[shape:.*]] = fir.shape %c100{{.*}}
+    ! CHECK-DAG: %[[slice:.*]] = fir.slice %c10{{.*}}, %c50{{.*}}, %c5{{.*}}
+    ! CHECK: %[[box:.*]] = fir.embox %[[target]](%[[shape]]) [%[[slice]]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: fir.has_value %[[insert]]
+  type(real_p1) :: brp1 = real_p1(real_array_target(10:50:5))
+
+  ! CHECK-LABEL: fir.global {{.*}}@_QMpinitEccp0
+    ! CHECK-DAG: %[[undef:.*]] = fir.undefined
+    ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+    ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEchar_target)
+    ! CHECK: %[[box:.*]] = fir.embox %[[target]] : (!fir.ref<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: fir.has_value %[[insert]]
+  type(cst_char_p0) :: ccp0 = cst_char_p0(char_target)
+
+  ! CHECK-LABEL: fir.global {{.*}}@_QMpinitEdcp1
+    ! CHECK-DAG: %[[undef:.*]] = fir.undefined
+    ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
+    ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEchar_array_target)
+    ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[target]] : (!fir.ref<!fir.array<100x!fir.char<1,10>>>) -> !fir.ptr<!fir.array<?x!fir.char<1,?>>>
+    ! CHECK-DAG: %[[shape:.*]] = fir.shape %c100{{.*}}
+    ! CHECK-DAG: %[[box:.*]] = fir.embox %[[cast]](%[[shape]]) typeparams %c10{{.*}} : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: fir.has_value %[[insert]]
+  type(def_char_p1) :: dcp1 = def_char_p1(char_array_target)
+end module

--- a/flang/test/Lower/dummy-argument-optional.f90
+++ b/flang/test/Lower/dummy-argument-optional.f90
@@ -2,20 +2,22 @@
 
 ! Test OPTIONAL lowering on caller/callee and PRESENT intrinsic.
 module opt
+  implicit none
+  type t
+    real, allocatable :: p(:)
+  end type
 contains
 
 ! Test simple scalar optional
 ! CHECK-LABEL: func @_QMoptPintrinsic_scalar
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<f32> {fir.optional})
 subroutine intrinsic_scalar(x)
-  implicit none
   real, optional :: x
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<f32>) -> i1
   print *, present(x)
 end subroutine
 ! CHECK-LABEL: @_QMoptPcall_intrinsic_scalar()
 subroutine call_intrinsic_scalar()
-  implicit none
   ! CHECK: %[[x:.*]] = fir.alloca f32
   real :: x
   ! CHECK: fir.call @_QMoptPintrinsic_scalar(%[[x]]) : (!fir.ref<f32>) -> ()
@@ -29,14 +31,12 @@ end subroutine
 ! CHECK-LABEL: func @_QMoptPintrinsic_f77_array
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.array<100xf32>> {fir.optional})
 subroutine intrinsic_f77_array(x)
-  implicit none
   real, optional :: x(100)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.array<100xf32>>) -> i1
   print *, present(x)
 end subroutine
 ! CHECK-LABEL: func @_QMoptPcall_intrinsic_f77_array()
 subroutine call_intrinsic_f77_array()
-  implicit none
   ! CHECK: %[[x:.*]] = fir.alloca !fir.array<100xf32>
   real :: x(100)
   ! CHECK: fir.call @_QMoptPintrinsic_f77_array(%[[x]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
@@ -50,7 +50,6 @@ end subroutine
 ! CHECK-LABEL: func @_QMoptPcharacter_scalar
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1> {fir.optional})
 subroutine character_scalar(x)
-  implicit none
   ! CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   character(10), optional :: x
   ! CHECK: fir.is_present %[[unboxed]]#0 : (!fir.ref<!fir.char<1,?>>) -> i1
@@ -58,7 +57,6 @@ subroutine character_scalar(x)
 end subroutine
 ! CHECK-LABEL: func @_QMoptPcall_character_scalar()
 subroutine call_character_scalar()
-  implicit none
   ! CHECK: %[[addr:.*]] = fir.alloca !fir.char<1,10>
   character(10) :: x
   ! CHECK: %[[addrCast:.*]] = fir.convert %[[addr]]
@@ -74,14 +72,12 @@ end subroutine
 ! CHECK-LABEL: func @_QMoptPassumed_shape
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional})
 subroutine assumed_shape(x)
-  implicit none
   real, optional :: x(:)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> i1
   print *, present(x)
 end subroutine
 ! CHECK: func @_QMoptPcall_assumed_shape()
 subroutine call_assumed_shape()
-  implicit none
   ! CHECK: %[[addr:.*]] = fir.alloca !fir.array<100xf32>
   real :: x(100)
   ! CHECK: %[[embox:.*]] = fir.embox %[[addr]]
@@ -97,14 +93,12 @@ end subroutine
 ! CHECK: func @_QMoptPallocatable_array
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.optional})
 subroutine allocatable_array(x)
-  implicit none
   real, allocatable, optional :: x(:)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> i1
   print *, present(x)
 end subroutine
 ! CHECK: func @_QMoptPcall_allocatable_array()
 subroutine call_allocatable_array()
-  implicit none
   ! CHECK: %[[x:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>>
   real, allocatable :: x(:)
   ! CHECK: fir.call @_QMoptPallocatable_array(%[[x]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> ()
@@ -117,18 +111,38 @@ end subroutine
 ! CHECK: func @_QMoptPallocatable_to_assumed_optional_array
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
 subroutine allocatable_to_assumed_optional_array(x)
-  implicit none
   real, allocatable :: x(:)
-  ! CHECK: %[[embox:.*]] = fir.embox %{{.*}}
 
   ! CHECK: %[[xboxload:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   ! CHECK: %[[xptr:.*]] = fir.box_addr %[[xboxload]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
   ! CHECK: %[[xaddr:.*]] = fir.convert %[[xptr]] : (!fir.heap<!fir.array<?xf32>>) -> i64
   ! CHECK: %[[isAlloc:.*]] = cmpi ne, %[[xaddr]], %c0{{.*}} : i64
   ! CHECK: %[[absent:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[embox:.*]] = fir.embox %{{.*}}
   ! CHECK: %[[actual:.*]] = select %[[isAlloc]], %[[embox]], %[[absent]] : !fir.box<!fir.array<?xf32>>
   ! CHECK: fir.call @_QMoptPassumed_shape(%[[actual]]) : (!fir.box<!fir.array<?xf32>>) -> ()
   call assumed_shape(x)
+end subroutine
+
+! CHECK-LABEL: func @_QMoptPalloc_component_to_optional_assumed_shape
+subroutine alloc_component_to_optional_assumed_shape(x)
+  type(t) :: x(100)
+  ! CHECK-DAG: %[[isAlloc:.*]] = cmpi ne
+  ! CHECK-DAG: %[[absent:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+  ! CHECK: %[[select:.*]] = select %[[isAlloc]], %{{.*}}, %[[absent]] : !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.call @_QMoptPassumed_shape(%[[select]])
+  call assumed_shape(x(55)%p)
+end subroutine
+
+! CHECK-LABEL: func @_QMoptPalloc_component_eval_only_once
+subroutine alloc_component_eval_only_once(x)
+  integer, external :: ifoo
+  type(t) :: x(100)
+  ! Verify that the index in the component reference are not evaluated twice
+  ! because if the optional handling logic.
+  ! CHECK: fir.call @_QPifoo()
+  ! CHECK-NOT: fir.call @_QPifoo()
+  call assumed_shape(x(ifoo())%p)
 end subroutine
 
 end module

--- a/flang/test/Lower/pointer-assignments.f90
+++ b/flang/test/Lower/pointer-assignments.f90
@@ -51,8 +51,9 @@ subroutine test_array_char(p, x)
   character(:), pointer :: p(:)
   ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[xaddr:.*]] = fir.convert %[[c]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<100x!fir.char<1,?>>>
-  ! CHECK: %[[shape:.*]] = fir.shape %c100{{.*}}
-  ! CHECK: %[[box:.*]] = fir.embox %[[xaddr]](%[[shape]]) typeparams %[[c]]#1
+  ! CHECK-DAG: %[[xaddr2:.*]] = fir.convert %[[xaddr]] : (!fir.ref<!fir.array<100x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[shape:.*]] = fir.shape %c100{{.*}}
+  ! CHECK: %[[box:.*]] = fir.embox %[[xaddr2]](%[[shape]]) typeparams %[[c]]#1
   ! CHECK: fir.store %[[box]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
   p => x
 end subroutine


### PR DESCRIPTION
- Lower allocatable and pointer component references outside of
  pointer/allocatable relevant contexts. Work in componentToExtendedValue.

- Lower allocatable and pointer component references in pointer/
  allocatable relevant contexts (passing them, allocate, deallocate,
  nullify, pointer assignments and intrinsics).
  Update genMutableBoxValue, and replace UnwrapWholeSymbolDataRef +
  IsAllocatableOrPointer usages by a single isAllocatableOrPointer
  that uses UnwrapWholeSymbolOrComponentDataRef and works with components.

- Fix double evaluation of the designator expressions when passing
  allocatable/pointers to optional assumed shape (since the designator
  can now contain side effects).

- Handle case where the allocatable/pointer is not the first or last
  part of a component ref (e.g. a%pointer%c). This requires breaking
  the fir.coordinate_of in two parts. This is handled in
  reverseComponents.

- Lower pointers in structure-component initializers (the runtime case
  is left TODO because it cannot use the same helper function). Expose
  a few other TODOs in structure-component.

- Enable fir.rebox in genarr() because I needed it to make more advanced
  tests.

- Fix a character type issue in mutable box update (exposed by the
  tests).