### PR TITLE
Fix inquiry intrinsic argument lowering

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1589,7 +1589,7 @@ public:
   /// Helper to lower intrinsic arguments for inquiry intrinsic.
   ExtValue
   lowerIntrinsicArgumentAsInquired(const Fortran::lower::SomeExpr &expr) {
-    if (IsAllocatableOrPointer(expr))
+    if (isAllocatableOrPointer(expr))
       return genMutableBoxValue(expr);
     return gen(expr);
   }


### PR DESCRIPTION
Inquiry argument lowering was using `evaluate::IsAllocatableOrPointer` ([defined here](https://github.com/llvm/llvm-project/blob/47f18af55fd59e813144cc76711806d57a160e50/flang/include/flang/Evaluate/tools.h#L863)) instead of `isAllocatableOrPointer`. The First one does not behave as needed when lowering inquired arguments, it was returning true on expression `x(i)` with x and allocatable, when `x(i)` designator should not be considered an allocatable designator in lowering (it cannot be allocated).

This fixes a sub-issue reported in #858, but ASSOCIATED with TARGET argument remains unimplemented.