### PR TITLE
Cherry-pick DescriptorInquiry fix and make unmapped symbol a fatal error

### DIFF
--- a/flang/lib/Evaluate/shape.cpp
+++ b/flang/lib/Evaluate/shape.cpp
@@ -490,16 +490,10 @@ auto GetShapeHelper::operator()(const Symbol &symbol) const -> Result {
           [&](const semantics::ProcBindingDetails &binding) {
             return (*this)(binding.symbol());
           },
-          [&](const semantics::UseDetails &use) {
-            return (*this)(use.symbol());
-          },
-          [&](const semantics::HostAssocDetails &assoc) {
-            return (*this)(assoc.symbol());
-          },
           [](const semantics::TypeParamDetails &) { return ScalarShape(); },
           [](const auto &) { return Result{}; },
       },
-      symbol.details());
+      symbol.GetUltimate().details());
 }
 
 auto GetShapeHelper::operator()(const Component &component) const -> Result {

--- a/flang/lib/Evaluate/variable.cpp
+++ b/flang/lib/Evaluate/variable.cpp
@@ -275,7 +275,7 @@ static std::optional<Expr<SubscriptInteger>> SymbolLEN(const Symbol &symbol) {
       }
       if (IsDescriptor(ultimate) && !ultimate.owner().IsDerivedType()) {
         return Expr<SubscriptInteger>{DescriptorInquiry{
-            NamedEntity{ultimate}, DescriptorInquiry::Field::Len}};
+            NamedEntity{symbol}, DescriptorInquiry::Field::Len}};
       }
     }
   }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -385,11 +385,8 @@ public:
             return genAllocatableOrPointerUnbox(boxAddr).toExtendedValue();
           },
           [&val](auto &) { return val.toExtendedValue(); });
-    llvm_unreachable("all symbols should be in the map");
-    auto addr = builder.createTemporary(getLoc(), converter.genType(sym),
-                                        toStringRef(sym->name()));
-    symMap.addSymbol(sym, addr);
-    return addr;
+    LLVM_DEBUG(llvm::dbgs() << "unknown symbol: " << sym << '\n');
+    fir::emitFatalError(getLoc(), "symbol is not mapped to any IR value");
   }
 
   /// Generate a load of a value from an address.

--- a/flang/test/Lower/variable-inquiries.f90
+++ b/flang/test/Lower/variable-inquiries.f90
@@ -1,0 +1,32 @@
+! Test property inquiries on variables
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module inquired
+  real(8), allocatable :: a(:)
+end module
+
+! CHECK-LABEL: @_QPissue844()
+subroutine issue844()
+  use inquired
+  ! Verify that evaluate::DescriptorInquiry are made using the symbol mapped
+  ! in lowering (the use associated one, and not directly the ultimate
+  ! symbol).
+
+  ! CHECK: %[[a:.*]] = fir.address_of(@_QMinquiredEa) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
+  ! CHECK: %[[box_load:.*]] = fir.load %[[a]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>
+  ! CHECK: %[[dim:.*]]:3 = fir.box_dims %[[box_load]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf64>>>, index) -> (index, index, index)
+  ! CHECK: %[[cast:.*]] = fir.convert %[[dim]]#1 : (index) -> i64
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %[[cast]]) : (!fir.ref<i8>, i64) -> i1
+  print *, size(a, kind=8)
+end subroutine
+
+! TODO: test HostAssociated in internal procedure when possible.
+!subroutine hostproc()
+!  real(8), allocatable :: a(:)
+!  allocate(a(100))
+!  call internal()
+!contains
+!subroutine internal()
+!  print *, size(internal)
+!end subroutine
+!end subroutine


### PR DESCRIPTION
Fixes #844.

- Cherry-pick https://reviews.llvm.org/D104385 that contains the actual fix.
- Add related regression test in lowering because I could not easily test this in the front-end.
- Promote `llvm_unreachable` for unmapped symbols into a fir::emitFatalError. This will avoid scary unrelated error messages/weird bugs for people using release compilers (we will probably have quite a few unmapped symbol issues until F2018).