### PR TITLE
Lower default initialization of local and dummy entities

### DIFF
--- a/flang/include/flang/Lower/DerivedRuntime.h
+++ b/flang/include/flang/Lower/DerivedRuntime.h
@@ -1,0 +1,37 @@
+//===-- Lower/DerivedRuntime.h - lower derived type runtime API -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_DERIVEDRUNTIME_H
+#define FORTRAN_LOWER_DERIVEDRUNTIME_H
+
+namespace mlir {
+class Value;
+class Location;
+} // namespace mlir
+
+namespace Fortran::lower {
+class FirOpBuilder;
+
+/// Generate call to derived type initialization runtime routine to
+/// default initialize \p box.
+void genDerivedTypeInitialize(Fortran::lower::FirOpBuilder &builder,
+                              mlir::Location loc, mlir::Value box);
+
+/// Generate call to derived type destruction runtime routine to
+/// destroy \p box.
+void genDerivedTypeDestroy(Fortran::lower::FirOpBuilder &builder,
+                           mlir::Location loc, mlir::Value box);
+
+/// Generate call to derived type assignment runtime routine to
+/// assign \p sourceBox to \p destinationBox.
+void genDerivedTypeAssign(Fortran::lower::FirOpBuilder &builder,
+                          mlir::Location loc, mlir::Value destinationBox,
+                          mlir::Value sourceBox);
+
+} // namespace Fortran::lower
+#endif

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -12,6 +12,7 @@ add_flang_library(FortranLower
   ConvertExpr.cpp
   ConvertType.cpp
   ConvertVariable.cpp
+  DerivedRuntime.cpp
   DoLoopHelper.cpp
   FIRBuilder.cpp
   HostAssociations.cpp

--- a/flang/lib/Lower/DerivedRuntime.cpp
+++ b/flang/lib/Lower/DerivedRuntime.cpp
@@ -1,0 +1,51 @@
+//===-- DerivedRuntime.cpp -- derived type runtime API --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/DerivedRuntime.h"
+#include "../../runtime/derived-api.h"
+#include "RTBuilder.h"
+#include "flang/Lower/FIRBuilder.h"
+#include "flang/Lower/Todo.h"
+
+using namespace Fortran::runtime;
+
+void Fortran::lower::genDerivedTypeInitialize(
+    Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+    mlir::Value box) {
+  auto func = getRuntimeFunc<mkRTKey(Initialize)>(loc, builder);
+  auto fTy = func.getType();
+  auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
+  auto sourceLine =
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(2));
+  auto args = Fortran::lower::createArguments(builder, loc, fTy, box,
+                                              sourceFile, sourceLine);
+  builder.create<fir::CallOp>(loc, func, args);
+}
+
+void Fortran::lower::genDerivedTypeDestroy(
+    Fortran::lower::FirOpBuilder &builder, mlir::Location loc,
+    mlir::Value box) {
+  auto func = getRuntimeFunc<mkRTKey(Destroy)>(loc, builder);
+  auto fTy = func.getType();
+  auto args = Fortran::lower::createArguments(builder, loc, fTy, box);
+  builder.create<fir::CallOp>(loc, func, args);
+}
+
+void Fortran::lower::genDerivedTypeAssign(Fortran::lower::FirOpBuilder &builder,
+                                          mlir::Location loc,
+                                          mlir::Value destinationBox,
+                                          mlir::Value sourceBox) {
+  auto func = getRuntimeFunc<mkRTKey(Assign)>(loc, builder);
+  auto fTy = func.getType();
+  auto sourceFile = Fortran::lower::locationToFilename(builder, loc);
+  auto sourceLine =
+      Fortran::lower::locationToLineNo(builder, loc, fTy.getInput(3));
+  auto args = Fortran::lower::createArguments(
+      builder, loc, fTy, destinationBox, sourceBox, sourceFile, sourceLine);
+  builder.create<fir::CallOp>(loc, func, args);
+}

