### PR TITLE
Fix #857 - assignment to contiguous local pointer from a fir.box

### DIFF
--- a/flang/include/flang/Lower/Support/BoxValue.h
+++ b/flang/include/flang/Lower/Support/BoxValue.h
@@ -201,6 +201,18 @@ public:
   mlir::Type getBaseTy() const {
     return fir::dyn_cast_ptrOrBoxEleTy(getBoxTy());
   }
+
+  /// Return the memory type of the data address inside the box:
+  /// - for fir.box<fir.ptr<T>>, return fir.ptr<T>
+  /// - for fir.box<fir.heap<T>>, return fir.heap<T>
+  /// - for fir.box<T>, return fir.ref<T>
+  mlir::Type getMemTy() const {
+    auto ty = getBoxTy().getEleTy();
+    if (fir::isa_ref_type(ty))
+      return ty;
+    return fir::ReferenceType::get(ty);
+  }
+
   /// Get the scalar type related to the described entity
   mlir::Type getEleTy() const {
     auto type = getBaseTy();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -57,8 +57,6 @@ static bool verifyInType(mlir::Type inType,
       if (verifyInType(field.second, visited))
         return true;
     visited.pop_back();
-  } else if (auto rt = inType.dyn_cast<fir::PointerType>()) {
-    return verifyInType(rt.getEleTy(), visited);
   }
   return false;
 }

--- a/flang/test/Fir/alloc.fir
+++ b/flang/test/Fir/alloc.fir
@@ -29,3 +29,10 @@ func @f4() -> !fir.heap<i32> {
   %1 = fir.allocmem i32, %0
   return %1 : !fir.heap<i32>
 }
+
+// CHECK-LABEL: define i32** @f5()
+func @f5() -> !fir.ref<!fir.ptr<!fir.array<?xi32>>> {
+  // CHECK: alloca i32*, i64 1
+  %1 = fir.alloca !fir.ptr<!fir.array<?xi32>>
+  return %1 : !fir.ref<!fir.ptr<!fir.array<?xi32>>>
+}


### PR DESCRIPTION
Fix #857.
Scalar and contiguous pointer assignment may be lowered to a set of local variable instead of a fir.re<fir.box>, in which case they should not be updated with a fir.box. It is possible that the RHS of assignments to such pointers is lowered to a fir.box because the contiguous aspects of the RHS may not be obvious or guaranteed in lowering.

Add handling for this case by reading the fir.box to implement the pointer assignment.

On the way, fix two related issues:
 - missing casts before store when updating the local variables
   representing the pointer. There were i64 to index store issues
   otherwise in some cases.
 - Alloca/Allocmem did not allow to allocate a fir.ptr<fir.array<?x...xT>>
   which is needed to track the address of a contiguous local array
   pointer. The alloc verify was going through the fir.ptr and then
   complained that not extents was provided in the alloc for the
   fir.array type. This looks bogus to me, and I do not see the
   purpose of this check, so I removed it.