### PR TITLE
[OpenMP] Handle privatisation for simple types in lowering

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -75,16 +75,21 @@ public:
   /// Copy the binding of src to target symbol.
   virtual void copySymbolBinding(SymbolRef src, SymbolRef target) = 0;
 
-  /// Binds the symbol to an mlir value and returns true if the symbol has no
-  /// existing binding. If there is an existing binding this function does
-  /// nothing and returns false.
-  virtual bool bindSymbol(const SymbolRef sym, mlir::Value val) = 0;
+  /// Binds the symbol to an fir extended value and returns true if the symbol
+  /// has no existing binding. If there is an existing binding this function
+  /// does nothing and returns false.
+  virtual bool bindSymbol(const SymbolRef sym,
+                          const fir::ExtendedValue &exval) = 0;
 
   /// Get the label set associated with a symbol.
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;
 
   /// Get the code defined by a label
   virtual pft::Evaluation *lookupLabel(pft::Label label) = 0;
+
+  /// For a give symbol which is host-associated, create a clone using parameters from
+  /// the host-associated symbol.
+  virtual bool createHostAssociateVarClone(const Fortran::semantics::Symbol &sym) = 0;
 
   //===--------------------------------------------------------------------===//
   // Expressions

--- a/flang/test/Lower/OpenMP/omp-check-privatise-params.f90
+++ b/flang/test/Lower/OpenMP/omp-check-privatise-params.f90
@@ -1,0 +1,22 @@
+! This test checks whether privatisation uses the correct parameters.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+!FIRDialect: func @_QParray(%{{.*}}: !fir.ref<!fir.array<?xi32>>, %[[ARG1:.*]]: !fir.ref<i32>) {
+!FIRDialect-DAG:  %[[N:.*]] = fir.load %[[ARG1]] : !fir.ref<i32>
+!FIRDialect-DAG:  %[[N_CVT1:.*]] = fir.convert %[[N]] : (i32) -> i64
+!FIRDialect-DAG:  %[[N_CVT2:.*]] = fir.convert %[[N_CVT1]] : (i64) -> index
+!FIRDialect-DAG:  omp.parallel {
+!FIRDialect-DAG:  {{.*}} = fir.alloca !fir.array<?xi32>, %[[N_CVT2]] {{{.*}}, uniq_name = "_QFarrayEx"}
+!FIRDialect:    omp.terminator
+
+subroutine array(x,n)
+integer :: i
+integer :: x(n)
+n = 5
+!$omp parallel private(x)
+x = i
+!$omp end parallel
+print *, x
+end subroutine

--- a/flang/test/Lower/OpenMP/omp-parallel-allocate-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-allocate-clause.f90
@@ -1,6 +1,6 @@
 ! This test checks lowering of OpenMP parallel Directive with
 ! `PRIVATE` clause present.
-
+! XFAIL: *
 ! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 


### PR DESCRIPTION
This patch implements privatisation (just the private clause) while lowering from parse-tree to MLIR. A new function createVar is added to the AbstractConverter so that the ability to create variables is available in Lower/OpenMP.cpp. The createVar function calls instantiateVar to create the privatised variable.

XFAILing the allocate clause test. To implement the allocate caluse we need to have the allocate operation in the OpenMP dialect.

Notes:
1. Will handle other private clauses (firstprivate, lastprivate etc) in later patches.
2. More complicated types (derived, polymorphic etc) will be handled in later patches
3. An alternative implementation will be to handle privatisation in the OpenMP dialect. We are discussing privatisation in https://llvm.discourse.group/t/rfc-privatisation-in-openmp-dialect/3526