### PR TITLE
Fix lowering of components with array section base

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -3693,7 +3693,8 @@ public:
                   auto ty = fir::dyn_cast_ptrOrBoxEleTy(refTy);
                   return addComponent(exv, ty);
                 }
-              return genSliceIndices(cmptData, r);
+              auto [exv, ty] = genSliceIndices(cmptData, r);
+              return addComponent(exv, ty);
             },
             [&](const Fortran::evaluate::CoarrayRef &r) -> RT {
               TODO(loc, "");

--- a/flang/test/Lower/components.f90
+++ b/flang/test/Lower/components.f90
@@ -56,3 +56,44 @@ contains
   end subroutine s1
 
 end module components_test
+
+! CHECK-LABEL: @_QPsliced_base
+subroutine sliced_base()
+  interface
+    subroutine takes_int_array(i)
+      integer :: i(:)
+    end subroutine
+  end interface
+  type t
+    real :: x
+    integer :: y
+  end type
+  type(t) :: a(100)
+  ! CHECK-DAG:  %[[VAL_0:.*]] = constant 100 : index
+  ! CHECK-DAG:  %[[VAL_1:.*]] = constant 42 : i32
+  ! CHECK-DAG:  %[[VAL_2:.*]] = constant 50 : i64
+  ! CHECK-DAG:  %[[VAL_3:.*]] = constant 1 : i64
+  ! CHECK-DAG:  %[[VAL_4:.*]] = constant 50 : index
+  ! CHECK-DAG:  %[[VAL_5:.*]] = constant 0 : index
+  ! CHECK-DAG:  %[[VAL_6:.*]] = constant 1 : index
+  ! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.array<100x!fir.type<_QFsliced_baseTt{x:f32,y:i32}>> {bindc_name = "a", uniq_name = "_QFsliced_baseEa"}
+  ! CHECK:  %[[VAL_8:.*]] = fir.field_index y, !fir.type<_QFsliced_baseTt{x:f32,y:i32}>
+  ! CHECK:  %[[VAL_9:.*]] = fir.shape %[[VAL_0]] : (index) -> !fir.shape<1>
+  ! CHECK:  %[[VAL_10:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] path %[[VAL_8]] : (i64, i64, i64, !fir.field) -> !fir.slice<1>
+  ! CHECK:  br ^bb1(%[[VAL_5]], %[[VAL_4]] : index, index)
+  ! CHECK:^bb1(%[[VAL_11:.*]]: index, %[[VAL_12:.*]]: index):
+  ! CHECK:  %[[VAL_13:.*]] = cmpi sgt, %[[VAL_12]], %[[VAL_5]] : index
+  ! CHECK:  cond_br %[[VAL_13]], ^bb2, ^bb3
+  ! CHECK:^bb2:
+  ! CHECK:  %[[VAL_14:.*]] = addi %[[VAL_11]], %[[VAL_6]] : index
+  ! CHECK:  %[[VAL_15:.*]] = fir.array_coor %[[VAL_7]](%[[VAL_9]]) {{\[}}%[[VAL_10]]] %[[VAL_14]] : (!fir.ref<!fir.array<100x!fir.type<_QFsliced_baseTt{x:f32,y:i32}>>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_1]] to %[[VAL_15]] : !fir.ref<i32>
+  ! CHECK:  %[[VAL_16:.*]] = subi %[[VAL_12]], %[[VAL_6]] : index
+  ! CHECK:  br ^bb1(%[[VAL_14]], %[[VAL_16]] : index, index)
+  a(1:50)%y = 42
+
+  ! CHECK:^bb3:
+  ! CHECK:  %[[VAL_17:.*]] = fir.embox %[[VAL_7]](%[[VAL_9]]) {{\[}}%[[VAL_10]]] : (!fir.ref<!fir.array<100x!fir.type<_QFsliced_baseTt{x:f32,y:i32}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xi32>>
+  ! CHECK:  fir.call @_QPtakes_int_array(%[[VAL_17]]) : (!fir.box<!fir.array<?xi32>>) -> ()
+  call takes_int_array(a(1:50)%y)
+end subroutine


### PR DESCRIPTION
When lowering `a(i:j:k)%y`, the `%y` part was dropped because `addComponent` was not called.