### PR TITLE
Lower default initialization of module and saved variables

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -401,11 +401,10 @@ struct Variable {
     AggregateStore(Interval &&interval, const Fortran::semantics::Scope &scope,
                    bool isDeclaration = false)
         : interval{std::move(interval)}, scope{&scope}, isDecl{isDeclaration} {}
-    AggregateStore(Interval &&interval, const Fortran::semantics::Scope &scope,
-                   const llvm::SmallVector<const semantics::Symbol *> &vars,
-                   bool isDeclaration = false)
-        : interval{std::move(interval)}, scope{&scope}, vars{vars},
-          isDecl{isDeclaration} {}
+    AggregateStore(
+        Interval &&interval, const Fortran::semantics::Scope &scope,
+        const llvm::SmallVector<const semantics::Symbol *> &unorderedVars,
+        bool isDeclaration = false);
 
     bool isGlobal() const { return vars.size() > 0; }
     bool isDeclaration() const { return isDecl; }

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1688,3 +1688,18 @@ Fortran::lower::pft::buildFuncResultDependencyList(
   variableList[0].pop_back();
   return variableList[0];
 }
+
+Fortran::lower::pft::Variable::AggregateStore::AggregateStore(
+    Interval &&interval, const Fortran::semantics::Scope &scope,
+    const llvm::SmallVector<const semantics::Symbol *> &unorderedVars,
+    bool isDeclaration)
+    : interval{std::move(interval)}, scope{&scope}, vars{unorderedVars},
+      isDecl{isDeclaration} {
+  // Sort the variables according to their offsets (they are coming here in
+  // source order because that is how the front-end is sorting symbol in
+  // scopes).
+  auto compare = [](const semantics::Symbol *a, const semantics::Symbol *b) {
+    return a->offset() < b->offset();
+  };
+  std::sort(vars.begin(), vars.end(), compare);
+}

--- a/flang/test/Lower/default-initialization-globals.f90
+++ b/flang/test/Lower/default-initialization-globals.f90
@@ -1,0 +1,238 @@
+! Test default initialization of global variables (static init)
+! RUN: bbc %s -o - | FileCheck %s
+
+module tinit
+  real, target :: ziel(100)
+
+  type tno_init
+    integer :: k
+  end type
+
+  type t0
+    integer :: k = 66
+  end type
+
+  ! Test type that combines all kinds of components with and without
+  ! default initialization.
+  type t1
+    ! Simple type component with default init
+    integer :: i = 42
+    ! Simple type component without default init
+    integer :: j
+
+    ! Pointer component with a default initial target
+    real, pointer :: x(:) => ziel
+    ! Pointer component with no init
+    real, pointer :: y(:)
+    ! Pointer component with null init
+    real, pointer :: z(:) => NULL()
+
+    ! Character component with init
+    character(10) c1 = "hello"
+    ! Character component without init
+    character(10) c2
+
+    ! Component with a derived type that has default init
+    type(t0) :: somet0
+    ! Component with a derived type that has no default init.
+    type(tno_init) :: sometno_init
+    ! Component whose type default init is overridden by
+    ! default init for the component.
+    type(t0) :: somet0_2 = t0(33)
+    ! Array component with a derived type that has default init
+    type(t0) :: somet0_array
+  end type
+
+  ! Test type that extends type with default init.
+  type, extends(t0) :: textendst0
+    integer :: l
+  end type
+
+  ! Test type with default init in equivalences
+  type tseq
+    sequence
+    integer :: i = 2
+    integer :: j = 3
+  end type
+
+  ! Test scalar with default init
+  type(t0) :: at0
+! CHECK-LABEL: fir.global linkonce @_QMtinitEat0 : !fir.type<_QMtinitTt0{k:i32}> {
+  ! CHECK: %[[VAL_0:.*]] = constant 66 : i32
+  ! CHECK: %[[VAL_1:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_2:.*]] = fir.insert_value %[[VAL_1]], %[[VAL_0]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: fir.has_value %[[VAL_2]] : !fir.type<_QMtinitTt0{k:i32}>
+
+  ! Test array with default init
+  type(t0) :: bt0(100)
+! CHECK-LABEL: linkonce @_QMtinitEbt0 : !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>> {
+  ! CHECK: %[[VAL_3:.*]] = constant 66 : i32
+  ! CHECK: %[[VAL_4:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_3]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_6:.*]] = fir.undefined !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>
+  ! CHECK: %[[VAL_7:.*]] = fir.insert_on_range %[[VAL_6]], %[[VAL_5]], [0 : index, 99 : index] : (!fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>
+  ! CHECK: fir.has_value %[[VAL_7]] : !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>
+
+  ! Test default init overridden by explicit init
+  type(t0) :: ct0 = t0(42)
+! CHECK-LABEL: fir.global linkonce @_QMtinitEct0 : !fir.type<_QMtinitTt0{k:i32}> {
+  ! CHECK: %[[VAL_8:.*]] = constant 42 : i32
+  ! CHECK: %[[VAL_9:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_8]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: fir.has_value %[[VAL_10]] : !fir.type<_QMtinitTt0{k:i32}>
+
+  ! Test a non trivial derived type mixing all sorts of default initialization
+  type(t1) :: dt1
+! CHECK-LABEL: linkonce @_QMtinitEdt1 : !fir.type<_QMtinitTt1{{.*}}> {
+  ! CHECK-DAG: %[[VAL_11:.*]] = constant 42 : i32
+  ! CHECK-DAG: %[[VAL_12:.*]] = constant 100 : index
+  ! CHECK-DAG: %[[VAL_13:.*]] = constant 0 : index
+  ! CHECK-DAG: %[[VAL_14:.*]] = constant 33 : i32
+  ! CHECK-DAG: %[[VAL_15:.*]] = constant 66 : i32
+  ! CHECK: %[[VAL_16:.*]] = fir.undefined !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_17:.*]] = fir.insert_value %[[VAL_16]], %[[VAL_11]], ["i", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, i32) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_18:.*]] = fir.undefined i32
+  ! CHECK: %[[VAL_19:.*]] = fir.insert_value %[[VAL_17]], %[[VAL_18]], ["j", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, i32) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_20:.*]] = fir.address_of(@_QMtinitEziel) : !fir.ref<!fir.array<100xf32>>
+  ! CHECK: %[[VAL_21:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+  ! CHECK: %[[VAL_22:.*]] = fir.embox %[[VAL_20]](%[[VAL_21]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[VAL_23:.*]] = fir.insert_value %[[VAL_19]], %[[VAL_22]], ["x", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_24:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[VAL_25:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
+  ! CHECK: %[[VAL_26:.*]] = fir.embox %[[VAL_24]](%[[VAL_25]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[VAL_27:.*]] = fir.insert_value %[[VAL_23]], %[[VAL_26]], ["y", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_28:.*]] = fir.insert_value %[[VAL_27]], %[[VAL_26]], ["z", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_29:.*]] = fir.string_lit "hello     "(10) : !fir.char<1,10>
+  ! CHECK: %[[VAL_30:.*]] = fir.insert_value %[[VAL_28]], %[[VAL_29]], ["c1", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.char<1,10>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_31:.*]] = fir.undefined !fir.char<1,10>
+  ! CHECK: %[[VAL_32:.*]] = fir.insert_value %[[VAL_30]], %[[VAL_31]], ["c2", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.char<1,10>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_33:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_34:.*]] = fir.insert_value %[[VAL_33]], %[[VAL_15]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_35:.*]] = fir.insert_value %[[VAL_32]], %[[VAL_34]], ["somet0", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_36:.*]] = fir.undefined !fir.type<_QMtinitTtno_init{k:i32}>
+  ! CHECK: %[[VAL_37:.*]] = fir.insert_value %[[VAL_35]], %[[VAL_36]], ["sometno_init", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTtno_init{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_38:.*]] = fir.insert_value %[[VAL_33]], %[[VAL_14]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_39:.*]] = fir.insert_value %[[VAL_37]], %[[VAL_38]], ["somet0_2", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_40:.*]] = fir.insert_value %[[VAL_39]], %[[VAL_34]], ["somet0_array", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: fir.has_value %[[VAL_40]] : !fir.type<_QMtinitTt1{{.*}}>
+
+  ! Test a type extending other type with a default init
+  type(textendst0) :: etextendst0
+! CHECK-LABEL: linkonce @_QMtinitEetextendst0 : !fir.type<_QMtinitTtextendst0{k:i32,l:i32}> {
+  ! CHECK: %[[VAL_42:.*]] = constant 66 : i32
+  ! CHECK: %[[VAL_43:.*]] = fir.undefined !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
+  ! CHECK: %[[VAL_44:.*]] = fir.insert_value %[[VAL_43]], %[[VAL_42]], ["k", !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>] : (!fir.type<_QMtinitTtextendst0{k:i32,l:i32}>, i32) -> !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
+  ! CHECK: %[[VAL_45:.*]] = fir.undefined i32
+  ! CHECK: %[[VAL_46:.*]] = fir.insert_value %[[VAL_44]], %[[VAL_45]], ["l", !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>] : (!fir.type<_QMtinitTtextendst0{k:i32,l:i32}>, i32) -> !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
+  ! CHECK: fir.has_value %[[VAL_46]] : !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
+end module
+
+
+! Test that default initialization is also applied to saved variables
+subroutine saved()
+  use tinit
+  type(t0), save :: savedt0
+! CHECK-LABEL: fir.global internal @_QFsavedEsavedt0 : !fir.type<_QMtinitTt0{k:i32}> {
+  ! CHECK: %[[VAL_47:.*]] = constant 66 : i32
+  ! CHECK: %[[VAL_48:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_49:.*]] = fir.insert_value %[[VAL_48]], %[[VAL_47]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: fir.has_value %[[VAL_49]] : !fir.type<_QMtinitTt0{k:i32}>
+end subroutine
+
+! Test default initialization in equivalences
+subroutine eqv()
+  use tinit
+  type(tseq), save :: somet
+  integer :: i(2)
+  equivalence (somet, i)
+! CHECK-LABEL: fir.global internal @_QFeqvEi : tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>> {
+  ! CHECK-DAG: %[[VAL_50:.*]] = constant 2 : i32
+  ! CHECK-DAG: %[[VAL_51:.*]] = constant 3 : i32
+  ! CHECK: %[[VAL_52:.*]] = fir.undefined tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+  ! CHECK: %[[VAL_53:.*]] = fir.undefined !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_54:.*]] = fir.insert_value %[[VAL_53]], %[[VAL_50]], ["i", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_55:.*]] = fir.insert_value %[[VAL_54]], %[[VAL_51]], ["j", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_56:.*]] = fir.insert_value %[[VAL_52]], %[[VAL_55]], [0 : index] : (tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>, !fir.type<_QMtinitTtseq{i:i32,j:i32}>) -> tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+  ! CHECK: fir.has_value %[[VAL_56]] : tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+end subroutine
+
+subroutine eqv_explicit_init()
+  use tinit
+  type(tseq), save :: somet
+  integer :: i(2) = [4, 5]
+  equivalence (somet, i)
+! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi : tuple<!fir.array<2xi32>> {
+  ! CHECK-DAG: %[[VAL_57:.*]] = constant 4 : i32
+  ! CHECK-DAG: %[[VAL_58:.*]] = constant 5 : i32
+  ! CHECK: %[[VAL_59:.*]] = fir.undefined tuple<!fir.array<2xi32>>
+  ! CHECK: %[[VAL_60:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_61:.*]] = fir.insert_value %[[VAL_60]], %[[VAL_57]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_62:.*]] = fir.insert_value %[[VAL_61]], %[[VAL_58]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_63:.*]] = fir.insert_value %[[VAL_59]], %[[VAL_62]], [0 : index] : (tuple<!fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>>
+  ! CHECK: fir.has_value %[[VAL_63]] : tuple<!fir.array<2xi32>>
+end subroutine
+
+subroutine eqv_same_default_init()
+  use tinit
+  type(tseq), save :: somet1(2), somet2
+  equivalence (somet1(1), somet2)
+! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 : tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>> {
+  ! CHECK-DAG: %[[VAL_64:.*]] = constant 2 : i32
+  ! CHECK-DAG: %[[VAL_65:.*]] = constant 3 : i32
+  ! CHECK: %[[VAL_66:.*]] = fir.undefined tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
+  ! CHECK: %[[VAL_67:.*]] = fir.undefined !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_68:.*]] = fir.insert_value %[[VAL_67]], %[[VAL_64]], ["i", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_69:.*]] = fir.insert_value %[[VAL_68]], %[[VAL_65]], ["j", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
+  ! CHECK: %[[VAL_70:.*]] = fir.undefined !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+  ! CHECK: %[[VAL_71:.*]] = fir.insert_on_range %[[VAL_70]], %[[VAL_69]], [0 : index, 1 : index] : (!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>, !fir.type<_QMtinitTtseq{i:i32,j:i32}>) -> !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+  ! CHECK: %[[VAL_72:.*]] = fir.insert_value %[[VAL_66]], %[[VAL_71]], [0 : index] : (tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>, !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>) -> tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
+  ! CHECK: fir.has_value %[[VAL_72]] : tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
+end subroutine
+
+subroutine eqv_full_overlaps_with_explicit_init()
+  use tinit
+  type(tseq), save :: somet
+  integer, save :: link(4)
+  integer :: i(2) = [5, 6]
+  integer :: j(2) = [7, 8]
+  ! Equivalence: somet fully covered by explicit init.
+  !   i(1)=5 | i(2)=6  |    -    |  -
+  !     -    | somet%i | somet%j |
+  !     -    |    -    | j(1)=7  | j(2)=8
+  equivalence (i, link(1))
+  equivalence (somet, link(2))
+  equivalence (j, link(3))
+! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi : tuple<!fir.array<2xi32>, !fir.array<2xi32>> {
+  ! CHECK-DAG: %[[VAL_73:.*]] = constant 5 : i32
+  ! CHECK-DAG: %[[VAL_74:.*]] = constant 6 : i32
+  ! CHECK-DAG: %[[VAL_75:.*]] = constant 7 : i32
+  ! CHECK-DAG: %[[VAL_76:.*]] = constant 8 : i32
+  ! CHECK: %[[VAL_77:.*]] = fir.undefined tuple<!fir.array<2xi32>, !fir.array<2xi32>>
+  ! CHECK: %[[VAL_78:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_79:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_73]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_80:.*]] = fir.insert_value %[[VAL_79]], %[[VAL_74]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_81:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_80]], [0 : index] : (tuple<!fir.array<2xi32>, !fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>, !fir.array<2xi32>>
+  ! CHECK: %[[VAL_82:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_75]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_83:.*]] = fir.insert_value %[[VAL_82]], %[[VAL_76]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_84:.*]] = fir.insert_value %[[VAL_81]], %[[VAL_83]], [1 : index] : (tuple<!fir.array<2xi32>, !fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>, !fir.array<2xi32>>
+  ! CHECK: fir.has_value %[[VAL_84]] : tuple<!fir.array<2xi32>, !fir.array<2xi32>>
+end subroutine
+
+! TODO: possible extension.
+! subroutine eqv_partial_overlaps_with_explicit_init()
+!   use tinit
+!   type(tseq), save :: somet
+!   integer, save :: link(4)
+!   integer :: i(2) = [5, 6]
+!   integer :: j = 7
+!   ! `somet` is only partially covered by explicit init, somet%j default
+!   ! init value should be used in the equiv storage init to match nvfortran,
+!   ! ifort, and nagfor behavior. Currently hits hard TODO. Note that gfortran
+!   ! refuses this code.
+!   !   i(1)=5 | i(2)=6  |    -    |  -
+!   !     -    | somet%i | somet%j |
+!   !     -    |    -    |    -    | j=7
+!   equivalence (i, link(1))
+!   equivalence (somet, link(2))
+!   equivalence (j, link(4))
+! end subroutine

--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -1,4 +1,4 @@
-! Test lowering of allocatable components
+! Test default initialization of local and dummy variables (dynamic initialization)
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 module test_dinit
@@ -158,26 +158,6 @@ contains
     ! CHECK: return
   end subroutine 
 
-! -----------------------------------------------------------------------------
-!            Test default initialization of global variables.
-! -----------------------------------------------------------------------------
-
-! TODO: Default initialization of static variables. Hits a hard TODO
-! for now.
-
-  !subroutine saved()
-  !  type(t), save :: x
-  !end subroutine
-  !subroutine saved_eq()
-  !  type(tseq), save :: x
-  !  type(tseq), save :: y
-  !  equivalence (x, y)
-  !end subroutine
-  !subroutine saved_eq2()
-  !  type(tseq), save :: x
-  !  integer, save :: i
-  !  equivalence (x, i)
-  !end subroutine
 end module
 
 ! End-to-end test for debug pruposes.

--- a/flang/test/Lower/equivalence-2.f90
+++ b/flang/test/Lower/equivalence-2.f90
@@ -24,7 +24,7 @@ subroutine test_eq_sets
   DIMENSION Ag(2), Bg(2)
   SAVE Ag, Bg
   EQUIVALENCE (Ag(1), Bg(2))
-  ! CHECK-DAG: %[[agbgStore:.*]] = fir.address_of(@_QFtest_eq_setsEag) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<8xi8>>>
+  ! CHECK-DAG: %[[agbgStore:.*]] = fir.address_of(@_QFtest_eq_setsEbg) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<8xi8>>>
   ! CHECK-DAG: %[[agbg:.*]] = fir.convert %[[agbgStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<8xi8>>>) -> !fir.ref<!fir.array<12xi8>>
   ! CHECK-DAG: %[[agAddr:.*]] = fir.coordinate_of %[[agbg]], %c4{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
   ! CHECK-DAG: %[[ag:.*]] = fir.convert %[[agAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
@@ -55,7 +55,7 @@ subroutine eq_and_entry_foo
   DIMENSION :: x(2)
   EQUIVALENCE (x(2), i) 
   call foo1(x, i)
-  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEi) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
+  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEx) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
   ! CHECK-DAG: %[[xi:.*]] = fir.convert %[[xiStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>) -> !fir.ref<!fir.array<8xi8>>
 
   ! CHECK-DAG: %[[iOffset:.*]] = constant 4 : index
@@ -73,7 +73,7 @@ subroutine eq_and_entry_foo
 end
 
 ! CHECK-LABEL: @_QPeq_and_entry_bar()
-  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEi) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
+  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEx) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
   ! CHECK-DAG: %[[xi:.*]] = fir.convert %[[xiStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>) -> !fir.ref<!fir.array<8xi8>>
 
   ! CHECK-DAG: %[[iOffset:.*]] = constant 4 : index

--- a/flang/test/Lower/equivalence-static-init.f90
+++ b/flang/test/Lower/equivalence-static-init.f90
@@ -1,0 +1,22 @@
+! RUN: bbc -emit-fir -o - %s | FileCheck %s
+
+! Test explicit static initialization of equivalence storage
+
+subroutine test_eqv_init
+  integer, save :: link(3)
+  integer :: i = 5
+  integer :: j = 7
+  equivalence (j, link(1))
+  equivalence (i, link(3))
+end subroutine
+
+! CHECK-LABEL: fir.global internal @_QFtest_eqv_initEj : tuple<i32, !fir.array<4xi8>, i32> {
+  ! CHECK: %[[VAL_0:.*]] = fir.undefined tuple<i32, !fir.array<4xi8>, i32>
+  ! CHECK: %[[VAL_1:.*]] = constant 7 : i32
+  ! CHECK: %[[VAL_2:.*]] = constant 0 : index
+  ! CHECK: %[[VAL_3:.*]] = fir.insert_value %[[VAL_0]], %[[VAL_1]], [0 : index] : (tuple<i32, !fir.array<4xi8>, i32>, i32) -> tuple<i32, !fir.array<4xi8>, i32>
+  ! CHECK: %[[VAL_4:.*]] = constant 5 : i32
+  ! CHECK: %[[VAL_5:.*]] = constant 2 : index
+  ! CHECK: %[[VAL_6:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_4]], [2 : index] : (tuple<i32, !fir.array<4xi8>, i32>, i32) -> tuple<i32, !fir.array<4xi8>, i32>
+  ! CHECK: fir.has_value %[[VAL_6]] : tuple<i32, !fir.array<4xi8>, i32>
+! CHECK }

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -21,10 +21,10 @@ module modEq1
   real :: y2(10)
   equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
 end module
-! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ex1 : tuple<!fir.array<36xi8>, !fir.array<40xi8>> {
-  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<36xi8>, !fir.array<40xi8>>
-  ! CHECK: fir.has_value %[[undef]] : tuple<!fir.array<36xi8>, !fir.array<40xi8>>
-! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey1 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ex3 : tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>  {
+  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>
+  ! CHECK: fir.has_value %[[undef]] : tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey2 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
   ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
   ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
   ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], [1 : index] : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>

--- a/flang/test/Lower/module_use_in_same_file.f90
+++ b/flang/test/Lower/module_use_in_same_file.f90
@@ -43,24 +43,24 @@ module modEq2
 contains
   ! CHECK-LABEL: func @_QMmodeq2Pfoo()
   real function foo()
-    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
-    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
     foo = x2(1) + y1
   end function
 end module
 ! CHECK-LABEL: func @_QPmodeq2use()
 real function modEq2use()
   use modEq2
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
   modEq2use = x2(1) + y1
 end function
 ! Test rename of used equivalence members
 ! CHECK-LABEL: func @_QPmodeq2use_rename()
 real function modEq2use_rename()
   use modEq2, only: renamedx => x2, renamedy => y1
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
   modEq2use = renamedx(1) + renamedy
 end function
 
@@ -114,9 +114,9 @@ real function test_no_equiv_conflicts()
   real :: y2l(10)
   save :: x1l, x2l, x3l, y1l, y2l
   equivalence (x1l(1), x2l(5), x3l(10)), (y1l, y2l(5))
-  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEx1l) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEy1l) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<tuple<!fir.array<36xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEx3l) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEy2l) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
   test_no_equiv_conflicts = x2(1) + y1 + x2l(1) + y1l
 end function


