### PR TITLE
Add hard TODO for non trivial variable in internal procedure

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -177,6 +177,7 @@ public:
 
   /// Declare a function.
   void declareFunction(Fortran::lower::pft::FunctionLikeUnit &funit) {
+    setCurrentPosition(funit.getStartingSourceLoc());
     for (int entryIndex = 0, last = funit.entryPointList.size();
          entryIndex < last; ++entryIndex) {
       funit.setActiveEntry(entryIndex);

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -98,6 +98,9 @@ mlir::Type Fortran::lower::HostAssociations::getArgumentType(
   llvm::SmallVector<mlir::Type> tupleTys;
   for (const auto *sym : symbols) {
     auto varTy = Fortran::lower::translateSymbolToFIRType(converter, *sym);
+    if (!fir::isa_trivial(varTy))
+      TODO(converter.getCurrentLocation(),
+           "non trivial associated variable in internal procedure");
     tupleTys.emplace_back(fir::PointerType::get(varTy));
   }
   argType = fir::ReferenceType::get(mlir::TupleType::get(ctxt, tupleTys));


### PR DESCRIPTION
Associated character, arrays, allocatable and pointers are not yet supported in internal procedure lowering, but compilation was currently not stopped, which lead to seemingly unrelated error messages like:

- not an array
- error: cannot build a pointer to type (#863)
- character buffer should be in CharBoxValue

Add a hard TODO with a clearer message. Also set location in declareFunction for better context in this TODO and other fatal errors coming from function declaration lowering.