### PR TITLE
[openacc] Fix lowering tests that violate the attach pointer/allocatble restriction

### DIFF
--- a/flang/test/Lower/OpenACC/acc-data.f90
+++ b/flang/test/Lower/OpenACC/acc-data.f90
@@ -2,17 +2,16 @@
 
 ! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 
-! FIXME: Test is violating semantic constraint: "Argument on the ATTACH
-! clause must be a variable or array with the POINTER or ALLOCATABLE attribute"
-! XFAIL: true
-
 subroutine acc_data
   real, dimension(10, 10) :: a, b, c
+  real, pointer :: d, e
   logical :: ifCondition = .TRUE.
 
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
+!CHECK: [[D:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "d", uniq_name = "{{.*}}Ed"}
+!CHECK: [[E:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "e", uniq_name = "{{.*}}Ee"}
 
   !$acc data if(.TRUE.) copy(a)
   !$acc end data
@@ -87,10 +86,10 @@ subroutine acc_data
 !CHECK:        acc.terminator
 !CHECK-NEXT: }{{$}}
 
-  !$acc data attach(b, c)
+  !$acc data attach(d, e)
   !$acc end data
 
-!CHECK:      acc.data attach([[B]], [[C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:      acc.data attach([[D]], [[E]] : !fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 !CHECK:        acc.terminator
 !CHECK-NEXT: }{{$}}
 

--- a/flang/test/Lower/OpenACC/acc-enter-data.f90
+++ b/flang/test/Lower/OpenACC/acc-enter-data.f90
@@ -2,18 +2,16 @@
 
 ! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 
-! FIXME: Test is violating semantic constraint: "Argument on the ATTACH
-! clause must be a variable or array with the POINTER or ALLOCATABLE attribute"
-! XFAIL: true
-
 subroutine acc_enter_data
   integer :: async = 1
   real, dimension(10, 10) :: a, b, c
+  real, pointer :: d
   logical :: ifCondition = .TRUE.
 
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
+!CHECK: [[D:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "d", uniq_name = "{{.*}}Ed"}
 
   !$acc enter data create(a)
 !CHECK: acc.enter_data create([[A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
@@ -33,8 +31,8 @@ subroutine acc_enter_data
   !$acc enter data create(a) create(b) create(zero: c)
 !CHECK: acc.enter_data create([[A]], [[B]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>) create_zero([[C]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
 
-  !$acc enter data copyin(a) create(b) attach(c)
-!CHECK: acc.enter_data copyin([[A]] : !fir.ref<!fir.array<10x10xf32>>) create([[B]] : !fir.ref<!fir.array<10x10xf32>>) attach([[C]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
+  !$acc enter data copyin(a) create(b) attach(d)
+!CHECK: acc.enter_data copyin([[A]] : !fir.ref<!fir.array<10x10xf32>>) create([[B]] : !fir.ref<!fir.array<10x10xf32>>) attach([[D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>){{$}}
 
   !$acc enter data create(a) async
 !CHECK: acc.enter_data create([[A]] : !fir.ref<!fir.array<10x10xf32>>) attributes {async}

--- a/flang/test/Lower/OpenACC/acc-exit-data.f90
+++ b/flang/test/Lower/OpenACC/acc-exit-data.f90
@@ -2,18 +2,16 @@
 
 ! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 
-! FIXME: Test is violating semantic constraint: "Argument on the ATTACH
-! clause must be a variable or array with the POINTER or ALLOCATABLE attribute"
-! XFAIL: true
-
 subroutine acc_exit_data
   integer :: async = 1
   real, dimension(10, 10) :: a, b, c
+  real, pointer :: d
   logical :: ifCondition = .TRUE.
 
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
+!CHECK: [[D:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "d", uniq_name = "{{.*}}Ed"}
 
   !$acc exit data delete(a)
 !CHECK: acc.exit_data delete([[A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
@@ -30,8 +28,8 @@ subroutine acc_exit_data
   !$acc exit data delete(a) delete(b) delete(c)
 !CHECK: acc.exit_data delete([[A]], [[B]], [[C]] : !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>, !fir.ref<!fir.array<10x10xf32>>){{$}}
 
-  !$acc exit data copyout(a) delete(b) detach(c)
-!CHECK: acc.exit_data copyout([[A]] : !fir.ref<!fir.array<10x10xf32>>) delete([[B]] : !fir.ref<!fir.array<10x10xf32>>) detach([[C]] : !fir.ref<!fir.array<10x10xf32>>){{$}}
+  !$acc exit data copyout(a) delete(b) detach(d)
+!CHECK: acc.exit_data copyout([[A]] : !fir.ref<!fir.array<10x10xf32>>) delete([[B]] : !fir.ref<!fir.array<10x10xf32>>) detach([[D]] : !fir.ref<!fir.box<!fir.ptr<f32>>>){{$}}
 
   !$acc exit data delete(a) async
 !CHECK: acc.exit_data delete([[A]] : !fir.ref<!fir.array<10x10xf32>>) attributes {async}

--- a/flang/test/Lower/OpenACC/acc-parallel.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel.f90
@@ -2,10 +2,6 @@
 
 ! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 
-! FIXME: Test is violating semantic constraint: "Argument on the ATTACH
-! clause must be a variable or array with the POINTER or ALLOCATABLE attribute"
-! XFAIL: true
-
 subroutine acc_parallel
   integer :: i, j
 
@@ -17,10 +13,13 @@ subroutine acc_parallel
   integer :: vectorLength = 128
   logical :: ifCondition = .TRUE.
   real, dimension(10, 10) :: a, b, c
+  real, pointer :: d, e
 
 !CHECK: [[A:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ea"}
 !CHECK: [[B:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Eb"}
 !CHECK: [[C:%.*]] = fir.alloca !fir.array<10x10xf32> {{{.*}}uniq_name = "{{.*}}Ec"}
+!CHECK: [[D:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "d", uniq_name = "{{.*}}Ed"}
+!CHECK: [[E:%.*]] = fir.alloca !fir.box<!fir.ptr<f32>> {bindc_name = "e", uniq_name = "{{.*}}Ee"}
 !CHECK: [[IFCONDITION:%.*]] = fir.address_of(@{{.*}}ifcondition) : !fir.ref<!fir.logical<4>>
 
   !$acc parallel
@@ -230,10 +229,10 @@ subroutine acc_parallel
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
 
-  !$acc parallel attach(b, c)
+  !$acc parallel attach(d, e)
   !$acc end parallel
 
-!CHECK:      acc.parallel attach([[B]]: !fir.ref<!fir.array<10x10xf32>>, [[C]]: !fir.ref<!fir.array<10x10xf32>>) {
+!CHECK:      acc.parallel attach([[D]]: !fir.ref<!fir.box<!fir.ptr<f32>>>, [[E]]: !fir.ref<!fir.box<!fir.ptr<f32>>>) {
 !CHECK:        acc.yield
 !CHECK-NEXT: }{{$}}
 


### PR DESCRIPTION
Some lowering tests were violating a restrictions that was added upstream. This PR fixes them and removes the XFAIL. 

Upstream patch introducing the semantic restriction: https://reviews.llvm.org/D103279