### PR TITLE
Part 1. Host associated variables support in lowering.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -120,6 +120,14 @@ public:
   /// analysis.
   virtual Fortran::evaluate::FoldingContext &getFoldingContext() = 0;
 
+  /// Host associated variables are grouped as a tuple. This returns that value,
+  /// which is itself a reference. Use bindTuple() to set this value.
+  virtual mlir::Value hostAssocTupleValue() = 0;
+
+  /// Record a binding for the ssa-value of the host assoications tuple for this
+  /// function.
+  virtual void bindHostAssocTuple(mlir::Value val) = 0;
+
   //===--------------------------------------------------------------------===//
   // Types
   //===--------------------------------------------------------------------===//

--- a/flang/include/flang/Lower/Bridge.h
+++ b/flang/include/flang/Lower/Bridge.h
@@ -90,7 +90,7 @@ public:
   void lower(const Fortran::parser::Program &program,
              const Fortran::semantics::SemanticsContext &semanticsContext);
 
-   fir::KindMapping &getKindMap() { return kindMap; }
+  fir::KindMapping &getKindMap() { return kindMap; }
 
 private:
   explicit LoweringBridge(

--- a/flang/include/flang/Lower/HostAssociations.h
+++ b/flang/include/flang/Lower/HostAssociations.h
@@ -46,8 +46,7 @@ public:
 
   /// Code gen the FIR for the local bindings for the host associated symbols
   /// for an internal (child) procedure using `builder`.
-  void internalProcedureBindings(AbstractConverter &converter, SymMap &symMap,
-                                 HostAssociations &internal);
+  void internalProcedureBindings(AbstractConverter &converter, SymMap &symMap);
 
   /// Return the type of the extra argument to add to each internal procedure.
   mlir::Type getArgumentType(AbstractConverter &convert);

--- a/flang/include/flang/Lower/HostAssociations.h
+++ b/flang/include/flang/Lower/HostAssociations.h
@@ -1,0 +1,65 @@
+//===-- Lower/HostAssociations.h --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_HOSTASSOCIATIONS_H
+#define FORTRAN_LOWER_HOSTASSOCIATIONS_H
+
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace Fortran {
+namespace semantics {
+class Symbol;
+}
+
+namespace lower {
+class AbstractConverter;
+class FirOpBuilder;
+class SymMap;
+
+/// Internal procedures in Fortran may access variables declared in the host
+/// procedure directly. We bundle these variables together in a tuple and pass
+/// them as an extra argument.
+class HostAssociations {
+public:
+  /// Returns true iff there are no host associations.
+  bool empty() const { return symbols.empty(); }
+
+  /// Adds a set of Symbols that will be the host associated bindings for this
+  /// host procedure.
+  void addSymbolsToBind(
+      const llvm::SetVector<const Fortran::semantics::Symbol *> &s) {
+    assert(empty());
+    symbols = s;
+  }
+
+  /// Code gen the FIR for the local bindings for the host associated symbols
+  /// for the host (parent) procedure using `builder`.
+  void hostProcedureBindings(AbstractConverter &converter, SymMap &symMap);
+
+  /// Code gen the FIR for the local bindings for the host associated symbols
+  /// for an internal (child) procedure using `builder`.
+  void internalProcedureBindings(AbstractConverter &converter, SymMap &symMap,
+                                 HostAssociations &internal);
+
+  /// Return the type of the extra argument to add to each internal procedure.
+  mlir::Type getArgumentType(AbstractConverter &convert);
+
+private:
+  /// Canonical vector of host associated symbols.
+  llvm::SetVector<const Fortran::semantics::Symbol *> symbols;
+
+  /// The type of the extra argument to be added to each internal procedure.
+  mlir::Type argType;
+};
+} // namespace lower
+} // namespace Fortran
+
+#endif // FORTRAN_LOWER_HOSTASSOCIATIONS_H

--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -638,7 +638,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   /// set of host associations.
   bool parentHasHostAssoc();
 
-  /// Return the host associations for this function like unit. The lis of host
+  /// Return the host associations for this function like unit. The list of host
   /// associations are kept in the host procedure.
   HostAssociations &getHostAssoc() { return hostAssociations; }
 

--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -19,6 +19,7 @@
 
 #include "flang/Common/reference.h"
 #include "flang/Common/template.h"
+#include "flang/Lower/HostAssociations.h"
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/attr.h"
@@ -620,6 +621,27 @@ struct FunctionLikeUnit : public ProgramUnit {
     return stmt.visit(common::visitors{[](const auto &x) { return x.source; }});
   }
 
+  //===--------------------------------------------------------------------===//
+  // Host associations
+  //===--------------------------------------------------------------------===//
+
+  void setHostAssociatedSymbols(
+      const llvm::SetVector<const semantics::Symbol *> &symbols) {
+    hostAssociations.addSymbolsToBind(symbols);
+  }
+
+  /// Return the host associations, if any, from the parent (host) procedure.
+  /// Crashes if the parent is not a procedure.
+  HostAssociations &parentHostAssoc();
+
+  /// Return true iff the parent is a procedure and the parent has a non-empty
+  /// set of host associations.
+  bool parentHasHostAssoc();
+
+  /// Return the host associations for this function like unit. The lis of host
+  /// associations are kept in the host procedure.
+  HostAssociations &getHostAssoc() { return hostAssociations; }
+
   LLVM_DUMP_METHOD void dump() const;
 
   /// Anonymous programs do not have a begin statement
@@ -646,6 +668,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   /// Terminal basic block (if any)
   mlir::Block *finalBlock{};
   std::vector<std::vector<Variable>> varList;
+  HostAssociations hostAssociations;
 };
 
 /// Module-like units contain a list of function-like units.

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -60,13 +60,25 @@ fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
-constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }
+static constexpr llvm::StringRef getContiguousAttrName() {
+  return "fir.contiguous";
+}
+
 /// Attribute to mark Fortran entities with the OPTIONAL attribute.
