### PR TITLE
Fix CharacterExprHelper::toExtendedValue for arrays

### DIFF
--- a/flang/lib/Lower/CharacterExpr.cpp
+++ b/flang/lib/Lower/CharacterExpr.cpp
@@ -115,7 +115,7 @@ Fortran::lower::CharacterExprHelper::toExtendedValue(mlir::Value character,
     type = eleType;
 
   if (auto arrayType = type.dyn_cast<fir::SequenceType>()) {
-    type = arrayType;
+    type = arrayType.getEleTy();
     auto indexType = builder.getIndexType();
     for (auto extent : arrayType.getShape()) {
       if (extent == fir::SequenceType::getUnknownExtent())
@@ -326,8 +326,7 @@ Fortran::lower::getLlvmMemset(Fortran::lower::FirOpBuilder &builder) {
 }
 
 /// Get the standard `realloc` function.
-mlir::FuncOp
-Fortran::lower::getRealloc(Fortran::lower::FirOpBuilder &builder) {
+mlir::FuncOp Fortran::lower::getRealloc(Fortran::lower::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, builder.getI64Type()};
   auto reallocTy = mlir::FunctionType::get(builder.getContext(), args, {ptrTy});

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -85,3 +85,10 @@ function hh(c1)
 entry qq(c1)
   qq = c1
 end
+
+! CHECK-LABEL: func @_QPchar_array()
+function char_array()
+  character(10), c(5)
+! CHECK-LABEL: func @_QPchar_array_entry(%arg0: !fir.boxchar<1>)
+entry char_array_entry(c)
+end


### PR DESCRIPTION
Fixes #808. The type was not peeled correctly in the array case.