### PR TITLE
Fix fir.coorfinate_of fir.box regression

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2005,7 +2005,8 @@ struct CoordinateOpConversion
           mlir::Value off = genConstantIndex(loc, idxTy, rewriter, 0);
           for (unsigned index = i, lastIndex = i + arrTy.getDimension();
                index < lastIndex; ++index) {
-            auto stride = loadStrideFromBox(loc, operands[0], index, rewriter);
+            auto stride =
+                loadStrideFromBox(loc, operands[0], index - i, rewriter);
             auto sc = rewriter.create<mlir::LLVM::MulOp>(
                 loc, idxTy, operands[index], stride);
             off = rewriter.create<mlir::LLVM::AddOp>(loc, idxTy, sc, off);

--- a/flang/test/Fir/coordinateof.fir
+++ b/flang/test/Fir/coordinateof.fir
@@ -62,3 +62,23 @@ func @foo5(%box : !fir.box<!fir.ptr<!fir.array<?xi32>>>, %i : index) -> i32 {
   %rv = fir.load %1 : !fir.ref<i32>
   return %rv : i32
 }
+
+// CHECK-LABEL: @foo6
+// CHECK-SAME: ({ [1 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[box:.*]], i64 %{{.*}}, [1 x i8]* %{{.*}}) 
+func @foo6(%box : !fir.box<!fir.ptr<!fir.array<?x!fir.char<1>>>>, %i : i64 , %res : !fir.ref<!fir.char<1>>) {
+  // CHECK: %[[addr_gep:.*]] = getelementptr { [1 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { [1 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[box]], i32 0, i32 0
+  // CHECK: %[[addr:.*]] = load [1 x i8]*, [1 x i8]** %[[addr_gep]]
+  // CHECK: %[[stride_gep:.*]] = getelementptr { [1 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { [1 x i8]*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[box]], i32 0, i32 7, i64 0, i32 2
+  // CHECK: %[[stride:.*]] = load i64, i64* %[[stride_gep]]
+  // CHECK: %[[mul:.*]] = mul i64 %{{.*}}, %[[stride]]
+  // CHECK: %[[offset:.*]] = add i64 %[[mul]], 0
+  // CHECK: %[[cast:.*]] = bitcast [1 x i8]* %[[addr]] to i8*
+  // CHECK: %[[gep:.*]] = getelementptr i8, i8* %[[cast]], i64 %[[offset]]
+  // CHECK: %[[cast2:.*]] = bitcast i8* %[[gep]] to [1 x i8]*
+  %coor = fir.coordinate_of %box, %i : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1>>>>, i64) -> !fir.ref<!fir.char<1>>
+
+  // CHECK: load [1 x i8], [1 x i8]* %[[cast2]]
+  %load = fir.load %coor : !fir.ref<!fir.char<1>>
+  fir.store %load to %res : !fir.ref<!fir.char<1>>
+  return
+}


### PR DESCRIPTION
`index` is starting at 1, so it cannot directly be used as an index into the dimension array that is zero based.