### PR TITLE
Apply lower bounds in array component reference

### DIFF
--- a/flang/test/Lower/components.f90
+++ b/flang/test/Lower/components.f90
@@ -24,9 +24,9 @@ contains
   subroutine s1(i,j)
     ! CHECK-DAG: %[[VAL_0:.*]] = constant 1 : i32
     ! CHECK-DAG: %[[VAL_1:.*]] = constant 6 : i32
-    ! CHECK-DAG: %[[VAL_2:.*]] = constant 1 : i64
-    ! CHECK-DAG: %[[VAL_3:.*]] = constant 2 : i64
-    ! CHECK-DAG: %[[VAL_4:.*]] = constant 3 : i64
+    ! CHECK-DAG: %[[VAL_2:.*]] = constant 0 : i64
+    ! CHECK-DAG: %[[VAL_3:.*]] = constant 1 : i64
+    ! CHECK-DAG: %[[VAL_4:.*]] = constant 2 : i64
     ! CHECK: %[[VAL_5:.*]] = fir.address_of(@_QMcomponents_testEinstance) : !fir.ref<!fir.type<_QMcomponents_testTt3{h1:!fir.array<3x!fir.type<_QMcomponents_testTt1{i:!fir.array<6xi32>,r:!fir.array<5xf32>}>>,h2:!fir.array<4x!fir.type<_QMcomponents_testTt2{g1:!fir.array<3x3x!fir.type<_QMcomponents_testTt1{i:!fir.array<6xi32>,r:!fir.array<5xf32>}>>,g2:!fir.array<4x4x4x!fir.type<_QMcomponents_testTt1{i:!fir.array<6xi32>,r:!fir.array<5xf32>}>>,g3:!fir.array<5xi32>}>>}>>
     ! CHECK: %[[VAL_6:.*]] = fir.load %[[VAL_7:.*]] : !fir.ref<i32>
     ! CHECK: %[[VAL_8:.*]] = cmpi sge, %[[VAL_6]], %[[VAL_0]] : i32
@@ -44,7 +44,8 @@ contains
     ! CHECK: %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_16]], %[[VAL_17]] : (!fir.ref<!fir.type<_QMcomponents_testTt1{i:!fir.array<6xi32>,r:!fir.array<5xf32>}>>, !fir.field) -> !fir.ref<!fir.array<6xi32>>
     ! CHECK: %[[VAL_19:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
     ! CHECK: %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
-    ! CHECK: %[[VAL_21:.*]] = fir.coordinate_of %[[VAL_18]], %[[VAL_20]] : (!fir.ref<!fir.array<6xi32>>, i64) -> !fir.ref<i32>
+    ! CHECK: %[[VAL_20_ADJ:.*]] = subi %[[VAL_20]], %[[VAL_3]] : i64
+    ! CHECK: %[[VAL_21:.*]] = fir.coordinate_of %[[VAL_18]], %[[VAL_20_ADJ]] : (!fir.ref<!fir.array<6xi32>>, i64) -> !fir.ref<i32>
     ! CHECK: %[[VAL_22:.*]] = fir.load %[[VAL_21]] : !fir.ref<i32>
     ! CHECK: fir.store %[[VAL_22]] to %[[VAL_23:.*]] : !fir.ref<i32>
     ! CHECK: br ^bb2

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -102,8 +102,11 @@ subroutine ref_scalar_real_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg1]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   ! CHECK: %[[box:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %c7{{.*}} : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %[[index]] : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
   call takes_real_scalar(a1_0%p(7))
 
@@ -111,8 +114,11 @@ subroutine ref_scalar_real_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   ! CHECK: %[[box:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %c7{{.*}} : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[addr]], %[[index]] : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
   call takes_real_scalar(a1_1(5)%p(7))
 end subroutine
@@ -177,8 +183,11 @@ subroutine ref_scalar_cst_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[base:.*]] = fir.box_addr %[[box]]
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %[[index]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
@@ -189,8 +198,11 @@ subroutine ref_scalar_cst_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[base:.*]] = fir.box_addr %[[box]]
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[base]], %[[index]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
@@ -229,9 +241,15 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
   ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
-  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[base]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index 
+  ! CHECK: %[[sub:.*]] = subi %[[c7]], %[[dims]]#0 : index 
+  ! CHECK: %[[mul:.*]] = muli %[[len]], %[[sub]] : index 
+  ! CHECK: %[[offset:.*]] = addi %[[mul]], %c0{{.*}} : index
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cast]], %[[offset]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(a1_0%p(7))
@@ -241,9 +259,15 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
   ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
-  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[base]], %c7{{.*}}
+  ! CHECK: %[[cast:.*]] = fir.convert %[[base]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index 
+  ! CHECK: %[[sub:.*]] = subi %[[c7]], %[[dims]]#0 : index 
+  ! CHECK: %[[mul:.*]] = muli %[[len]], %[[sub]] : index 
+  ! CHECK: %[[offset:.*]] = addi %[[mul]], %c0{{.*}} : index
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cast]], %[[offset]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(a1_1(5)%p(7))
@@ -276,7 +300,10 @@ subroutine ref_scalar_derived(a0_0, a1_0, a0_1, a1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[fldx:.*]] = fir.field_index x
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
@@ -286,7 +313,10 @@ subroutine ref_scalar_derived(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[fldx:.*]] = fir.field_index x
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])

