### PR TITLE
[flang] Implement the NOT() intrinsic

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -440,6 +440,7 @@ struct IntrinsicLibrary {
   mlir::Value genMod(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genModulo(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genNint(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  mlir::Value genNot(mlir::Type, llvm::ArrayRef<mlir::Value>);
   fir::ExtendedValue genPresent(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genProduct(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   void genRandomInit(llvm::ArrayRef<fir::ExtendedValue>);
@@ -645,6 +646,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"mod", &I::genMod},
     {"modulo", &I::genModulo},
     {"nint", &I::genNint},
+    {"not", &I::genNot},
     {"present",
      &I::genPresent,
      {{{"a", asInquired}}},
@@ -2085,6 +2087,14 @@ mlir::Value IntrinsicLibrary::genNint(mlir::Type resultType,
   // Skip optional kind argument to search the runtime; it is already reflected
   // in result type.
   return genRuntimeCall("nint", resultType, {args[0]});
+}
+
+// NOT
+mlir::Value IntrinsicLibrary::genNot(mlir::Type resultType,
+                                     llvm::ArrayRef<mlir::Value> args) {
+  assert(args.size() == 1);
+  auto allOnes = builder.createIntegerConstant(loc, resultType, -1);
+  return builder.create<mlir::XOrOp>(loc, args[0],allOnes);
 }
 
 // PRESENT

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -717,6 +717,22 @@ subroutine modulo_testi(r, a, p)
   r = modulo(a, p)
 end subroutine
 
+! NOT
+! CHECK-LABEL: not_test
+subroutine not_test
+  integer :: source
+  integer :: destination
+  ! CHECK_LABEL: not_test
+  ! CHECK: %[[dest:.*]] = fir.alloca i32 {bindc_name = "destination", uniq_name = "_QFnot_testEdestination"}
+  ! CHECK: %[[source:.*]] = fir.alloca i32 {bindc_name = "source", uniq_name = "_QFnot_testEsource"}
+  ! CHECK: %[[loaded_source:.*]] = fir.load %[[source]] : !fir.ref<i32>
+  ! CHECK: %[[all_ones:.*]] = constant -1 : i32
+  ! CHECK: %[[result:.*]] = xor %[[loaded_source]], %[[all_ones]] : i32
+  ! CHECK: fir.store %[[result]] to %[[dest]] : !fir.ref<i32>
+  ! CHECK: return
+  destination = not(source)
+end subroutine
+
 ! PRODUCT 
 ! CHECK-LABEL: product_test
 ! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xi32>>) -> i32 


### PR DESCRIPTION
I added FIR generation so that the integer argument gets compared as not
equal with a value consisting of all 1 bits.  I assumed that all target
architectures use two's complement arithmetic where the value -1 is
represented as all 1 bits.

I also added a test.