### PR TITLE
Missing basic block

### DIFF
--- a/flang/test/Lower/irreducible.f90
+++ b/flang/test/Lower/irreducible.f90
@@ -1,0 +1,24 @@
+      ! RUN: bbc %s -o "-" | FileCheck %s
+
+      ! CHECK-LABEL: irreducible
+      subroutine irreducible(k)
+        ! CHECK: cond_br %{{[0-9]+}}, ^bb1, ^bb2
+        if (k < 5) goto 20
+        ! CHECK: ^bb1:  // 2 preds: ^bb0, ^bb2
+10      print*, k                             ! scc entry #1: (k < 5) is false
+        k = k + 1
+        ! CHECK: ^bb2:  // 2 preds: ^bb0, ^bb1
+        ! CHECK: cond_br %{{[0-9]+}}, ^bb1, ^bb3
+20      if (k < 3) goto 10                    ! scc entry #2: (k < 5) is true
+        ! CHECK: ^bb3:  // pred: ^bb2
+      end
+
+      ! CHECK-LABEL: main
+      program p
+        do i = 0, 6
+          n = i
+          print*
+          print*, 1000 + n
+          call irreducible(n)
+        enddo
+      end


### PR DESCRIPTION
The following subroutine has an irreducible control flow graph.
Its CFG contains a strongly connected component with two distinct
entry points.

```
      subroutine irreducible(k)
        if (k < 5) goto 20
10      print*, k           ! scc entry #1: (k < 5) is false
        k = k + 1
20      if (k < 3) goto 10  ! scc entry #2: (k < 5) is true
      end
```

The IF construct generated from:

`    if (k < 5) goto 20`

is rewritten to eliminate the goto, and the result is initially found
to be structured (which at that point is correct).  So the goto target
of the first IF statement, which is the second IF statement:

`    if (k < 3) goto 10`

is not marked as starting a new basic block.  Eventually the backward
branch (which happens to also be the second IF statement) is processed,
and at that point the first IF is marked as unstructured.  However, its
goto target statement is never marked as starting a basic block.

The fix is to mark the goto target as starting a basic block at the
point where the first IF is marked as unstructured.