### PR TITLE
Fix standalone builds broken by last rebase

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -19,10 +19,6 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT MSVC_IDE)
           `CMakeFiles'. Please delete them.")
 endif()
 
-# Add Flang-centric modules to cmake path.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
-include(AddFlang)
-
 if (MSVC)
   set(_FLANG_ENABLE_WERROR_DEFAULT OFF)
 else ()
@@ -127,10 +123,6 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   link_directories("${LLVM_LIBRARY_DIR}")
 
-  set(LLVM_TOOLS_BINARY_DIR ${TOOLS_BINARY_DIR} CACHE PATH "Path to llvm/bin")
-  find_program(MLIR_TABLEGEN_EXE "mlir-tblgen" ${LLVM_TOOLS_BINARY_DIR}
-    NO_DEFAULT_PATH)
-
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX})
@@ -219,7 +211,6 @@ if(FLANG_BUILD_NEW_DRIVER)
     include_directories(SYSTEM ${CLANG_INCLUDE_DIR})
 endif()
 
-# Add Flang-centric modules to cmake path.
 include_directories(BEFORE
   ${FLANG_BINARY_DIR}/include
   ${FLANG_SOURCE_DIR}/include)
@@ -247,6 +238,8 @@ set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 # Add Flang-centric modules to cmake path.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+include(AddFlang)
+
 
 if (NOT DEFAULT_SYSROOT)
   set(DEFAULT_SYSROOT "" CACHE PATH

--- a/flang/test/lit.site.cfg.py.in
+++ b/flang/test/lit.site.cfg.py.in
@@ -2,7 +2,7 @@
 
 import sys
 
-config.llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
 config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_src_dir = "@FLANG_SOURCE_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"


### PR DESCRIPTION
- Reproduce llvm main fix for related issue that was dropped during the rebase:
https://github.com/llvm/llvm-project/commit/30b7dfafdb620420ad3498aae01130bc7e2fb9cd

- Fix out-to-tree lit tests that were broken by redefinition of LLVM_TOOLS_BINARY_DIR
  that was actually making it empty. LLVM_TOOLS_BINARY_DIR is already
  defined by the `find_package(LLVM REQUIRED ..)`.

- Remove redundant ` find_program(MLIR_TABLEGEN_EXE ..)`, the same is
  already done 40 lines above (https://github.com/flang-compiler/f18-llvm-project/blob/85e8f6fa6255cfe99440a31b9de48b330532e70a/flang/CMakeLists.txt#L93)

- [NFC] Use LLVM_TOOLS_DIR in lit config file. It what upstream uses, as well
  as most llvm projects,  and is actually an alias of LLVM_TOOLS_BINARY_DIR
  defined by `configure_lit_site_cfg`.

Tested OK for me in in-tree builds, and both shared-libs/static-libs out-of-tree builds.