### PR TITLE
Fix lowering of local character array with lower bounds and static length

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1210,8 +1210,7 @@ void Fortran::lower::mapSymbolAttributes(
         mlir::Value local =
             isDummy ? addr
                     : createNewLocal(converter, loc, var, preAlloc, extents);
-        assert(isDummy || Fortran::lower::isExplicitShape(sym) ||
-               Fortran::semantics::IsAllocatableOrPointer(sym));
+        assert(isDummy || Fortran::lower::isExplicitShape(sym));
         symMap.addSymbolWithBounds(sym, local, extents, lbounds, isDummy);
       },
 
@@ -1255,8 +1254,7 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local array with computed bounds
-        assert(Fortran::lower::isExplicitShape(sym) ||
-               Fortran::semantics::IsAllocatableOrPointer(sym));
+        assert(Fortran::lower::isExplicitShape(sym));
         auto local = createNewLocal(converter, loc, var, preAlloc, extents);
         symMap.addSymbolWithBounds(sym, local, extents, lbounds);
       },
@@ -1310,11 +1308,8 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local CHARACTER array with computed bounds
-        assert(Fortran::lower::isExplicitShape(sym) ||
-               Fortran::semantics::IsAllocatableOrPointer(sym));
-        llvm::SmallVector<mlir::Value> lengths = {len};
-        auto local =
-            createNewLocal(converter, loc, var, preAlloc, extents, lengths);
+        assert(Fortran::lower::isExplicitShape(sym));
+        auto local = createNewLocal(converter, loc, var, preAlloc, extents);
         symMap.addCharSymbolWithBounds(sym, local, len, extents, lbounds);
       },
 
@@ -1383,9 +1378,7 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local CHARACTER array with computed bounds
-        assert((!mustBeDummy) &&
-               (Fortran::lower::isExplicitShape(sym) ||
-                Fortran::semantics::IsAllocatableOrPointer(sym)));
+        assert((!mustBeDummy) && (Fortran::lower::isExplicitShape(sym)));
         auto local =
             createNewLocal(converter, loc, var, preAlloc, llvm::None, lengths);
         symMap.addCharSymbolWithBounds(sym, local, len, extents, lbounds);
@@ -1442,8 +1435,7 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local CHARACTER array with computed bounds
-        assert(Fortran::lower::isExplicitShape(sym) ||
-               Fortran::semantics::IsAllocatableOrPointer(sym));
+        assert(Fortran::lower::isExplicitShape(sym));
         auto local = createNewLocal(converter, loc, var, preAlloc, extents);
         symMap.addCharSymbolWithBounds(sym, local, len, extents, lbounds);
       },
@@ -1516,8 +1508,7 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local CHARACTER array with computed bounds
-        assert(Fortran::lower::isExplicitShape(sym) ||
-               Fortran::semantics::IsAllocatableOrPointer(sym));
+        assert(Fortran::lower::isExplicitShape(sym));
         auto local =
             createNewLocal(converter, loc, var, preAlloc, extents, lengths);
         symMap.addCharSymbolWithBounds(sym, local, len, extents, lbounds);

--- a/flang/test/Lower/character-local-variables.f90
+++ b/flang/test/Lower/character-local-variables.f90
@@ -9,10 +9,11 @@ subroutine scalar_cst_len()
 end subroutine
 
 ! CHECK-LABEL: func @_QPscalar_dyn_len
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>
 subroutine scalar_dyn_len(l)
   integer :: l
   character(l) :: c
-  ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK: %[[l:.*]] = fir.load %[[arg0]] : !fir.ref<i32>
   ! CHECK: fir.alloca !fir.char<1,?>(%[[l]] : i32) {{{.*}}uniq_name = "_QFscalar_dyn_lenEc"}
 end subroutine
 
@@ -23,28 +24,71 @@ subroutine cst_array_cst_len()
 end subroutine
 
 ! CHECK-LABEL: func @_QPcst_array_dyn_len
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>
 subroutine cst_array_dyn_len(l)
   integer :: l
