### PR TITLE
Bug fix - unstructured code followed by a (structured) directive

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1995,7 +1995,7 @@ private:
     if (unstructuredContext) {
       // When transitioning from unstructured to structured code,
       // the structured code could be a target that starts a new block.
-      maybeStartBlock(eval.isConstruct() && eval.lowerAsStructured()
+      maybeStartBlock(eval.hasNestedEvaluations() && eval.lowerAsStructured()
                           ? eval.getFirstNestedEvaluation().block
                           : eval.block);
     }


### PR DESCRIPTION
```
    IF (X /= 1) stop
    !$OMP PARALLEL
    X = 777
    !$OMP END PARALLEL
```

This is a case where structured code following unstructured code starts a new explicit basic block. The IF statement is unstructured because the STOP statement is an unstructured branch. The code that follows the IF statement is structured. Like Construct PFT nodes, Directive PFT nodes contain nested Evaluations. The first nested Evaluation may start a new block. The top-level generic `genFIR` function needs to consider Directives as well as Constructs in such transitions.