### PR TITLE
Fix #862 - remove redundant fir::getBase call in structure constructor lowering

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -529,8 +529,7 @@ public:
         mlir::Value addrField = builder.create<fir::FieldIndexOp>(
             loc, fieldTy, addrFieldName, componentTy,
             /*typeParams=*/mlir::ValueRange{});
-        auto castAddr =
-            builder.createConvert(loc, addrFieldTy, fir::getBase(baseAddr));
+        auto castAddr = builder.createConvert(loc, addrFieldTy, baseAddr);
         auto val = builder.create<fir::InsertValueOp>(loc, componentTy, undef,
                                                       castAddr, addrField);
         res = builder.create<fir::InsertValueOp>(loc, recTy, res, val, field);

--- a/flang/test/Lower/derived-type-descriptor.f90
+++ b/flang/test/Lower/derived-type-descriptor.f90
@@ -31,3 +31,16 @@ end subroutine
   !CHECK: fir.address_of(@_QFfooE.n.sometype)
   !CHECK: fir.address_of(@_QFfooE.c.sometype)
 ! CHECK:}
+
+subroutine char_comp_init()
+  implicit none  
+  type t
+     character(8) :: name='Empty'
+  end type t
+  type(t) :: a
+end subroutine
+
+! CHECK-LABEL: fir.global internal @_QE.di.t.name("Empty   ") : !fir.char<1,8>
+! CHECK-LABEL: fir.global internal @_QFchar_comp_initE.c.t : {{.*}} {
+  ! CHECK: fir.address_of(@_QE.di.t.name) : !fir.ref<!fir.char<1,8>>
+! CHECK: }


### PR DESCRIPTION
Fixes #862.
In structure constructor lowering in initializer context, a fir::getBase() call was made on a value that was already the resul of a fir::getBase(). As a result, this implicitly constructed an fir::ExtendedValue from the mlir::Value, potentially violating ctor constraints and triggering asserts.

Note: in the bug context, the structure constructor exposing the issue was a compiler generated initial expression for derived type descriptor related symbols.