-constexpr llvm::StringRef getOptionalAttrName() { return "fir.optional"; }
+static constexpr llvm::StringRef getOptionalAttrName() {
+  return "fir.optional";
+}
+
 /// Attribute to mark Fortran entities with the TARGET attribute.
-constexpr llvm::StringRef getTargetAttrName() { return "fir.target"; }
+static constexpr llvm::StringRef getTargetAttrName() { return "fir.target"; }
+
 /// Attribute to keep track of Fortran scoping information for a symbol.
-constexpr llvm::StringRef getSymbolAttrName() { return "fir.sym_name"; }
+static constexpr llvm::StringRef getSymbolAttrName() { return "fir.sym_name"; }
+
+/// Attribute to mark a function that takes a host associations argument.
+static constexpr llvm::StringRef getHostAssocAttrName() {
+  return "fir.host_assoc";
+}
 
 /// Tell if \p value is:
 ///   - a function argument that has attribute \p attributeName
@@ -77,6 +89,11 @@ constexpr llvm::StringRef getSymbolAttrName() { return "fir.sym_name"; }
 ///   - or, a fir.box loaded from a fir.ref<fir.box> that matches one of the
 ///     previous cases.
 bool valueHasFirAttribute(mlir::Value value, llvm::StringRef attributeName);
+
+/// Scan the arguments of a FuncOp to determine if any arguments have the
+/// attribute `attr` placed on them. This can be used to determine if the
+/// function has any host associations, for example.
+bool anyFuncArgsHaveAttr(mlir::FuncOp func, llvm::StringRef attr);
 
 } // namespace fir
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2045,11 +2045,13 @@ private:
         auto box = charHelp.createEmboxChar(arg.firArgument, arg.firLength);
         addSymbol(arg.entity->get(), box);
       } else {
-        if (arg.entity.has_value())
+        if (arg.entity.has_value()) {
           addSymbol(arg.entity->get(), arg.firArgument);
-        else if (funit.parentHasHostAssoc())
-          funit.parentHostAssoc().internalProcedureBindings(
-              *this, localSymbols, funit.getHostAssoc());
+        } else {
+          assert(funit.parentHasHostAssoc());
+          funit.parentHostAssoc().internalProcedureBindings(*this,
+                                                            localSymbols);
+        }
       }
     };
     for (const auto &arg : callee.getPassedArguments())
@@ -2130,6 +2132,7 @@ private:
       if (const auto *varDetails =
               sym.detailsIf<Fortran::semantics::HostAssocDetails>()) {
         auto hostBox = localSymbols.lookupSymbol(varDetails->symbol());
+        assert(hostBox && "host association is not in map");
         localSymbols.addSymbol(sym, hostBox.toExtendedValue());
         continue;
       }

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -14,6 +14,7 @@ add_flang_library(FortranLower
   ConvertVariable.cpp
   DoLoopHelper.cpp
   FIRBuilder.cpp
+  HostAssociations.cpp
   IntrinsicCall.cpp
   IO.cpp
   Mangler.cpp

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -543,7 +543,7 @@ public:
     }
   }
 