-  character(l) :: c
-  ! CHECK: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: fir.alloca !fir.char<1,?>(%[[l]] : i32) {{{.*}}uniq_name = "_QFcst_array_dyn_lenEc"}
+  character(l) :: c(10)
+  ! CHECK: %[[l:.*]] = fir.load %[[arg0]] : !fir.ref<i32>
+  ! CHECK: fir.alloca !fir.array<10x!fir.char<1,?>>(%[[l]] : i32) {{{.*}}uniq_name = "_QFcst_array_dyn_lenEc"}
 end subroutine
 
 ! CHECK-LABEL: func @_QPdyn_array_cst_len
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>
 subroutine dyn_array_cst_len(n)
   integer :: n
   character(10) :: c(n)
-  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK: %[[n:.*]] = fir.load %[[arg0]] : !fir.ref<i32>
   ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
   ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[ni]] {{{.*}}uniq_name = "_QFdyn_array_cst_lenEc"}
 end subroutine
 
 ! CHECK: func @_QPdyn_array_dyn_len
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.ref<i32>
 subroutine dyn_array_dyn_len(l, n)
   integer :: l, n
   character(l) :: c(n)
-  ! CHECK-DAG: %[[l:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK-DAG: %[[n:.*]] = fir.load %arg1 : !fir.ref<i32>
+  ! CHECK-DAG: %[[l:.*]] = fir.load %[[arg0]] : !fir.ref<i32>
+  ! CHECK-DAG: %[[n:.*]] = fir.load %[[arg1]] : !fir.ref<i32>
   ! CHECK: %[[ni:.*]] = fir.convert %[[n]] : (i32) -> index
   ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>(%[[l]] : i32), %[[ni]] {{{.*}}uniq_name = "_QFdyn_array_dyn_lenEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_array_cst_len_lb
+subroutine cst_array_cst_len_lb()
+  character(10) :: c(11:30)
+  ! CHECK: fir.alloca !fir.array<20x!fir.char<1,10>> {{{.*}}uniq_name = "_QFcst_array_cst_len_lbEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_array_dyn_len_lb
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>
+subroutine cst_array_dyn_len_lb(l)
+  integer(8) :: l
+  character(l) :: c(11:20)
+  ! CHECK: %[[l:.*]] = fir.load %[[arg0]] : !fir.ref<i64>
+  ! CHECK: fir.alloca !fir.array<10x!fir.char<1,?>>(%[[l]] : i64) {{{.*}}uniq_name = "_QFcst_array_dyn_len_lbEc"}
+end subroutine
+
+! CHECK-LABEL: func @_QPdyn_array_cst_len_lb
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>
+subroutine dyn_array_cst_len_lb(n)
+  integer(8) :: n
+  character(10) :: c(11:n)
+  ! CHECK-DAG: %[[cm10:.*]] = constant -10 : index
+  ! CHECK-DAG: %[[n:.*]] = fir.load %[[arg0]] : !fir.ref<i64>
+  ! CHECK-DAG: %[[ni:.*]] = fir.convert %[[n]] : (i64) -> index
+  ! CHECK: %[[extent:.*]] = addi %[[ni]], %[[cm10]] : index
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[extent]] {{{.*}}uniq_name = "_QFdyn_array_cst_len_lbEc"}
+end subroutine
+
+! CHECK: func @_QPdyn_array_dyn_len_lb
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>, %[[arg1:.*]]: !fir.ref<i64>
+subroutine dyn_array_dyn_len_lb(l, n)
+  integer(8) :: l, n
+  character(l) :: c(11:n)
+  ! CHECK-DAG: %[[cm10:.*]] = constant -10 : index
+  ! CHECK-DAG: %[[l:.*]] = fir.load %[[arg0]] : !fir.ref<i64>
+  ! CHECK-DAG: %[[n:.*]] = fir.load %[[arg1]] : !fir.ref<i64>
+  ! CHECK-DAG: %[[ni:.*]] = fir.convert %[[n]] : (i64) -> index
+  ! CHECK: %[[extent:.*]] = addi %[[ni]], %[[cm10]] : index
+  ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>(%[[l]] : i64), %[[extent]] {{{.*}}uniq_name = "_QFdyn_array_dyn_len_lbEc"}
 end subroutine


### PR DESCRIPTION
A length was passed to `fir.alloca` for a static length character type when instantiating `StaticArrayStaticChar` in variable lowering.

This caused error: " 'fir.alloca' op LEN params do not correspond to type ".

Do not pass the length in this case, and add tests of local with lower bounds.

Also remove `IsAllocatedOrPointer` from some asserts in variable lowering since this case is handled before, and not expected where the assert were (This was not an issue, but troubled me when fixing this bug).