### PR TITLE
Host association in internal procedure part 2: non trivial variables

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -270,6 +270,8 @@ public:
 
   /// Helper class to create if-then-else in a structured way:
   /// Usage: genIfOp().then([&](){...}).else([&](){...}).end();
+  /// Alternatively, getResults() can be used instead of end() to end the ifOp
+  /// and get the ifOp results.
   class IfBuilder {
   public:
     IfBuilder(fir::IfOp ifOp, FirOpBuilder &builder)
@@ -288,6 +290,12 @@ public:
       return *this;
     }
     void end() { builder.setInsertionPointAfter(ifOp); }
+
+    /// End the IfOp and return the results if any.
+    mlir::Operation::result_range getResults() {
+      end();
+      return ifOp.getResults();
+    }
 
   private:
     fir::IfOp ifOp;
@@ -315,6 +323,9 @@ public:
     auto op = create<fir::IfOp>(loc, llvm::None, cdt, true);
     return IfBuilder(op, *this);
   }
+
+  /// Generate code testing \p addr is not a null address.
+  mlir::Value genIsNotNull(mlir::Location loc, mlir::Value addr);
 
 private:
   const fir::KindMapping &kindMap;

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1147,8 +1147,8 @@ def fir_EmboxCharOp : fir_Op<"emboxchar", [NoSideEffect]> {
   }];
 
   let verifier = [{
-    auto eleTy = elementTypeOf(memref().getType());
-    if (!eleTy.dyn_cast<CharacterType>())
+    auto eleTy = fir::dyn_cast_ptrEleTy(memref().getType());
+    if (!eleTy.dyn_cast_or_null<CharacterType>())
       return mlir::failure();
     return mlir::success();
   }];
@@ -1821,7 +1821,7 @@ def fir_CoordinateOp : fir_Op<"coordinate_of", [NoSideEffect]> {
     TypeAttr:$baseType
   );
 
-  let results = (outs fir_ReferenceType);
+  let results = (outs RefOrLLVMPtr);
 
   let parser =  [{ return parseCoordinateCustom(parser, result); }];
   let printer = [{ ::print(p, *this); }];

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -224,6 +224,28 @@ def fir_LogicalType : FIR_Type<"Logical", "logical"> {
   }];
 }
 