--- a/flang/test/Lower/derived-pointer-components.f90
+++ b/flang/test/Lower/derived-pointer-components.f90
@@ -102,7 +102,10 @@ subroutine ref_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[arg1]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
   ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %c7{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[load]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %[[index]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
   call takes_real_scalar(p1_0%p(7))
 
@@ -110,7 +113,10 @@ subroutine ref_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_1_coor]], %[[fld]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
   ! CHECK: %[[load:.*]] = fir.load %[[coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %c7{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[load]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]] : i64
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[load]], %[[index]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[coor]]) : (!fir.ref<f32>) -> ()
   call takes_real_scalar(p1_1(5)%p(7))
 end subroutine
@@ -209,7 +215,10 @@ subroutine ref_scalar_cst_char_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
@@ -220,7 +229,10 @@ subroutine ref_scalar_cst_char_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[addr]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}}
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
@@ -260,7 +272,10 @@ subroutine ref_scalar_def_char_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
-  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK-DAG: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK-DAG: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(p1_0%p(7))
@@ -271,7 +286,10 @@ subroutine ref_scalar_def_char_p(p0_0, p1_0, p0_1, p1_1)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
-  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK-DAG: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK-DAG: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK-DAG: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK-DAG: %[[addr:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(p1_1(5)%p(7))
@@ -304,7 +322,10 @@ subroutine ref_scalar_derived(p0_0, p1_0, p0_1, p1_1)
   ! CHECK: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[p1_0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[fldx:.*]] = fir.field_index x
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
@@ -314,7 +335,10 @@ subroutine ref_scalar_derived(p0_0, p1_0, p0_1, p1_1)
   ! CHECK-DAG: %[[fld:.*]] = fir.field_index p
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], %[[fld]]
   ! CHECK: %[[box:.*]] = fir.load %[[coor]]
-  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %c7{{.*}}
+  ! CHECK: %[[dims:.*]]:3 = fir.box_dims %[[box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[dims]]#0 : (index) -> i64
+  ! CHECK: %[[index:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK: %[[elem:.*]] = fir.coordinate_of %[[box]], %[[index]]
   ! CHECK: %[[fldx:.*]] = fir.field_index x
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[elem]], %[[fldx]]
   ! CHECK: fir.call @_QPtakes_real_scalar(%[[addr]])
@@ -637,11 +661,15 @@ subroutine very_long(x)
   ! CHECK-DAG: %[[fldc:.*]] = fir.field_index c
   ! CHECK-DAG: %[[fldd:.*]] = fir.field_index d
   ! CHECK: %[[coor2:.*]] = fir.coordinate_of %[[b_box]], %[[fldc]], %[[fldd]]
-  ! CHECK: %[[coor3:.*]] = fir.coordinate_of %[[coor2]], %c6{{.*}}
+  ! CHECK: %[[index:.*]] = subi %c6{{.*}}, %c1{{.*}} : i64
+  ! CHECK: %[[coor3:.*]] = fir.coordinate_of %[[coor2]], %[[index]]
   ! CHECK: %[[flde:.*]] = fir.field_index e
   ! CHECK: %[[coor4:.*]] = fir.coordinate_of %[[coor3]], %[[flde]]
   ! CHECK: %[[e_box:.*]] = fir.load %[[coor4]]
-  ! CHECK: %[[coor5:.*]] = fir.coordinate_of %[[e_box]], %c7{{.*}}
+  ! CHECK: %[[edims:.*]]:3 = fir.box_dims %[[e_box]], %c0{{.*}}
+  ! CHECK: %[[lb:.*]] = fir.convert %[[edims]]#0 : (index) -> i64
+  ! CHECK: %[[index2:.*]] = subi %c7{{.*}}, %[[lb]]
+  ! CHECK: %[[coor5:.*]] = fir.coordinate_of %[[e_box]], %[[index2]]
   ! CHECK: %[[fldf:.*]] = fir.field_index f
   ! CHECK: %[[coor6:.*]] = fir.coordinate_of %[[coor5]], %[[fldf:.*]]
   ! CHECK: fir.load %[[coor6]] : !fir.ref<f32>

--- a/flang/test/Lower/derived-types.f90
+++ b/flang/test/Lower/derived-types.f90
@@ -82,7 +82,9 @@ subroutine array_comp_elt_ref()
   ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<_QMdTr2{x_array:!fir.array<10x20xf32>}>
   ! CHECK: %[[field:.*]] = fir.field_index x_array, !fir.type<_QMdTr2{x_array:!fir.array<10x20xf32>}>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[alloc]], %[[field]] : (!fir.ref<!fir.type<_QMdTr2{x_array:!fir.array<10x20xf32>}>>, !fir.field) -> !fir.ref<!fir.array<10x20xf32>>
-  ! CHECK: fir.coordinate_of %[[coor]], %c5{{.*}}, %c6{{.*}} : (!fir.ref<!fir.array<10x20xf32>>, i64, i64) -> !fir.ref<f32>
+  ! CHECK-DAG: %[[index1:.*]] = subi %c5{{.*}}, %c1{{.*}} : i64
+  ! CHECK-DAG: %[[index2:.*]] = subi %c6{{.*}}, %c1{{.*}} : i64
+  ! CHECK: fir.coordinate_of %[[coor]], %[[index1]], %[[index2]] : (!fir.ref<!fir.array<10x20xf32>>, i64, i64) -> !fir.ref<f32>
   call real_bar(some_r2%x_array(5, 6))
 end subroutine
 
@@ -91,7 +93,9 @@ end subroutine
 subroutine char_array_comp_elt_ref()
   type(c2) :: some_c2
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>, !fir.field) -> !fir.ref<!fir.array<20x30x!fir.char<1,10>>>
-  ! CHECK: fir.coordinate_of %[[coor]], %c5{{.*}}, %c6{{.*}} : (!fir.ref<!fir.array<20x30x!fir.char<1,10>>>, i64, i64) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK-DAG: %[[index1:.*]] = subi %c5{{.*}}, %c1{{.*}} : i64
+  ! CHECK-DAG: %[[index2:.*]] = subi %c6{{.*}}, %c1{{.*}} : i64
+  ! CHECK: fir.coordinate_of %[[coor]], %[[index1]], %[[index2]] : (!fir.ref<!fir.array<20x30x!fir.char<1,10>>>, i64, i64) -> !fir.ref<!fir.char<1,10>>
   ! CHECK: fir.emboxchar %{{.*}}, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   call char_bar(some_c2%ch_array(5, 6))
 end subroutine

--- a/flang/test/Lower/dummy-argument-contiguous.f90
+++ b/flang/test/Lower/dummy-argument-contiguous.f90
@@ -17,7 +17,7 @@ subroutine test_element_ref(x, y)
   ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
 
   call bar(x(100))
-  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
   call bar(y(100))
   ! Test that for an entity that is not know to be contiguous, the fir.box is passed
   ! to coordinate of and that the lower bounds is already applied by lowering.
@@ -45,7 +45,7 @@ subroutine test_element_assign(x, y)
   real :: y(4:)
   ! CHECK-DAG: %[[c4:.*]] = fir.convert %c4{{.*}} : (i64) -> index
   x(100) = 42.
-  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK: fir.coordinate_of %[[xaddr]], %{{.*}} : (!fir.ref<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
   y(100) = 42.
   ! CHECK: %[[c4_2:.*]] = fir.convert %[[c4]] : (index) -> i64
   ! CHECK: %[[index:.*]] = subi %c100{{.*}}, %[[c4_2]] : i64
@@ -122,7 +122,7 @@ end subroutine
 subroutine foo(x)
   real, allocatable :: x(:)
   call bar(x(100))
-  ! CHECK: fir.coordinate_of {{.*}} (!fir.ref<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK: fir.coordinate_of %{{.*}}, %{{.*}} (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
 end subroutine
 
 ! Test that non-contiguous dummy are propagated with their memory layout (we


### PR DESCRIPTION
An old FIXME never got fixed. Finally implement it by regrouping the
logic of ArrayRef lowering for both symbols and components base.
Rename the `gen` functions helper to clarify what is happening.

Also force use of collapsed coordinate_of in case the array is a
dynamic length characters without fir.box. Otherwise, the length
info is lost in the fir.coordinate_of.

And prevent collapsing of fir.coordinate_of for rank 1 array with
dynamic length but no dynamic length.

Fix all the tests that were wrong or are impacted by these changes.

Note 1: this fixes the second bug observed in #902.