### PR DESCRIPTION
Add a `genDefaultInitializerValue` method in variable lowering that
generates the body of the global op that must be default initialized.

Default initialized defers from explicit initialization because all the
component may not have an initialization, therefore the front-end is not
providing a top level `ev::Expr` that can be lowered for the derived type.
Hence, lowering visits each components and lower any default
initialization if present or leave the component undefined otherwise.

`genDefaultInitializerValue` is recursive because component without a
default initialization value can be of a derived type whose component
have default initialization.

Default initialization also applies to variable in equivalences. The
standard is not 100% clear about the possibility of mixing overlapping
default and explicit initialization. This PR support full overlaps (the
default initialization is completely overridden by explicit
initialization of other equivalence members), no overlap (the default
initialization is fully apply to the equivalence storage). It however
does not support mixing pieces of explicit initialization from other
equivalence members over part of the default initialization (the
situation is detected and a TODO emitted). Not all compilers support
this last case (nagfor, ifort and nvfortran support this, gfortran refuses it,
and xlf silently ignores the explicit initialization).

In its first commit, this PR fixes a bug with equivalences that became obvious while testing default initialization. The AggregateStore variables were sorted in source order while the initialization algorithm expected them in offset order. For most tests, it was not an issue because the source and offset order happened to match, or there was no initialization and the bug lead to bigger storage than needed, so it was not really visible. Sort the variables in offset order in `AggregateStore` constructor to solve the issue.