--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -1,0 +1,197 @@
+! Test lowering of allocatable components
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module test_dinit
+  type t
+    integer :: i = 42 
+  end type
+  type t_alloc_comp
+    real, allocatable :: i(:)
+  end type
+  type tseq
+    sequence
+    integer :: i = 42 
+  end type
+contains
+
+! -----------------------------------------------------------------------------
+!            Test default initialization of local and dummy variables.
+! -----------------------------------------------------------------------------
+
+  ! Test local scalar is default initialized
+  ! CHECK-LABEL: func @_QMtest_dinitPlocal()
+  subroutine local
+    ! CHECK: %[[x:.*]] = fir.alloca !fir.type<_QMtest_dinitTt{i:i32}>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    type(t) :: x
+    print *, x%i
+  end subroutine 
+
+  ! Test local array is default initialized
+  ! CHECK-LABEL: func @_QMtest_dinitPlocal_array()
+  subroutine local_array()
+    ! CHECK: %[[x:.*]] = fir.alloca !fir.array<4x!fir.type<_QMtest_dinitTt{i:i32}>>
+    ! CHECK: %[[xshape:.*]] = fir.shape %c4{{.*}} : (index) -> !fir.shape<1>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]](%[[xshape]]) : (!fir.ref<!fir.array<4x!fir.type<_QMtest_dinitTt{i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.array<4x!fir.type<_QMtest_dinitTt{i:i32}>>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    type(t) :: x(4)
+    print *, x(2)%i
+  end subroutine 
+
+  ! Test allocatable component triggers default initialization of local
+  ! scalars.
+  ! CHECK-LABEL: func @_QMtest_dinitPlocal_alloc_comp()
+  subroutine local_alloc_comp
+    ! CHECK: %[[x:.*]] = fir.alloca !fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    type(t_alloc_comp) :: x
+  end subroutine 
+
+  ! Test function results are default initialized.
+  ! CHECK-LABEL: func @_QMtest_dinitPresult() -> !fir.type<_QMtest_dinitTt{i:i32}>
+  function result()
+    ! CHECK: %[[x:.*]] = fir.alloca !fir.type<_QMtest_dinitTt{i:i32}>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    type(t) :: result
+  end function
+
+  ! Test intent(out) dummies are default initialized
+  ! CHECK-LABEL: func @_QMtest_dinitPintent_out(
+  ! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>
+  subroutine intent_out(x)
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    type(t), intent(out) :: x
+  end subroutine
+
+  ! Test that optional intent(out) are default initialized only when
+  ! present.
+  ! CHECK-LABEL: func @_QMtest_dinitPintent_out_optional(
+  ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>> {fir.optional})
+  subroutine intent_out_optional(x)
+    ! CHECK: %[[isPresent:.*]] = fir.is_present %[[x]] : (!fir.box<!fir.type<_QMtest_dinitTt{i:i32}>>) -> i1
+    ! CHECK: fir.if %[[isPresent]] {
+      ! CHECK: %[[xboxNone:.*]] = fir.convert %[[x]]
+      ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    ! CHECK: }
+    type(t), intent(out), optional :: x
+  end subroutine
+
+  ! Test local equivalences where one entity has default initialization
+  ! CHECK-LABEL: func @_QMtest_dinitPlocal_eq()
+  subroutine local_eq()
+    type(tseq) :: x
+    integer :: zi
+    ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
+    ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
+    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    equivalence (x, zi)
+    print *, i
+  end subroutine
+
+  ! Test local equivalences with both equivalenced entities being
+  ! default initialized. Note that the standard allow default initialization
+  ! to be performed several times as long as the values are the same. So
+  ! far that is what lowering is doing to stay simple.
+  ! CHECK-LABEL: func @_QMtest_dinitPlocal_eq2()
+  subroutine local_eq2()
+    type(tseq) :: x
+    type(tseq) :: y
+    ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
+    ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
+    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+
+  
+    ! CHECK: %[[ycoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
+    ! CHECK: %[[y:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[ybox:.*]] = fir.embox %[[y]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[yboxNone:.*]] = fir.convert %[[ybox]]
+    ! CHECK: fir.call @_FortranAInitialize(%[[yboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+    equivalence (x, y)
+    print *, y%i
+  end subroutine
+
+
+! -----------------------------------------------------------------------------
+!        Test for local and dummy variables that must not be initialized
+! -----------------------------------------------------------------------------
+
+  ! CHECK-LABEL: func @_QMtest_dinitPnoinit_local_alloc
+  subroutine noinit_local_alloc
+    ! CHECK-NOT: fir.call @_FortranAInitialize
+    type(t), allocatable :: x
+    ! CHECK: return
+  end subroutine 
+
+  ! CHECK-LABEL: func @_QMtest_dinitPnoinit_local_pointer
+  subroutine noinit_local_pointer
+    ! CHECK-NOT: fir.call @_FortranAInitialize
+    type(t), pointer :: x
+    ! CHECK: return
+  end subroutine 
+
+  ! CHECK-LABEL: func @_QMtest_dinitPnoinit_normal_dummy
+  subroutine noinit_normal_dummy(x)
+    ! CHECK-NOT: fir.call @_FortranAInitialize
+    type(t) :: x
+    ! CHECK: return
+  end subroutine
+
+  ! CHECK-LABEL: func @_QMtest_dinitPnoinit_intentinout_dummy
+  subroutine noinit_intentinout_dummy(x)
+    ! CHECK-NOT: fir.call @_FortranAInitialize
+    type(t), intent(inout) :: x
+    ! CHECK: return
+  end subroutine 
+
+! -----------------------------------------------------------------------------
+!            Test default initialization of global variables.
+! -----------------------------------------------------------------------------
+
+! TODO: Default initialization of static variables. Hits a hard TODO
+! for now.
+
+  !subroutine saved()
+  !  type(t), save :: x
+  !end subroutine
+  !subroutine saved_eq()
+  !  type(tseq), save :: x
+  !  type(tseq), save :: y
+  !  equivalence (x, y)
+  !end subroutine
+  !subroutine saved_eq2()
+  !  type(tseq), save :: x
+  !  integer, save :: i
+  !  equivalence (x, i)
+  !end subroutine
+end module
+
+! End-to-end test for debug pruposes.
+  use test_dinit
+  type(t) :: at
+  call local()
+  call local_array()
+  at%i = 66
+  call intent_out(at)
+  print *, at%i
+  at%i = 66
+  call intent_out_optional(at)
+  print *, at%i
+  call intent_out_optional()
+  call local_eq()
+  call local_eq2()
+end


### PR DESCRIPTION
When instantiating variables, identify the ones that must be default
initialized at runtime (locals and intent(out) dummies). Call the
default initialization runtime routine to perform the initialization.

Global variables that have no explicit initialization and have a default
initialization are left TODO. The runtime cannot be used for them, the
fir.global generation will need to be updated for these variables (it was
generating an undefined undefined until now). For now, simply catch and
add a hard TODO for these cases. For information, it is firing 13 times
in NAG F95 tests.

Runtime interface for finalization is added, but nothing is done with it
yet (Final procedures are not F95).