### PR TITLE
Fix offsets of common block members declared in module

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -774,7 +774,7 @@ static void instantiateCommon(Fortran::lower::AbstractConverter &converter,
 
     symMap.addSymbol(common, commonAddr);
   }
-  auto byteOffset = varSym.offset();
+  auto byteOffset = varSym.GetUltimate().offset();
   auto i8Ty = builder.getIntegerType(8);
   auto i8Ptr = builder.getRefType(i8Ty);
   auto seqTy = builder.getRefType(builder.getVarLenSeqTy(i8Ty));

--- a/flang/test/Lower/common-block.f90
+++ b/flang/test/Lower/common-block.f90
@@ -44,3 +44,17 @@ subroutine s3
  ! x and c are not directly initialized, but overlapping aliases are.
  common /z/ x, c
 end
+
+
+module mod_with_common
+  integer :: i, j
+  common /c_in_mod/ i, j
+end module
+! CHECK-LABEL: _QPs4
+subroutine s4
+  use mod_with_common
+  ! CHECK: load i32, i32* bitcast ([8 x i8]* @_QBc_in_mod to i32*)
+  print *, i
+  ! CHECK: load i32, i32* bitcast (i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_QBc_in_mod, i32 0, i64 4) to i32*)
+  print *, j
+end subroutine


### PR DESCRIPTION
The offset to be considered for common block members must be the one from the ultimate symbols (the symbols declared in the module/parent functions). Symbols with HostAssociated details have null offset.