+def fir_LLVMPointerType : FIR_Type<"LLVMPointer", "llvm_ptr"> {
+  let summary = "Like LLVM pointer type";
+
+  let description = [{
+    A pointer type that does not have any of the constraints and semantics
+    of other FIR pointer types and that translates to llvm pointer types.
+    It is meant to implement indirection that cannot be expressed directly
+    in Fortran, but are needed to implement some Fortran features (e.g,
+    double indirections).
+  }];
+
+  let parameters = (ins "mlir::Type":$eleTy);
+
+  let skipDefaultBuilders = 1;
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "mlir::Type":$elementType), [{
+      return Base::get(elementType.getContext(), elementType);
+    }]>,
+  ];
+}
+
 def fir_PointerType : FIR_Type<"Pointer", "ptr"> {
   let summary = "Reference to a POINTER attribute type";
 
@@ -513,7 +535,11 @@ def AnyCompositeLike : TypeConstraint<Or<[fir_RecordType.predicate,
 
 // Reference types
 def AnyReferenceLike : TypeConstraint<Or<[fir_ReferenceType.predicate,
-    fir_HeapType.predicate, fir_PointerType.predicate]>, "any reference">;
+    fir_HeapType.predicate, fir_PointerType.predicate,
+    fir_LLVMPointerType.predicate]>, "any reference">;
+
+def RefOrLLVMPtr : TypeConstraint<Or<[fir_ReferenceType.predicate,
+    fir_LLVMPointerType.predicate]>, "fir.ref or fir.llvm_ptr">;
 
 def AnyBoxLike : TypeConstraint<Or<[fir_BoxType.predicate,
     fir_BoxCharType.predicate, fir_BoxProcType.predicate]>, "any box">;

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -950,8 +950,8 @@ void Fortran::lower::mapSymbolAttributes(
   const auto isResult = Fortran::semantics::IsFunctionResult(sym);
   const auto replace = isDummy || isResult;
   Fortran::lower::CharacterExprHelper charHelp{builder, loc};
-  Fortran::lower::BoxAnalyzer sba;
-  sba.analyze(sym);
+  Fortran::lower::BoxAnalyzer ba;
+  ba.analyze(sym);
 
   // First deal with pointers an allocatables, because their handling here
   // is the same regardless of their rank.
@@ -968,8 +968,8 @@ void Fortran::lower::mapSymbolAttributes(
       boxAlloc = createNewLocal(converter, loc, var, preAlloc);
     // Lower non deferred parameters.
     llvm::SmallVector<mlir::Value> nonDeferredLenParams;
-    if (sba.isChar()) {
-      if (auto len = lowerExplicitCharLen(converter, loc, sba, symMap, stmtCtx))
+    if (ba.isChar()) {
+      if (auto len = lowerExplicitCharLen(converter, loc, ba, symMap, stmtCtx))
         nonDeferredLenParams.push_back(len);
       else if (Fortran::semantics::IsAssumedLengthCharacter(sym))
         TODO(loc, "assumed length character allocatable");
@@ -993,13 +993,13 @@ void Fortran::lower::mapSymbolAttributes(
       llvm::SmallVector<mlir::Value> explicitParams;
       // Lower lower bounds, explicit type parameters and explicit
       // extents if any.
-      if (sba.isChar())
+      if (ba.isChar())
         if (auto len =
-                lowerExplicitCharLen(converter, loc, sba, symMap, stmtCtx))
+                lowerExplicitCharLen(converter, loc, ba, symMap, stmtCtx))
           explicitParams.push_back(len);
       // TODO: derived type length parameters.
-      lowerExplicitLowerBounds(converter, loc, sba, lbounds, symMap, stmtCtx);
-      lowerExplicitExtents(converter, loc, sba, lbounds, extents, symMap,
+      lowerExplicitLowerBounds(converter, loc, ba, lbounds, symMap, stmtCtx);
+      lowerExplicitExtents(converter, loc, ba, lbounds, extents, symMap,
                            stmtCtx);
       symMap.addBoxSymbol(sym, dummyArg, lbounds, explicitParams, extents,
                           replace);
@@ -1085,7 +1085,7 @@ void Fortran::lower::mapSymbolAttributes(
     }
   };
 
-  sba.match(
+  ba.match(
       //===--------------------------------------------------------------===//
       // Trivial case.
       //===--------------------------------------------------------------===//

--- a/flang/lib/Lower/FIRBuilder.cpp
+++ b/flang/lib/Lower/FIRBuilder.cpp
@@ -418,6 +418,14 @@ Fortran::lower::FirOpBuilder::createBox(mlir::Location loc,
       });
 }
 
+mlir::Value Fortran::lower::FirOpBuilder::genIsNotNull(mlir::Location loc,
+                                                       mlir::Value addr) {
+  auto intPtrTy = getIntPtrType();
+  auto ptrToInt = createConvert(loc, intPtrTy, addr);
+  auto c0 = createIntegerConstant(loc, intPtrTy, 0);
+  return create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ne, ptrToInt, c0);
+}
+
 //===--------------------------------------------------------------------===//
 // ExtendedValue inquiry helper implementation
 //===--------------------------------------------------------------------===//

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -7,17 +7,428 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/HostAssociations.h"
+#include "BoxAnalyzer.h"
 #include "SymbolMap.h"
+#include "flang/Evaluate/check-expression.h"
 #include "flang/Lower/AbstractConverter.h"
+#include "flang/Lower/Allocatable.h"
+#include "flang/Lower/CharacterExpr.h"
 #include "flang/Lower/ConvertType.h"
 #include "flang/Lower/FIRBuilder.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Todo.h"
+#include "flang/Optimizer/Support/FatalError.h"
+#include "flang/Semantics/tools.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "flang-host-assoc"
+
+// Host association inside internal procedures is implemented by allocating an
+// mlir tuple (a struct) inside the host containing the addresses and properties
+// of variables that are accessed by internal procedures. The address of this
+// tuple is passed as an argument by the host when calling internal procedures.
+// Internal procedures are propagating this tuple address when calling other
+// internal procedures of the host.
+//
+// This file defines how the type of the host tuple is built, how the tuple
+// value is created inside the host, and how the host associated variables are
+// instantiated inside the internal procedures from the tuple value. The
+// CapturedXXX classes are defining each of these three actions for a specific
+// kind of variables by providing a `getType`, a `placeInTuple`, and a
+// `getFromTuple` method. These classes are structured as follow:
+//
+//   class CapturedKindOfVar : public CapturedSymbols<CapturedKindOfVar> {
+//     // Return the type of the tuple element for a host associated
+//     // variable given its symbol inside the host. This is called when
+//     // building function interfaces.
+//     static mlir::Type getType();
+//     // Build the tuple element value for a host associated variable given its
+//     // value inside the host. This is called when lowering the host body.
+//     static void placeInTuple();
+//     // Instantiate a host variable inside an internal procedure given its
+//     // tuple element value. This is called when lowering internal procedure
+//     // bodies.
+//     static void getFromTuple();
+//   };
+//
+// If a new kind of variables requires ad-hoc handling, a new CapturedXXX class
+// should be added to handle it, and `walkCaptureCategories` should be updated
+// to dispatch this new kind of variable to this new class.
+
+/// Struct to be used as argument in walkCaptureCategories when building the
+/// tuple element type for a host associated variable.
+struct GetTypeInTuple {
+  /// walkCaptureCategories must return a type.
+  using Result = mlir::Type;
+};
+
+/// Struct to be used as argument in walkCaptureCategories when building the
+/// tuple element value for a host associated variable.
+struct PlaceInTuple {
+  /// walkCaptureCategories returns nothing.
+  using Result = void;
+  /// Value of the variable inside the host procedure.
+  fir::ExtendedValue hostValue;
+  /// Address of the tuple element of the variable.
+  mlir::Value addrInTuple;
+  mlir::Location loc;
+};
+
+/// Struct to be used as argument in walkCaptureCategories when instantiating a
+/// host associated variables from its tuple element value.
+struct GetFromTuple {
+  /// walkCaptureCategories returns nothing.
+  using Result = void;
+  /// Symbol map inside the internal procedure.
+  Fortran::lower::SymMap &symMap;
+  /// Value of the tuple element for the host associated variable.
+  mlir::Value valueInTuple;
+  mlir::Location loc;
+};
+
+/// Base class that must be inherited with CRTP by classes defining
+/// how host association is implemented for a type of symbol.
+/// It simply dispatches visit() calls to the implementations according
+/// to the argument type.
+template <typename SymbolCategory>
+class CapturedSymbols {
+public:
+  template <typename T>
+  static void visit(const T &, Fortran::lower::AbstractConverter &,
+                    const Fortran::semantics::Symbol &,
+                    const Fortran::lower::BoxAnalyzer &) {
+    static_assert(!std::is_same_v<T, T> &&
+                  "default visit must not be instantiated");
+  }
+  static mlir::Type visit(const GetTypeInTuple &,
+                          Fortran::lower::AbstractConverter &converter,
+                          const Fortran::semantics::Symbol &sym,
+                          const Fortran::lower::BoxAnalyzer &) {
+    return SymbolCategory::getType(converter, sym);
+  }
+  static void visit(const PlaceInTuple &args,
+                    Fortran::lower::AbstractConverter &converter,
+                    const Fortran::semantics::Symbol &sym,
+                    const Fortran::lower::BoxAnalyzer &) {
+    return SymbolCategory::placeInTuple(args, converter, sym);
+  }
+  static void visit(const GetFromTuple &args,
+                    Fortran::lower::AbstractConverter &converter,
+                    const Fortran::semantics::Symbol &sym,
+                    const Fortran::lower::BoxAnalyzer &sba) {
+    return SymbolCategory::getFromTuple(args, converter, sym, sba);
+  }
+};
+
+/// Class defining simple scalars are captured in internal procedures.
+/// Simple scalars are non character intrinsic scalars. They are captured
+/// as !fir.ptr<T> (.e.g !fir.ptr<i32> for INTEGER(4)).
+class CapturedSimpleScalars : public CapturedSymbols<CapturedSimpleScalars> {
+public:
+  static mlir::Type getType(Fortran::lower::AbstractConverter &converter,
+                            const Fortran::semantics::Symbol &sym) {
+    return fir::PointerType::get(converter.genType(sym));
+  }
+
+  static void placeInTuple(const PlaceInTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &) {
+    auto &builder = converter.getFirOpBuilder();
+    auto typeInTuple = fir::dyn_cast_ptrEleTy(args.addrInTuple.getType());
+    assert(typeInTuple && "addrInTuple must be an address");
+    auto castBox = builder.createConvert(args.loc, typeInTuple,
+                                         fir::getBase(args.hostValue));
+    builder.create<fir::StoreOp>(args.loc, castBox, args.addrInTuple);
+  }
+
+  static void getFromTuple(const GetFromTuple &args,
+                           Fortran::lower::AbstractConverter &,
+                           const Fortran::semantics::Symbol &sym,
+                           const Fortran::lower::BoxAnalyzer &) {
+    args.symMap.addSymbol(sym, args.valueInTuple);
+  }
+};
+
+/// Class defining how character scalars are captured in internal procedures.
+/// Character scalars are passed as !fir.boxchar<kind> in the tuple.
+class CapturedCharacterScalars
+    : public CapturedSymbols<CapturedCharacterScalars> {
+public:
+  // Note: so far, do not specialize constant length characters. They can be
+  // implemented by only passing the address. This could be done later in
+  // lowering or a CapturedStaticLenCharacterScalars class could be added here.
+
+  static mlir::Type getType(Fortran::lower::AbstractConverter &converter,
+                            const Fortran::semantics::Symbol &sym) {
+    auto kind = converter.genType(sym).cast<fir::CharacterType>().getFKind();
+    return fir::BoxCharType::get(&converter.getMLIRContext(), kind);
+  }
+
+  static void placeInTuple(const PlaceInTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &) {
+    auto *charBox = args.hostValue.getCharBox();
+    assert(charBox && "host value must be a fir::CharBoxValue");
+    auto &builder = converter.getFirOpBuilder();
+    auto boxchar = Fortran::lower::CharacterExprHelper(builder, args.loc)
+                       .createEmbox(*charBox);
+    builder.create<fir::StoreOp>(args.loc, boxchar, args.addrInTuple);
+  }
+
+  static void getFromTuple(const GetFromTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &sym,
+                           const Fortran::lower::BoxAnalyzer &) {
+    Fortran::lower::CharacterExprHelper charHelp(converter.getFirOpBuilder(),
+                                                 args.loc);
+    auto unboxchar = charHelp.createUnboxChar(args.valueInTuple);
+    args.symMap.addCharSymbol(sym, unboxchar.first, unboxchar.second);
+  }
+};
+
+/// Is \p sym a derived type entity with length parameters ?
+static bool
+isDerivedWithLengthParameters(const Fortran::semantics::Symbol &sym) {
+  if (const auto *declTy = sym.GetType())
+    if (const auto *derived = declTy->AsDerived())
+      return Fortran::semantics::CountLenParameters(*derived) != 0;
+  return false;
+}
+
+/// Class defining how allocatable and pointers entities are captured in
+/// internal procedures. Allocatable and pointers are simply captured by placing
+/// their !fir.ref<fir.box<>> address in the host tuple.
+class CapturedAllocatableAndPointer
+    : public CapturedSymbols<CapturedAllocatableAndPointer> {
+public:
+  static mlir::Type getType(Fortran::lower::AbstractConverter &converter,
+                            const Fortran::semantics::Symbol &sym) {
+    return fir::ReferenceType::get(converter.genType(sym));
+  }
+  static void placeInTuple(const PlaceInTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &) {
+    assert(args.hostValue.getBoxOf<fir::MutableBoxValue>() &&
+           "host value must be a fir::MutableBoxValue");
+    auto &builder = converter.getFirOpBuilder();
+    auto typeInTuple = fir::dyn_cast_ptrEleTy(args.addrInTuple.getType());
+    assert(typeInTuple && "addrInTuple must be an address");
+    auto castBox = builder.createConvert(args.loc, typeInTuple,
+                                         fir::getBase(args.hostValue));
+    builder.create<fir::StoreOp>(args.loc, castBox, args.addrInTuple);
+  }
+  static void getFromTuple(const GetFromTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &sym,
+                           const Fortran::lower::BoxAnalyzer &sba) {
+    auto &builder = converter.getFirOpBuilder();
+    auto loc = args.loc;
+    // Non deferred type parameters impact the semantics of some statements
+    // where allocatables/pointer can appear. For instance, assignment to a
+    // scalar character allocatable with has a different semantics in F2003 and
+    // later if the length is non deferred vs when it is deferred. So it is
+    // important to keep track of the non deferred parameters here.
+    llvm::SmallVector<mlir::Value> nonDeferredLenParams;
+    if (sba.isChar()) {
+      auto idxTy = builder.getIndexType();
+      if (auto len = sba.getCharLenConst()) {
+        nonDeferredLenParams.push_back(
+            builder.createIntegerConstant(loc, idxTy, *len));
+      } else if (Fortran::semantics::IsAssumedLengthCharacter(sym) ||
+                 sba.getCharLenExpr()) {
+        // Read length from fir.box (explicit expr cannot safely be re-evaluated
+        // here).
+        auto readLength = [&]() {
+          fir::BoxValue boxLoad =
+              builder.create<fir::LoadOp>(loc, fir::getBase(args.valueInTuple))
+                  .getResult();
+          return Fortran::lower::readCharLen(builder, loc, boxLoad);
+        };
+        if (Fortran::semantics::IsOptional(sym)) {
+          // It is not safe to unconditionally read boxes of optionals in case
+          // they are absents. According to 15.5.2.12 3 (9), it is illegal to
+          // inquire the length of absent optional, even if non deferred, so
+          // it's fine to use undefOp in this case.
+          auto isPresent = builder.create<fir::IsPresentOp>(
+              loc, builder.getI1Type(), fir::getBase(args.valueInTuple));
+          auto len =
+              builder.genIfOp(loc, {idxTy}, isPresent, true)
+                  .genThen([&]() {
+                    builder.create<fir::ResultOp>(loc, readLength());
+                  })
+                  .genElse([&]() {
+                    auto undef = builder.create<fir::UndefOp>(loc, idxTy);
+                    builder.create<fir::ResultOp>(loc, undef.getResult());
+                  })
+                  .getResults()[0];
+          nonDeferredLenParams.push_back(len);
+        } else {
+          nonDeferredLenParams.push_back(readLength());
+        }
+      }
+    } else if (isDerivedWithLengthParameters(sym)) {
+      TODO(loc, "host associated derived type allocatable or pointer with "
+                "length parameters");
+    }
+    args.symMap.addSymbol(
+        sym, fir::MutableBoxValue(args.valueInTuple, nonDeferredLenParams, {}));
+  }
+};
+
+/// Class defining how arrays are captured inside internal procedures.
+/// Array are captured via a fir.box<fir.ptr<T>> pointer descriptor that
+/// belongs to the host tuple. This allows capturing lower bounds, which
+/// a non pointer descriptor (fir.box<T>) would not allow.
+class CapturedArrays : public CapturedSymbols<CapturedArrays> {
+
+  // Note: Constant shape arrays are not specialized (their base address would
+  // be sufficient information inside the tuple). They could be specialized in
+  // a later FIR pass, or A CapturedStaticShapeArrays could be added to deal
+  // with them here.
+public:
+  static mlir::Type getType(Fortran::lower::AbstractConverter &converter,
+                            const Fortran::semantics::Symbol &sym) {
+    auto type = converter.genType(sym);
+    assert(type.isa<fir::SequenceType>() && "must be a sequence type");
+    return fir::BoxType::get(fir::PointerType::get(type));
+  }
+
+  static void placeInTuple(const PlaceInTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &sym) {
+    auto &builder = converter.getFirOpBuilder();
+    auto loc = args.loc;
+    fir::MutableBoxValue boxInTuple(args.addrInTuple, {}, {});
+    if (args.hostValue.getBoxOf<fir::BoxValue>() &&
+        Fortran::semantics::IsOptional(sym)) {
+      // The assumed shape optional case need some care because it is illegal to
+      // read the incoming box if it is absent (this would cause segfaults).
+      // Pointer association requires reading the target box, so it can only be
+      // done on present optional. For absent optionals, simply create a
+      // disassociated pointer (it is illegal to inquire about lower bounds or
+      // lengths of optional according to 15.5.2.12 3 (9) and 10.1.11 2 (7)b).
+      auto isPresent = builder.create<fir::IsPresentOp>(
+          loc, builder.getI1Type(), fir::getBase(args.hostValue));
+      builder.genIfThenElse(loc, isPresent)
+          .genThen([&]() {
+            Fortran::lower::associateMutableBoxWithShift(
+                builder, loc, boxInTuple, args.hostValue, /*shift*/ llvm::None);
+          })
+          .genElse([&]() {
+            Fortran::lower::disassociateMutableBox(builder, loc, boxInTuple);
+          })
+          .end();
+    } else {
+      Fortran::lower::associateMutableBoxWithShift(
+          builder, loc, boxInTuple, args.hostValue, /*shift*/ llvm::None);
+    }
+  }
+
+  static void getFromTuple(const GetFromTuple &args,
+                           Fortran::lower::AbstractConverter &converter,
+                           const Fortran::semantics::Symbol &sym,
+                           const Fortran::lower::BoxAnalyzer &sba) {
+    auto &builder = converter.getFirOpBuilder();
+    auto loc = args.loc;
+    auto box = args.valueInTuple;
+    auto idxTy = builder.getIndexType();
+    llvm::SmallVector<mlir::Value> lbounds;
+    if (!sba.lboundIsAllOnes()) {
+      if (sba.isStaticArray()) {
+        for (auto lb : sba.staticLBound())
+          lbounds.emplace_back(builder.createIntegerConstant(loc, idxTy, lb));
+      } else {
+        // Cannot re-evaluate specification expressions here.
+        // Operands values may have changed. Get value from fir.box
+        const unsigned rank = sym.Rank();
+        for (unsigned dim = 0; dim < rank; ++dim) {
+          auto dimVal = builder.createIntegerConstant(loc, idxTy, dim);
+          auto dims = builder.create<fir::BoxDimsOp>(loc, idxTy, idxTy, idxTy,
+                                                     box, dimVal);
+          lbounds.emplace_back(dims.getResult(0));
+        }
+      }
+    }
+
+    if (canReadCapturedBoxValue(converter, sym)) {
+      fir::BoxValue boxValue(box, lbounds, /*explicitParams=*/llvm::None);
+      args.symMap.addSymbol(
+          sym, Fortran::lower::readBoxValue(builder, loc, boxValue));
+    } else {
+      // Keep variable as a fir.box.
+      // If this is an optional that is absent, the fir.box needs to be an
+      // AbsentOp result, otherwise it will not work properly with IsPresentOp
+      // (absent boxes are null descriptor addresses, not descriptors containing
+      // a null base address).
+      if (Fortran::semantics::IsOptional(sym)) {
+        auto boxTy = box.getType().cast<fir::BoxType>();
+        auto addr = builder.create<fir::BoxAddrOp>(loc, boxTy.getEleTy(), box);
+        auto isPresent = builder.genIsNotNull(loc, addr);
+        auto absentBox = builder.create<fir::AbsentOp>(loc, boxTy);
+        box = builder.create<mlir::SelectOp>(loc, isPresent, box, absentBox);
+      }
+      fir::BoxValue boxValue(box, lbounds, /*explicitParams=*/llvm::None);
+      args.symMap.addSymbol(sym, boxValue);
+    }
+  }
+
+private:
+  /// Can the fir.box from the host link be read into simpler values ?
+  /// Later, without the symbol information, it might not be possible
+  /// to tell if the fir::BoxValue from the host link is contiguous.
+  static bool
+  canReadCapturedBoxValue(Fortran::lower::AbstractConverter &converter,
+                          const Fortran::semantics::Symbol &sym) {
+    bool isScalarOrContiguous =
+        sym.Rank() == 0 || Fortran::evaluate::IsSimplyContiguous(
+                               Fortran::evaluate::AsGenericExpr(sym).value(),
+                               converter.getFoldingContext());
+    const auto *type = sym.GetType();
+    bool isPolymorphic = type && type->IsPolymorphic();
+    return isScalarOrContiguous && !isPolymorphic &&
+           !isDerivedWithLengthParameters(sym);
+  }
+};
+
+/// Dispatch \p visitor to the CapturedSymbols which is handling how host
+/// association is implemented for this kind of symbols. This ensures the same
+/// dispatch decision is taken when building the tuple type, when creating the
+/// tuple, and when instantiating host associated variables from it.
+template <typename T>
+typename T::Result
+walkCaptureCategories(T visitor, Fortran::lower::AbstractConverter &converter,
+                      const Fortran::semantics::Symbol &sym) {
+  if (isDerivedWithLengthParameters(sym))
+    TODO(converter.genLocation(sym.name()),
+         "host associated derived type with length parameters");
+  Fortran::lower::BoxAnalyzer sba;
+  sba.analyze(sym);
+  if (Fortran::evaluate::IsAllocatableOrPointer(sym))
+    return CapturedAllocatableAndPointer::visit(visitor, converter, sym, sba);
+  if (sba.isArray())
+    return CapturedArrays::visit(visitor, converter, sym, sba);
+  if (sba.isChar())
+    return CapturedCharacterScalars::visit(visitor, converter, sym, sba);
+  assert(sba.isTrivial() && "must be trivial scalar");
+  return CapturedSimpleScalars::visit(visitor, converter, sym, sba);
+}
 
 // `t` should be the result of getArgumentType, which has a type of
 // `!fir.ref<tuple<...>>`.
 static mlir::TupleType unwrapTupleTy(mlir::Type t) {
   return fir::dyn_cast_ptrEleTy(t).cast<mlir::TupleType>();
+}
+
+static mlir::Value genTupleCoor(Fortran::lower::FirOpBuilder &builder,
+                                mlir::Location loc, mlir::Type varTy,
+                                mlir::Value tupleArg, mlir::Value offset) {
+  // fir.ref<fir.ref> and fir.ptr<fir.ref> are forbidden. Use
+  // fir.llvm_ptr if needed.
+  auto ty = varTy.isa<fir::ReferenceType>()
+                ? mlir::Type(fir::LLVMPointerType::get(varTy))
+                : mlir::Type(builder.getRefType(varTy));
+  return builder.create<fir::CoordinateOp>(loc, ty, tupleArg, offset);
 }
 
 void Fortran::lower::HostAssociations::hostProcedureBindings(
@@ -35,14 +446,13 @@ void Fortran::lower::HostAssociations::hostProcedureBindings(
 
   // Walk the list of symbols and update the pointers in the tuple.
   for (auto s : llvm::enumerate(symbols)) {
-    auto box = symMap.lookupSymbol(s.value());
-    auto boxAddr = fir::getBase(box.toExtendedValue());
-    auto off = builder.createIntegerConstant(loc, offTy, s.index());
-    auto varTy = tupTy.getType(s.index());
-    auto refTy = builder.getRefType(varTy);
-    auto eleOff = builder.create<fir::CoordinateOp>(loc, refTy, hostTuple, off);
-    auto castBox = builder.createConvert(loc, varTy, boxAddr);
-    builder.create<fir::StoreOp>(loc, castBox, eleOff);
+    auto indexInTuple = s.index();
+    auto off = builder.createIntegerConstant(loc, offTy, indexInTuple);
+    auto varTy = tupTy.getType(indexInTuple);
+    auto eleOff = genTupleCoor(builder, loc, varTy, hostTuple, off);
+    PlaceInTuple placeInTuple{symMap.lookupSymbol(s.value()).toExtendedValue(),
+                              eleOff, loc};
+    walkCaptureCategories(placeInTuple, converter, *s.value());
   }
 
   converter.bindHostAssocTuple(hostTuple);
@@ -77,11 +487,11 @@ void Fortran::lower::HostAssociations::internalProcedureBindings(
   // Walk the list and add the bindings to the symbol table.
   for (auto s : llvm::enumerate(symbols)) {
     auto off = builder.createIntegerConstant(loc, offTy, s.index());
-    auto varTy = builder.getRefType(tupTy.getType(s.index()));
-    auto eleOff = builder.create<fir::CoordinateOp>(loc, varTy, tupleArg, off);
-    auto box = builder.create<fir::LoadOp>(loc, eleOff);
-    Fortran::semantics::SymbolRef symRef = *s.value();
-    symMap.addSymbol(symRef, box.getResult());
+    auto varTy = tupTy.getType(s.index());
+    auto eleOff = genTupleCoor(builder, loc, varTy, tupleArg, off);
+    mlir::Value valueInTuple = builder.create<fir::LoadOp>(loc, eleOff);
+    GetFromTuple getFromTuple{symMap, valueInTuple, loc};
+    walkCaptureCategories(getFromTuple, converter, *s.value());
   }
 }
 
@@ -96,13 +506,9 @@ mlir::Type Fortran::lower::HostAssociations::getArgumentType(
   // to a tuple.
   auto *ctxt = &converter.getMLIRContext();
   llvm::SmallVector<mlir::Type> tupleTys;
-  for (const auto *sym : symbols) {
-    auto varTy = Fortran::lower::translateSymbolToFIRType(converter, *sym);
-    if (!fir::isa_trivial(varTy))
-      TODO(converter.getCurrentLocation(),
-           "non trivial associated variable in internal procedure");
-    tupleTys.emplace_back(fir::PointerType::get(varTy));
-  }
+  for (const auto *sym : symbols)
+    tupleTys.emplace_back(
+        walkCaptureCategories(GetTypeInTuple{}, converter, *sym));
   argType = fir::ReferenceType::get(mlir::TupleType::get(ctxt, tupleTys));
   return argType;
 }

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -58,6 +58,9 @@ public:
       return mlir::IntegerType::get(
           &getContext(), kindMapping.getLogicalBitsize(boolTy.getFKind()));
     });
+    addConversion([&](fir::LLVMPointerType pointer) {
+      return convertPointerLike(pointer);
+    });
     addConversion(
         [&](fir::PointerType pointer) { return convertPointerLike(pointer); });
     addConversion(

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1256,16 +1256,8 @@ mlir::Value fir::IterWhileOp::blockArgToSourceOp(unsigned blockArgNum) {
 // LoadOp
 //===----------------------------------------------------------------------===//
 
-/// Get the element type of a reference like type; otherwise null
-static mlir::Type elementTypeOf(mlir::Type ref) {
-  return llvm::TypeSwitch<mlir::Type, mlir::Type>(ref)
-      .Case<ReferenceType, PointerType, HeapType>(
-          [](auto type) { return type.getEleTy(); })
-      .Default([](mlir::Type) { return mlir::Type{}; });
-}
-
 mlir::ParseResult fir::LoadOp::getElementOf(mlir::Type &ele, mlir::Type ref) {
-  if ((ele = elementTypeOf(ref)))
+  if ((ele = fir::dyn_cast_ptrEleTy(ref)))
     return mlir::success();
   return mlir::failure();
 }
@@ -2058,13 +2050,7 @@ unsigned fir::SliceOp::getOutputRank(mlir::ValueRange triples) {
 //===----------------------------------------------------------------------===//
 
 mlir::Type fir::StoreOp::elementType(mlir::Type refType) {
-  if (auto ref = refType.dyn_cast<ReferenceType>())
-    return ref.getEleTy();
-  if (auto ref = refType.dyn_cast<PointerType>())
-    return ref.getEleTy();
-  if (auto ref = refType.dyn_cast<HeapType>())
-    return ref.getEleTy();
-  return {};
+  return fir::dyn_cast_ptrEleTy(refType);
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -199,7 +199,8 @@ bool isa_fir_or_std_type(mlir::Type t) {
 }
 
 bool isa_ref_type(mlir::Type t) {
-  return t.isa<ReferenceType>() || t.isa<PointerType>() || t.isa<HeapType>();
+  return t.isa<ReferenceType>() || t.isa<PointerType>() || t.isa<HeapType>() ||
+         t.isa<fir::LLVMPointerType>();
 }
 
 bool isa_box_type(mlir::Type t) {
@@ -218,15 +219,15 @@ bool isa_aggregate(mlir::Type t) {
 
 mlir::Type dyn_cast_ptrEleTy(mlir::Type t) {
   return llvm::TypeSwitch<mlir::Type, mlir::Type>(t)
-      .Case<fir::ReferenceType, fir::PointerType, fir::HeapType>(
-          [](auto p) { return p.getEleTy(); })
+      .Case<fir::ReferenceType, fir::PointerType, fir::HeapType,
+            fir::LLVMPointerType>([](auto p) { return p.getEleTy(); })
       .Default([](mlir::Type) { return mlir::Type{}; });
 }
 
 mlir::Type dyn_cast_ptrOrBoxEleTy(mlir::Type t) {
   return llvm::TypeSwitch<mlir::Type, mlir::Type>(t)
-      .Case<fir::ReferenceType, fir::PointerType, fir::HeapType>(
-          [](auto p) { return p.getEleTy(); })
+      .Case<fir::ReferenceType, fir::PointerType, fir::HeapType,
+            fir::LLVMPointerType>([](auto p) { return p.getEleTy(); })
       .Case<fir::BoxType>([](auto p) {
         auto eleTy = p.getEleTy();
         if (auto ty = fir::dyn_cast_ptrEleTy(eleTy))
@@ -364,8 +365,8 @@ BoxProcType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
   return emitError() << "invalid type for boxproc" << eleTy << '\n';
 }
 
-static bool canBePointerOrHeapElementType(mlir::Type eleTy) {
-  return eleTy.isa<BoxCharType, BoxProcType, ShapeType, ShapeShiftType,
+static bool cannotBePointerOrHeapElementType(mlir::Type eleTy) {
+  return eleTy.isa<BoxType, BoxCharType, BoxProcType, ShapeType, ShapeShiftType,
                    SliceType, FieldType, LenType, HeapType, PointerType,
                    ReferenceType, TypeDescType>();
 }
@@ -500,7 +501,7 @@ void fir::HeapType::print(mlir::DialectAsmPrinter &printer) const {
 mlir::LogicalResult
 fir::HeapType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                       mlir::Type eleTy) {
-  if (canBePointerOrHeapElementType(eleTy))
+  if (cannotBePointerOrHeapElementType(eleTy))
     return emitError() << "cannot build a heap pointer to type: " << eleTy
                        << '\n';
   return mlir::success();
@@ -535,6 +536,20 @@ void fir::LogicalType::print(mlir::DialectAsmPrinter &printer) const {
 }
 
 //===----------------------------------------------------------------------===//
+// LLVMPointerType
+//===----------------------------------------------------------------------===//
+
+// `llvm_ptr` `<` type `>`
+mlir::Type fir::LLVMPointerType::parse(mlir::MLIRContext *context,
+                                       mlir::DialectAsmParser &parser) {
+  return parseTypeSingleton<fir::LLVMPointerType>(parser);
+}
+
+void fir::LLVMPointerType::print(mlir::DialectAsmPrinter &printer) const {
+  printer << getMnemonic() << "<" << getEleTy() << '>';
+}
+
+//===----------------------------------------------------------------------===//
 // PointerType
 //===----------------------------------------------------------------------===//
 
@@ -551,7 +566,7 @@ void fir::PointerType::print(mlir::DialectAsmPrinter &printer) const {
 mlir::LogicalResult fir::PointerType::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
     mlir::Type eleTy) {
-  if (canBePointerOrHeapElementType(eleTy))
+  if (cannotBePointerOrHeapElementType(eleTy))
     return emitError() << "cannot build a pointer to type: " << eleTy << '\n';
   return mlir::success();
 }
@@ -939,7 +954,7 @@ bool fir::VectorType::isValidElementType(mlir::Type t) {
 void FIROpsDialect::registerTypes() {
   addTypes<BoxType, BoxCharType, BoxProcType, CharacterType, fir::ComplexType,
            FieldType, HeapType, fir::IntegerType, LenType, LogicalType,
-           PointerType, RealType, RecordType, ReferenceType, SequenceType,
-           ShapeType, ShapeShiftType, ShiftType, SliceType, TypeDescType,
-           fir::VectorType>();
+           LLVMPointerType, PointerType, RealType, RecordType, ReferenceType,
+           SequenceType, ShapeType, ShapeShiftType, ShiftType, SliceType,
+           TypeDescType, fir::VectorType>();
 }

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -365,7 +365,7 @@ BoxProcType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 }
 
 static bool canBePointerOrHeapElementType(mlir::Type eleTy) {
-  return eleTy.isa<BoxType, BoxCharType, BoxProcType, ShapeType, ShapeShiftType,
+  return eleTy.isa<BoxCharType, BoxProcType, ShapeType, ShapeShiftType,
                    SliceType, FieldType, LenType, HeapType, PointerType,
                    ReferenceType, TypeDescType>();
 }

--- a/flang/test/Fir/fir-types.fir
+++ b/flang/test/Fir/fir-types.fir
@@ -53,10 +53,12 @@ func private @arr7() -> !fir.array<1x2x?x4x5x6x7x8x9xf32>
 // CHECK-LABEL: func private @mem2() -> !fir.ptr<i32>
 // CHECK-LABEL: func private @mem3() -> !fir.heap<i32>
 // CHECK-LABEL: func private @mem4() -> !fir.ref<() -> ()>
+// CHECK-LABEL: func private @mem5() -> !fir.llvm_ptr<!fir.ref<f32>>
 func private @mem1() -> !fir.ref<i32>
 func private @mem2() -> !fir.ptr<i32>
 func private @mem3() -> !fir.heap<i32>
 func private @mem4() -> !fir.ref<() -> ()>
+func private @mem5() -> !fir.llvm_ptr<!fir.ref<f32>>
 
 // FIR box types (descriptors)
 // CHECK-LABEL: func private @box1() -> !fir.box<!fir.array<?xf32>>

--- a/flang/test/Fir/types-to-llvm.fir
+++ b/flang/test/Fir/types-to-llvm.fir
@@ -13,3 +13,6 @@ func private @foo4(%arg0: !fir.ref<!fir.array<?x?x?xi32>>)
 
 // CHECK-LABEL: declare void @byval5(i32*)
 func private @byval5(%arg0: !fir.array<?x?x?xi32>)
+
+// CHECK-LABEL: declare void @foo6(float**)
+func private @foo6(%arg0: !fir.llvm_ptr<!fir.ref<f32>>)

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -1,7 +1,15 @@
+! Test internal procedure host association lowering.
 ! RUN: bbc %s -o - | FileCheck %s
+
+! -----------------------------------------------------------------------------
+!     Test non character intrinsic scalars
+! -----------------------------------------------------------------------------
+
+!!! Test scalar (with implicit none)
 
 ! CHECK: func @_QPtest1(
 subroutine test1
+  implicit none
   integer i
   ! CHECK-DAG: %[[i:.*]] = fir.alloca i32 {{.*}}uniq_name = "_QFtest1Ei"
   ! CHECK-DAG: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<i32>>
@@ -18,9 +26,12 @@ contains
   ! CHECK: %[[val:.*]] = fir.call @_QPifoo() : () -> i32
   ! CHECK: fir.store %[[val]] to %[[i]] : !fir.ptr<i32>
   subroutine test1_internal
+    integer, external :: ifoo
     i = ifoo()
   end subroutine test1_internal
 end subroutine test1
+
+!!! Test scalar
 
 ! CHECK: func @_QPtest2() {
 subroutine test2
@@ -65,3 +76,216 @@ contains
     end if
   end subroutine test2_inner
 end subroutine test2
+
+! -----------------------------------------------------------------------------
+!     Test non character scalars
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest6(
+! CHECK-SAME: %[[c:.*]]: !fir.boxchar<1>
+subroutine test6(c)
+  character(*) :: c
+  ! CHECK: %[[cunbox:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.boxchar<1>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+  ! CHECK: %[[emboxchar:.*]] = fir.emboxchar %[[cunbox]]#0, %[[cunbox]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: fir.store %[[emboxchar]] to %[[coor]] : !fir.ref<!fir.boxchar<1>>
+  ! CHECK: fir.call @_QFtest6Ptest6_inner(%[[tup]]) : (!fir.ref<tuple<!fir.boxchar<1>>>) -> ()
+  call test6_inner
+  print *, c
+
+contains
+  ! CHECK-LABEL: func @_QFtest6Ptest6_inner(
+  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.boxchar<1>>> {fir.host_assoc}) {
+  subroutine test6_inner
+    ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+    ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.boxchar<1>>
+    ! CHECK: fir.unboxchar %[[load]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+    c = "Hi there"
+  end subroutine test6_inner
+end subroutine test6
+
+! -----------------------------------------------------------------------------
+!     Test non allocatable and pointer arrays
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest3(
+! CHECK-SAME: %[[p:[^:]+]]: !fir.box<!fir.array<?xf32>>,
+! CHECK-SAME: %[[q:.*]]: !fir.box<!fir.array<?xf32>>,
+! CHECK-SAME: %[[i:.*]]: !fir.ref<i64>
+subroutine test3(p,q,i)
+  integer(8) :: i
+  real :: p(i:)
+  real :: q(:)
+  ! CHECK: %[[iload:.*]] = fir.load %[[i]] : !fir.ref<i64>
+  ! CHECK: %[[icast:.*]] = fir.convert %[[iload]] : (i64) -> index
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[pshift:.*]] = fir.shift %[[icast]] : (index) -> !fir.shift<1>
+  ! CHECK: %[[pbox:.*]] = fir.rebox %[[p]](%[[pshift]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[qbox:.*]] = fir.rebox %[[q]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+
+  i = i + 1
+  q = -42.0
+
+  ! CHECK: fir.call @_QFtest3Ptest3_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>) -> ()
+  call test3_inner
+
+  if (p(2) .ne. -42.0) then
+     print *, "failed"
+  end if
+  
+contains
+  ! CHECK-LABEL: func @_QFtest3Ptest3_inner(
+  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>> {fir.host_assoc}) {
+  subroutine test3_inner
+    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+    ! CHECK: %[[pbounds:.]]:3 = fir.box_dims %[[p]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+    ! CHECK: %[[qbounds:.]]:3 = fir.box_dims %[[q]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+
+
+    ! CHECK: %[[qlb:.*]] = fir.convert %[[qbounds]]#0 : (index) -> i64
+    ! CHECK: %[[qoffset:.*]] = subi %c1{{.*}}, %[[qlb]] : i64
+    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[q]], %[[qoffset]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[qload:.*]] = fir.load %[[qelt]] : !fir.ref<f32>
+    ! CHECK: %[[plb:.*]] = fir.convert %[[pbounds]]#0 : (index) -> i64
+    ! CHECK: %[[poffset:.*]] = subi %c2{{.*}}, %[[plb]] : i64
+    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[p]], %[[poffset]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+    ! CHECK: fir.store %[[qload]] to %[[pelt]] : !fir.ref<f32>
+    p(2) = q(1)
+  end subroutine test3_inner
+end subroutine test3
+
+! CHECK-LABEL: func @_QPtest3a(
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.array<10xf32>>) {
+subroutine test3a(p)
+  real :: p(10)
+  real :: q(10)
+  ! CHECK: %[[q:.*]] = fir.alloca !fir.array<10xf32> {bindc_name = "q", uniq_name = "_QFtest3aEq"}
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[shape:.*]] = fir.shape %c10{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[pbox:.*]] = fir.embox %[[p]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<10xf32>>>
+  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[qbox:.*]] = fir.embox %[[q]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<10xf32>>>
+  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+
+  q = -42.0
+  ! CHECK: fir.call @_QFtest3aPtest3a_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>) -> ()
+  call test3a_inner
+
+  if (p(1) .ne. -42.0) then
+     print *, "failed"
+  end if
+  
+contains
+  ! CHECK: func @_QFtest3aPtest3a_inner(
+  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>> {fir.host_assoc}) {
+  subroutine test3a_inner
+    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+    ! CHECK: %[[paddr:.*]] = fir.box_addr %[[p]] : (!fir.box<!fir.ptr<!fir.array<10xf32>>>) -> !fir.ptr<!fir.array<10xf32>>
+    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+    ! CHECK: %[[qaddr:.*]] = fir.box_addr %[[q]] : (!fir.box<!fir.ptr<!fir.array<10xf32>>>) -> !fir.ptr<!fir.array<10xf32>>
+
+    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[qaddr]], %c0{{.*}} : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[qload:.*]] = fir.load %[[qelt]] : !fir.ref<f32>
+    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[paddr]], %c0{{.*}} : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+    ! CHECK: fir.store %[[qload]] to %[[pelt]] : !fir.ref<f32>
+    p(1) = q(1)
+  end subroutine test3a_inner
+end subroutine test3a
+
+! -----------------------------------------------------------------------------
+!     Test allocatable and pointer scalars
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest4() {
+subroutine test4
+  real, pointer :: p
+  real, allocatable, target :: ally
+  ! CHECK: %[[ally:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = "ally", fir.target, uniq_name = "_QFtest4Eally"}
+  ! CHECK: %[[p:.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "p", uniq_name = "_QFtest4Ep"}
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>
+  ! CHECK: %[[atup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<f32>>>>
+  ! CHECK: fir.store %[[ally]] to %[[atup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<f32>>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<f32>>>>
+  ! CHECK: fir.store %[[p]] to %[[ptup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<f32>>>>
+  ! CHECK: fir.call @_QFtest4Ptest4_inner(%[[tup]]) : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>>) -> ()
+
+  allocate(ally)
+  ally = -42.0
+  call test4_inner
+
+  if (p .ne. -42.0) then
+     print *, "failed"
+  end if
+  
+contains
+  ! CHECK-LABEL: func @_QFtest4Ptest4_inner(
+  ! CHECK-SAME:%[[tup:.*]]: !fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>> {fir.host_assoc}) {
+  subroutine test4_inner
+    ! CHECK: %[[atup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<f32>>>>
+    ! CHECK: %[[a:.*]] = fir.load %[[atup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<f32>>>>
+    ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<f32>>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[ptup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<f32>>>>
+    ! CHECK: %[[abox:.*]] = fir.load %[[a]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+    ! CHECK: %[[addr:.*]] = fir.box_addr %[[abox]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+    ! CHECK: %[[ptr:.*]] = fir.embox %[[addr]] : (!fir.heap<f32>) -> !fir.box<!fir.ptr<f32>>
+    ! CHECK: fir.store %[[ptr]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+    p => ally
+  end subroutine test4_inner
+end subroutine test4
+
+! -----------------------------------------------------------------------------
+!     Test allocatable and pointer arrays
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest5() {
+subroutine test5
+  real, pointer :: p(:)
+  real, allocatable, target :: ally(:)
+
+  ! CHECK: %[[ally:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {bindc_name = "ally", fir.target
+  ! CHECK: %[[p:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xf32>>> {bindc_name = "p"
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>
+  ! CHECK: %[[atup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>>
+  ! CHECK: fir.store %[[ally]] to %[[atup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>
+  ! CHECK: fir.store %[[p]] to %[[ptup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>
+  ! CHECK: fir.call @_QFtest5Ptest5_inner(%[[tup]]) : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>>) -> ()
+
+  allocate(ally(10))
+  ally = -42.0
+  call test5_inner
+
+  if (p(1) .ne. -42.0) then
+     print *, "failed"
+  end if
+  
+contains
+  ! CHECK-LABEL: func @_QFtest5Ptest5_inner(
+  ! CHECK-SAME:%[[tup:.*]]: !fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>> {fir.host_assoc}) {
+  subroutine test5_inner
+    ! CHECK: %[[atup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>>
+    ! CHECK: %[[a:.*]] = fir.load %[[atup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>>
+    ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[ptup]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>>
+    ! CHECK: %[[abox:.*]] = fir.load %[[a]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    ! CHECK-DAG: %[[adims:.*]]:3 = fir.box_dims %[[abox]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+    ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[abox]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+    ! CHECK-DAG: %[[ashape:.*]] = fir.shape_shift %[[adims]]#0, %[[adims]]#1 : (index, index) -> !fir.shapeshift<1>
+
+    ! CHECK: %[[ptr:.*]] = fir.embox %[[addr]](%[[ashape]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+    ! CHECK: fir.store %[[ptr]] to %[[p]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+    p => ally
+  end subroutine test5_inner
+end subroutine test5


### PR DESCRIPTION
This patch adds lowering for host associated characters, arrays,
pointers, and allocatables.

- Characters are associated by placing a fir.boxchar into the host tuple.
- Arrays are associated by placing a pointer descriptor (fir.box<fir.ptr>)
  inside the host tuples.
- Pointers and allocatables are associated by placing their descriptor address
  (fir.ref<fir.box<>>) inside the host tuple.

A special attentions is given to:
 - propagating array lower bounds. Simple fir.box<T> would lose this
   info, using pointer association with fir.box<fir.ptr<T>> ensures
   these do not get lost.
 - handling host associated optional dummies. The packaging/un-packaging
   of such variable should account for the fact that the dummy cannot be
   unconditionally read. Besides, the optional aspect must be preserved
   inside the internal procedure (PRESENT must work there).
 - Keeping allocatable and pointers non-deferred type parameters knowledge.
   This knowledge has impacts on the semantic of statement where such
   entities can appear inside the host (e.g. allocatable assignment).

To deal with this, the host association handling is refactored to group
the work according to the type of variable instead of having the work
group according to the phases (getting the type, building the tuple,
instantiating the variable). This allows better mirror reading of things
that must happen when packaging and unpacking the tuple for special
kind of variables.

To makes all this works:
- a change in the frontend is needed to ensure HostAssocsDetails are always created. It will be reviewed in LLVM an is included here in its own commit.
- a fir.llvm_ptr new FIR type was needed to handle double indirection without hacks. Also included in its own commit.