-  void appendExtraArgument(mlir::Type tupTy) {
+  void appendHostAssocTupleArg(mlir::Type tupTy) {
     auto *ctxt = tupTy.getContext();
     addFirOperand(tupTy, nextPassedArgPosition(), Property::BaseAddress,
                   {mlir::NamedAttribute{
@@ -859,9 +859,12 @@ void Fortran::lower::CallInterface<T>::determineInterface(
     impl.buildImplicitInterface(procedure);
   else
     impl.buildExplicitInterface(procedure);
+  // We only expect the extra host asspciations argument from the callee side as
+  // the definition of internal procedures will be present, and we'll always
+  // have a FuncOp definition in the ModuleOp, when lowering.
   if constexpr (std::is_same_v<T, Fortran::lower::CalleeInterface>) {
     if (side().hasHostAssociated())
-      impl.appendExtraArgument(side().getHostAssociatedTy());
+      impl.appendHostAssocTupleArg(side().getHostAssociatedTy());
   }
 }
 

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -50,8 +50,7 @@ void Fortran::lower::HostAssociations::hostProcedureBindings(
 
 void Fortran::lower::HostAssociations::internalProcedureBindings(
     Fortran::lower::AbstractConverter &converter,
-    Fortran::lower::SymMap &symMap,
-    Fortran::lower::HostAssociations &internal) {
+    Fortran::lower::SymMap &symMap) {
   if (symbols.empty())
     return;
 
@@ -68,9 +67,9 @@ void Fortran::lower::HostAssociations::internalProcedureBindings(
       tupleArg = arg;
       break;
     }
-
   if (!tupleArg)
     fir::emitFatalError(loc, "no host association argument found");
+
   converter.bindHostAssocTuple(tupleArg);
 
   auto offTy = builder.getIntegerType(32);

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -1,0 +1,106 @@
+//===-- HostAssociations.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/HostAssociations.h"
+#include "SymbolMap.h"
+#include "flang/Lower/AbstractConverter.h"
+#include "flang/Lower/ConvertType.h"
+#include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/PFTBuilder.h"
+#include "flang/Lower/Todo.h"
+
+// `t` should be the result of getArgumentType, which has a type of
+// `!fir.ref<tuple<...>>`.
+static mlir::TupleType unwrapTupleTy(mlir::Type t) {
+  return fir::dyn_cast_ptrEleTy(t).cast<mlir::TupleType>();
+}
+
+void Fortran::lower::HostAssociations::hostProcedureBindings(
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::lower::SymMap &symMap) {
+  if (symbols.empty())
+    return;
+
+  // Create the tuple variable.
+  auto tupTy = unwrapTupleTy(getArgumentType(converter));
+  auto &builder = converter.getFirOpBuilder();
+  auto loc = converter.genLocation();
+  auto hostTuple = builder.create<fir::AllocaOp>(loc, tupTy);
+  auto offTy = builder.getIntegerType(32);
+
+  // Walk the list of symbols and update the pointers in the tuple.
+  for (auto s : llvm::enumerate(symbols)) {
+    auto box = symMap.lookupSymbol(s.value());
+    auto boxAddr = fir::getBase(box.toExtendedValue());
+    auto off = builder.createIntegerConstant(loc, offTy, s.index());
+    auto varTy = tupTy.getType(s.index());
+    auto refTy = builder.getRefType(varTy);
+    auto eleOff = builder.create<fir::CoordinateOp>(loc, refTy, hostTuple, off);
+    auto castBox = builder.createConvert(loc, varTy, boxAddr);
+    builder.create<fir::StoreOp>(loc, castBox, eleOff);
+  }
+
+  converter.bindHostAssocTuple(hostTuple);
+}
+
+void Fortran::lower::HostAssociations::internalProcedureBindings(
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::lower::SymMap &symMap,
+    Fortran::lower::HostAssociations &internal) {
+  if (symbols.empty())
+    return;
+
+  // Find the argument with the tuple type. The argument ought to be appended.
+  auto &builder = converter.getFirOpBuilder();
+  auto argTy = getArgumentType(converter);
+  auto tupTy = unwrapTupleTy(argTy);
+  auto loc = converter.genLocation();
+  auto func = builder.getFunction();
+  mlir::Value tupleArg;
+  for (auto [ty, arg] : llvm::reverse(
+           llvm::zip(func.getType().getInputs(), func.front().getArguments())))
+    if (ty == argTy) {
+      tupleArg = arg;
+      break;
+    }
+
+  if (!tupleArg)
+    fir::emitFatalError(loc, "no host association argument found");
+  converter.bindHostAssocTuple(tupleArg);
+
+  auto offTy = builder.getIntegerType(32);
+
+  // Walk the list and add the bindings to the symbol table.
+  for (auto s : llvm::enumerate(symbols)) {
+    auto off = builder.createIntegerConstant(loc, offTy, s.index());
+    auto varTy = builder.getRefType(tupTy.getType(s.index()));
+    auto eleOff = builder.create<fir::CoordinateOp>(loc, varTy, tupleArg, off);
+    auto box = builder.create<fir::LoadOp>(loc, eleOff);
+    Fortran::semantics::SymbolRef symRef = *s.value();
+    symMap.addSymbol(symRef, box.getResult());
+  }
+}
+
+mlir::Type Fortran::lower::HostAssociations::getArgumentType(
+    Fortran::lower::AbstractConverter &converter) {
+  if (symbols.empty())
+    return {};
+  if (argType)
+    return argType;
+
+  // Walk the list of Symbols and create their types. Wrap them in a reference
+  // to a tuple.
+  auto *ctxt = &converter.getMLIRContext();
+  llvm::SmallVector<mlir::Type> tupleTys;
+  for (const auto *sym : symbols) {
+    auto varTy = Fortran::lower::translateSymbolToFIRType(converter, *sym);
+    tupleTys.emplace_back(fir::PointerType::get(varTy));
+  }
+  argType = fir::ReferenceType::get(mlir::TupleType::get(ctxt, tupleTys));
+  return argType;
+}

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1519,6 +1519,19 @@ Fortran::lower::pft::FunctionLikeUnit::FunctionLikeUnit(
   processSymbolTable(*symbol->scope(), varList, isRecursive());
 }
 
+Fortran::lower::HostAssociations &
+Fortran::lower::pft::FunctionLikeUnit::parentHostAssoc() {
+  if (auto *par = parent.getIf<FunctionLikeUnit>())
+    return par->hostAssociations;
+  llvm::report_fatal_error("parent is not a function");
+}
+
+bool Fortran::lower::pft::FunctionLikeUnit::parentHasHostAssoc() {
+  if (auto *par = parent.getIf<FunctionLikeUnit>())
+    return !par->hostAssociations.empty();
+  return false;
+}
+
 Fortran::lower::pft::ModuleLikeUnit::ModuleLikeUnit(
     const parser::Module &m, const lower::pft::PftNode &parent)
     : ProgramUnit{m, parent}, beginStmt{getModuleStmt<parser::ModuleStmt>(m)},

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -2237,11 +2237,9 @@ bool fir::valueHasFirAttribute(mlir::Value value,
           return true;
     return false;
   }
-
   if (auto definingOp = value.getDefiningOp()) {
     // If this is an allocated value, look at the allocation attributes.
-    if (mlir::isa<fir::AllocMemOp>(definingOp) ||
-        mlir::isa<AllocaOp>(definingOp))
+    if (mlir::isa<fir::AllocMemOp, fir::AllocaOp, mlir::FuncOp>(definingOp))
       return definingOp->hasAttr(attributeName);
     // If this is an imported global, look at AddrOfOp and GlobalOp attributes.
     // Both operations are looked at because use/host associated variable (the
@@ -2258,6 +2256,13 @@ bool fir::valueHasFirAttribute(mlir::Value value,
   }
   // TODO: Construct associated entities attributes. Decide where the fir
   // attributes must be placed/looked for in this case.
+  return false;
+}
+
+bool fir::anyFuncArgsHaveAttr(mlir::FuncOp func, llvm::StringRef attr) {
+  for (unsigned i = 0, end = func.getNumArguments(); i < end; ++i)
+    if (func.getArgAttr(i, attr))
+      return true;
   return false;
 }
 

--- a/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
+++ b/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
@@ -517,7 +517,8 @@ public:
     auto copyElement = [&](mlir::Value coor) {
       auto input = update.merge();
       if (auto inEleTy = fir::dyn_cast_ptrEleTy(input.getType())) {
-        auto outEleTy = fir::unwrapSequenceType(update.getType());
+        [[maybe_unused]] auto outEleTy =
+            fir::unwrapSequenceType(update.getType());
         if (auto inChrTy = inEleTy.dyn_cast<fir::CharacterType>()) {
           assert(outEleTy.isa<fir::CharacterType>());
           fir::factory::genCharacterCopy(input, recoverCharLen(input), coor,

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -1,0 +1,67 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! CHECK: func @_QPtest1(
+subroutine test1
+  integer i
+  ! CHECK-DAG: %[[i:.*]] = fir.alloca i32 {{.*}}uniq_name = "_QFtest1Ei"
+  ! CHECK-DAG: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<i32>>
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[tup]], %c0
+  ! CHECK: %[[ii:.*]] = fir.convert %[[i]]
+  ! CHECK: fir.store %[[ii]] to %[[addr]] : !fir.ref<!fir.ptr<i32>>
+  ! CHECK: fir.call @_QFtest1Ptest1_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ptr<i32>>>) -> ()
+  call test1_internal
+  print *, i
+contains
+  ! CHECK: func @_QFtest1Ptest1_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<i32>>> {fir.host_assoc}) {
+  ! CHECK: %[[iaddr:.*]] = fir.coordinate_of %[[arg]], %c0
+  ! CHECK: %[[i:.*]] = fir.load %[[iaddr]] : !fir.ref<!fir.ptr<i32>>
+  ! CHECK: %[[val:.*]] = fir.call @_QPifoo() : () -> i32
+  ! CHECK: fir.store %[[val]] to %[[i]] : !fir.ptr<i32>
+  subroutine test1_internal
+    i = ifoo()
+  end subroutine test1_internal
+end subroutine test1
+
+! CHECK: func @_QPtest2() {
+subroutine test2
+  a = 1.0
+  b = 2.0
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<f32>, !fir.ptr<f32>>
+  ! CHECK-DAG: %[[a0:.*]] = fir.coordinate_of %[[tup]], %c0
+  ! CHECK-DAG: %[[p0:.*]] = fir.convert %{{.*}} : (!fir.ref<f32>) -> !fir.ptr<f32>
+  ! CHECK: fir.store %[[p0]] to %[[a0]] : !fir.ref<!fir.ptr<f32>>
+  ! CHECK-DAG: %[[b0:.*]] = fir.coordinate_of %[[tup]], %c1
+  ! CHECK-DAG: %[[p1:.*]] = fir.convert %{{.*}} : (!fir.ref<f32>) -> !fir.ptr<f32>
+  ! CHECK: fir.store %[[p1]] to %[[b0]] : !fir.ref<!fir.ptr<f32>>
+  ! CHECK: fir.call @_QFtest2Ptest2_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>>) -> ()
+  call test2_internal
+  print *, a, b
+contains
+  ! CHECK: func @_QFtest2Ptest2_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>> {fir.host_assoc}) {
+  subroutine test2_internal
+    ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
+    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: %[[b:.*]] = fir.coordinate_of %[[arg]], %c1
+    ! CHECK: %{{.*}} = fir.load %[[b]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: fir.alloca
+    ! CHECK: fir.load %[[aa]] : !fir.ptr<f32>
+    c = a
+    a = b
+    b = c
+    call test2_inner
+  end subroutine test2_internal
+
+  ! CHECK: func @_QFtest2Ptest2_inner(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>> {fir.host_assoc}) {
+  subroutine test2_inner
+    ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
+    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: %[[b:.*]] = fir.coordinate_of %[[arg]], %c1
+    ! CHECK: %[[bb:.*]] = fir.load %[[b]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK-DAG: %[[bd:.*]] = fir.load %[[bb]] : !fir.ptr<f32>
+    ! CHECK-DAG: %[[ad:.*]] = fir.load %[[aa]] : !fir.ptr<f32>
+    ! CHECK: %{{.*}} = cmpf ogt, %[[ad]], %[[bd]] : f32
+    if (a > b) then
+       b = b + 2.0
+    end if
+  end subroutine test2_inner
+end subroutine test2


### PR DESCRIPTION
This implements the lowering of host/internal procedures when host
associated variables are present. (That was a TODO.) This PR handles the
basic case of accessing scalar variables of intrinsic type.
Optimizations and final code gen will be implemented in subsequent PRs.