### PR TITLE
Fix search of unrestricted intrinsics (atan2 failure)

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1427,7 +1427,7 @@ mlir::SymbolRefAttr IntrinsicLibrary::getUnrestrictedIntrinsicSymbolRefAttr(
         argTypes.push_back(type);
     }
     auto soughtFuncType =
-        builder.getFunctionType(signature.getResults(), argTypes);
+        builder.getFunctionType(argTypes, signature.getResults());
     auto rtCallGenerator = getRuntimeCallGenerator(name, soughtFuncType);
     funcOp = getWrapper(rtCallGenerator, name, signature, loadRefArguments);
   }


### PR DESCRIPTION
Lowering of intrinsic passed as arguments was failing because the runtime search was mixing-up result and argument types (for
most intrinsic, it bug did not matter, but for intrinsic with more than one argument, like atan2 it was casing issues).

Also enable a TODO test related to dummy procedure for which lowering has been implemented since then.