### PR TITLE
Suppress program requirement violation warning

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2051,9 +2051,9 @@ public:
         // some compilers are not complaining about it.  The front end is not
         // protecting lowering from this currently. Support this with a
         // discouraging warning.
-        mlir::emitWarning(loc,
-                          "return type mismatches were never standard"
-                          " compliant and may lead to undefined behavior.");
+        LLVM_DEBUG(mlir::emitWarning(
+            loc, "a return type mismatch is not standard compliant and may "
+                 "lead to undefined behavior."));
         // Cast the actual function to the current caller implicit type because
         // that is the behavior we would get if we could not see the definition.
         funcPointer =


### PR DESCRIPTION
The program below, based on test nag_f95_handbook/f87.f90, is
nonconformant.  Local structure constructor values have rational_mod1
rational type.  Function dummy arguments and result have rational_mod2
rational2 type.  This program violates:
 - 15.5.2.4p2 The dummy argument shall be type compatible with the
   actual argument.
 - 7.3.2.3p5 A nonpolymorphic entity is type compatible only with
   entities of the same declared type.

Lowering code "converts" the call signature for this call, and execution
results are "correct".

Renaming type rational2 -> rational makes the program conformant:
 - 7.5.2.4p2 [...] Data entities also have the same type if they are
declared with reference to different derived-type definitions that
specify the same type name, all have the SEQUENCE attribute or all have
the BIND attribute, have no components with PRIVATE accessibility, and
have components that agree in order, name, and attributes.

With or without renaming, program p and function rational_plus could be
in separate files.

It is reasonable for the compiler to emit a warning for this violation,
but that should be done in the front end, rather than in lowering.
The lowering warning can be reinstated with either
 -debug
 -debug-only=flang-lower-expr.

```
module rational_mod1
  type :: rational
    integer :: n, d
  end type rational
end module rational_mod1

module rational_mod2
  type :: rational2 ! rename -> rational
    integer :: n, d
  end type rational2
end module rational_mod2

program p
  use rational_mod1
  interface operator (.plus.)
     function rational_plus (l, r)
        use rational_mod1
        type (rational), intent (in) :: l, r
        type (rational)              :: rational_plus
     end function rational_plus
  end interface
  print*, rational(1,3) .plus. rational (1,4)
end

type (rational2) function rational_plus (x, y)
  use rational_mod2
  type (rational2), intent(in) :: x, y
  rational_plus%n = x%n * y%d + x%d * y%n
  rational_plus%d = x%d * y%d
end function rational_plus
```