### PR TITLE
Fix indices origin in elemental calls

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -37,6 +37,7 @@
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Support/FatalError.h"
+#include "flang/Optimizer/Transforms/Factory.h"
 #include "flang/Semantics/expression.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
@@ -3378,8 +3379,11 @@ public:
     if (isReferentiallyOpaque()) {
       auto refEleTy = builder.getRefType(eleTy);
       return [=](IterSpace iters) -> ExtValue {
+        // ArrayCoorOp does not expect zero based indices.
+        auto indices = fir::factory::originateIndices(loc, builder, shape,
+                                                      iters.iterVec());
         mlir::Value coor = builder.create<fir::ArrayCoorOp>(
-            loc, refEleTy, memref, shape, slice, iters.iterVec(),
+            loc, refEleTy, memref, shape, slice, indices,
             fir::getTypeParams(extMemref));
         return arrayElementToExtendedValue(builder, loc, extMemref, coor);
       };


### PR DESCRIPTION
For elemental call arguments, a `fir.array_coor` is generated in array expression lowering. The `fir.array_coor` operation expects indices based on the entity origin (1 by default), but array expression indices are zero based.
I considered making the shape argument passed to the fir.array_coor a zero based shapeshift, but that does not play well with cases where there is a slice (that needs the actual entity origin in the shape). So I went for shifting the indices passed to array_coor (similar to what is done in ArrayCopyValue pass when transforming fir.array_fetch to fir.array_coor).