### PR TITLE
Namelist array element read

### DIFF
--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -51,17 +51,18 @@ end
 subroutine sss
   integer xxx(11:13)
   namelist /rrr/ xxx
+  ! CHECK: [[xxx:%[0-9]+]] = fir.alloca {{.*}} = "xxx"
   ! CHECK: [[cookie:%[0-9]+]] = fir.call @_FortranAioBeginExternalListInput
   ! CHECK: alloca
   ! CHECK: undefined
-  ! CHECK: fir.address_of
+  ! CHECK: fir.address_of{{.*}}787878
   ! CHECK: fir.insert_value
-  ! CHECK: fir.shape_shift
-  ! CHECK: fir.embox
+  ! CHECK: fir.shape_shift %c11
+  ! CHECK: fir.embox [[xxx]]
   ! CHECK: fir.insert_value
   ! CHECK: fir.alloca
   ! CHECK: fir.undefined
-  ! CHECK: fir.address_of
+  ! CHECK: fir.address_of{{.*}}727272
   ! CHECK-COUNT-3: fir.insert_value
   ! CHECK: fir.call @_FortranAioInputNamelist([[cookie]]
   ! CHECK: fir.call @_FortranAioEndIoStatement([[cookie]]

--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -46,6 +46,28 @@ program p
   ! CHECK: fir.call @_FortranAioEndIoStatement([[cookie]]
   write(*, nnn)
 end
+
+! CHECK-LABEL: sss
+subroutine sss
+  integer xxx(11:13)
+  namelist /rrr/ xxx
+  ! CHECK: [[cookie:%[0-9]+]] = fir.call @_FortranAioBeginExternalListInput
+  ! CHECK: alloca
+  ! CHECK: undefined
+  ! CHECK: fir.address_of
+  ! CHECK: fir.insert_value
+  ! CHECK: fir.shape_shift
+  ! CHECK: fir.embox
+  ! CHECK: fir.insert_value
+  ! CHECK: fir.alloca
+  ! CHECK: fir.undefined
+  ! CHECK: fir.address_of
+  ! CHECK-COUNT-3: fir.insert_value
+  ! CHECK: fir.call @_FortranAioInputNamelist([[cookie]]
+  ! CHECK: fir.call @_FortranAioEndIoStatement([[cookie]]
+  read(*, rrr)
+end
+
   ! CHECK-DAG: fir.global linkonce @_QQcl.6A6A6A00 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.63636300 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.6E6E6E00 constant : !fir.char<1,4>

--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """A script to generate FileCheck statements for mlir unit tests.
 
+# mlir/utils/generate-test-checks.py
+
 This script is a utility to add FileCheck patterns to an mlir file.
 
 NOTE: The input .mlir is expected to be the output from the parser, not a


### PR DESCRIPTION
A namelist read of an array element requires a descriptor with explicit bounds.