### PR TITLE
Harden to produce an error when a symbol is not in the map.

### DIFF
--- a/flang/include/flang/Lower/HostAssociations.h
+++ b/flang/include/flang/Lower/HostAssociations.h
@@ -36,7 +36,7 @@ public:
   /// host procedure.
   void addSymbolsToBind(
       const llvm::SetVector<const Fortran::semantics::Symbol *> &s) {
-    assert(empty());
+    assert(empty() && "symbol set must be initially empty");
     symbols = s;
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -212,8 +212,10 @@ public:
     for (const auto &var : funit.getOrderedSymbolTable()) {
       const auto &sym = var.getSymbol();
       if (const auto *details =
-              sym.detailsIf<Fortran::semantics::HostAssocDetails>())
+              sym.detailsIf<Fortran::semantics::HostAssocDetails>()) {
+        LLVM_DEBUG(llvm::dbgs() << "host associated symbol " << sym << '\n');
         escapees.insert(&details->symbol());
+      }
     }
   }
 


### PR DESCRIPTION
This is currently happening for some host associated symbols in internal
procedures. Not all of those symbols are being entered into the scope,
so lowering does not see them.