### PR TITLE
Fix the sporadic bug for when the resolution on the CPU timer is too …

### DIFF
--- a/flang/unittests/RuntimeGTest/Time.cpp
+++ b/flang/unittests/RuntimeGTest/Time.cpp
@@ -31,5 +31,5 @@ TEST(TimeIntrinsics, CpuTime) {
 
   ASSERT_GE(start, 0.0);
   ASSERT_GT(end, 0.0);
-  ASSERT_GT(end, start);
+  ASSERT_GE(end, start);
 }


### PR DESCRIPTION
…imprecise to detect the time between two successive function calls.