### PR TITLE
zero size common blocks

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -777,9 +777,12 @@ defineCommonBlock(Fortran::lower::AbstractConverter &converter,
   auto idxTy = builder.getIndexType();
   auto linkage = builder.createCommonLinkage();
   if (!common.name().size() || !commonBlockHasInit(cmnBlkMems)) {
-    const auto sz = static_cast<fir::SequenceType::Extent>(common.size());
-    // anonymous COMMON must always be initialized to zero
-    // a named COMMON sans initializers is also initialized to zero
+    // A blank (anonymous) COMMON block must always be initialized to zero.
+    // A named COMMON block sans initializers is also initialized to zero.
+    // mlir::Vector types must have a strictly positive size, so at least
+    // temporarily, force a zero size COMMON block to have one byte.
+    const auto sz = static_cast<fir::SequenceType::Extent>(
+        common.size() > 0 ? common.size() : 1);
     fir::SequenceType::Shape shape = {sz};
     auto i8Ty = builder.getIntegerType(8);
     auto commonTy = fir::SequenceType::get(shape, i8Ty);

--- a/flang/test/Lower/common-block.f90
+++ b/flang/test/Lower/common-block.f90
@@ -4,6 +4,7 @@
 ! CHECK: @_QBx = global { float, float } { float 1.0{{.*}}, float 2.0{{.*}} }
 ! CHECK: @_QBy = common global [12 x i8] zeroinitializer
 ! CHECK: @_QBz = global { i32, [4 x i8], float } { i32 42, [4 x i8] undef, float 3.000000e+00 }
+! CHECK: @_QBrien = common global [1 x i8] zeroinitializer
 
 ! CHECK-LABEL: _QPs0
 subroutine s0
@@ -12,7 +13,6 @@ subroutine s0
   ! CHECK: call void @_QPs(float* bitcast ([8 x i8]* @_QB to float*), float* bitcast (i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_QB, i32 0, i64 4) to float*))
   call s(a0, b0)
 end subroutine s0
-
 
 ! CHECK-LABEL: _QPs1
 subroutine s1
@@ -43,8 +43,7 @@ subroutine s3
  equivalence (i, x), (glue(1), c), (glue(2), y)
  ! x and c are not directly initialized, but overlapping aliases are.
  common /z/ x, c
-end
-
+end subroutine s3
 
 module mod_with_common
   integer :: i, j
@@ -57,4 +56,10 @@ subroutine s4
   print *, i
   ! CHECK: load i32, i32* bitcast (i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_QBc_in_mod, i32 0, i64 4) to i32*)
   print *, j
-end subroutine
+end subroutine s4
+
+! CHECK-LABEL: _QPs5
+subroutine s5
+  real r(1:0)
+  common /rien/ r
+end subroutine s5


### PR DESCRIPTION
Common blocks without explicit initialization are initialized with an mlir::VectorType initializer, which must have a strictly positive size:

```
  real nada(1:0)
  common /empty/ nada
```

```
  fir.global common @_QBempty(dense<0> : vector<0xi8>) : !fir.array<0xi8>
```

```
  error: vector types must have positive constant sizes
```

An alternative is to instead initialize with a fir::SequenceType, but that leads to a tco error:

```
  fir.global common @_QBempty : !fir.array<0xi8> {
    %0 = fir.undefined !fir.array<0xi8>
    fir.has_value %0 : !fir.array<0xi8>
  }
```

```
  'common' global must have a zero initializer!
  [0 x i8]* @_QBempty
  error: could not emit LLVM-IR
```

Work around these issues by forcing zero size common blocks to have one byte:

```
  fir.global common @_QBempty(dense<0> : vector<1xi8>) : !fir.array<1xi8>
```

Note:  There is an additional front end bug where most zero size common blocks are incorrectly given non-zero size.  This additional bug needs to be addressed to allow correct compilation of those cases.