### PR TITLE
Add and use pointer runtime entry points for pointer allocation (fix Invalid Descriptor runtime errors).

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -12,6 +12,7 @@
 
 #include "flang/Lower/Allocatable.h"
 #include "../runtime/allocatable.h"
+#include "../runtime/pointer.h"
 #include "RTBuilder.h"
 #include "StatementContext.h"
 #include "flang/Evaluate/tools.h"
@@ -111,15 +112,20 @@ private:
 //===----------------------------------------------------------------------===//
 
 using namespace Fortran::runtime;
-/// Generate a runtime call to set the bounds of an allocatable descriptor.
-static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
-                                    mlir::Location loc, mlir::Value boxAddress,
-                                    mlir::Value dimIndex,
-                                    mlir::Value lowerBound,
-                                    mlir::Value upperBound) {
-  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableSetBounds)>(
-      loc, builder);
-  llvm::SmallVector<mlir::Value> args{boxAddress, dimIndex, lowerBound,
+/// Generate a runtime call to set the bounds of an allocatable or pointer
+/// descriptor.
+static void genRuntimeSetBounds(Fortran::lower::FirOpBuilder &builder,
+                                mlir::Location loc,
+                                const fir::MutableBoxValue &box,
+                                mlir::Value dimIndex, mlir::Value lowerBound,
+                                mlir::Value upperBound) {
+  auto callee =
+      box.isPointer()
+          ? Fortran::lower::getRuntimeFunc<mkRTKey(PointerSetBounds)>(loc,
+                                                                      builder)
+          : Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableSetBounds)>(
+                loc, builder);
+  llvm::SmallVector<mlir::Value> args{box.getAddr(), dimIndex, lowerBound,
                                       upperBound};
   llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
@@ -127,15 +133,18 @@ static void genAllocatableSetBounds(Fortran::lower::FirOpBuilder &builder,
   builder.create<fir::CallOp>(loc, callee, operands);
 }
 
-/// Generate runtime call to set the lengths of a character allocatable
-/// descriptor.
-static void genAllocatableInitCharacter(Fortran::lower::FirOpBuilder &builder,
-                                        mlir::Location loc,
-                                        const fir::MutableBoxValue &box,
-                                        mlir::Value len) {
+/// Generate runtime call to set the lengths of a character allocatable or
+/// pointer descriptor.
+static void genRuntimeInitCharacter(Fortran::lower::FirOpBuilder &builder,
+                                    mlir::Location loc,
+                                    const fir::MutableBoxValue &box,
+                                    mlir::Value len) {
   auto callee =
-      Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableInitCharacter)>(
-          loc, builder);
+      box.isPointer()
+          ? Fortran::lower::getRuntimeFunc<mkRTKey(PointerNullifyCharacter)>(
+                loc, builder)
+          : Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableInitCharacter)>(
+                loc, builder);
   auto inputTypes = callee.getType().getInputs();
   if (inputTypes.size() != 5)
     fir::emitFatalError(
@@ -154,14 +163,18 @@ static void genAllocatableInitCharacter(Fortran::lower::FirOpBuilder &builder,
 }
 
 /// Generate a sequence of runtime calls to allocate memory.
-static mlir::Value genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
-                                          mlir::Location loc,
-                                          mlir::Value boxAddress,
-                                          ErrorManager &errorManager) {
-  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableAllocate)>(
-      loc, builder);
+static mlir::Value genRuntimeAllocate(Fortran::lower::FirOpBuilder &builder,
+                                      mlir::Location loc,
+                                      const fir::MutableBoxValue &box,
+                                      ErrorManager &errorManager) {
+  auto callee =
+      box.isPointer()
+          ? Fortran::lower::getRuntimeFunc<mkRTKey(PointerAllocate)>(loc,
+                                                                     builder)
+          : Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableAllocate)>(
+                loc, builder);
   llvm::SmallVector<mlir::Value> args{
-      boxAddress, errorManager.hasStat, errorManager.errMsgAddr,
+      box.getAddr(), errorManager.hasStat, errorManager.errMsgAddr,
       errorManager.sourceFile, errorManager.sourceLine};
   llvm::SmallVector<mlir::Value> operands;
   for (auto [fst, snd] : llvm::zip(args, callee.getType().getInputs()))
@@ -170,12 +183,18 @@ static mlir::Value genAllocatableAllocate(Fortran::lower::FirOpBuilder &builder,
 }
 
 /// Generate a runtime call to deallocate memory.
-static mlir::Value
-genAllocatableDeallocate(Fortran::lower::FirOpBuilder &builder,
-                         mlir::Location loc, mlir::Value boxAddress,
-                         ErrorManager &errorManager) {
-  auto callee = Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableDeallocate)>(
-      loc, builder);
+static mlir::Value genRuntimeDeallocate(Fortran::lower::FirOpBuilder &builder,
+                                        mlir::Location loc,
+                                        const fir::MutableBoxValue &box,
+                                        ErrorManager &errorManager) {
+  // Ensure fir.box is up-to-date before passing it to deallocate runtime.
+  auto boxAddress = Fortran::lower::getMutableIRBox(builder, loc, box);
+  auto callee =
+      box.isPointer()
+          ? Fortran::lower::getRuntimeFunc<mkRTKey(PointerDeallocate)>(loc,
+                                                                       builder)
+          : Fortran::lower::getRuntimeFunc<mkRTKey(AllocatableDeallocate)>(
+                loc, builder);
   llvm::SmallVector<mlir::Value> args{
       boxAddress, errorManager.hasStat, errorManager.errMsgAddr,
       errorManager.sourceFile, errorManager.sourceLine};
@@ -668,7 +687,6 @@ private:
     auto idxTy = builder.getIndexType();
     auto i32Ty = builder.getIntegerType(32);
     Fortran::lower::StatementContext stmtCtx;
-    auto addr = box.getAddr();
     for (const auto &iter : llvm::enumerate(alloc.getShapeSpecs())) {
       mlir::Value lb;
       const auto &bounds = iter.value().t;
@@ -681,9 +699,9 @@ private:
           Fortran::semantics::GetExpr(std::get<1>(bounds)), stmtCtx, loc));
       auto dimIndex = builder.createIntegerConstant(loc, i32Ty, iter.index());
       // Runtime call
-      genAllocatableSetBounds(builder, loc, addr, dimIndex, lb, ub);
+      genRuntimeSetBounds(builder, loc, box, dimIndex, lb, ub);
     }
