### PR TITLE
[flang] Remove an unneeded call to createBox

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -2977,9 +2977,9 @@ IntrinsicLibrary::genUnpack(mlir::Type resultType,
   fir::BoxValue vectorTmp = builder.createBox(loc, args[0]);
 
   // Handle required mask argument
-  auto mask = builder.createBox(loc, args[1]);
-  fir::BoxValue maskTmp = builder.createBox(loc, args[1]);
-  auto maskRank = maskTmp.rank();
+  fir::BoxValue maskBox = builder.createBox(loc, args[1]);
+  auto mask = fir::getBase(maskBox);
+  auto maskRank = maskBox.rank();
 
   // Handle required field argument
   auto field = builder.createBox(loc, args[2]);


### PR DESCRIPTION
In processing the UNPACK intrinsic, my implementation had an unneeded
extra call to createBox().  This change removes it.