### PR TITLE
Add lowering for the DOT_PRODUCT intrinsic

### DIFF
--- a/flang/include/flang/Lower/ReductionRuntime.h
+++ b/flang/include/flang/Lower/ReductionRuntime.h
@@ -56,6 +56,11 @@ void genCountDim(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
                  mlir::Value resultBox, mlir::Value maskBox, mlir::Value dim,
                  mlir::Value kind);
 
+/// Generate call to DotProduct intrinsic runtime routine.
+mlir::Value genDotProduct(Fortran::lower::FirOpBuilder &builder,
+                          mlir::Location loc, mlir::Value vectorABox,
+                          mlir::Value vectorBBox, mlir::Value resultBox);
+
 /// Generate call to Maxloc intrinsic runtime routine. This is the version
 /// that does not take a dim argument.
 void genMaxloc(Fortran::lower::FirOpBuilder &builder, mlir::Location loc,

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -205,6 +205,36 @@ genProdOrSum(FN func, FD funcDim, mlir::Type resultType,
                     args[1], mask, rank);
 }
 
+/// Process calls to DotProduct
+template <typename FN>
+static fir::ExtendedValue genDotProd(FN func, mlir::Type resultType,
+                                     Fortran::lower::FirOpBuilder &builder,
+                                     mlir::Location loc,
+                                     Fortran::lower::StatementContext *stmtCtx,
+                                     llvm::ArrayRef<fir::ExtendedValue> args) {
+
+  assert(args.size() == 2);
+
+  // Handle required vector arguments
+  fir::BoxValue vecTmpA = builder.createBox(loc, args[0]);
+  mlir::Value vectorA = fir::getBase(vecTmpA);
+  fir::BoxValue vecTmpB = builder.createBox(loc, args[1]);
+  mlir::Value vectorB = fir::getBase(vecTmpB);
+
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(vectorA.getType())
+                   .cast<fir::SequenceType>()
+                   .getEleTy();
+  if (fir::isa_complex(eleTy)) {
+    auto result = builder.createTemporary(loc, eleTy);
+    func(builder, loc, vectorA, vectorB, result);
+    return builder.create<fir::LoadOp>(loc, result);
+  }
+
+  auto resultBox = builder.create<fir::AbsentOp>(
+      loc, fir::BoxType::get(builder.getI1Type()));
+  return func(builder, loc, vectorA, vectorB, resultBox);
+}
+
 /// Process calls to Maxval, Minval, Product, Sum intrinsic functions
 template <typename FN, typename FD, typename FC>
 static fir::ExtendedValue