-    auto stat = genAllocatableAllocate(builder, loc, addr, errorManager);
+    auto stat = genRuntimeAllocate(builder, loc, box, errorManager);
     Fortran::lower::syncMutableBoxFromIRBox(builder, loc, box);
     errorManager.assignStat(builder, loc, stat);
   }
@@ -720,7 +738,7 @@ private:
     // that the length is the same (AllocatableCheckLengthParameter runtime
     // call).
     if (box.isCharacter())
-      genAllocatableInitCharacter(builder, loc, box, lenParams[0]);
+      genRuntimeInitCharacter(builder, loc, box, lenParams[0]);
 
     if (box.isDerived())
       TODO(loc, "derived type length parameters in allocate");
@@ -799,8 +817,7 @@ static void genDeallocate(Fortran::lower::FirOpBuilder &builder,
   // Use runtime calls to deallocate descriptor cases. Sync MutableBoxValue
   // with its descriptor before and after calls if needed.
   errorManager.genStatCheck(builder, loc);
-  auto irBox = Fortran::lower::getMutableIRBox(builder, loc, box);
-  auto stat = genAllocatableDeallocate(builder, loc, irBox, errorManager);
+  auto stat = genRuntimeDeallocate(builder, loc, box, errorManager);
   Fortran::lower::syncMutableBoxFromIRBox(builder, loc, box);
   errorManager.assignStat(builder, loc, stat);
 }

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1189,15 +1189,9 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
                        this->genConstantOffset(loc, rewriter, hasAddendum));
 
     if (hasAddendum) {
-      // TODO: For now, set addendum flags to zero. The runtime expects some
-      // information such as TARGET here.
       auto isArray =
           fir::dyn_cast_ptrOrBoxEleTy(boxTy).template isa<fir::SequenceType>();
       unsigned typeDescFieldId = isArray ? 8 : 7;
-      unsigned flagsFieldId = typeDescFieldId + 1;
-      auto i64Ty = mlir::IntegerType::get(box.getContext(), 64);
-      dest = insertField(rewriter, loc, dest, flagsFieldId,
-                         genConstantIndex(loc, i64Ty, rewriter, 0));
       auto typeDesc =
           getTypeDescriptor(box, rewriter, loc, unwrapIfDerived(boxTy));
       dest = insertField(rewriter, loc, dest, {typeDescFieldId}, typeDesc,

--- a/flang/lib/Optimizer/CodeGen/DescriptorModel.h
+++ b/flang/lib/Optimizer/CodeGen/DescriptorModel.h
@@ -131,11 +131,9 @@ static constexpr TypeBuilderFunc getExtendedDescFieldTypeModel() {
   if constexpr (Field == 8) {
     return getModel<void *>();
   } else if constexpr (Field == 9) {
-    return getModel<std::uint64_t>();
-  } else if constexpr (Field == 10) {
     return getModel<Fortran::runtime::typeInfo::TypeParameterValue>();
   } else {
-    llvm_unreachable("extended ISO descriptor only has 11 fields");
+    llvm_unreachable("extended ISO descriptor only has 10 fields");
   }
 }
 

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -31,8 +31,7 @@ public:
     addConversion([&](BoxType box) { return convertBoxType(box); });
     addConversion([&](BoxCharType boxchar) {
       LLVM_DEBUG(llvm::dbgs() << "type convert: " << boxchar << '\n');
-      return 
-          convertType(specifics->boxcharMemoryType(boxchar.getEleTy()));
+      return convertType(specifics->boxcharMemoryType(boxchar.getEleTy()));
     });
     addConversion(
         [&](BoxProcType boxproc) { return convertBoxProcType(boxproc); });
@@ -171,8 +170,7 @@ public:
     // opt-type-ptr: i8* (see fir.tdesc)
     if (requiresExtendedDesc(ele)) {
       parts.push_back(getExtendedDescFieldTypeModel<8>()(&getContext()));
-      parts.push_back(getExtendedDescFieldTypeModel<9>()(&getContext()));
-      auto rowTy = getExtendedDescFieldTypeModel<10>()(&getContext());
+      auto rowTy = getExtendedDescFieldTypeModel<9>()(&getContext());
       parts.push_back(mlir::LLVM::LLVMArrayType::get(rowTy, 1));
       if (auto recTy = fir::unwrapSequenceType(ele).dyn_cast<fir::RecordType>())
         if (recTy.getNumLenParams() > 0) {

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -56,6 +56,7 @@ add_flang_library(FortranRuntime PARTIAL_SOURCES_INTENDED
   numeric.cpp
   random.cpp
   reduction.cpp
+  pointer.cpp
   product.cpp
   stat.cpp
   stop.cpp

--- a/flang/runtime/allocatable.cpp
+++ b/flang/runtime/allocatable.cpp
@@ -53,6 +53,20 @@ void RTNAME(AllocatableSetBounds)(Descriptor &descriptor, int zeroBasedDim,
   // The byte strides are computed when the object is allocated.
 }
 
+void RTNAME(AllocatableSetDerivedLength)(
+    Descriptor &descriptor, int which, SubscriptValue x) {
+  DescriptorAddendum *addendum{descriptor.Addendum()};
+  INTERNAL_CHECK(addendum != nullptr);
+  addendum->SetLenParameterValue(which, x);
+}
+
+void RTNAME(AllocatableApplyMold)(
+    Descriptor &descriptor, const Descriptor &mold) {
+  descriptor = mold;
+  descriptor.set_base_addr(nullptr);
+  descriptor.raw().attribute = CFI_attribute_allocatable;
+}
+
 int RTNAME(AllocatableAllocate)(Descriptor &descriptor, bool hasStat,
     const Descriptor *errMsg, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
@@ -63,6 +77,7 @@ int RTNAME(AllocatableAllocate)(Descriptor &descriptor, bool hasStat,
     return ReturnError(terminator, StatBaseNotNull, errMsg, hasStat);
   }
   return ReturnError(terminator, descriptor.Allocate(), errMsg, hasStat);
+  // TODO: default component initialization
 }
 
 int RTNAME(AllocatableDeallocate)(Descriptor &descriptor, bool hasStat,
@@ -76,5 +91,7 @@ int RTNAME(AllocatableDeallocate)(Descriptor &descriptor, bool hasStat,
   }
   return ReturnError(terminator, descriptor.Deallocate(), errMsg, hasStat);
 }
+
+// TODO: AllocatableCheckLengthParameter, AllocatableAllocateSource
 }
 } // namespace Fortran::runtime

--- a/flang/runtime/allocatable.h
+++ b/flang/runtime/allocatable.h
@@ -10,14 +10,12 @@
 // to manipulate and query allocatable variables, dummy arguments, & components.
 #ifndef FORTRAN_RUNTIME_ALLOCATABLE_H_
 #define FORTRAN_RUNTIME_ALLOCATABLE_H_
+
 #include "descriptor.h"
 #include "entry-names.h"
 
-namespace Fortran::runtime::typeInfo {
-class DerivedType;
-}
-
 namespace Fortran::runtime {
+
 extern "C" {
 
 // Initializes the descriptor for an allocatable of intrinsic or derived type.
@@ -55,7 +53,7 @@ void RTNAME(AllocatableApplyMold)(Descriptor &, const Descriptor &mold);
 void RTNAME(AllocatableSetBounds)(
     Descriptor &, int zeroBasedDim, SubscriptValue lower, SubscriptValue upper);
 
-// The upper bound is ignored for the last codimension.
+// The upper cobound is ignored for the last codimension.
 void RTNAME(AllocatableSetCoBounds)(Descriptor &, int zeroBasedCoDim,
     SubscriptValue lower, SubscriptValue upper = 0);
 

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -160,9 +160,6 @@ int Descriptor::Deallocate(bool finalize) {
 void Descriptor::Destroy(bool finalize) const {
   if (const DescriptorAddendum * addendum{Addendum()}) {
     if (const typeInfo::DerivedType * dt{addendum->derivedType()}) {
-      if (addendum->flags() & DescriptorAddendum::DoNotFinalize) {
-        finalize = false;
-      }
       runtime::Destroy(*this, finalize, *dt);
     }
   }
@@ -278,7 +275,6 @@ void Descriptor::Dump(FILE *f) const {
 DescriptorAddendum &DescriptorAddendum::operator=(
     const DescriptorAddendum &that) {
   derivedType_ = that.derivedType_;
-  flags_ = that.flags_;
   auto lenParms{that.LenParameters()};
   for (std::size_t j{0}; j < lenParms; ++j) {
     len_[j] = that.len_[j];
@@ -297,8 +293,10 @@ std::size_t DescriptorAddendum::LenParameters() const {
 
 void DescriptorAddendum::Dump(FILE *f) const {
   std::fprintf(
-      f, "  derivedType @ %p\n", reinterpret_cast<const void *>(derivedType_));
-  std::fprintf(f, "  flags 0x%jx\n", static_cast<std::intmax_t>(flags_));
-  // TODO: LEN parameter values
+      f, "  derivedType @ %p\n", reinterpret_cast<const void *>(derivedType()));
+  std::size_t lenParms{LenParameters()};
+  for (std::size_t j{0}; j < lenParms; ++j) {
+    std::fprintf(f, "  len[%zd] %jd\n", j, static_cast<std::intmax_t>(len_[j]));
+  }
 }
 } // namespace Fortran::runtime

--- a/flang/runtime/descriptor.h
+++ b/flang/runtime/descriptor.h
@@ -345,8 +345,8 @@ public:
   static constexpr int maxRank{MAX_RANK};
   static constexpr int maxLengthTypeParameters{MAX_LEN_PARMS};
   static constexpr bool hasAddendum{ADDENDUM || MAX_LEN_PARMS > 0};
-  static constexpr std::size_t byteSize{std::max(sizeof(Descriptor),
-      Descriptor::SizeInBytes(maxRank, hasAddendum, maxLengthTypeParameters))};
+  static constexpr std::size_t byteSize{
+      Descriptor::SizeInBytes(maxRank, hasAddendum, maxLengthTypeParameters)};
 
   StaticDescriptor() { new (storage_) Descriptor{}; }
 

--- a/flang/runtime/descriptor.h
+++ b/flang/runtime/descriptor.h
@@ -83,16 +83,8 @@ private:
 // array is determined by derivedType_->LenParameters().
 class DescriptorAddendum {
 public:
-  enum Flags {
-    StaticDescriptor = 0x001,
-    ImplicitAllocatable = 0x002, // compiler-created allocatable
-    DoNotFinalize = 0x004, // compiler temporary
-    Target = 0x008, // TARGET attribute
-  };
-
-  explicit DescriptorAddendum(
-      const typeInfo::DerivedType *dt = nullptr, std::uint64_t flags = 0)
-      : derivedType_{dt}, flags_{flags} {}
+  explicit DescriptorAddendum(const typeInfo::DerivedType *dt = nullptr)
+      : derivedType_{dt} {}
   DescriptorAddendum &operator=(const DescriptorAddendum &);
 
   const typeInfo::DerivedType *derivedType() const { return derivedType_; }
@@ -100,8 +92,6 @@ public:
     derivedType_ = dt;
     return *this;
   }
-  std::uint64_t &flags() { return flags_; }
-  const std::uint64_t &flags() const { return flags_; }
 
   std::size_t LenParameters() const;
 
@@ -123,7 +113,6 @@ public:
 
 private:
   const typeInfo::DerivedType *derivedType_;
-  std::uint64_t flags_{0};
   typeInfo::TypeParameterValue len_[1]; // must be the last component
   // The LEN type parameter values can also include captured values of
   // specification expressions that were used for bounds and for LEN type
@@ -356,8 +345,8 @@ public:
   static constexpr int maxRank{MAX_RANK};
   static constexpr int maxLengthTypeParameters{MAX_LEN_PARMS};
   static constexpr bool hasAddendum{ADDENDUM || MAX_LEN_PARMS > 0};
-  static constexpr std::size_t byteSize{
-      Descriptor::SizeInBytes(maxRank, hasAddendum, maxLengthTypeParameters)};
+  static constexpr std::size_t byteSize{std::max(sizeof(Descriptor),
+      Descriptor::SizeInBytes(maxRank, hasAddendum, maxLengthTypeParameters))};
 
   StaticDescriptor() { new (storage_) Descriptor{}; }
 

--- a/flang/runtime/misc-intrinsic.cpp
+++ b/flang/runtime/misc-intrinsic.cpp
@@ -41,9 +41,6 @@ void RTNAME(TransferSize)(Descriptor &result, const Descriptor &source,
   }
   if (const DescriptorAddendum * addendum{mold.Addendum()}) {
     *result.Addendum() = *addendum;
-    auto &flags{result.Addendum()->flags()};
-    flags &= ~DescriptorAddendum::StaticDescriptor;
-    flags |= DescriptorAddendum::DoNotFinalize;
   }
   if (int stat{result.Allocate()}) {
     Terminator{sourceFile, line}.Crash(

--- a/flang/runtime/pointer.cpp
+++ b/flang/runtime/pointer.cpp
@@ -1,0 +1,160 @@
+//===-- runtime/pointer.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "pointer.h"
+#include "stat.h"
+#include "terminator.h"
+#include "tools.h"
+
+namespace Fortran::runtime {
+extern "C" {
+
+void RTNAME(PointerNullifyIntrinsic)(Descriptor &pointer, TypeCategory category,
+    int kind, int rank, int corank) {
+  INTERNAL_CHECK(corank == 0);
+  pointer.Establish(TypeCode{category, kind},
+      Descriptor::BytesFor(category, kind), nullptr, rank, nullptr,
+      CFI_attribute_pointer);
+}
+
+void RTNAME(PointerNullifyCharacter)(Descriptor &pointer, SubscriptValue length,
+    int kind, int rank, int corank) {
+  INTERNAL_CHECK(corank == 0);
+  pointer.Establish(
+      kind, length, nullptr, rank, nullptr, CFI_attribute_pointer);
+}
+
+void RTNAME(PointerNullifyDerived)(Descriptor &pointer,
+    const typeInfo::DerivedType &derivedType, int rank, int corank) {
+  INTERNAL_CHECK(corank == 0);
+  pointer.Establish(derivedType, nullptr, rank, nullptr, CFI_attribute_pointer);
+}
+
+void RTNAME(PointerSetBounds)(Descriptor &pointer, int zeroBasedDim,
+    SubscriptValue lower, SubscriptValue upper) {
+  INTERNAL_CHECK(zeroBasedDim >= 0 && zeroBasedDim < pointer.rank());
+  pointer.GetDimension(zeroBasedDim).SetBounds(lower, upper);
+  // The byte strides are computed when the pointer is allocated.
+}
+
+// TODO: PointerSetCoBounds
+
+void RTNAME(PointerSetDerivedLength)(
+    Descriptor &pointer, int which, SubscriptValue x) {
+  DescriptorAddendum *addendum{pointer.Addendum()};
+  INTERNAL_CHECK(addendum != nullptr);
+  addendum->SetLenParameterValue(which, x);
+}
+
+void RTNAME(PointerApplyMold)(Descriptor &pointer, const Descriptor &mold) {
+  pointer = mold;
+  pointer.set_base_addr(nullptr);
+  pointer.raw().attribute = CFI_attribute_pointer;
+}
+
+void RTNAME(PointerAssociateScalar)(Descriptor &pointer, void *target) {
+  pointer.set_base_addr(target);
+}
+
+void RTNAME(PointerAssociate)(Descriptor &pointer, const Descriptor &target) {
+  pointer = target;
+  pointer.raw().attribute = CFI_attribute_pointer;
+}
+
+void RTNAME(PointerAssociateLowerBounds)(Descriptor &pointer,
+    const Descriptor &target, const Descriptor &lowerBounds) {
+  pointer = target;
+  pointer.raw().attribute = CFI_attribute_pointer;
+  int rank{pointer.rank()};
+  Terminator terminator{__FILE__, __LINE__};
+  std::size_t boundElementBytes{lowerBounds.ElementBytes()};
+  for (int j{0}; j < rank; ++j) {
+    pointer.GetDimension(j).SetLowerBound(
+        GetInt64(lowerBounds.ZeroBasedIndexedElement<const char>(j),
+            boundElementBytes, terminator));
+  }
+}
+
+void RTNAME(PointerAssociateRemapping)(Descriptor &pointer,
+    const Descriptor &target, const Descriptor &bounds, const char *sourceFile,
+    int sourceLine) {
+  pointer = target;
+  pointer.raw().attribute = CFI_attribute_pointer;
+  int rank{pointer.rank()};
+  Terminator terminator{sourceFile, sourceLine};
+  SubscriptValue byteStride{/*captured from first dimension*/};
+  std::size_t boundElementBytes{bounds.ElementBytes()};
+  for (int j{0}; j < rank; ++j) {
+    auto &dim{pointer.GetDimension(j)};
+    dim.SetBounds(GetInt64(bounds.ZeroBasedIndexedElement<const char>(2 * j),
+                      boundElementBytes, terminator),
+        GetInt64(bounds.ZeroBasedIndexedElement<const char>(2 * j + 1),
+            boundElementBytes, terminator));
+    if (j == 0) {
+      byteStride = dim.ByteStride();
+    } else {
+      dim.SetByteStride(byteStride);
+      byteStride *= dim.Extent();
+    }
+  }
+  if (pointer.Elements() > target.Elements()) {
+    terminator.Crash("PointerAssociateRemapping: too many elements in remapped "
+                     "pointer (%zd > %zd)",
+        pointer.Elements(), target.Elements());
+  }
+}
+
+int RTNAME(PointerAllocate)(Descriptor &pointer, bool hasStat,
+    const Descriptor *errMsg, const char *sourceFile, int sourceLine) {
+  Terminator terminator{sourceFile, sourceLine};
+  if (!pointer.IsPointer()) {
+    return ReturnError(terminator, StatInvalidDescriptor, errMsg, hasStat);
+  }
+  return ReturnError(terminator, pointer.Allocate(), errMsg, hasStat);
+  // TODO: default component initialization
+}
+
+int RTNAME(PointerDeallocate)(Descriptor &pointer, bool hasStat,
+    const Descriptor *errMsg, const char *sourceFile, int sourceLine) {
+  Terminator terminator{sourceFile, sourceLine};
+  if (!pointer.IsPointer()) {
+    return ReturnError(terminator, StatInvalidDescriptor, errMsg, hasStat);
+  }
+  if (!pointer.IsAllocated()) {
+    return ReturnError(terminator, StatBaseNull, errMsg, hasStat);
+  }
+  return ReturnError(terminator, pointer.Deallocate(), errMsg, hasStat);
+}
+
+bool RTNAME(PointerIsAssociated)(const Descriptor &pointer) {
+  return pointer.raw().base_addr != nullptr;
+}
+
+bool RTNAME(PointerIsAssociatedWith)(
+    const Descriptor &pointer, const Descriptor &target) {
+  int rank{pointer.rank()};
+  if (pointer.raw().base_addr != target.raw().base_addr ||
+      pointer.ElementBytes() != target.ElementBytes() ||
+      rank != target.rank()) {
+    return false;
+  }
+  for (int j{0}; j < rank; ++j) {
+    const Dimension &pDim{pointer.GetDimension(j)};
+    const Dimension &tDim{target.GetDimension(j)};
+    if (pDim.Extent() != tDim.Extent() ||
+        pDim.ByteStride() != tDim.ByteStride()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// TODO: PointerCheckLengthParameter, PointerAllocateSource
+
+} // extern "C"
+} // namespace Fortran::runtime

--- a/flang/runtime/pointer.h
+++ b/flang/runtime/pointer.h
@@ -1,0 +1,112 @@
+//===-- runtime/pointer.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Defines APIs for Fortran runtime library support of code generated
+// to manipulate and query data pointers.
+
+#ifndef FORTRAN_RUNTIME_POINTER_H_
+#define FORTRAN_RUNTIME_POINTER_H_
+
+#include "descriptor.h"
+#include "entry-names.h"
+
+namespace Fortran::runtime {
+extern "C" {
+
+// Data pointer initialization for NULLIFY(), "p=>NULL()`, & for ALLOCATE().
+
+// Initializes a pointer to a disassociated state for NULLIFY() or "p=>NULL()".
+void RTNAME(PointerNullifyIntrinsic)(
+    Descriptor &, TypeCategory, int kind, int rank = 0, int corank = 0);
+void RTNAME(PointerNullifyCharacter)(Descriptor &, SubscriptValue length = 0,
+    int kind = 1, int rank = 0, int corank = 0);
+void RTNAME(PointerNullifyDerived)(
+    Descriptor &, const typeInfo::DerivedType &, int rank = 0, int corank = 0);
+
+// Explicitly sets the bounds of an initialized disassociated pointer.
+// The upper cobound is ignored for the last codimension.
+void RTNAME(PointerSetBounds)(
+    Descriptor &, int zeroBasedDim, SubscriptValue lower, SubscriptValue upper);
+void RTNAME(PointerSetCoBounds)(Descriptor &, int zeroBasedCoDim,
+    SubscriptValue lower, SubscriptValue upper = 0);
+
+// Length type parameters are indexed in declaration order; i.e., 0 is the
+// first length type parameter in the deepest base type.  (Not for use
+// with CHARACTER; see above.)
+void RTNAME(PointerSetDerivedLength)(Descriptor &, int which, SubscriptValue);
+
+// For MOLD= allocation: acquires information from another descriptor
+// to initialize a null data pointer.
+void RTNAME(PointerApplyMold)(Descriptor &, const Descriptor &mold);
+
+// Data pointer association for "p=>TARGET"
+
+// Associates a scalar pointer with a simple scalar target.
+void RTNAME(PointerAssociateScalar)(Descriptor &, void *);
+
+// Associates a pointer with a target of the same rank, possibly with new lower
+// bounds, which are passed in a vector whose length must equal the rank.
+void RTNAME(PointerAssociate)(Descriptor &, const Descriptor &target);
+void RTNAME(PointerAssociateLowerBounds)(
+    Descriptor &, const Descriptor &target, const Descriptor &lowerBounds);
+
+// Associates a pointer with a target with bounds remapping.  The target must be
+// simply contiguous &/or of rank 1.  The bounds constitute a [2,newRank]
+// integer array whose columns are [lower bound, upper bound] on each dimension.
+void RTNAME(PointerAssociateRemapping)(Descriptor &, const Descriptor &target,
+    const Descriptor &bounds, const char *sourceFile = nullptr,
+    int sourceLine = 0);
+
+// Data pointer allocation and deallocation
+
+// When an explicit type-spec appears in an ALLOCATE statement for an
+// pointer with an explicit (non-deferred) length type paramater for
+// a derived type or CHARACTER value, the explicit value has to match
+// the length type parameter's value.  This API checks that requirement.
+// Returns 0 for success, or the STAT= value on failure with hasStat==true.
+int RTNAME(PointerCheckLengthParameter)(Descriptor &,
+    int which /* 0 for CHARACTER length */, SubscriptValue other,
+    bool hasStat = false, const Descriptor *errMsg = nullptr,
+    const char *sourceFile = nullptr, int sourceLine = 0);
+
+// Allocates a data pointer.  Its descriptor must have been initialized
+// and its bounds and length type parameters set.  It need not be disassociated.
+// On failure, if hasStat is true, returns a nonzero error code for
+// STAT= and (if present) fills in errMsg; if hasStat is false, the
+// image is terminated.  On success, leaves errMsg alone and returns zero.
+// Successfully allocated memory is initialized if the pointer has a
+// derived type, and is always initialized by PointerAllocateSource().
+// Performs all necessary coarray synchronization and validation actions.
+int RTNAME(PointerAllocate)(Descriptor &, bool hasStat = false,
+    const Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
+    int sourceLine = 0);
+int RTNAME(PointerAllocateSource)(Descriptor &, const Descriptor &source,
+    bool hasStat = false, const Descriptor *errMsg = nullptr,
+    const char *sourceFile = nullptr, int sourceLine = 0);
+
+// Deallocates a data pointer, which must have been allocated by
+// PointerAllocate(), possibly copied with PointerAssociate().
+// Finalizes elements &/or components as needed.  The pointer is left
+// in an initialized disassociated state suitable for reallocation
+// with the same bounds, cobounds, and length type parameters.
+int RTNAME(PointerDeallocate)(Descriptor &, bool hasStat = false,
+    const Descriptor *errMsg = nullptr, const char *sourceFile = nullptr,
+    int sourceLine = 0);
+
+// Association inquiries for ASSOCIATED()
+
+// True when the pointer is not disassociated.
+bool RTNAME(PointerIsAssociated)(const Descriptor &);
+
+// True when the pointer is associated with a specific target.
+bool RTNAME(PointerIsAssociatedWith)(
+    const Descriptor &, const Descriptor &target);
+
+} // extern "C"
+} // namespace Fortran::runtime
+#endif // FORTRAN_RUNTIME_POINTER_H_

--- a/flang/test/Fir/type-descriptor.fir
+++ b/flang/test/Fir/type-descriptor.fir
@@ -8,6 +8,6 @@ fir.global internal @_QFfooEx : !fir.box<!fir.heap<!sometype>> {
   fir.has_value %1 : !fir.box<!fir.heap<!sometype>>
 }
 
-// CHECK: @_QFfooEx = internal global { %_QFfooTsometype*, i64, i32, i8, i8, i8, i8, i8*, i64, [1 x i64] }
+// CHECK: @_QFfooEx = internal global { %_QFfooTsometype*, i64, i32, i8, i8, i8, i8, i8*, [1 x i64] }
 // CHECK-SAME: { %_QFfooTsometype* null, i64 ptrtoint (%_QFfooTsometype* getelementptr (%_QFfooTsometype, %_QFfooTsometype* null, i32 1) to i64),
-// CHECK-SAME: i32 20180515, i8 0, i8 34, i8 2, i8 1, i8* @_QFfooE.dt.sometype, i64 0, [1 x i64] undef }
+// CHECK-SAME: i32 20180515, i8 0, i8 34, i8 2, i8 1, i8* @_QFfooE.dt.sometype, [1 x i64] undef }

--- a/flang/test/Lower/pointer-runtime.f90
+++ b/flang/test/Lower/pointer-runtime.f90
@@ -1,0 +1,50 @@
+! RUN: bbc -emit-fir -use-alloc-runtime %s -o - | FileCheck %s
+
+! Test lowering of allocatables using runtime for allocate/deallocate statements.
+! CHECK-LABEL: _QPpointer_runtime(
+subroutine pointer_runtime(n)
+  integer :: n
+  character(:), pointer :: scalar, array(:)
+  ! CHECK-DAG: %[[sBoxAddr:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFpointer_runtimeEscalar"}
+  ! CHECK-DAG: %[[sNullAddr:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
+  ! CHECK-DAG: %[[sInitBox:.*]] = fir.embox %[[sNullAddr]] typeparams %c0{{.*}} : (!fir.ptr<!fir.char<1,?>>, index) -> !fir.box<!fir.ptr<!fir.char<1,?>>>
+  ! CHECK-DAG: fir.store %[[sInitBox]] to %[[sBoxAddr]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+
+  ! CHECK-DAG: %[[aBoxAddr:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFpointer_runtimeEarray"}
+  ! CHECK-DAG: %[[aNullAddr:.*]] = fir.zero_bits !fir.ptr<!fir.array<?x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[aNullShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK-DAG: %[[aInitBox:.*]] = fir.embox %[[aNullAddr]](%[[aNullShape]]) typeparams %c0{{.*}} : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+  ! CHECK-DAG: fir.store %[[aInitBox]] to %[[aBoxAddr]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
+
+  allocate(character(10):: scalar, array(30))
+  ! CHECK-DAG: %[[sBoxCast1:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten1:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}PointerNullifyCharacter(%[[sBoxCast1]], %[[ten1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-NOT: PointerSetBounds
+  ! CHECK: %[[sBoxCast2:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerAllocate(%[[sBoxCast2]]
+
+  ! CHECK-DAG: %[[aBoxCast1:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK-DAG: %[[ten2:.*]] = fir.convert %c10{{.*}} : (i32) -> i64
+  ! CHECK: fir.call @{{.*}}PointerNullifyCharacter(%[[aBoxCast1]], %[[ten2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+  ! CHECK: %[[aBoxCast2:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerSetBounds(%[[aBoxCast2]]
+  ! CHECK: %[[aBoxCast3:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerAllocate(%[[aBoxCast3]]
+
+  deallocate(scalar, array)
+  ! CHECK: %[[sBoxCast3:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerDeallocate(%[[sBoxCast3]]
+  ! CHECK: %[[aBoxCast4:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerDeallocate(%[[aBoxCast4]]
+
+  ! only testing that the correct length is set in the descriptor.
+  allocate(character(n):: scalar, array(40))
+  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[ncast1:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[sBoxCast4:.*]] = fir.convert %[[sBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerNullifyCharacter(%[[sBoxCast4]], %[[ncast1]], %c1{{.*}}, %c0{{.*}}, %c0{{.*}})
+  ! CHECK-DAG: %[[ncast2:.*]] = fir.convert %[[n]] : (i32) -> i64
+  ! CHECK-DAG: %[[aBoxCast5:.*]] = fir.convert %[[aBoxAddr]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: fir.call @{{.*}}PointerNullifyCharacter(%[[aBoxCast5]], %[[ncast2]], %c1{{.*}}, %c1{{.*}}, %c0{{.*}})
+end subroutine

--- a/flang/test/Semantics/offsets01.f90
+++ b/flang/test/Semantics/offsets01.f90
@@ -47,8 +47,8 @@ subroutine s5(n)
     integer, len :: l2
     real :: b(l1, l2)
   end type
-  type(t1(n))   :: x1 !CHECK: x1 size=48 offset=
-  type(t2(n,n)) :: x2 !CHECK: x2 size=56 offset=
+  type(t1(n))   :: x1 !CHECK: x1 size=40 offset=
+  type(t2(n,n)) :: x2 !CHECK: x2 size=48 offset=
   !CHECK: a size=48 offset=0:
   !CHECK: b size=72 offset=0:
 end


### PR DESCRIPTION
- Cherry-pick pointer runtime entry points. Add a small fix to this runtime patch found while running NAG tests.
- Use new runtime entry points for pointer in allocate/deallocate statement lowering.
- Update fir.box and embox codegen to align with the runtime change that also removed the addendum flags that were unused.

This fixes the "Invalid descriptor" error messages that occurred at runtime when allocating derived type pointers.