### PR TITLE
Use array_coor on where masks instead of fir.coordinate_of

### DIFF
--- a/flang/lib/Lower/MaskExpr.h
+++ b/flang/lib/Lower/MaskExpr.h
@@ -61,9 +61,11 @@ public:
     return maskList;
   }
 
+  /// Hold the address and shapeOp of lowered mask expressions.
+  using MaskAddrAndShape = std::pair<mlir::Value, mlir::Value>;
   // Map each mask expression back to the temporary holding the initial
   // evaluation results.
-  llvm::DenseMap<FrontEndMaskExpr, mlir::Value> vmap;
+  llvm::DenseMap<FrontEndMaskExpr, MaskAddrAndShape> vmap;
 
   // Inflate the statement context for the entire WHERE construct. We have to
   // cache the mask expression results across the entire construct.

--- a/flang/test/Lower/where.f90
+++ b/flang/test/Lower/where.f90
@@ -15,7 +15,7 @@
    ! CHECK: cmpf ogt, %{{.*}}, %[[four]]
    ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[tvec]]
    ! CHECK: fir.do_loop
-   ! CHECK: fir.coordinate_of %[[tvec]]
+   ! CHECK: fir.array_coor %[[tvec]]
    ! CHECK: fir.if
    ! CHECK: fir.array_fetch
    ! CHECK: negf
@@ -38,7 +38,7 @@
      ! CHECK: cmpf ogt, %{{.*}}, %[[cst]]
      ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[tvec]]
      ! CHECK: fir.do_loop
-     ! CHECK: fir.coordinate_of %[[tvec]]
+     ! CHECK: fir.array_coor %[[tvec]]
      ! CHECK: fir.if
      ! CHECK: fir.array_fetch
      ! CHECK: mulf
@@ -58,10 +58,10 @@
      ! CHECK: cmpf ogt, %{{.*}}, %[[cst50]]
      ! CHECK: fir.array_merge_store %{{.*}}, %{{.*}} to %[[uvec]]
      ! CHECK: fir.do_loop
-     ! CHECK: fir.coordinate_of %[[tvec]]
+     ! CHECK: fir.array_coor %[[tvec]]
      ! CHECK: fir.if
      ! CHECK: } else {
-     ! CHECK: fir.coordinate_of %[[uvec]]
+     ! CHECK: fir.array_coor %[[uvec]]
      ! CHECK: fir.if
      ! CHECK: fir.array_fetch
      ! CHECK: addf
@@ -73,10 +73,10 @@
      b = 3.0 + a
    ! Use cached conditions
      ! CHECK: fir.do_loop
-     ! CHECK: fir.coordinate_of %[[tvec]]
+     ! CHECK: fir.array_coor %[[tvec]]
      ! CHECK: fir.if
      ! CHECK: } else {
-     ! CHECK: fir.coordinate_of %[[uvec]]
+     ! CHECK: fir.array_coor %[[uvec]]
      ! CHECK: fir.if
      ! CHECK: fir.array_fetch
      ! CHECK: subf
@@ -89,10 +89,10 @@
    elsewhere
    ! Use cached conditions, always false
      ! CHECK: fir.do_loop
-     ! CHECK: fir.coordinate_of %[[tvec]]
+     ! CHECK: fir.array_coor %[[tvec]]
      ! CHECK: fir.if
      ! CHECK: } else {
-     ! CHECK: fir.coordinate_of %[[uvec]]
+     ! CHECK: fir.array_coor %[[uvec]]
      ! CHECK: fir.if
      ! CHECK: } else {
      ! CHECK: fir.array_fetch


### PR DESCRIPTION
[Edit: changed from fir.array_load based solution to fir.array_coor after discussion].

Fixes #855.
fir.coordinate_of was used to fetch pre-computed values inside
where statements in a way that was only valid with compile time
constant shape masks.

To fix this, there was three alternatives I considered:
 - Keep fir.coordinate_of, but collapse dimensions an compute offset
   in lowering.
 - Use fir.array_coor, taking into account lower bounds.
 - Use fir.array_load + fir.array_fetch, directly using loop indexes.

~~I went for the last one that was the easiest to deploy, and adds the less index computation noise inside the fir loops, which as far as I understand it should be better for future loop optimizations (affine...).~~

I went for the fir.array_coor because using fir.array_load was creating array_loads of the masks that were used in different loop nests, which is not the nominal usage of fir.array_load. Besides, fir.array_load is meant to deal with array aliasing, and there is none here since masks are lowered into temps.

Fir.array_coor generate less index computation noise inside the fir loops
compared to collapsing fir.coordinate_of. As far as I understand it,
this should be better for future loop optimizations (affine...).
