### PR TITLE
Add missing result type for genFuncDim() function and fix typo.

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -140,6 +140,15 @@ genFuncDim(FD funcDim, mlir::Type resultType,
             [=]() { bldr->create<fir::FreeMemOp>(loc, temp); });
         return box;
       },
+      [&](const fir::CharArrayBoxValue &box) -> fir::ExtendedValue {
+        // Add cleanup code
+        assert(stmtCtx);
+        auto *bldr = &builder;
+        auto temp = box.getAddr();
+        stmtCtx->attachCleanup(
+            [=]() { bldr->create<fir::FreeMemOp>(loc, temp); });
+        return box;
+      },
       [&](const auto &) -> fir::ExtendedValue {
         fir::emitFatalError(loc, errMsg);
       });

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -263,7 +263,7 @@ end subroutine
 
 ! COUNT
 ! CHECK-LABEL: test_count3
-! CHRECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>) 
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>) 
 subroutine test_count3(rslt, mask)
   integer :: rslt
   logical :: mask(:)


### PR DESCRIPTION
Note: The missing result type was exposed by intrin051 and intrin058
tests.