### PR TITLE
Change the IR to avoid rewrites that violate LLVM constraints.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1862,12 +1862,17 @@ def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [NoSideEffect]> {
 
   let arguments = (ins
     AnyCompositeLike:$adt,
-    Variadic<AnyComponentType>:$coor
+    ArrayAttr:$coor
   );
 
   let assemblyFormat = [{
     $adt `,` $coor attr-dict `:` functional-type(operands, results)
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt,
+      "llvm::ArrayRef<mlir::Value>":$vcoor)>
+  ];
 }
 
 def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
@@ -2177,13 +2182,17 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]> {
     ```
   }];
 
-  let arguments = (ins AnyCompositeLike:$adt, AnyType:$val,
-                       Variadic<AnyComponentType>:$coor);
+  let arguments = (ins AnyCompositeLike:$adt, AnyType:$val, ArrayAttr:$coor);
   let results = (outs AnyCompositeLike);
 
   let assemblyFormat = [{
-    operands attr-dict `:` functional-type(operands, results)
+    $adt `,` $val `,` $coor attr-dict `:` functional-type(operands, results)
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt, "mlir::Value":$val,
+      "llvm::ArrayRef<mlir::Value>":$vcoor)>
+  ];
 
   let hasCanonicalizer = 1;
 }
@@ -2197,13 +2206,17 @@ def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoSideEffect]> {
     replaced with the constant. The result is an array type entity.
   }];
 
-  let arguments = (ins fir_SequenceType:$seq, AnyType:$val,
-                       Variadic<Index>:$coor);
+  let arguments = (ins fir_SequenceType:$seq, AnyType:$val, ArrayAttr:$coor);
   let results = (outs fir_SequenceType);
 
   let assemblyFormat = [{
-    operands attr-dict `:` functional-type(operands, results)
+    $seq `,` $val `,` $coor attr-dict `:` functional-type(operands, results)
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt, "mlir::Value":$val,
+      "llvm::ArrayRef<mlir::Value>":$vcoor)>
+  ];
 }
 
 def fir_LenParamIndexOp : fir_OneResultOp<"len_param_index", [NoSideEffect]> {

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -894,8 +894,7 @@ mlir::ParseResult fir::GlobalOp::verifyValidLinkage(StringRef linkage) {
 //===----------------------------------------------------------------------===//
 
 template <bool AllowFields>
-static void appendAsAttribute(OperationState &result,
-                              llvm::SmallVectorImpl<mlir::Attribute> &attrs,
+static void appendAsAttribute(llvm::SmallVectorImpl<mlir::Attribute> &attrs,
                               mlir::Value val) {
   if (auto op = val.getDefiningOp()) {
     if (auto cop = mlir::dyn_cast<mlir::ConstantOp>(op)) {
@@ -922,7 +921,7 @@ static mlir::ArrayAttr collectAsAttributes(mlir::MLIRContext *ctxt,
                                            llvm::ArrayRef<mlir::Value> inds) {
   llvm::SmallVector<mlir::Attribute> attrs;
   for (auto v : inds)
-    appendAsAttribute<AllowFields>(result, attrs, v);
+    appendAsAttribute<AllowFields>(attrs, v);
   assert(!attrs.empty());
   return mlir::ArrayAttr::get(ctxt, attrs);
 }

--- a/flang/test/Fir/complex.fir
+++ b/flang/test/Fir/complex.fir
@@ -27,7 +27,7 @@ func @foo(%a : !fir.complex<4>, %b : !fir.complex<4>, %c : !fir.complex<4>, %d :
 func @real_part(%a : !fir.complex<4>) -> f32 {
   %0 = constant 0 : i32
   // LLVMIR: extractvalue
-  %1 = fir.extract_value %a, %0 : (!fir.complex<4>, i32) -> f32
+  %1 = fir.extract_value %a, [0 : i32] : (!fir.complex<4>) -> f32
   return %1 : f32
 }
 
@@ -35,11 +35,11 @@ func @real_part(%a : !fir.complex<4>) -> f32 {
 func @conj(%a : !fir.complex<4>) -> !fir.complex<4> {
   %0 = constant 1 : i32
   // LLVMIR: extractvalue
-  %1 = fir.extract_value %a, %0 : (!fir.complex<4>, i32) -> f32
+  %1 = fir.extract_value %a, [1 : i32] : (!fir.complex<4>) -> f32
   // LLVMIR: fneg float
   %2 = fir.negf %1 : f32
   // LLVMIR: insertvalue
-  %3 = fir.insert_value %a, %2, %0 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %3 = fir.insert_value %a, %2, [1 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
   return %3 : !fir.complex<4>
 }
 
@@ -58,8 +58,8 @@ func @main() -> i32 {
 
   %f0 = constant 4.0 : f32
   %f1 = constant 52.5 : f32
-  %6 = fir.insert_value %5, %f0, %c0 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
-  %7 = fir.insert_value %6, %f1, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %6 = fir.insert_value %5, %f0, [0 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
+  %7 = fir.insert_value %6, %f1, [1 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
   fir.store %7 to %0 : !fir.ref<!fir.complex<4>>
 
   %8 = fir.load %0 : !fir.ref<!fir.complex<4>>
@@ -68,20 +68,20 @@ func @main() -> i32 {
 
   %a0 = constant 95.65 : f32
   %a1 = constant 234.1 : f32
-  %a2 = fir.insert_value %5, %a0, %c0 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
-  %a3 = fir.insert_value %a2, %a1, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %a2 = fir.insert_value %5, %a0, [0 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
+  %a3 = fir.insert_value %a2, %a1, [1 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
   fir.store %a3 to %2 : !fir.ref<!fir.complex<4>>
 
   %b0 = constant 33.0 : f32
   %b1 = constant 87.69 : f32
-  %b2 = fir.insert_value %5, %b0, %c0 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
-  %b3 = fir.insert_value %b2, %b1, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %b2 = fir.insert_value %5, %b0, [0 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
+  %b3 = fir.insert_value %b2, %b1, [1 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
   fir.store %b3 to %3 : !fir.ref<!fir.complex<4>>
 
   %d0 = constant 791.0 : f32
   %d1 = constant 3.5923 : f32
-  %d2 = fir.insert_value %5, %d0, %c0 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
-  %d3 = fir.insert_value %d2, %d1, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %d2 = fir.insert_value %5, %d0, [0 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
+  %d3 = fir.insert_value %d2, %d1, [1 : i32] : (!fir.complex<4>, f32) -> !fir.complex<4>
   fir.store %d3 to %4 : !fir.ref<!fir.complex<4>>
 
   %l0 = fir.load %0 : !fir.ref<!fir.complex<4>>
@@ -91,8 +91,8 @@ func @main() -> i32 {
   %l4 = fir.load %4 : !fir.ref<!fir.complex<4>>
 
   %10 = fir.call @foo(%l0, %l1, %l2, %l3, %l4) : (!fir.complex<4>, !fir.complex<4>, !fir.complex<4>, !fir.complex<4>, !fir.complex<4>) -> !fir.complex<4>
-  %11 = fir.extract_value %10, %c0 : (!fir.complex<4>, i32) -> f32
-  %12 = fir.extract_value %10, %c1 : (!fir.complex<4>, i32) -> f32
+  %11 = fir.extract_value %10, [0 : i32] : (!fir.complex<4>) -> f32
+  %12 = fir.extract_value %10, [1 : i32] : (!fir.complex<4>) -> f32
   fir.call @print_complex(%11, %12) : (f32, f32) -> ()
   return %c0 : i32
 }

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -89,22 +89,22 @@ func @instructions() {
 // CHECK: [[VAL_22:%.*]] = fir.coordinate_of [[VAL_5]], [[VAL_21]] : (!fir.heap<!fir.array<100xf32>>, i32) -> !fir.ref<f32>
 // CHECK: [[VAL_23:%.*]] = fir.field_index f, !fir.type<derived{f:f32}>
 // CHECK: [[VAL_24:%.*]] = fir.undefined !fir.type<derived{f:f32}>
-// CHECK: [[VAL_25:%.*]] = fir.extract_value [[VAL_24]], [[VAL_23]] : (!fir.type<derived{f:f32}>, !fir.field) -> f32
+// CHECK: [[VAL_25:%.*]] = fir.extract_value [[VAL_24]], ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>) -> f32
   %19 = constant 10 : i32
   %20 = fir.coordinate_of %5, %19 : (!fir.heap<!fir.array<100xf32>>, i32) -> !fir.ref<f32>
   %21 = fir.field_index f, !fir.type<derived{f:f32}>
   %22 = fir.undefined !fir.type<derived{f:f32}>
-  %23 = fir.extract_value %22, %21 : (!fir.type<derived{f:f32}>, !fir.field) -> f32
+  %23 = fir.extract_value %22, ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>) -> f32
 
 // CHECK: [[VAL_26:%.*]] = constant 1 : i32
 // CHECK: [[VAL_27:%.*]] = fir.shape [[VAL_21]] : (i32) -> !fir.shape<1>
 // CHECK: [[VAL_28:%.*]] = constant 1.0
-// CHECK: [[VAL_29:%.*]] = fir.insert_value [[VAL_24]], [[VAL_28]], [[VAL_23]] : (!fir.type<derived{f:f32}>, f32, !fir.field) -> !fir.type<derived{f:f32}>
+// CHECK: [[VAL_29:%.*]] = fir.insert_value [[VAL_24]], [[VAL_28]], ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>, f32) -> !fir.type<derived{f:f32}>
 // CHECK: [[VAL_30:%.*]] = fir.len_param_index f, !fir.type<derived3{f:f32}>
   %c1 = constant 1 : i32
   %24 = fir.shape %19 : (i32) -> !fir.shape<1>
   %cf1 = constant 1.0 : f32
-  %25 = fir.insert_value %22, %cf1, %21 : (!fir.type<derived{f:f32}>, f32, !fir.field) -> !fir.type<derived{f:f32}>
+  %25 = fir.insert_value %22, %cf1, ["f", !fir.type<derived{f:f32}>] : (!fir.type<derived{f:f32}>, f32) -> !fir.type<derived{f:f32}>
   %26 = fir.len_param_index f, !fir.type<derived3{f:f32}>
 
 // CHECK: [[VAL_31:%.*]] = fir.call @box3() : () -> !fir.box<!fir.type<derived3{f:f32}>>
@@ -150,10 +150,10 @@ func @boxing_match() {
 // CHECK: [[VAL_48:%.*]] = fir.undefined !fir.type<qq2{f1:i32,f2:f64}>
 // CHECK: [[VAL_49:%.*]] = constant 0 : i32
 // CHECK: [[VAL_50:%.*]] = constant 12 : i32
-// CHECK: [[VAL_51:%.*]] = fir.insert_value [[VAL_48]], [[VAL_50]], [[VAL_49]] : (!fir.type<qq2{f1:i32,f2:f64}>, i32, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
+// CHECK: [[VAL_51:%.*]] = fir.insert_value [[VAL_48]], [[VAL_50]], [0 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
 // CHECK: [[VAL_52:%.*]] = constant 1 : i32
 // CHECK: [[VAL_53:%.*]] = constant 4.213000e+01 : f64
-// CHECK: [[VAL_54:%.*]] = fir.insert_value [[VAL_48]], [[VAL_53]], [[VAL_52]] : (!fir.type<qq2{f1:i32,f2:f64}>, f64, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
+// CHECK: [[VAL_54:%.*]] = fir.insert_value [[VAL_48]], [[VAL_53]], [1 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, f64) -> !fir.type<qq2{f1:i32,f2:f64}>
 // CHECK: fir.store [[VAL_54]] to [[VAL_39]] : !fir.ref<!fir.type<qq2{f1:i32,f2:f64}>>
 // CHECK: [[VAL_55:%.*]] = fir.emboxproc @method_impl, [[VAL_41]] : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32, f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
 // CHECK: [[VAL_56:%.*]], [[VAL_57:%.*]] = fir.unboxproc [[VAL_55]] : (!fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>) -> ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<!fir.type<qq2{f1:i32,f2:f64}>>>)
@@ -176,10 +176,10 @@ func @boxing_match() {
   %6 = fir.undefined !fir.type<qq2{f1:i32,f2:f64}>
   %z = constant 0 : i32
   %c12 = constant 12 : i32
-  %a2 = fir.insert_value %6, %c12, %z : (!fir.type<qq2{f1:i32,f2:f64}>, i32, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
+  %a2 = fir.insert_value %6, %c12, [0 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
   %z1 = constant 1 : i32
   %c42 = constant 42.13 : f64
-  %a3 = fir.insert_value %6, %c42, %z1 : (!fir.type<qq2{f1:i32,f2:f64}>, f64, i32) -> !fir.type<qq2{f1:i32,f2:f64}>
+  %a3 = fir.insert_value %6, %c42, [1 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, f64) -> !fir.type<qq2{f1:i32,f2:f64}>
   fir.store %a3 to %d6 : !fir.ref<!fir.type<qq2{f1:i32,f2:f64}>>
   %7 = fir.emboxproc @method_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
   %8:2 = fir.unboxproc %7 : (!fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>) -> ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<!fir.type<qq2{f1:i32,f2:f64}>>>)
@@ -621,10 +621,10 @@ func @test_misc_ops(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m : index, %n : inde
   %c1_i32 = constant 9 : i32
 
   // CHECK: [[ARR2:%.*]] = fir.zero_bits !fir.array<10xi32>
-  // CHECK: [[ARR3:%.*]] = fir.insert_on_range [[ARR2]], [[C1_I32]], [[C2]], [[C9]] : (!fir.array<10xi32>, i32, index, index) -> !fir.array<10xi32>
+  // CHECK: [[ARR3:%.*]] = fir.insert_on_range [[ARR2]], [[C1_I32]], [2 : index, 9 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
   // CHECK: fir.call @noret1([[ARR3]]) : (!fir.array<10xi32>) -> ()
   %arr2 = fir.zero_bits !fir.array<10xi32>
-  %arr3 = fir.insert_on_range %arr2, %c1_i32, %c2, %c9 : (!fir.array<10xi32>, i32, index, index) -> !fir.array<10xi32>
+  %arr3 = fir.insert_on_range %arr2, %c1_i32, [2 : index, 9 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
   fir.call @noret1(%arr3) : (!fir.array<10xi32>) -> ()
 
   // CHECK: [[SHAPE:%.*]] = fir.shape_shift [[INDXM:%.*]], [[INDXN:%.*]], [[INDXO:%.*]], [[INDXP:%.*]] : (index, index, index, index) -> !fir.shapeshift<2>

--- a/flang/test/Fir/target.fir
+++ b/flang/test/Fir/target.fir
@@ -12,10 +12,10 @@ func @gen4() -> !fir.complex<4> {
   %2 = constant 2.0 : f32
   %3 = fir.convert %2 : (f32) -> !fir.real<4>
   %c0 = constant 0 : i32
-  %4 = fir.insert_value %1, %3, %c0 : (!fir.complex<4>, !fir.real<4>, i32) -> !fir.complex<4>
+  %4 = fir.insert_value %1, %3, [0 : index] : (!fir.complex<4>, !fir.real<4>) -> !fir.complex<4>
   %c1 = constant 1 : i32
   %5 = constant -42.0 : f32
-  %6 = fir.insert_value %4, %5, %c1 : (!fir.complex<4>, f32, i32) -> !fir.complex<4>
+  %6 = fir.insert_value %4, %5, [1 : index] : (!fir.complex<4>, f32) -> !fir.complex<4>
   // I32: store { float, float } { float 2.000000e+00, float -4.200000e+01 }
   // I32: %[[load:.*]] = load i64, i64*
   // I32: ret i64 %[[load]]
@@ -36,9 +36,9 @@ func @gen8() -> !fir.complex<8> {
   %2 = constant 1.0 : f64
   %3 = constant -4.0 : f64
   %c0 = constant 0 : i32
-  %4 = fir.insert_value %1, %3, %c0 : (!fir.complex<8>, f64, i32) -> !fir.complex<8>
+  %4 = fir.insert_value %1, %3, [0 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   %c1 = constant 1 : i32
-  %5 = fir.insert_value %4, %2, %c1 : (!fir.complex<8>, f64, i32) -> !fir.complex<8>
+  %5 = fir.insert_value %4, %2, [1 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   // I32: store { double, double } { double -4.000000e+00, double 1.000000e+00 }
   // I64: store { double, double } { double -4.000000e+00, double 1.000000e+00 }
   // I64: %[[load:.*]] = load { double, double }

--- a/flang/test/Fir/undo-complex-pattern.fir
+++ b/flang/test/Fir/undo-complex-pattern.fir
@@ -6,17 +6,17 @@
 func @add(%z: !fir.ref<!fir.complex<8>>, %z1 : !fir.complex<8>, %z2 : !fir.complex<8>) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %real1 = fir.extract_value %z1, %c0 : (!fir.complex<8>, index) -> f64
-  %imag1 = fir.extract_value %z1, %c1 : (!fir.complex<8>, index) -> f64
-  %real2 = fir.extract_value %z2, %c0 : (!fir.complex<8>, index) -> f64
-  %imag2 = fir.extract_value %z2, %c1 : (!fir.complex<8>, index) -> f64
+  %real1 = fir.extract_value %z1, [0 : index] : (!fir.complex<8>) -> f64
+  %imag1 = fir.extract_value %z1, [1 : index] : (!fir.complex<8>) -> f64
+  %real2 = fir.extract_value %z2, [0 : index] : (!fir.complex<8>) -> f64
+  %imag2 = fir.extract_value %z2, [1 : index] : (!fir.complex<8>) -> f64
 
   // CHECK-LABEL: fir.addc
   %real = addf %real1, %real2 : f64
   %imag = addf %imag1, %imag2 : f64
   %undef = fir.undefined !fir.complex<8>
-  %insert_real = fir.insert_value %undef, %real, %c0 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
-  %insert_imag = fir.insert_value %insert_real, %imag, %c1 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
+  %insert_real = fir.insert_value %undef, %real, [0 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
+  %insert_imag = fir.insert_value %insert_real, %imag, [1 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   fir.store %insert_imag to %z : !fir.ref<!fir.complex<8>>
   return
 }
@@ -25,17 +25,17 @@ func @add(%z: !fir.ref<!fir.complex<8>>, %z1 : !fir.complex<8>, %z2 : !fir.compl
 func @sub(%z: !fir.ref<!fir.complex<8>>, %z1 : !fir.complex<8>, %z2 : !fir.complex<8>) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %real1 = fir.extract_value %z1, %c0 : (!fir.complex<8>, index) -> f64
-  %imag1 = fir.extract_value %z1, %c1 : (!fir.complex<8>, index) -> f64
-  %real2 = fir.extract_value %z2, %c0 : (!fir.complex<8>, index) -> f64
-  %imag2 = fir.extract_value %z2, %c1 : (!fir.complex<8>, index) -> f64
+  %real1 = fir.extract_value %z1, [0 : index] : (!fir.complex<8>) -> f64
+  %imag1 = fir.extract_value %z1, [1 : index] : (!fir.complex<8>) -> f64
+  %real2 = fir.extract_value %z2, [0 : index] : (!fir.complex<8>) -> f64
+  %imag2 = fir.extract_value %z2, [1 : index] : (!fir.complex<8>) -> f64
 
   // CHECK-LABEL: fir.subc
   %real = subf %real1, %real2 : f64
   %imag = subf %imag1, %imag2 : f64
   %undef = fir.undefined !fir.complex<8>
-  %insert_real = fir.insert_value %undef, %real, %c0 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
-  %insert_imag = fir.insert_value %insert_real, %imag, %c1 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
+  %insert_real = fir.insert_value %undef, %real, [0 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
+  %insert_imag = fir.insert_value %insert_real, %imag, [1 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   fir.store %insert_imag to %z : !fir.ref<!fir.complex<8>>
   return
 }
@@ -60,14 +60,14 @@ func @undefOpHiddenByBranch(%z: !fir.ref<!fir.complex<8>>, %b: i1) {
 // CHECK:  fir.addc %[[z1]], %[[z2]] : !fir.complex<8>
 
 ^bb3(%undef : !fir.complex<8>, %z1 : !fir.complex<8>, %z2 : !fir.complex<8>):  // 2 preds: ^bb1, ^bb2
-  %real1 = fir.extract_value %z1, %c0 : (!fir.complex<8>, index) -> f64
-  %imag1 = fir.extract_value %z1, %c1 : (!fir.complex<8>, index) -> f64
-  %real2 = fir.extract_value %z2, %c0 : (!fir.complex<8>, index) -> f64
-  %imag2 = fir.extract_value %z2, %c1 : (!fir.complex<8>, index) -> f64
+  %real1 = fir.extract_value %z1, [0 : index] : (!fir.complex<8>) -> f64
+  %imag1 = fir.extract_value %z1, [1 : index] : (!fir.complex<8>) -> f64
+  %real2 = fir.extract_value %z2, [0 : index] : (!fir.complex<8>) -> f64
+  %imag2 = fir.extract_value %z2, [1 : index] : (!fir.complex<8>) -> f64
   %real = addf %real1, %real2 : f64
   %imag = addf %imag1, %imag2 : f64
-  %insert_real = fir.insert_value %undef, %real, %c0 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
-  %insert_imag = fir.insert_value %insert_real, %imag, %c1 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
+  %insert_real = fir.insert_value %undef, %real, [0 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
+  %insert_imag = fir.insert_value %insert_real, %imag, [1 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   fir.store %insert_imag to %z : !fir.ref<!fir.complex<8>>
   return
 }
@@ -78,20 +78,20 @@ func private @bar2() -> !fir.complex<8>
 func @close_but_bad_pattern(%z: !fir.ref<!fir.complex<8>>, %z1 : !fir.complex<8>, %z2 : !fir.complex<8>) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %real1 = fir.extract_value %z1, %c0 : (!fir.complex<8>, index) -> f64
+  %real1 = fir.extract_value %z1, [0 : index] : (!fir.complex<8>) -> f64
   // extracting %c0 instead of %c1 
-  %imag1 = fir.extract_value %z1, %c0 : (!fir.complex<8>, index) -> f64
-  %real2 = fir.extract_value %z2, %c0 : (!fir.complex<8>, index) -> f64
-  %imag2 = fir.extract_value %z2, %c1 : (!fir.complex<8>, index) -> f64
+  %imag1 = fir.extract_value %z1, [0 : index] : (!fir.complex<8>) -> f64
+  %real2 = fir.extract_value %z2, [0 : index] : (!fir.complex<8>) -> f64
+  %imag2 = fir.extract_value %z2, [1 : index] : (!fir.complex<8>) -> f64
   // CHECK: subf
   // CHECK: subf
   %real = subf %real1, %real2 : f64
   %imag = subf %imag1, %imag2 : f64
   %undef = fir.undefined !fir.complex<8>
-  // CHECK: %[[insert1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, %{{.*}}
-  // CHECK: %[[insert2:.*]] = fir.insert_value %[[insert1]], %{{.*}}, %{{.*}}
-  %insert_real = fir.insert_value %undef, %real, %c0 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
-  %insert_imag = fir.insert_value %insert_real, %imag, %c1 : (!fir.complex<8>, f64, index) -> !fir.complex<8>
+  // CHECK: %[[insert1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, [0
+  // CHECK: %[[insert2:.*]] = fir.insert_value %[[insert1]], %{{.*}}, [1
+  %insert_real = fir.insert_value %undef, %real, [0 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
+  %insert_imag = fir.insert_value %insert_real, %imag, [1 : index] : (!fir.complex<8>, f64) -> !fir.complex<8>
   // CHECK: fir.store %[[insert2]] to {{.*}}
   fir.store %insert_imag to %z : !fir.ref<!fir.complex<8>>
   return

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -93,21 +93,14 @@ end subroutine range
   ! CHECK-DAG: %[[c1_i32:.*]] = constant 1 : i32
   ! CHECK-DAG: %[[c2_i32:.*]] = constant 2 : i32
   ! CHECK-DAG: %[[c3_i32:.*]] = constant 3 : i32
-  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
-  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
-  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
-  ! CHECK-DAG: %[[c9:.*]] = constant 9 : index
-  ! CHECK: %[[r1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, %{{.*}} :
-  ! CHECK: %[[r2:.*]] = fir.insert_value %[[r1]], %{{.*}}, %{{.*}} :
-  ! CHECK: %[[r3:.*]] = fir.insert_on_range %[[r2]], %[[c3_i32]], %[[c2]], %[[c9]] :
+  ! CHECK: %[[r1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, [0 : index] :
+  ! CHECK: %[[r2:.*]] = fir.insert_value %[[r1]], %{{.*}}, [1 : index] :
+  ! CHECK: %[[r3:.*]] = fir.insert_on_range %[[r2]], %[[c3_i32]], [2 : index, 9 : index] :
 
 ! a1 array constructor
 ! CHECK: fir.global internal @_QQro.2x3xr4.{{.*}} constant : !fir.array<2x3xf32> {
   ! CHECK-DAG: %cst = constant {{.*}} : f32
-  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
-  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
-  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
-  ! CHECK: %{{.*}} = fir.insert_on_range %{{[0-9]+}}, %cst, %[[c0]], %[[c1]], %[[c0]], %[[c2]] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{[0-9]+}}, %cst, [0 : index, 1 : index, 0 : index, 2 : index] :
 
 ! a2 array constructor
 ! CHECK: fir.global internal @_QQro.3x4xi4.{{.*}} constant : !fir.array<3x4xi32> {
@@ -116,36 +109,45 @@ end subroutine range
   ! CHECK-DAG: %[[c5_i32:.*]] = constant 5 : i32
   ! CHECK-DAG: %[[c8_i32:.*]] = constant 8 : i32
   ! CHECK-DAG: %[[c9_i32:.*]] = constant 9 : i32
-  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
-  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
-  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
-  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
-  ! CHECK: %[[r1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
-  ! CHECK: %[[r2:.*]] = fir.insert_on_range %[[r1]], %[[c3_i32]], %[[c1]], %[[c2]], %[[c0]], %[[c0]] :
-  ! CHECK: %[[r3:.*]] = fir.insert_value %[[r2]], %{{.*}}, %{{.*}}, %{{.*}} :
-  ! CHECK: %[[r4:.*]] = fir.insert_on_range %[[r3]], %[[c3_i32]], %[[c1]], %[[c1]], %[[c1]], %[[c2]] :
-  ! CHECK: %[[r5:.*]] = fir.insert_on_range %[[r4]], %[[c9_i32]], %[[c2]], %[[c1]], %[[c2]], %[[c3]] :
-  ! CHECK: %[[r6:.*]] = fir.insert_value %[[r5]], %{{.*}}, %{{.*}}, %{{.*}} :
+  ! CHECK: %[[r1:.*]] = fir.insert_value %{{.*}}, %{{.*}}, [0 : index, 0 : index] :
+  ! CHECK: %[[r2:.*]] = fir.insert_on_range %[[r1]], %[[c3_i32]], [1 : index, 2 : index, 0 : index, 0 : index] :
+  ! CHECK: %[[r3:.*]] = fir.insert_value %[[r2]], %{{.*}}, [0 : index, 1 : index] :
+  ! CHECK: %[[r4:.*]] = fir.insert_on_range %[[r3]], %[[c3_i32]], [1 : index, 1 : index, 1 : index, 2 : index] :
+  ! CHECK: %[[r5:.*]] = fir.insert_on_range %[[r4]], %[[c9_i32]], [2 : index, 1 : index, 2 : index, 3 : index] :
+  ! CHECK: %[[r6:.*]] = fir.insert_value %[[r5]], %{{.*}}, [2 : index, 3 : index] :
 
 ! CHECK-LABEL rangeGlobal
 subroutine rangeGlobal()
   ! CHECK-DAG: %[[c1_i32:.*]] = constant 1 : i32
   ! CHECK-DAG: %[[c2_i32:.*]] = constant 2 : i32
   ! CHECK-DAG: %[[c3_i32:.*]] = constant 3 : i32
-  ! CHECK-DAG: %[[c0:.*]] = constant 0 : index
-  ! CHECK-DAG: %[[c1:.*]] = constant 1 : index
-  ! CHECK-DAG: %[[c2:.*]] = constant 2 : index
-  ! CHECK-DAG: %[[c3:.*]] = constant 3 : index
-  ! CHECK-DAG: %[[c4:.*]] = constant 4 : index
-  ! CHECK-DAG: %[[c5:.*]] = constant 5 : index
-  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c1_i32]], %[[c0]], %[[c1]] :
-  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c2_i32]], %[[c2]], %[[c3]] :
-  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c3_i32]], %[[c4]], %[[c5]] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c1_i32]], [0 : index, 1 : index] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c2_i32]], [2 : index, 3 : index] :
+  ! CHECK: %{{.*}} = fir.insert_on_range %{{.*}}, %[[c3_i32]], [4 : index, 5 : index] :
   integer, dimension(6) :: a0 = (/ 1, 1, 2, 2, 3, 3 /)
 
 end subroutine rangeGlobal
 
 block data
+   ! CHECK: %[[VAL_223:.*]] = constant 1.000000e+00 : f32
+   ! CHECK: %[[VAL_224:.*]] = constant 2.400000e+00 : f32
+   ! CHECK: %[[VAL_225:.*]] = constant 0.000000e+00 : f32
+   ! CHECK: %[[VAL_226:.*]] = fir.undefined tuple<!fir.array<5x5xf32>>
+   ! CHECK: %[[VAL_227:.*]] = fir.undefined !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_228:.*]] = fir.insert_on_range %[[VAL_227]], %[[VAL_223]], [0 : index, 1 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_229:.*]] = fir.insert_on_range %[[VAL_228]], %[[VAL_225]], [2 : index, 4 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_230:.*]] = fir.insert_on_range %[[VAL_229]], %[[VAL_223]], [0 : index, 1 : index, 1 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_231:.*]] = fir.insert_value %[[VAL_230]], %[[VAL_225]], [2 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_232:.*]] = fir.insert_value %[[VAL_231]], %[[VAL_224]], [3 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_233:.*]] = fir.insert_value %[[VAL_232]], %[[VAL_225]], [4 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_234:.*]] = fir.insert_on_range %[[VAL_233]], %[[VAL_223]], [0 : index, 1 : index, 2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_235:.*]] = fir.insert_value %[[VAL_234]], %[[VAL_225]], [2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_236:.*]] = fir.insert_value %[[VAL_235]], %[[VAL_224]], [3 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_237:.*]] = fir.insert_on_range %[[VAL_236]], %[[VAL_225]], [4 : index, 2 : index, 2 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_238:.*]] = fir.insert_value %[[VAL_237]], %[[VAL_224]], [3 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_239:.*]] = fir.insert_on_range %[[VAL_238]], %[[VAL_225]], [4 : index, 4 : index, 3 : index, 4 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+   ! CHECK: %[[VAL_240:.*]] = fir.insert_value %[[VAL_226]], %[[VAL_239]], [0 : index] : (tuple<!fir.array<5x5xf32>>, !fir.array<5x5xf32>) -> tuple<!fir.array<5x5xf32>>
+   ! CHECK: fir.has_value %[[VAL_240]] : tuple<!fir.array<5x5xf32>>
   real :: x(5,5)
   common /block/ x
   data x(1,1), x(2,1), x(3,1) / 1, 1, 0 /

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -18,7 +18,7 @@ subroutine assign1(lhs, rhs)
   ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%{{.*}}, %[[src]], %[[count]], %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
 
   ! Padding
-  ! CHECK-DAG: %[[blank:.*]] = fir.insert_value %{{.*}}, %c32{{.*}}, %c0{{.*}} : (!fir.char<1>, i8, index) -> !fir.char<1>
+  ! CHECK-DAG: %[[blank:.*]] = fir.insert_value %{{.*}}, %c32{{.*}}, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
   ! CHECK: fir.do_loop %[[ij:.*]] =
     ! CHECK-DAG: %[[lhs_cast:.*]] = fir.convert %[[lhs]]#0
     ! CHECK: %[[lhs_addr:.*]] = fir.coordinate_of %[[lhs_cast]], %[[ij]]
@@ -75,7 +75,7 @@ subroutine assign_constant(lhs)
   ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[dst]], %[[src]], %[[count]], %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
 
   ! Padding
-  ! CHECK-DAG: %[[blank:.*]] = fir.insert_value %{{.*}}, %c32{{.*}}, %c0{{.*}} : (!fir.char<1>, i8, index) -> !fir.char<1>
+  ! CHECK-DAG: %[[blank:.*]] = fir.insert_value %{{.*}}, %c32{{.*}}, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
   ! CHECK: fir.do_loop %[[j:.*]] = %{{.*}} to %{{.*}} {
     ! CHECK-DAG: %[[jhs_cast:.*]] = fir.convert %[[lhs]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
     ! CHECK: %[[jhs_addr:.*]] = fir.coordinate_of %[[jhs_cast]], %[[j]]

--- a/flang/test/Lower/derived-pointer-components.f90
+++ b/flang/test/Lower/derived-pointer-components.f90
@@ -689,7 +689,7 @@ module pinit
     ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
     ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEreal_target)
     ! CHECK: %[[box:.*]] = fir.embox %[[target]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
-    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], ["p", !fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>] :
     ! CHECK: fir.has_value %[[insert]]
   type(real_p0) :: arp0 = real_p0(real_target)
 
@@ -700,7 +700,7 @@ module pinit
     ! CHECK-DAG: %[[shape:.*]] = fir.shape %c100{{.*}}
     ! CHECK-DAG: %[[slice:.*]] = fir.slice %c10{{.*}}, %c50{{.*}}, %c5{{.*}}
     ! CHECK: %[[box:.*]] = fir.embox %[[target]](%[[shape]]) [%[[slice]]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], ["p", !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>] :
     ! CHECK: fir.has_value %[[insert]]
   type(real_p1) :: brp1 = real_p1(real_array_target(10:50:5))
 
@@ -709,7 +709,7 @@ module pinit
     ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
     ! CHECK-DAG: %[[target:.*]] = fir.address_of(@_QMpcompEchar_target)
     ! CHECK: %[[box:.*]] = fir.embox %[[target]] : (!fir.ref<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
-    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], ["p", !fir.type<_QMpcompTcst_char_p0{p:!fir.box<!fir.ptr<!fir.char<1,10>>>}>] :
     ! CHECK: fir.has_value %[[insert]]
   type(cst_char_p0) :: ccp0 = cst_char_p0(char_target)
 
@@ -720,7 +720,7 @@ module pinit
     ! CHECK-DAG: %[[cast:.*]] = fir.convert %[[target]] : (!fir.ref<!fir.array<100x!fir.char<1,10>>>) -> !fir.ptr<!fir.array<?x!fir.char<1,?>>>
     ! CHECK-DAG: %[[shape:.*]] = fir.shape %c100{{.*}}
     ! CHECK-DAG: %[[box:.*]] = fir.embox %[[cast]](%[[shape]]) typeparams %c10{{.*}} : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
-    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], %[[fld]]
+    ! CHECK: %[[insert:.*]] = fir.insert_value %[[undef]], %[[box]], ["p", !fir.type<_QMpcompTdef_char_p1{p:!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>}>] :
     ! CHECK: fir.has_value %[[insert]]
   type(def_char_p1) :: dcp1 = def_char_p1(char_array_target)
 end module

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -159,7 +159,7 @@ end subroutine
 !CHECK-LABEL: func private @fir.aimag.f32.ref_z4(%arg0: !fir.ref<!fir.complex<4>>)
   !CHECK: %[[load:.*]] = fir.load %arg0
   !CHECK: %[[cst1:.*]] = constant 1
-  !CHECK: %[[imag:.*]] = fir.extract_value %[[load]], %[[cst1]] : (!fir.complex<4>, index) -> f32
+  !CHECK: %[[imag:.*]] = fir.extract_value %[[load]], [1 : index] : (!fir.complex<4>) -> f32
   !CHECK: return %[[imag]] : f32
 
 !CHECK-LABEL: func private @fir.len.i32.bc1(%arg0: !fir.boxchar<1>)

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -333,14 +333,14 @@ subroutine ichar_test(c)
   ! CHECK-DAG: %[[STR:.*]] = fir.alloca !fir.array{{.*}} {{{.*}}uniq_name = "{{.*}}Estr"}
   ! CHECK: %[[BOX:.*]] = fir.convert %[[unbox]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1>>
   ! CHECK: %[[CHAR:.*]] = fir.load %[[BOX]] : !fir.ref<!fir.char<1>>
-  ! CHECK: fir.extract_value %[[CHAR]], %c0{{.*}}
+  ! CHECK: fir.extract_value %[[CHAR]], [0 : index] :
   print *, ichar(c)
   ! CHECK: fir.call @{{.*}}EndIoStatement
 
   ! CHECK-DAG: %{{.*}} = fir.load %[[J]] : !fir.ref<i32>
   ! CHECK: %[[ptr:.*]] = fir.coordinate_of %[[STR]], %
   ! CHECK: %[[VAL:.*]] = fir.load %[[ptr]] : !fir.ref<!fir.char<1>>
-  ! CHECK: fir.extract_value %[[VAL]], %c0{{.*}}
+  ! CHECK: fir.extract_value %[[VAL]], [0 : index] :
   print *, ichar(str(J))
   ! CHECK: fir.call @{{.*}}EndIoStatement
 end subroutine

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -27,7 +27,7 @@ end module
 ! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
   ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
   ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
-  ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], %c1{{.*}} : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32, index) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
+  ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], [1 : index] : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
   ! CHECK: fir.has_value %[[init]] : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
 
 ! Module defines variable in common block without initializer
@@ -48,5 +48,5 @@ module modCommonInit1
   common /named2/ i_named2
 end module
 ! CHECK-LABEL: fir.global @_QBnamed2 : tuple<i32> {
-  ! CHECK: %[[init:.*]] = fir.insert_value %{{.*}}, %c42{{.*}}, %c0{{.*}} : (tuple<i32>, i32, index) -> tuple<i32>
+  ! CHECK: %[[init:.*]] = fir.insert_value %{{.*}}, %c42{{.*}}, [0 : index] : (tuple<i32>, i32) -> tuple<i32>
   ! CHECK: fir.has_value %[[init]] : tuple<i32>

--- a/flang/test/Lower/pointer-initial-target-2.f90
+++ b/flang/test/Lower/pointer-initial-target-2.f90
@@ -42,7 +42,7 @@ block data
   ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.box<!fir.ptr<f32>>>
   ! CHECK: %[[b:.*]] = fir.address_of(@_QEb) : !fir.ref<f32>
   ! CHECK: %[[box:.*]] = fir.embox %[[b]] : (!fir.ref<f32>) -> !fir.box<!fir.ptr<f32>>
-  ! CHECK: %[[a:.*]] = fir.insert_value %[[undef]], %[[box]], %c0{{.*}} : (tuple<!fir.box<!fir.ptr<f32>>>, !fir.box<!fir.ptr<f32>>, index) -> tuple<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[a:.*]] = fir.insert_value %[[undef]], %[[box]], [0 : index] : (tuple<!fir.box<!fir.ptr<f32>>>, !fir.box<!fir.ptr<f32>>) -> tuple<!fir.box<!fir.ptr<f32>>>
   ! CHECK: fir.has_value %[[a]] : tuple<!fir.box<!fir.ptr<f32>>>
 end block data
 
@@ -58,8 +58,8 @@ block data snake
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[byteView]], %c24{{.*}} : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
   ! CHECK: %[[bAddr:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i32>
   ! CHECK: %[[box:.*]] = fir.embox %[[bAddr]] : (!fir.ref<i32>) -> !fir.box<!fir.ptr<i32>>
-  ! CHECK: %[[tuple1:.*]] = fir.insert_value %[[tuple0]], %[[box]], %c0{{.*}} : (tuple<!fir.box<!fir.ptr<i32>>, i32>, !fir.box<!fir.ptr<i32>>, index) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
-  ! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple1]], %c42{{.*}}, %c1{{.*}} : (tuple<!fir.box<!fir.ptr<i32>>, i32>, i32, index) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: %[[tuple1:.*]] = fir.insert_value %[[tuple0]], %[[box]], [0 : index] : (tuple<!fir.box<!fir.ptr<i32>>, i32>, !fir.box<!fir.ptr<i32>>) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
+  ! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple1]], %c42{{.*}}, [1 : index] : (tuple<!fir.box<!fir.ptr<i32>>, i32>, i32) -> tuple<!fir.box<!fir.ptr<i32>>, i32>
   ! CHECK: fir.has_value %[[tuple2]] : tuple<!fir.box<!fir.ptr<i32>>, i32>
 end block data
 


### PR DESCRIPTION
There are constraints on LLVM instructions that cannot be adequately
enforced on MLIR Ops. This change converts insert_value, extract_value,
and insert_on_range to use explicitly captured constants in attributes
rather than try to use constant ops. Constant ops are problematic
because MLIR can treat them as ssa-values and convert ops expecting
constant values as operands into ops with non-constant operands.