### PR TITLE
Implement most of allocatable assignment

### DIFF
--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -87,7 +87,8 @@ fir::MutableBoxValue createTempMutableBox(Fortran::lower::FirOpBuilder &,
 /// to be null).
 Fortran::lower::SymbolBox genMutableBoxRead(Fortran::lower::FirOpBuilder &,
                                             mlir::Location,
-                                            const fir::MutableBoxValue &);
+                                            const fir::MutableBoxValue &,
+                                            bool mayBePolymorphic = true);
 
 /// Update a MutableBoxValue to describe entity \p source (that must be in
 /// memory). If \lbounds is not empty, it is used to defined the MutableBoxValue
@@ -123,6 +124,21 @@ void associateMutableBoxWithRemap(Fortran::lower::FirOpBuilder &,
 /// address field of the MutableBoxValue to zero.
 void disassociateMutableBox(Fortran::lower::FirOpBuilder &, mlir::Location,
                             const fir::MutableBoxValue &);
+
+/// Generate code to conditionally reallocate a MutableBoxValue with a new
+/// shape, lower bounds, and length parameters if it is unallocated or if its
+/// current shape or deferred  length parameters do not match the provided ones.
+/// Lower bounds are only used if the entity needs to be allocated, otherwise,
+/// the MutableBoxValue will keep its current lower bounds.
+/// If the MutableBoxValue is an array, the provided shape can be empty, in
+/// which case the MutableBoxValue must already be allocated at runtime and its
+/// shape and lower bounds will be kept. If \p shape is empty, only a length
+/// parameter mismatch can trigger a reallocation. See Fortran 10.2.1.3 point 3
+/// that this function is implementing for more details. The polymorphic
+/// requirements are not yet covered by this function.
+void genReallocIfNeeded(Fortran::lower::FirOpBuilder &, mlir::Location,
+                        const fir::MutableBoxValue &, mlir::ValueRange lbounds,
+                        mlir::ValueRange shape, mlir::ValueRange lengthParams);
 
 /// Returns the fir.ref<fir.box<T>> of a MutableBoxValue filled with the current
 /// association / allocation properties. If the fir.ref<fir.box> already exists

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -117,6 +117,14 @@ void createMaskedArrayAssignment(AbstractConverter &converter,
                                  Fortran::lower::MaskExpr &masks,
                                  SymMap &symMap, StatementContext &stmtCtx);
 
+/// Lower an assignment to an allocatable array, allocating the array if
+/// it is not allocated yet or reallocation it if it does not conform
+/// with the right hand side.
+void createAllocatableArrayAssignment(
+    AbstractConverter &converter, const fir::MutableBoxValue &lhs,
+    const evaluate::Expr<evaluate::SomeType> &rhs, SymMap &symMap,
+    StatementContext &stmtCtx);
+
 /// Lower an array expression with "parallel" semantics. Such a rhs expression
 /// is fully evaluated prior to being assigned back to a temporary array.
 fir::ExtendedValue

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -1,0 +1,409 @@
+! Test allocatable assignments
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module alloc_assign
+  type t
+    integer :: i
+  end type
+contains
+
+! -----------------------------------------------------------------------------
+!            Test simple scalar RHS
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_simple_scalar(
+! CHECK-SAME: %[[box:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>) {
+subroutine test_simple_scalar(x)
+  real, allocatable  :: x
+  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[box]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[boxLoad]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: %[[addrCast:.*]] = fir.convert %[[addr]] : (!fir.heap<f32>) -> i64
+  ! CHECK: %[[isAlloc:.*]] = cmpi ne, %[[addrCast]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[isAlloc]] {
+  ! CHECK:   fir.if %false{{.*}} {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[alloc:.*]] = fir.allocmem f32 {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[embox:.*]] = fir.embox %[[alloc]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+  ! CHECK:   fir.store %[[embox]] to %[[box]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: }
+  ! CHECK: %[[boxLoad2:.*]] = fir.load %[[box]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[addr2:.*]] = fir.box_addr %[[boxLoad2]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+  ! CHECK: fir.store %[[cst]] to %[[addr2]] : !fir.heap<f32>
+  x = 42.
+end subroutine
+
+subroutine test_simple_local_scalar()
+  real, allocatable  :: x
+  ! CHECK: %[[x:.*]] = fir.alloca !fir.heap<f32> {uniq_name = "_QMalloc_assignFtest_simple_local_scalarEx.addr"}
+  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
+  ! CHECK: %[[xAddr:.*]] = fir.load %[[x]] : !fir.ref<!fir.heap<f32>>
+  ! CHECK: %[[xCast:.*]] = fir.convert %[[xAddr]] : (!fir.heap<f32>) -> i64
+  ! CHECK: %[[isAlloc:.*]] = cmpi ne, %[[xCast]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[isAlloc]] {
+  ! CHECK:   fir.if %false{{.*}} {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[alloc:.*]] = fir.allocmem f32 {uniq_name = ".auto.alloc"}
+  ! CHECK:   fir.store %[[alloc]] to %[[x]] : !fir.ref<!fir.heap<f32>>
+  ! CHECK: }
+  ! CHECK: %[[xAddr2:.*]] = fir.load %[[x]] : !fir.ref<!fir.heap<f32>>
+  ! CHECK: fir.store %[[cst]] to %[[xAddr2]] : !fir.heap<f32>
+  x = 42.
+  print *, x
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test character scalar RHS
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_deferred_char_scalar(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) {
+subroutine test_deferred_char_scalar(x)
+  character(:), allocatable  :: x
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: %[[xAddr:.]] = fir.box_addr %[[boxLoad]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[xLen:.*]] = fir.box_elesize %[[boxLoad]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+  ! CHECK:   %[[cmpLen:.*]] = cmpi ne, %[[xLen]], %c12{{.*}} : index
+  ! CHECK:   %[[realloc:.*]] = select %[[cmpLen]], %[[cmpLen]], %false{{.*}} : i1
+  ! CHECK:   fir.if %[[realloc]] {
+  ! CHECK:     fir.freemem %[[xAddr]] : !fir.heap<!fir.char<1,?>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.char<1,?>(%c12{{.*}} : index) {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]] typeparams %c12{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.char<1,?>(%c12{{.*}} : index) {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]] typeparams %c12{{.*}} : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  x = "Hello world!"
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_cst_char_scalar(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) {
+subroutine test_cst_char_scalar(x)
+  character(10), allocatable  :: x
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false{{.*}} {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.char<1,10> {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  x = "Hello world!"
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_dyn_char_scalar(
+! CHECK: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>, %[[nAddr:.*]]: !fir.ref<i32>) {
+subroutine test_dyn_char_scalar(x, n)
+  integer :: n
+  character(n), allocatable  :: x
+  ! CHECK: %[[n:.*]] = fir.load %[[nAddr]] : !fir.ref<i32>
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false_0 {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[nCast:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.char<1,?>(%[[nCast]] : index) {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]] typeparams %[[nCast]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  x = "Hello world!"
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_derived_scalar(
+! CHECK-SAME: %[[box:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>, %{{.*}}) {
+subroutine test_derived_scalar(x, s)
+  type(t), allocatable  :: x
+  type(t) :: s
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false{{.*}} {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.type<_QMalloc_assignTt{i:i32}> {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]] : (!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>) -> !fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>
+  x = s
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test numeric/logical array RHS
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_from_cst_shape_array(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>, %{{.*}}) {
+subroutine test_from_cst_shape_array(x, y)
+  real, allocatable  :: x(:, :)
+  real :: y(2, 3)
+  ! CHECK: %[[boxLoad:.*]] = fir.load %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim1:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[dim2:.*]]:3 = fir.box_dims %[[boxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp1:.*]] = cmpi ne, %[[dim1]]#1, %c2{{.*}} : index
+  ! CHECK:   %[[mustRealloc1:.*]] = select %[[cmp1]], %[[cmp1]], %false : i1
+  ! CHECK:   %[[cmp2:.*]] = cmpi ne, %[[dim2]]#1, %c3{{.*}} : index
+  ! CHECK:   %[[mustRealloc2:.*]] = select %[[cmp2]], %[[cmp2]], %[[mustRealloc1]] : i1
+  ! CHECK:   fir.if %[[mustRealloc2]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %c2{{.*}}, %c3{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape %c2{{.*}}, %c3{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %c2{{.*}}, %c3{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape %c2{{.*}}, %c3{{.*}} : (index, index) -> !fir.shape<2>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  x = y
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_from_dyn_shape_array(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>, %[[y:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+subroutine test_from_dyn_shape_array(x, y)
+  real, allocatable  :: x(:, :)
+  ! CHECK: %[[ydim1:.*]]:3 = fir.box_dims %[[y]], %c0{{.*}} : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+  ! CHECK: %[[ydim2:.*]]:3 = fir.box_dims %[[y]], %c1{{.*}} : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+  real :: y(:, :)
+  ! CHECK: %[[boxLoad:.*]] = fir.load %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim1:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[dim2:.*]]:3 = fir.box_dims %[[boxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp1:.*]] = cmpi ne, %[[dim1]]#1, %[[ydim1]]#1 : index
+  ! CHECK:   %[[mustRealloc1:.*]] = select %[[cmp1]], %[[cmp1]], %false : i1
+  ! CHECK:   %[[cmp2:.*]] = cmpi ne, %[[dim2]]#1, %[[ydim2]]#1 : index
+  ! CHECK:   %[[mustRealloc2:.*]] = select %[[cmp2]], %[[cmp2]], %[[mustRealloc1]] : i1
+  ! CHECK:   fir.if %[[mustRealloc2]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape %[[ydim1]]#1, %[[ydim2]]#1 : (index, index) -> !fir.shape<2>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape %[[ydim1]]#1, %[[ydim2]]#1 : (index, index) -> !fir.shape<2>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  x = y
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_with_lbounds(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>, %[[y:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+subroutine test_with_lbounds(x, y)
+  real, allocatable  :: x(:, :)
+  ! CHECK-DAG: %[[lb1:.*]] = fir.convert %c10{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[lb2:.*]] = fir.convert %c20{{.*}} : (i64) -> index
+  ! CHECK-DAG: %[[ydim1:.*]]:3 = fir.box_dims %[[y]], %c0{{.*}} : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[ydim2:.*]]:3 = fir.box_dims %[[y]], %c1{{.*}} : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+  real :: y(10:, 20:)
+  ! CHECK: %[[boxLoad:.*]] = fir.load %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim1:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[dim2:.*]]:3 = fir.box_dims %[[boxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp1:.*]] = cmpi ne, %[[dim1]]#1, %[[ydim1]]#1 : index
+  ! CHECK:   %[[mustRealloc1:.*]] = select %[[cmp1]], %[[cmp1]], %false : i1
+  ! CHECK:   %[[cmp2:.*]] = cmpi ne, %[[dim2]]#1, %[[ydim2]]#1 : index
+  ! CHECK:   %[[mustRealloc2:.*]] = select %[[cmp2]], %[[cmp2]], %[[mustRealloc1]] : i1
+  ! CHECK:   fir.if %[[mustRealloc2]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape_shift %[[lb1]], %[[ydim1]]#1, %[[lb2]], %[[ydim2]]#1 : (index, index, index, index) -> !fir.shapeshift<2>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape_shift %[[lb1]], %[[ydim1]]#1, %[[lb2]], %[[ydim2]]#1 : (index, index, index, index) -> !fir.shapeshift<2>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: }
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  x = y
+end subroutine
+
+subroutine test_runtime_shape(x)
+  real, allocatable  :: x(:, :)
+  interface
+   function return_pointer()
+     real, pointer :: return_pointer(:, :)
+   end function
+  end interface
+  ! CHECK: %[[call:.*]] = fir.call @_QPreturn_pointer() : () -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+  ! CHECK: fir.save_result %[[call]] to %[[resultStorage:.*]] : !fir.box<!fir.ptr<!fir.array<?x?xf32>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+  ! CHECK: %[[result:.*]] = fir.load %[[resultStorage]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+  ! CHECK: fir.array_load
+  ! CHECK-DAG: %[[ydim1:.*]]:3 = fir.box_dims %[[result]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK-DAG: %[[ydim2:.*]]:3 = fir.box_dims %[[result]], %c1{{.*}} : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+
+  ! CHECK: %[[boxLoad:.*]] = fir.load %arg0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim1:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[dim2:.*]]:3 = fir.box_dims %[[boxLoad]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp1:.*]] = cmpi ne, %[[dim1]]#1, %[[ydim1]]#1 : index
+  ! CHECK:   %[[mustRealloc1:.*]] = select %[[cmp1]], %[[cmp1]], %false : i1
+  ! CHECK:   %[[cmp2:.*]] = cmpi ne, %[[dim2]]#1, %[[ydim2]]#1 : index
+  ! CHECK:   %[[mustRealloc2:.*]] = select %[[cmp2]], %[[cmp2]], %[[mustRealloc1]] : i1
+  ! CHECK:   fir.if %[[mustRealloc2]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x?xf32>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape %[[ydim1]]#1, %[[ydim2]]#1 : (index, index) -> !fir.shape<2>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x?xf32>, %[[ydim1]]#1, %[[ydim2]]#1 {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape %[[ydim1]]#1, %[[ydim2]]#1 : (index, index) -> !fir.shape<2>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.heap<!fir.array<?x?xf32>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK: }
+
+  ! CHECK-NOT: fir.call @_QPreturn_pointer()
+  ! CHECK: fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
+  ! CHECK-NOT: fir.call @_QPreturn_pointer()
+  x = return_pointer()
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_scalar_rhs(
+subroutine test_scalar_rhs(x, y)
+  real, allocatable  :: x(:)
+  real :: y
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! TODO: runtime error if unallocated
+  ! CHECK-NOT: allocmem
+  ! CHECK: }
+  x = y
+end subroutine
+
+! -----------------------------------------------------------------------------
+!            Test character array RHS
+! -----------------------------------------------------------------------------
+
+
+! Hit TODO: gathering lhs length in array expression
+!subroutine test_deferred_char_rhs_scalar(x)
+!  character(:), allocatable  :: x(:)
+!  x = "Hello world!"
+!end subroutine
+
+! CHECK: func @_QMalloc_assignPtest_cst_char_rhs_scalar(
+subroutine test_cst_char_rhs_scalar(x)
+  character(10), allocatable  :: x(:)
+  x = "Hello world!"
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! TODO: runtime error if unallocated
+  ! CHECK-NOT: allocmem
+  ! CHECK: }
+end subroutine
+
+! CHECK: func @_QMalloc_assignPtest_dyn_char_rhs_scalar(
+subroutine test_dyn_char_rhs_scalar(x, n)
+  integer :: n
+  character(n), allocatable  :: x(:)
+  x = "Hello world!"
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   fir.if %false {
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! TODO: runtime error if unallocated
+  ! CHECK-NOT: allocmem
+  ! CHECK: }
+end subroutine
+
+! Hit TODO: gathering lhs length in array expression
+!subroutine test_deferred_char(x, c)
+!  character(:), allocatable  :: x(:)
+!  character(12) :: c(20)
+!  x = "Hello world!"
+!end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_cst_char(
+! CHECK-SAME: %[[x]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>, %{{.*}}) {
+subroutine test_cst_char(x, c)
+  character(10), allocatable  :: x(:)
+  character(12) :: c(20)
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp:.*]] = cmpi ne, %[[dim]]#1, %c20{{.*}} : index
+  ! CHECK:   %[[mustRealloc:.*]] = select %[[cmp]], %[[cmp]], %false : i1
+  ! CHECK:   fir.if %[[mustRealloc]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x!fir.char<1,10>>, %c20{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x!fir.char<1,10>>, %c20{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK: }
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  x = c
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_dyn_char(
+! CHECK-SAME: %[[x]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>, %[[nAddr:.*]]: !fir.ref<i32>, %{{.*}}) {
+subroutine test_dyn_char(x, n, c)
+  integer :: n
+  character(n), allocatable  :: x(:)
+  character(*) :: c(20)
+  ! CHECK: %[[n:.*]] = fir.load %[[nAddr]] : !fir.ref<i32>
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK: fir.if %{{.*}} {
+  ! CHECK:   %[[dim:.*]]:3 = fir.box_dims %[[boxLoad]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>, index) -> (index, index, index)
+  ! CHECK:   %[[cmp:.*]] = cmpi ne, %[[dim]]#1, %c20{{.*}} : index
+  ! CHECK:   %[[mustRealloc:.*]] = select %[[cmp]], %[[cmp]], %false : i1
+  ! CHECK:   fir.if %[[mustRealloc]] {
+  ! CHECK:     fir.freemem %{{.*}} : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK:     %[[nCast:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK:     %[[newAddr:.*]] = fir.allocmem !fir.array<?x!fir.char<1,?>>(%[[nCast]] : index), %c20{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:     %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK:     %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) typeparams %[[nCast]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK:     fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK:   }
+  ! CHECK: } else {
+  ! CHECK:   %[[nCast:.*]] = fir.convert %[[n]] : (i32) -> index
+  ! CHECK:   %[[newAddr:.*]] = fir.allocmem !fir.array<?x!fir.char<1,?>>(%[[nCast]] : index), %c20{{.*}} {uniq_name = ".auto.alloc"}
+  ! CHECK:   %[[shape:.*]] = fir.shape %c20{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK:   %[[box:.*]] = fir.embox %[[newAddr]](%[[shape]]) typeparams %[[nCast]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK:   fir.store %[[box]] to %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK: }
+  ! CHECK: %[[boxLoad:.*]] = fir.load %[[x]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  x = c
+end subroutine
+
+end module
+
+!  use alloc_assign
+!  real :: y(2, 3) = reshape([1,2,3,4,5,6], [2,3])
+!  real, allocatable :: x (:, :)
+!  allocate(x(2,2))
+!  call test_with_lbounds(x, y) 
+!  print *, x(10, 20)
+!  print *, x
+!end

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -49,17 +49,17 @@ contains
   subroutine t_to_t(a1,b1)
     type(t), intent(out) :: a1
     type(t), intent(in) :: b1
-    ! CHECK: %[[a:.*]] = fir.field_index a, !fir.type<_QMm2Tt{a:i32,b:i32}>
-    ! CHECK: %[[a1a:.*]] = fir.coordinate_of %[[a1]], %[[a]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QMm2Tt{a:i32,b:i32}>
     ! CHECK: %[[b1b:.*]] = fir.coordinate_of %[[b1]], %[[b]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: %[[v:.*]] = fir.load %[[b1b]] : !fir.ref<i32>
+    ! CHECK: %[[a:.*]] = fir.field_index a, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[a1a:.*]] = fir.coordinate_of %[[a1]], %[[a]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: fir.store %[[v]] to %[[a1a]] : !fir.ref<i32>
-    ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QMm2Tt{a:i32,b:i32}>
-    ! CHECK: %[[a1b:.*]] = fir.coordinate_of %[[a1]], %[[b]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: %[[a:.*]] = fir.field_index a, !fir.type<_QMm2Tt{a:i32,b:i32}>
     ! CHECK: %[[b1a:.*]] = fir.coordinate_of %[[b1]], %[[a]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: %[[v:.*]] = fir.load %[[b1a]] : !fir.ref<i32>
+    ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QMm2Tt{a:i32,b:i32}>
+    ! CHECK: %[[a1b:.*]] = fir.coordinate_of %[[a1]], %[[b]] : (!fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
     ! CHECK: fir.store %[[v]] to %[[a1b]] : !fir.ref<i32>
     a1%a = b1%b
     a1%b = b1%a

--- a/flang/test/Lower/pointer-references.f90
+++ b/flang/test/Lower/pointer-references.f90
@@ -26,9 +26,9 @@ subroutine char_ptr(p)
   character(12), pointer :: p
   character(12) :: x
 
+  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl.68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
   ! CHECK: %[[boxload:.*]] = fir.load %[[arg0]]
   ! CHECK: %[[addr:.*]] = fir.box_addr %[[boxload]]
-  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl.68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
   ! CHECK-DAG: %[[one:.*]] = constant 1
   ! CHECK-DAG: %[[size:.*]] = fir.convert %{{.*}} : (index) -> i64
   ! CHECK: %[[count:.*]] = muli %[[one]], %[[size]] : i64


### PR DESCRIPTION
Done:
 - Assignment to allocatable scalar intrinsic, and derived type entities without
   without length parameters. Deferred length scalar character are covered.
 - Allocatable array assignment to numeric, logical and character with non
   deferred length.

Missing:
 - Support for assignment to allocatable character array with deferred
   length
 - Support for polymorphic allocatable. They are more requirements for
   those.
 - Tests for simple derived type arrays are not yet added, nothing particular
   is needed regarding the allocatable aspect, but it needs to be
   supported in normal array assignment, which is used after the
   conditional reallocation.

How:

Add a genReallocIfNeeded function to Allocatable.cpp that is
centralizing the generation of the conditional reallocation logic both
for the scalar and array assignment cases.

For the scalar path, evaluate rhs first so that length parameters, if
needed, are available to perform the conditional re-allocation.
Perform conditional reallocation, and proceed with the regular
assignment path.

For the array path, add createAllocatableArrayAssignment entry point to
the array framework, that takes a MutableBoxValue for the lhs, and
drive the reallocation and assignment.
The MutableBoxValue is kept as an optional pointer, in the framework,
the rhs is lowered to continuation as usual. When generating the
iteration space, gather the rhs shape, length (TODO), lbounds if any,
and pass that to genReallocIfNeeded. Then, load the allocatable into
arrayLoad and proceed with array assignment as usual.

Small change on the way: share some logic in Allocatable.cpp. Function `genInlinedAllocation` and `genFinalizeAndFree` extract existing code so they can be used in `genReallocIfNeeded`. A parameter is added to `genMutableBoxRead` to avoid keeping scalar derived into box (the rational behind this is that at the ExtendedValue level, we cannot know if an allocatable is polymoprhic or not, but in F95, that is not an issue, and it is safe to get rid of the box when working with the entity).