### PR TITLE
restrict block data processing to object entities

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2378,8 +2378,10 @@ private:
     builder = new Fortran::lower::FirOpBuilder(func, bridge.getKindMap());
     Fortran::lower::AggregateStoreMap fakeMap;
     for (const auto &[_, sym] : bdunit.symTab) {
-      Fortran::lower::pft::Variable var(*sym, true);
-      instantiateVar(var, fakeMap);
+      if (sym->has<Fortran::semantics::ObjectEntityDetails>()) {
+        Fortran::lower::pft::Variable var(*sym, true);
+        instantiateVar(var, fakeMap);
+      }
     }
 
     if (auto *region = func.getCallableRegion())

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -148,7 +148,7 @@ block data
    ! CHECK: %[[VAL_239:.*]] = fir.insert_on_range %[[VAL_238]], %[[VAL_225]], [4 : index, 4 : index, 3 : index, 4 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
    ! CHECK: %[[VAL_240:.*]] = fir.insert_value %[[VAL_226]], %[[VAL_239]], [0 : index] : (tuple<!fir.array<5x5xf32>>, !fir.array<5x5xf32>) -> tuple<!fir.array<5x5xf32>>
    ! CHECK: fir.has_value %[[VAL_240]] : tuple<!fir.array<5x5xf32>>
-  real :: x(5,5)
+  real(selected_real_kind(6)) :: x(5,5)
   common /block/ x
   data x(1,1), x(2,1), x(3,1) / 1, 1, 0 /
   data x(1,2), x(2,2), x(4,2) / 1, 1, 2.4 /


### PR DESCRIPTION
Compilation of the following code attempts to generate a global
definition of intrinsic selected_int_kind, which is part of the
specification expression declaring object entity I.  An object in
a block data program unit must be in a common block (14.3p1),
which in turn implies that it must not be a procedure (C8119).
Suppress this invalid definition attempt by restricting block data
processing to object entities.

```
    block data
      integer(selected_int_kind(3)) :: I = 42
      common /NAME/ I
    end block data
```