### PR TITLE
Lowering and codegen of derived type descriptors

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -809,8 +809,9 @@ Fortran::lower::createUnallocatedBox(Fortran::lower::FirOpBuilder &builder,
   auto eleTy = type;
   if (auto seqType = eleTy.dyn_cast<fir::SequenceType>())
     eleTy = seqType.getEleTy();
-  if (eleTy.isa<fir::RecordType>())
-    TODO(loc, "Derived type allocatable initialization");
+  if (auto recTy = eleTy.dyn_cast<fir::RecordType>())
+    if (recTy.getNumLenParams() > 0)
+      TODO(loc, "creating unallocated fir.box of derived type with length parameters");
   auto nullAddr = builder.createNullConstant(loc, heapType);
   mlir::Value shape;
   if (auto seqTy = type.dyn_cast<fir::SequenceType>()) {

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1742,8 +1742,8 @@ private:
             [&](const Fortran::evaluate::Assignment::BoundsSpec &lbExprs) {
               // Pointer assignment with possibly empty bounds-spec
               auto lhs = genExprMutableBox(loc, assign.lhs);
-              if (Fortran::common::Unwrap<Fortran::evaluate::NullPointer>(
-                      assign.rhs.u)) {
+              if (Fortran::evaluate::UnwrapExpr<Fortran::evaluate::NullPointer>(
+                      assign.rhs)) {
                 Fortran::lower::disassociateMutableBox(*builder, loc, lhs);
                 return;
               }
@@ -1770,8 +1770,8 @@ private:
                     &boundExprs) {
               // Pointer assignment with bounds-remapping
               auto lhs = genExprMutableBox(loc, assign.lhs);
-              if (Fortran::common::Unwrap<Fortran::evaluate::NullPointer>(
-                      assign.rhs.u)) {
+              if (Fortran::evaluate::UnwrapExpr<Fortran::evaluate::NullPointer>(
+                      assign.rhs)) {
                 Fortran::lower::disassociateMutableBox(*builder, loc, lhs);
                 return;
               }

--- a/flang/lib/Lower/BuiltinModules.h
+++ b/flang/lib/Lower/BuiltinModules.h
@@ -1,0 +1,26 @@
+//===-- BuiltinModules.h --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+///
+/// Define information about builtin derived types from flang/module/xxx.f90
+/// files so that these types can be manipulated by lowering.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_BUILTINMODULES_H
+#define FORTRAN_LOWER_BUILTINMODULES_H
+
+namespace Fortran::lower::builtin {
+/// Address field name of __builtin_c_f_pointer and __builtin_c_ptr types.
+constexpr char cptrFieldName[] = "__address";
+} // namespace Fortran::lower::builtin
+
+#endif // FORTRAN_LOWER_BUILTINMODULES_H

--- a/flang/lib/Lower/ConvertVariable.h
+++ b/flang/lib/Lower/ConvertVariable.h
@@ -24,7 +24,8 @@
 
 namespace fir {
 class GlobalOp;
-}
+class ExtendedValue;
+} // namespace fir
 namespace Fortran {
 namespace semantics {
 class Scope;
@@ -77,6 +78,12 @@ void mapCallInterfaceSymbols(AbstractConverter &,
                              const Fortran::lower::CallerInterface &caller,
                              SymMap &symMap);
 
+// TODO: consider saving the initial expression symbol dependence analysis in
+// in the PFT variable and dealing with the dependent symbols instantiation in
+// the fir::GlobalOp body at the fir::GlobalOp creation point rather than by
+// having genExtAddrInInitializer and genInitialDataTarget custom entry points
+// here to deal with this while lowering the initial expression value.
+
 /// Create initial-data-target fir.box in a global initializer region.
 /// This handles the local instantiation of the target variable.
 mlir::Value
@@ -84,6 +91,11 @@ genInitialDataTarget(Fortran::lower::AbstractConverter &, mlir::Location,
                      mlir::Type boxType,
                      const evaluate::Expr<evaluate::SomeType> &initialTarget);
 
+/// Generate address \p addr inside an initializer.
+fir::ExtendedValue
+genExtAddrInInitializer(Fortran::lower::AbstractConverter &converter,
+                        mlir::Location loc,
+                        const evaluate::Expr<evaluate::SomeType> &addr);
 } // namespace lower
 } // namespace Fortran
 #endif // FORTRAN_LOWER_CONVERT_VARIABLE_H

--- a/flang/test/Fir/type-descriptor.fir
+++ b/flang/test/Fir/type-descriptor.fir
@@ -1,0 +1,13 @@
+// RUN: tco -o - %s | FileCheck %s
+
+!sometype = type !fir.type<_QFfooTsometype{num:i32,values:!fir.box<!fir.ptr<!fir.array<?x?xf32>>>}>
+fir.global internal @_QFfooE.dt.sometype : i8
+fir.global internal @_QFfooEx : !fir.box<!fir.heap<!sometype>> {
+  %0 = fir.zero_bits !fir.heap<!sometype>
+  %1 = fir.embox %0 : (!fir.heap<!sometype>) -> !fir.box<!fir.heap<!sometype>>
+  fir.has_value %1 : !fir.box<!fir.heap<!sometype>>
+}
+
+// CHECK: @_QFfooEx = internal global { %_QFfooTsometype*, i64, i32, i8, i8, i8, i8, i8*, i64, [1 x i64] }
+// CHECK-SAME: { %_QFfooTsometype* null, i64 ptrtoint (%_QFfooTsometype* getelementptr (%_QFfooTsometype, %_QFfooTsometype* null, i32 1) to i64),
+// CHECK-SAME: i32 20180515, i8 0, i8 34, i8 2, i8 1, i8* @_QFfooE.dt.sometype, i64 0, [1 x i64] undef }

--- a/flang/test/Lower/derived-type-descriptor.f90
+++ b/flang/test/Lower/derived-type-descriptor.f90
@@ -1,0 +1,33 @@
+! Test lowering of derived type descriptors builtin data
+! RUN: %bbc -emit-fir %s -o - | FileCheck %s
+
+subroutine foo()
+  real, save, target :: init_values(10, 10)
+  type sometype
+    integer :: num = 42
+    real, pointer :: values(:, :) => init_values
+  end type
+  type(sometype), allocatable, save :: x(:)
+end subroutine
+
+! FIXME: n.xxx and di.xxx symbol mangling is not bijective (lacks Ffoo prefix)
+! because the related symbols are inside sometype derived type scope, and FIR
+! mangling was not made to support global in such scopes. Whether lowering
+! should handle this or the symbols should be in foo scope is under discussion.
+
+! CHECK-DAG: fir.global internal @_QE.n.num("num") : !fir.char<1,3>
+! CHECK-DAG: fir.global internal @_QE.n.values("values") : !fir.char<1,6>
+! CHECK-DAG: fir.global internal @_QE.di.sometype.num : i32
+! CHECK-DAG: fir.global internal @_QFfooE.n.sometype("sometype") : !fir.char<1,8>
+
+! CHECK-LABEL: fir.global internal @_QFfooE.c.sometype {{.*}} {
+  ! CHECK: fir.address_of(@_QE.n.num)
+  ! CHECK: fir.address_of(@_QE.di.sometype.num) : !fir.ref<i32>
+  ! CHECK: fir.address_of(@_QE.n.values)
+  ! CHECK: fir.address_of(@_QFfooEinit_values)
+! CHECK: }
+
+! CHECK-LABEL: fir.global internal @_QFfooE.dt.sometype {{.*}} {
+  !CHECK: fir.address_of(@_QFfooE.n.sometype)
+  !CHECK: fir.address_of(@_QFfooE.c.sometype)
+! CHECK:}

--- a/flang/test/Lower/pointer-initial-target.f90
+++ b/flang/test/Lower/pointer-initial-target.f90
@@ -49,8 +49,8 @@ end subroutine
 subroutine scalar_null()
   real, pointer :: p => NULL()
 ! CHECK-LABEL: fir.global internal @_QFscalar_nullEp : !fir.box<!fir.ptr<f32>>
-  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ref<none>
-  ! CHECK: %[[box:.*]] = fir.embox %[[zero]] : (!fir.ref<none>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ptr<f32>
+  ! CHECK: %[[box:.*]] = fir.embox %[[zero]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
   ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<f32>>
 end subroutine
 
@@ -106,8 +106,9 @@ end subroutine
 subroutine array_null()
   real, pointer :: p(:) => NULL()
 ! CHECK-LABEL: fir.global internal @_QFarray_nullEp : !fir.box<!fir.ptr<!fir.array<?xf32>>>
-  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ref<none>
-  ! CHECK: %[[box:.*]] = fir.embox %[[zero]] : (!fir.ref<none>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[box:.*]] = fir.embox %[[zero]](%[[shape]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
   ! CHECK: fir.has_value %[[box]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
 end subroutine
 

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -34,6 +34,7 @@
 #include "flang/Parser/provenance.h"
 #include "flang/Parser/unparse.h"
 #include "flang/Semantics/expression.h"
+#include "flang/Semantics/runtime-type-info.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/unparse-with-symbols.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
@@ -212,6 +213,14 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
   if (semantics.AnyFatalError()) {
     llvm::errs() << programPrefix << "semantic errors in " << path << '\n';
     return mlir::failure();
+  }
+  Fortran::semantics::RuntimeDerivedTypeTables tables;
+  if (!semantics.AnyFatalError()) {
+    tables =
+        Fortran::semantics::BuildRuntimeDerivedTypeTables(semanticsContext);
+    if (!tables.schemata)
+      llvm::errs() << programPrefix
+                   << "could not find module file for __fortran_type_info\n";
   }
   if (dumpSymbols)
     semantics.DumpSymbols(llvm::outs());


### PR DESCRIPTION
Lowering:
 - Enable creation of front-end generated symbols describing derived type instances.
 - Finish adding sufficient support to lower the related initializer (need to handle c_ptr/c_funptr builtin types, as well as derived type arrays).
 - Fix an Unwrap that was doing nothing in pointer data target init (should have been UnwrapExpr).
 
Codegen:
 - Add addendum to derived-type/polymorphic derived type fir.box llvm  type.
 - Lower type code and size (computed with a GEP) of derived type.
 - Find the global that is the type descriptor given a fir derived type (use the name patterns), and insert that into the addendum.
 
This patch include some front-end fixes that were already merged in LLVM (https://reviews.llvm.org/D102768).

With all that, I was able to generate derived type descriptors up to object files that looks OK to me.
Note that the compiler generated global have awful types that makes the IR unreadable. I am working on making alias for derived type, but did not managed to get that fully cleaned-up (may need some more MLIR support, I opened a discourse discussion [here](https://llvm.discourse.group/t/how-to-produce-type-alias-inside-nested-types/3518))