@@ -433,6 +463,8 @@ struct IntrinsicLibrary {
   void genCpuTime(llvm::ArrayRef<fir::ExtendedValue>);
   void genDateAndTime(llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genDim(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  fir::ExtendedValue genDotProduct(mlir::Type,
+                                   llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genDprod(mlir::Type, llvm::ArrayRef<mlir::Value>);
   template <Extremum, ExtremumBehavior>
   mlir::Value genExtremum(mlir::Type, llvm::ArrayRef<mlir::Value>);
@@ -638,6 +670,10 @@ static constexpr IntrinsicHandler handlers[]{
      /*isElemental=*/false},
     {"dble", &I::genConversion},
     {"dim", &I::genDim},
+    {"dot_product",
+     &I::genDotProduct,
+     {{{"vector_a", asAddr}, {"vector_b", asAddr}}},
+     /*isElemental=*/false},
     {"dprod", &I::genDprod},
     {"floor", &I::genFloor},
     {"iachar", &I::genIchar},
@@ -2004,6 +2040,14 @@ mlir::Value IntrinsicLibrary::genDim(mlir::Type resultType,
   return builder.create<mlir::SelectOp>(loc, cmp, diff, zero);
 }
 
+// DOT_PRODUCT
+fir::ExtendedValue
+IntrinsicLibrary::genDotProduct(mlir::Type resultType,
+                                llvm::ArrayRef<fir::ExtendedValue> args) {
+  return genDotProd(Fortran::lower::genDotProduct, resultType, builder, loc,
+                    stmtCtx, args);
+}
+
 // DPROD
 mlir::Value IntrinsicLibrary::genDprod(mlir::Type resultType,
                                        llvm::ArrayRef<mlir::Value> args) {
@@ -2025,7 +2069,6 @@ mlir::Value IntrinsicLibrary::genFloor(mlir::Type resultType,
   auto floor = genRuntimeCall("floor", arg.getType(), {arg});
   return builder.createConvert(loc, resultType, floor);
 }
-
 // IAND
 mlir::Value IntrinsicLibrary::genIand(mlir::Type resultType,
                                       llvm::ArrayRef<mlir::Value> args) {

--- a/flang/test/Lower/intrinsic-procedures.f90
+++ b/flang/test/Lower/intrinsic-procedures.f90
@@ -249,6 +249,251 @@ subroutine dim_testi(i, j, k)
   k = dim(i, j)
 end subroutine
 
+! DOT_PROD
+! CHECK-LABEL: dot_prod_int_default
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi32>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi32>>
+subroutine dot_prod_int_default (x, y, z)
+  integer, dimension(1:) :: x,y
+  integer, dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_int_kind_1
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi8>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi8>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi8>>
+subroutine dot_prod_int_kind_1 (x, y, z)
+  integer(kind=1), dimension(1:) :: x,y
+  integer(kind=1), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger1(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i8
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_int_kind_2
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi16>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi16>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi16>>
+subroutine dot_prod_int_kind_2 (x, y, z)
+  integer(kind=2), dimension(1:) :: x,y
+  integer(kind=2), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger2(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i16
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_int_kind_4
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi32>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi32>>
+subroutine dot_prod_int_kind_4 (x, y, z)
+  integer(kind=4), dimension(1:) :: x,y
+  integer(kind=4), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_int_kind_8
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi64>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi64>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi64>>
+subroutine dot_prod_int_kind_8 (x, y, z)
+  integer(kind=8), dimension(1:) :: x,y
+  integer(kind=8), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i64
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_int_kind_16
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi128>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi128>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi128>>
+subroutine dot_prod_int_kind_16 (x, y, z)
+  integer(kind=16), dimension(1:) :: x,y
+  integer(kind=16), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi128>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi128>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger16(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i128
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_real_kind_default
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf32>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf32>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf32>>
+subroutine dot_prod_real_kind_default (x, y, z)
+  real, dimension(1:) :: x,y
+  real, dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_real_kind_4
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf32>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf32>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf32>>
+subroutine dot_prod_real_kind_4 (x, y, z)
+  real(kind=4), dimension(1:) :: x,y
+  real(kind=4), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_real_kind_8
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf64>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf64>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf64>>
+subroutine dot_prod_real_kind_8 (x, y, z)
+  real(kind=8), dimension(1:) :: x,y
+  real(kind=8), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_real_kind_10
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf80>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf80>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf80>>
+subroutine dot_prod_real_kind_10 (x, y, z)
+  real(kind=10), dimension(1:) :: x,y
+  real(kind=10), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal10(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f80
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_real_kind_16
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf128>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf128>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf128>>
+subroutine dot_prod_real_kind_16 (x, y, z)
+  real(kind=16), dimension(1:) :: x,y
+  real(kind=16), dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal16(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f128
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_double_default
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf64>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf64>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf64>>
+subroutine dot_prod_double_default (x, y, z)
+  double precision, dimension(1:) :: x,y
+  double precision, dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_complex_default
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+subroutine dot_prod_complex_default (x, y, z)
+  complex, dimension(1:) :: x,y
+  complex, dimension(1:) :: z
+  ! CHECK-DAG: %0 = fir.alloca !fir.complex<4> {uniq_name = ""}
+  ! CHECK-DAG: %[[res_conv:[0-9]+]] = fir.convert %0 : (!fir.ref<!fir.complex<4>>) -> !fir.ref<complex<f32>>
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res_conv]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_complex_kind_4
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.complex<4>>>
+subroutine dot_prod_complex_kind_4 (x, y, z)
+  complex(kind=4), dimension(1:) :: x,y
+  complex(kind=4), dimension(1:) :: z
+  ! CHECK-DAG: %0 = fir.alloca !fir.complex<4> {uniq_name = ""}
+  ! CHECK-DAG: %[[res_conv:[0-9]+]] = fir.convert %0 : (!fir.ref<!fir.complex<4>>) -> !fir.ref<complex<f32>>
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res_conv]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_complex_kind_8
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.complex<8>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.complex<8>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.complex<8>>>
+subroutine dot_prod_complex_kind_8 (x, y, z)
+  complex(kind=8), dimension(1:) :: x,y
+  complex(kind=8), dimension(1:) :: z
+  ! CHECK-DAG: %0 = fir.alloca !fir.complex<8> {uniq_name = ""}
+  ! CHECK-DAG: %[[res_conv:[0-9]+]] = fir.convert %0 : (!fir.ref<!fir.complex<8>>) -> !fir.ref<complex<f64>>
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.complex<8>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.complex<8>>>) -> !fir.box<none>
+  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex8(%[[res_conv]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.ref<complex<f64>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_complex_kind_10
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.complex<10>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.complex<10>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.complex<10>>>
+subroutine dot_prod_complex_kind_10 (x, y, z)
+  complex(kind=10), dimension(1:) :: x,y
+  complex(kind=10), dimension(1:) :: z
+  ! CHECK-DAG: %0 = fir.alloca !fir.complex<10> {uniq_name = ""}
+  ! CHECK-DAG: %[[res_conv:[0-9]+]] = fir.convert %0 : (!fir.ref<!fir.complex<10>>) -> !fir.ref<complex<f80>>
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.complex<10>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.complex<10>>>) -> !fir.box<none>
+  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex10(%[[res_conv]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.ref<complex<f80>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_complex_kind_16
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.complex<16>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.complex<16>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.complex<16>>>
+subroutine dot_prod_complex_kind_16 (x, y, z)
+  complex(kind=16), dimension(1:) :: x,y
+  complex(kind=16), dimension(1:) :: z
+  ! CHECK-DAG: %0 = fir.alloca !fir.complex<16> {uniq_name = ""}
+  ! CHECK-DAG: %[[res_conv:[0-9]+]] = fir.convert %0 : (!fir.ref<!fir.complex<16>>) -> !fir.ref<complex<f128>>
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.complex<16>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.complex<16>>>) -> !fir.box<none>
+  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex16(%[[res_conv]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.ref<complex<f128>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  z = dot_product(x,y)
+end subroutine
+
+! CHECK-LABEL: dot_prod_logical
+! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.logical<4>>>
+! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.logical<4>>>
+! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.logical<4>>>
+subroutine dot_prod_logical (x, y, z)
+  logical, dimension(1:) :: x,y
+  logical, dimension(1:) :: z
+  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
+  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductLogical(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) : (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i1
+  z = dot_product(x,y)
+end subroutine
+
 ! DPROD
 ! CHECK-LABEL: dprod_test
 subroutine dprod_test (x, y, z)


### PR DESCRIPTION
Hi, I still have a few cases left to implement in `Fortran::lower::genDotProduct`. Any pointers would be much appreciated!

I'm sending this for early feedback to make sure that this is the right approach.