### PR TITLE
Lower NULL(MOLD) and function results as pointers

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -448,6 +448,7 @@ struct IntrinsicLibrary {
   mlir::Value genModulo(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genNint(mlir::Type, llvm::ArrayRef<mlir::Value>);
   mlir::Value genNot(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  fir::ExtendedValue genNull(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genPresent(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   fir::ExtendedValue genProduct(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   void genRandomInit(llvm::ArrayRef<fir::ExtendedValue>);
@@ -665,6 +666,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"modulo", &I::genModulo},
     {"nint", &I::genNint},
     {"not", &I::genNot},
+    {"null", &I::genNull, {{{"mold", asInquired}}}, /*isElemental=*/false},
     {"present",
      &I::genPresent,
      {{{"a", asInquired}}},
@@ -2317,6 +2319,23 @@ mlir::Value IntrinsicLibrary::genNot(mlir::Type resultType,
   assert(args.size() == 1);
   auto allOnes = builder.createIntegerConstant(loc, resultType, -1);
   return builder.create<mlir::XOrOp>(loc, args[0], allOnes);
+}
+
+// NULL
+fir::ExtendedValue
+IntrinsicLibrary::genNull(mlir::Type, llvm::ArrayRef<fir::ExtendedValue> args) {
+  // NULL() without MOLD must be handled in the contexts where it can appear
+  // (see table 16.5 of Fortran 2018 standard).
+  assert(args.size() == 1 && isPresent(args[0]) &&
+         "MOLD argument required to lower NULL outside of any context");
+  const auto *mold = args[0].getBoxOf<fir::MutableBoxValue>();
+  assert(mold && "MOLD must be a pointer or allocatable");
+  auto boxType = mold->getBoxTy();
+  auto boxStorage = builder.createTemporary(loc, boxType);
+  auto box = Fortran::lower::createUnallocatedBox(builder, loc, boxType,
+                                                  mold->nonDeferredLenParams());
+  builder.create<fir::StoreOp>(loc, box, boxStorage);
+  return fir::MutableBoxValue(boxStorage, mold->nonDeferredLenParams(), {});
 }
 
 // PRESENT

--- a/flang/lib/Lower/SymbolMap.h
+++ b/flang/lib/Lower/SymbolMap.h
@@ -94,13 +94,6 @@ struct SymbolBox : public fir::details::matcher<SymbolBox> {
         [](const Fortran::lower::SymbolBox::None &) -> fir::ExtendedValue {
           llvm::report_fatal_error("symbol not mapped");
         },
-        [](const Fortran::lower::SymbolBox::PointerOrAllocatable &)
-            -> fir::ExtendedValue {
-          // Until there is a use case, PointerOrAllocatable are not
-          // ExtendedValue.
-          llvm::report_fatal_error(
-              "Pointer and Allocatable to exv needs unboxing");
-        },
         [](const auto &box) -> fir::ExtendedValue { return box; });
   }
 

--- a/flang/test/Lower/pointer-disassociate.f90
+++ b/flang/test/Lower/pointer-disassociate.f90
@@ -50,5 +50,57 @@ subroutine test_array_remap(p)
   p(10:20) => NULL()
 end subroutine
 
+! -----------------------------------------------------------------------------
+!     Test p => NULL(MOLD)
+! -----------------------------------------------------------------------------
 
-! TODO: p => NULL(MOLD). Requires array function/intrinsic lowering work.
+! CHECK-LABEL: func @_QPtest_scalar_mold(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
+subroutine test_scalar_mold(p, x)
+  real, pointer :: p, x
+  ! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {uniq_name = ""}
+  ! CHECK: %[[VAL_1:.*]] = fir.zero_bits !fir.ptr<f32>
+  ! CHECK: %[[VAL_2:.*]] = fir.embox %[[VAL_1]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.store %[[VAL_2]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  ! CHECK: %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+  ! CHECK: %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+  ! CHECK: fir.store %[[VAL_5]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+  p => NULL(x)
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_scalar_char_mold(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>,
+subroutine test_scalar_char_mold(p, x)
+  character(:), pointer :: p, x
+  ! CHECK: %[[VAL_7:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.char<1,?>>> {uniq_name = ""}
+  ! CHECK: %[[VAL_8:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
+  ! CHECK: %[[VAL_9:.*]] = constant 0 : index
+  ! CHECK: %[[VAL_10:.*]] = fir.embox %[[VAL_8]] typeparams %[[VAL_9]] : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: fir.store %[[VAL_10]] to %[[VAL_7]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+  ! CHECK: %[[VAL_11:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+  ! CHECK: %[[VAL_12:.*]] = fir.box_elesize %[[VAL_11]] : (!fir.box<!fir.ptr<!fir.char<1,?>>>) -> index
+  ! CHECK: %[[VAL_13:.*]] = fir.box_addr %[[VAL_11]] : (!fir.box<!fir.ptr<!fir.char<1,?>>>) -> !fir.ptr<!fir.char<1,?>>
+  ! CHECK: %[[VAL_14:.*]] = fir.embox %[[VAL_13]] typeparams %[[VAL_12]] : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK: fir.store %[[VAL_14]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+  p => NULL(x)
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_array_mold(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+subroutine test_array_mold(p, x)
+  real, pointer :: p(:), x(:)
+  ! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xf32>>> {uniq_name = ""}
+  ! CHECK: %[[VAL_1:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[VAL_2:.*]] = constant 0 : index
+  ! CHECK: %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+  ! CHECK: %[[VAL_4:.*]] = fir.embox %[[VAL_1]](%[[VAL_3]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[VAL_4]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[VAL_5:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[VAL_6:.*]] = constant 0 : index
+  ! CHECK: %[[VAL_7:.*]]:3 = fir.box_dims %[[VAL_5]], %[[VAL_6]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[VAL_8:.*]] = fir.shift %[[VAL_7]]#0 : (index) -> !fir.shift<1>
+  ! CHECK: %[[VAL_9:.*]] = fir.rebox %[[VAL_5]](%[[VAL_8]]) : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[VAL_9]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  p => NULL(x)
+end subroutine

--- a/flang/test/Lower/pointer-results-as-arguments.f90
+++ b/flang/test/Lower/pointer-results-as-arguments.f90
@@ -1,0 +1,85 @@
+! Test passing pointers results to pointer dummy arguments
+! RUN: bbc %s -o - | FileCheck %s
+
+module presults
+  interface
+    subroutine bar_scalar(x)
+      real, pointer :: x
+    end subroutine
+    subroutine bar(x)
+      real, pointer :: x(:, :)
+    end subroutine
+    function get_scalar_pointer()
+      real, pointer :: get_scalar_pointer
+    end function
+    function get_pointer()
+      real, pointer :: get_pointer(:, :)
+    end function
+  end interface
+  real, pointer :: x
+  real, pointer :: xa(:, :)
+contains
+
+! CHECK-LABEL: test_scalar_null
+subroutine test_scalar_null()
+! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {uniq_name = ""}
+! CHECK: %[[VAL_1:.*]] = fir.zero_bits !fir.ptr<f32>
+! CHECK: %[[VAL_2:.*]] = fir.embox %[[VAL_1]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+! CHECK: fir.store %[[VAL_2]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK: fir.call @_QPbar_scalar(%[[VAL_0]]) : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> ()
+  call bar_scalar(null())
+end subroutine
+
+! CHECK-LABEL: test_scalar_null_mold
+subroutine test_scalar_null_mold()
+! CHECK: %[[VAL_3:.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {uniq_name = ""}
+! CHECK: %[[VAL_4:.*]] = fir.zero_bits !fir.ptr<f32>
+! CHECK: %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+! CHECK: fir.store %[[VAL_5]] to %[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK: fir.call @_QPbar_scalar(%[[VAL_3]]) : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> ()
+  call bar_scalar(null(x))
+end subroutine
+
+! CHECK-LABEL: test_scalar_result
+subroutine test_scalar_result()
+! CHECK: %[[VAL_6:.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {uniq_name = ".result"}
+! CHECK: %[[VAL_7:.*]] = fir.call @_QPget_scalar_pointer() : () -> !fir.box<!fir.ptr<f32>>
+! CHECK: fir.save_result %[[VAL_7]] to %[[VAL_6]] : !fir.box<!fir.ptr<f32>>, !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK: fir.call @_QPbar_scalar(%[[VAL_6]]) : (!fir.ref<!fir.box<!fir.ptr<f32>>>) -> ()
+  call bar_scalar(get_scalar_pointer())
+end subroutine
+
+! CHECK-LABEL: test_null
+subroutine test_null()
+! CHECK: %[[VAL_8:.*]] = constant 0 : index
+! CHECK: %[[VAL_9:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xf32>>> {uniq_name = ""}
+! CHECK: %[[VAL_10:.*]] = fir.zero_bits !fir.ptr<!fir.array<?x?xf32>>
+! CHECK: %[[VAL_11:.*]] = fir.shape %[[VAL_8]], %[[VAL_8]] : (index, index) -> !fir.shape<2>
+! CHECK: %[[VAL_12:.*]] = fir.embox %[[VAL_10]](%[[VAL_11]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK: fir.store %[[VAL_12]] to %[[VAL_9]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK: fir.call @_QPbar(%[[VAL_9]]) : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) -> ()
+  call bar(null())
+end subroutine
+
+! CHECK-LABEL: test_null_mold
+subroutine test_null_mold()
+! CHECK: %[[VAL_13:.*]] = constant 0 : index
+! CHECK: %[[VAL_14:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xf32>>> {uniq_name = ""}
+! CHECK: %[[VAL_15:.*]] = fir.zero_bits !fir.ptr<!fir.array<?x?xf32>>
+! CHECK: %[[VAL_16:.*]] = fir.shape %[[VAL_13]], %[[VAL_13]] : (index, index) -> !fir.shape<2>
+! CHECK: %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK: fir.store %[[VAL_17]] to %[[VAL_14]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK: fir.call @_QPbar(%[[VAL_14]]) : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) -> ()
+  call bar(null(xa))
+end subroutine
+
+! CHECK-LABEL: test_result
+subroutine test_result()
+! CHECK: %[[VAL_18:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xf32>>> {uniq_name = ".result"}
+! CHECK: %[[VAL_19:.*]] = fir.call @_QPget_pointer() : () -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK: fir.save_result %[[VAL_19]] to %[[VAL_18]] : !fir.box<!fir.ptr<!fir.array<?x?xf32>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK: fir.call @_QPbar(%[[VAL_18]]) : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>) -> ()
+  call bar(get_pointer())
+end subroutine
+
+end module


### PR DESCRIPTION
NULL(MOLD) is still represented as an intrinsic call after lowering
(which is not the case for NULL() that is an evaluate::NullPointer).
Lower NULL(MOLD) in the intrinsic framework.

Functions returning pointers were already lowered OK, however, the
contexts where the function results is still considered to be a pointer
were not handled yet because there is only one such context: when
passing a result pointer to a pointer arguments. Update genMutableBoxValue
to deal with this case.

To do so, move genPorcedureRef content inside genRawProcedureRef that does not
automatically read pointers/allocatable results into normal values,
and keep this automatic read in genPorcedureRef.

Last, the case foo(NULL()) needs special handling in call lowering because
the created disassociated pointer takes the characteritsics of the dummy,
and cannot be lowered by genMutableBoxValue().