### PR TITLE
Fix bad locations

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -585,13 +585,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   }
 
   /// Get the starting source location for this function like unit
-  parser::CharBlock getStartingSourceLoc() {
-    if (beginStmt)
-      return stmtSourceLoc(*beginStmt);
-    if (!evaluationList.empty())
-      return evaluationList.front().position;
-    return stmtSourceLoc(endStmt);
-  }
+  parser::CharBlock getStartingSourceLoc() const;
 
   void setActiveEntry(int entryIndex) {
     assert(entryIndex >= 0 && entryIndex < (int)entryPointList.size() &&
@@ -614,11 +608,6 @@ struct FunctionLikeUnit : public ProgramUnit {
   /// This is null for a primary entry point.
   Evaluation *getEntryEval() const {
     return entryPointList[activeEntry].second;
-  }
-
-  /// Helper to get location from FunctionLikeUnit begin/end statements.
-  static parser::CharBlock stmtSourceLoc(const FunctionStatement &stmt) {
-    return stmt.visit(common::visitors{[](const auto &x) { return x.source; }});
   }
 
   //===--------------------------------------------------------------------===//
@@ -690,6 +679,9 @@ struct ModuleLikeUnit : public ProgramUnit {
 
   std::vector<Variable> getOrderedSymbolTable() { return varList[0]; }
 
+  /// Get the starting source location for this module like unit.
+  parser::CharBlock getStartingSourceLoc() const;
+
   ModuleStatement beginStmt;
   ModuleStatement endStmt;
   std::list<FunctionLikeUnit> nestedFunctions;
@@ -741,6 +733,13 @@ private:
 /// of a function result.
 std::vector<pft::Variable>
 buildFuncResultDependencyList(const Fortran::semantics::Symbol &);
+
+/// Helper to get location from FunctionLikeUnit/ModuleLikeUnit begin/end
+/// statements.
+template <typename T>
+static parser::CharBlock stmtSourceLoc(const T &stmt) {
+  return stmt.visit(common::visitors{[](const auto &x) { return x.source; }});
+}
 
 } // namespace Fortran::lower::pft
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -798,7 +798,8 @@ private:
   ///  - unstructured infinite and while loops
   ///  - structured and unstructured increment loops
   ///  - structured and unstructured concurrent loops
-  void genFIR(const Fortran::parser::DoConstruct &) {
+  void genFIR(const Fortran::parser::DoConstruct &doConstruct) {
+    setCurrentPosition(Fortran::parser::FindSourceLocation(doConstruct));
     // Collect loop nest information.
     // Generate begin loop code directly for infinite and while loops.
     auto &eval = getEval();
@@ -2290,8 +2291,7 @@ private:
 
   /// Emit return and cleanup after the function has been translated.
   void endNewFunction(Fortran::lower::pft::FunctionLikeUnit &funit) {
-    setCurrentPosition(
-        Fortran::lower::pft::FunctionLikeUnit::stmtSourceLoc(funit.endStmt));
+    setCurrentPosition(Fortran::lower::pft::stmtSourceLoc(funit.endStmt));
     if (funit.isMainProgram())
       genExitRoutine();
     else
@@ -2334,6 +2334,7 @@ private:
 
   /// Lower a procedure (nest).
   void lowerFunc(Fortran::lower::pft::FunctionLikeUnit &funit) {
+    setCurrentPosition(funit.getStartingSourceLoc());
     for (int entryIndex = 0, last = funit.entryPointList.size();
          entryIndex < last; ++entryIndex) {
       funit.setActiveEntry(entryIndex);
@@ -2352,6 +2353,7 @@ private:
     // FIXME: get rid of the bogus function context and instantiate the
     // globals directly into the module.
     auto *context = &getMLIRContext();
+    setCurrentPosition(mod.getStartingSourceLoc());
     auto func = Fortran::lower::FirOpBuilder::createFunction(
         mlir::UnknownLoc::get(context), getModuleOp(),
         fir::NameUniquer::doGenerated("ModuleSham"),

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1131,6 +1131,7 @@ getFunctionStmt(const T &func) {
       std::get<parser::Statement<A>>(func.t)};
   return result;
 }
+
 template <typename A, typename T>
 static lower::pft::ModuleLikeUnit::ModuleStatement getModuleStmt(const T &mod) {
   lower::pft::ModuleLikeUnit::ModuleStatement result{
@@ -1474,6 +1475,10 @@ static void processSymbolTable(
   sdd.finalize();
 }
 
+//===----------------------------------------------------------------------===//
+// FunctionLikeUnit implementation
+//===----------------------------------------------------------------------===//
+
 Fortran::lower::pft::FunctionLikeUnit::FunctionLikeUnit(
     const parser::MainProgram &func, const lower::pft::PftNode &parent,
     const semantics::SemanticsContext &semanticsContext)
@@ -1541,6 +1546,19 @@ bool Fortran::lower::pft::FunctionLikeUnit::parentHasHostAssoc() {
   return false;
 }
 
+parser::CharBlock
+Fortran::lower::pft::FunctionLikeUnit::getStartingSourceLoc() const {
+  if (beginStmt)
+    return stmtSourceLoc(*beginStmt);
+  if (!evaluationList.empty())
+    return evaluationList.front().position;
+  return stmtSourceLoc(endStmt);
+}
+
+//===----------------------------------------------------------------------===//
+// ModuleLikeUnit implementation
+//===----------------------------------------------------------------------===//
+
 Fortran::lower::pft::ModuleLikeUnit::ModuleLikeUnit(
     const parser::Module &m, const lower::pft::PftNode &parent)
     : ProgramUnit{m, parent}, beginStmt{getModuleStmt<parser::ModuleStmt>(m)},
@@ -1557,6 +1575,15 @@ Fortran::lower::pft::ModuleLikeUnit::ModuleLikeUnit(
   auto symbol = getSymbol(beginStmt);
   processSymbolTable(*symbol->scope(), varList, /*reentrant=*/false);
 }
+
+parser::CharBlock
+Fortran::lower::pft::ModuleLikeUnit::getStartingSourceLoc() const {
+  return stmtSourceLoc(beginStmt);
+}
+
+//===----------------------------------------------------------------------===//
+// BlockDataUnit implementation
+//===----------------------------------------------------------------------===//
 
 Fortran::lower::pft::BlockDataUnit::BlockDataUnit(
     const parser::BlockData &bd, const lower::pft::PftNode &parent,


### PR DESCRIPTION
PR #865 added a `setCurrentLocation` call in function declaration that had the side effect of changing some previously "unknown" location into bad locations when later lowering functions bodies.

The root-cause was that `lowerFunc` itself was not calling `setCurrentLocation`, so the first function was now lowered with the location of the last declaration.

In the process, also set locations for modules, and before starting lowering do constructs. There are probably other constructs/evaluation that are not calling `setCurrentLocation` as they should, but now at least they won't get the location from a later function. Location/debug info will require some more careful work / tests at some point.