### PR TITLE
Set extent of impossible triplet slices to zero

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2454,17 +2454,22 @@ public:
     auto triples = slOp.triples();
     auto idxTy = builder.getIndexType();
     auto loc = getLoc();
+    auto zero = builder.createIntegerConstant(loc, idxTy, 0);
     for (unsigned i = 0, end = triples.size(); i < end; i += 3) {
       if (!mlir::isa_and_nonnull<fir::UndefOp>(
               triples[i + 1].getDefiningOp())) {
-        // (..., lb:ub:step, ...) case:  extent = (ub-lb+step)/step
+        // (..., lb:ub:step, ...) case:  extent = max((ub-lb+step)/step, 0)
+        // See Fortran 2018 9.5.3.3.2 section for more details.
         auto lb = builder.createConvert(loc, idxTy, triples[i]);
         auto ub = builder.createConvert(loc, idxTy, triples[i + 1]);
         auto step = builder.createConvert(loc, idxTy, triples[i + 2]);
         auto diff = builder.create<mlir::SubIOp>(loc, ub, lb);
         auto add = builder.create<mlir::AddIOp>(loc, diff, step);
+        auto div = builder.create<mlir::SignedDivIOp>(loc, add, step);
+        auto cmp = builder.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::sgt,
+                                                div, zero);
         slicedShape.emplace_back(
-            builder.create<mlir::SignedDivIOp>(loc, add, step));
+            builder.create<mlir::SelectOp>(loc, cmp, div, zero));
       }
       // else (..., i, ...) case: dimension is dropped (do nothing).
     }

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -143,7 +143,9 @@ func @box6(%0 : !fir.ref<!fir.array<?x?x?x?xf32>>, %1 : index, %2 : index) -> i3
   // CHECK: %[[diff:.*]] = sub i64 %[[ARG2]], %[[ARG1]]
   // CHECK: %[[dp2:.*]] = add i64 %[[diff]], 2
   // CHECK: %[[sdp2:.*]] = sdiv i64 %[[dp2]], 2
-  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 25, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 0, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[sdp2]], 7, 0, 1
+  // CHECK: %[[cmp:.*]] = icmp sgt i64 %[[sdp2]], 0
+  // CHECK: %[[extent:.*]] = select i1 %[[cmp]], i64 %[[sdp2]], i64 0
+  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 25, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 0, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[extent]], 7, 0, 1
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 800, 7, 0, 2
   // CHECK: %[[op25:.*]] = add i64 25000, %[[i100p40]]
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 0, 7, 1, 0

--- a/flang/test/Lower/array-derived.f90
+++ b/flang/test/Lower/array-derived.f90
@@ -53,7 +53,9 @@ contains
     ! CHECK: %[[VAL_46:.*]] = fir.slice %[[VAL_37]], %[[VAL_44]]#1, %[[VAL_37]] path %[[VAL_43]], %[[VAL_33]] : (index, index, index, !fir.field, i64) -> !fir.slice<1>
     ! CHECK: %[[VAL_47:.*]] = fir.slice %[[VAL_37]], %[[VAL_44]]#1, %[[VAL_37]] path %[[VAL_43]], %[[VAL_34]] : (index, index, index, !fir.field, i64) -> !fir.slice<1>
     ! CHECK: %[[VAL_48:.*]] = fir.slice %[[VAL_37]], %[[VAL_44]]#1, %[[VAL_37]] path %[[VAL_43]], %[[VAL_35]] : (index, index, index, !fir.field, i64) -> !fir.slice<1>
