### PR TITLE
Handle vector subscript in output IO (TODO left for input)

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -304,7 +304,8 @@ public:
   fir::ExtendedValue genExprBox(const Fortran::lower::SomeExpr &expr,
                                 Fortran::lower::StatementContext &context,
                                 mlir::Location loc) override final {
-    if (expr.Rank() > 0 && Fortran::evaluate::IsVariable(expr))
+    if (expr.Rank() > 0 && Fortran::evaluate::IsVariable(expr) &&
+        !Fortran::evaluate::HasVectorSubscript(expr))
       return createSomeArrayBox(*this, expr, localSymbols, context);
     return fir::BoxValue(
         builder->createBox(loc, genExprAddr(expr, context, &loc)));

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -3405,6 +3405,8 @@ public:
                   // Note: 9.5.3.3.3(3) specifies undefined behavior for
                   // multiple updates to any specific array element through a
                   // vector subscript with replicated values.
+                  assert(!isBoxValue() &&
+                         "fir.box cannot be created with vector subscripts");
                   auto base = x.base();
                   ScalarExprLowering sel{loc, converter, symMap, stmtCtx};
                   auto exv = base.IsSymbol() ? sel.gen(base.GetFirstSymbol())

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -504,6 +504,8 @@ static void genInputItemList(Fortran::lower::AbstractConverter &converter,
 
     llvm::SmallVector<mlir::Value> inputFuncArgs = {cookie};
     if (argType.isa<fir::BoxType>()) {
+      if (Fortran::evaluate::HasVectorSubscript(*expr))
+        TODO(loc, "IO input item with vector subscripts");
       auto box = fir::getBase(converter.genExprBox(*expr, stmtCtx, loc));
       inputFuncArgs.push_back(builder.createConvert(loc, argType, box));
     } else {

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -12,7 +12,7 @@ subroutine pass_assumed_len_char_unformatted_io(c)
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[castedBox]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
 end
 
-! CHECK-LABEL: func @_QPpass_assumed_len_char_array 
+! CHECK-LABEL: func @_QPpass_assumed_len_char_array
 subroutine pass_assumed_len_char_array(carray)
   character(*) :: carray(2, 3)
   ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -30,20 +30,54 @@ end
 ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>
 subroutine pass_array_slice_read(x)
   real :: x(:)
-  read(5, *) x(101:200:2) 
+  read(5, *) x(101:200:2)
   ! CHECK: %[[slice:.*]] = fir.slice %c101{{.*}}, %c200{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
   ! CHECK: %[[box:.*]] = fir.rebox %[[x]] [%[[slice]]] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
   ! CHECK: %[[box_cast:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   ! CHECK: fir.call @_FortranAioInputDescriptor(%{{.*}}, %[[box_cast]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
-end 
+end
 
 ! CHECK-LABEL: func @_QPpass_array_slice_write
 ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>
 subroutine pass_array_slice_write(x)
   real :: x(:)
-  write(1, rec=1) x(101:200:2) 
+  write(1, rec=1) x(101:200:2)
   ! CHECK: %[[slice:.*]] = fir.slice %c101{{.*}}, %c200{{.*}}, %c2{{.*}} : (i64, i64, i64) -> !fir.slice<1>
   ! CHECK: %[[box:.*]] = fir.rebox %[[x]] [%[[slice]]] : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
   ! CHECK: %[[box_cast:.*]] = fir.convert %[[box]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[box_cast]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
-end 
+end
+
+
+! CHECK-LABEL: func @_QPpass_vector_subscript_write(
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>>, %[[j:.*]]: !fir.ref<!fir.array<10xi32>>)
+subroutine pass_vector_subscript_write(x, j)
+  ! Check that a temp is made for array with vector subscript in output IO.
+  integer :: j(10)
+  real :: x(100)
+  ! CHECK: %[[jload:.*]] = fir.array_load %[[j]](%{{.*}}) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
+  ! CHECK: %[[xload:.*]] = fir.array_load %[[x]](%{{.*}}) [%{{.*}}] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
+  ! CHECK: %[[temp:.*]] = fir.allocmem !fir.array<10xf32>
+  ! CHECK: %[[tempload:.*]] = fir.array_load %[[temp]](%{{.*}}) : (!fir.heap<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+  ! CHECK: %[[copy:.*]] = fir.do_loop
+  ! CHECK:   %[[jfetch:.*]] = fir.array_fetch %[[jload]], %{{.*}} : (!fir.array<10xi32>, index) -> i32
+  ! CHECK:   %[[jcast:.*]] = fir.convert %[[jfetch]] : (i32) -> index
+  ! CHECK:   %[[jindex:.*]] = subi %[[jcast]], %c1{{.*}} : index
+  ! CHECK:   %[[xfetch:.*]] = fir.array_fetch %[[xload]], %[[jindex]] : (!fir.array<100xf32>, index) -> f32
+  ! CHECK:   %[[update:.*]] = fir.array_update %{{.*}}, %[[xfetch]], %{{.*}} : (!fir.array<10xf32>, f32, index) -> !fir.array<10xf32>
+  ! CHECK:   fir.result %[[update]] : !fir.array<10xf32>
+  ! CHECK: }
+  ! CHECK: fir.array_merge_store %[[tempload]], %[[copy]] to %[[temp]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.heap<!fir.array<10xf32>>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[temp]](%{{.*}}) : (!fir.heap<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  ! CHECK: %[[boxCast:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<10xf32>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAioOutputDescriptor(%{{.*}}, %[[boxCast]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+  ! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<10xf32>>
+  write(1, rec=1) x(j)
+end
+
+! TODO: handle vector subscript in input IO
+!subroutine pass_vector_subscript_read(x, j)
+!  integer :: j(10)
+!  real :: x(100)
+!  read(5, *) x(j)
+!end subroutine


### PR DESCRIPTION
When provided with an expr containing a vector section, genExprBox
was trying to build a fir.box without making a temp. This is not
possible. Fix this by testing for vector subscripts before calling
createSomeArrayBox.

This caused crash: "Assertion `Index < Length && "Invalid index!"' failed."
The crash was mainly observed in IO statement where genExprBox is used.

This fix output IO, but for input IO, something special will need to be done
for array with vector subscript, most likely making a temp, pass that to the
IO input runtime and copy back the temp into the array section. There are
alternatives, so this more complex case is left TODO until a solution
is chosen for it.