### PR TITLE
Do not generate temps for whole component in genExtAddr

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -353,6 +353,14 @@ llvm::SmallVector<mlir::Value> getExtents(FirOpBuilder &builder,
                                           mlir::Location loc,
                                           const fir::ExtendedValue &box);
 
+/// Read a fir::BoxValue into an fir::UnboxValue, a fir::ArrayBoxValue or a
+/// fir::CharArrayBoxValue. This should only be called if the fir::BoxValue is
+/// known to be contiguous given the context (or if the resulting address will
+/// not be used). If the value is polymorphic, its dynamic type will be lost.
+/// This must not be used on unlimited polymorphic and assumed rank entities.
+fir::ExtendedValue readBoxValue(FirOpBuilder &builder, mlir::Location loc,
+                                const fir::BoxValue &box);
+
 //===--------------------------------------------------------------------===//
 // String literal helper helpers
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
`genExtAddr` was creating temps for expressions like `x%array`, which
is wrong because the expression is a variable.

- Use `UnwrapWholeSymbolOrComponentDataRef` to prevent that instead of
simply using `UnwrapWholeSymbolDataRef`.

- With this fixed, the copy-in/copy-out code could face more case where
  an expr is lowered to a fir.box because we currently have no way in
  FIR to convey the contiguous attribute on derived type components, so
  genExtAddr does not open the related fir.box automatically.
  Improve the code by adding a readBoxValue helper that forces the
  fir.box read when it is known to be OK (like in copy-in/copy-out
  because IsSimplyContiguous determined the expr is contiguous).