-    ! CHECK: br ^bb1(%[[VAL_36]], %[[VAL_40]]#1 : index, index)
+    ! CHECK: %[[CMP:.*]] = cmpi sgt, %[[VAL_40]]#1, %[[VAL_36]] : index 
+    ! CHECK: %[[SELECT:.*]] = select %[[CMP]], %[[VAL_40]]#1, %[[VAL_36]] : index 
+    ! CHECK: br ^bb1(%[[VAL_36]], %[[SELECT]] : index, index)
     ! CHECK: ^bb1(%[[VAL_49:.*]]: index, %[[VAL_50:.*]]: index):
     ! CHECK: %[[VAL_51:.*]] = cmpi sgt, %[[VAL_50]], %[[VAL_36]] : index
     ! CHECK: cond_br %[[VAL_51]], ^bb2, ^bb3
@@ -96,7 +98,9 @@ contains
     ! CHECK: %[[VAL_76:.*]] = fir.field_index f1, !fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>
     ! CHECK: %[[VAL_77:.*]]:3 = fir.box_dims %[[arg1]], %[[VAL_68]] : (!fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>, index) -> (index, index, index)
     ! CHECK: %[[VAL_79:.*]] = fir.slice %[[VAL_69]], %[[VAL_77]]#1, %[[VAL_69]] path %[[VAL_70]], %[[VAL_66]], %[[VAL_66]], %[[VAL_76]], %[[VAL_63]] : (index, index, index, !fir.field, i64, i64, !fir.field, i64) -> !fir.slice<1>
-    ! CHECK: br ^bb1(%[[VAL_68]], %[[VAL_73]]#1 : index, index)
+    ! CHECK: %[[CMP:.*]] = cmpi sgt, %[[VAL_73]]#1, %[[VAL_68]] : index 
+    ! CHECK: %[[SELECT:.*]] = select %[[CMP]], %[[VAL_73]]#1, %[[VAL_68]] : index 
+    ! CHECK: br ^bb1(%[[VAL_68]], %[[SELECT]] : index, index)
     ! CHECK: ^bb1(%[[VAL_80:.*]]: index, %[[VAL_81:.*]]: index):
     ! CHECK: %[[VAL_82:.*]] = cmpi sgt, %[[VAL_81]], %[[VAL_68]] : index
     ! CHECK: cond_br %[[VAL_82]], ^bb2, ^bb3
@@ -113,7 +117,9 @@ contains
     ! CHECK: %[[VAL_89:.*]] = fir.slice %[[VAL_69]], %[[VAL_77]]#1, %[[VAL_69]] path %[[VAL_70]], %[[VAL_64]], %[[VAL_64]], %[[VAL_76]], %[[VAL_66]] : (index, index, index, !fir.field, i64, i64, !fir.field, i64) -> !fir.slice<1>
     ! CHECK: %[[VAL_90:.*]] = fir.field_index d, !fir.type<_QMcsTr{n:i32,d:i32}>
     ! CHECK: %[[VAL_91:.*]] = fir.slice %[[VAL_69]], %[[VAL_73]]#1, %[[VAL_69]] path %[[VAL_70]], %[[VAL_65]], %[[VAL_66]], %[[VAL_71]], %[[VAL_90]] : (index, index, index, !fir.field, i64, i64, !fir.field, !fir.field) -> !fir.slice<1>
-    ! CHECK: br ^bb4(%[[VAL_68]], %[[VAL_77]]#1 : index, index)
+    ! CHECK: %[[CMP2:.*]] = cmpi sgt, %[[VAL_77]]#1, %[[VAL_68]] : index 
+    ! CHECK: %[[SELECT2:.*]] = select %[[CMP2]], %[[VAL_77]]#1, %[[VAL_68]] : index 
+    ! CHECK: br ^bb4(%[[VAL_68]], %[[SELECT2]] : index, index)
     ! CHECK: ^bb4(%[[VAL_92:.*]]: index, %[[VAL_93:.*]]: index):
     ! CHECK: %[[VAL_94:.*]] = cmpi sgt, %[[VAL_93]], %[[VAL_68]] : index
     ! CHECK: cond_br %[[VAL_94]], ^bb5, ^bb6


### PR DESCRIPTION
The previous lowering/codegen code was not accounting for the fact
that in slice (lb:ub:step), it is legal to have `ub-lb` and `step`
with different signs, in which case the resulting dimension extent
is zero as per 9.5.3.3.2 point 3 and 4.

This led to negative extents to be computed and used, leading to
crashes like #832.