### PR TITLE
Ensure scalar args are lowered to ref if needed in elemental calls

### DIFF
--- a/flang/test/Lower/array-elemental-calls.f90
+++ b/flang/test/Lower/array-elemental-calls.f90
@@ -1,0 +1,52 @@
+! Test lowering of elemental calls in array expressions.
+! RUN: bbc -o - -emit-fir %s | FileCheck %s
+
+module scalar_in_elem
+
+contains
+elemental integer function elem_by_ref(a,b) result(r)
+  integer, intent(in) :: a
+  real, intent(in) :: b
+  r = a + b
+end function
+elemental integer function elem_by_valueref(a,b) result(r)
+  integer, value :: a
+  real, value :: b
+  r = a + b
+end function
+
+! CHECK-LABEL: func @_QMscalar_in_elemPtest_elem_by_ref(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>
+subroutine test_elem_by_ref(i, j)
+  integer :: i(100), j(100)
+  ! CHECK: %[[tmp:.*]] = fir.alloca f32
+  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
+  ! CHECK: fir.store %[[cst]] to %[[tmp]] : !fir.ref<f32>
+
+  ! CHECK: fir.do_loop
+    ! CHECK: %[[j:.*]] = fir.array_coor %[[arg1]](%{{.*}}) %{{.*}} : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
+    ! CHECK: fir.call @_QMscalar_in_elemPelem_by_ref(%[[j]], %[[tmp]]) : (!fir.ref<i32>, !fir.ref<f32>) -> i32
+    ! CHECK: fir.result
+  i = elem_by_ref(j, 42.)
+end
+
+! CHECK-LABEL: func @_QMscalar_in_elemPtest_elem_by_valueref(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>,
+! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>
+subroutine test_elem_by_valueref(i, j)
+  integer :: i(100), j(100)
+  ! CHECK-DAG: %[[tmpA:.*]] = fir.alloca i32 {adapt.valuebyref, uniq_name = {{.*}}}
+  ! CHECK-DAG: %[[tmpB:.*]] = fir.alloca f32 {adapt.valuebyref, uniq_name = {{.*}}}
+  ! CHECK: %[[jload:.*]] = fir.array_load %[[arg1]]
+  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
+  ! CHECK: fir.store %[[cst]] to %[[tmpB]] : !fir.ref<f32>
+
+  ! CHECK: fir.do_loop
+    ! CHECK: %[[j:.*]] = fir.array_fetch %[[jload]], %{{.*}} : (!fir.array<100xi32>, index) -> i32
+    ! CHECK: fir.store %[[j]] to %[[tmpA]] : !fir.ref<i32>
+    ! CHECK: fir.call @_QMscalar_in_elemPelem_by_valueref(%[[tmpA]], %[[tmpB]]) : (!fir.ref<i32>, !fir.ref<f32>) -> i32
+    ! CHECK: fir.result
+  i = elem_by_valueref(j, 42.)
+end
+end module


### PR DESCRIPTION
Scalars were args were lowered to value in elemental calls where they needed
to be passed by reference. Lower scalar to a reference when the elemental function
takes a reference. In case the elemental arg is passed by value, lower the arg by
value and store the value in a temp that is passed to the call.

This fixes the error "'llvm.call' op operand type mismatch for operand 1" in
nag_f08_95 l7.f90, e7.f90, e8.f90, and e9.f90.

It is not 100% clear to me that the by address case is OK from an aliasing point
of view (e.g. in `i = foo(j, i(10))` the current passing the raw address of i(10)
at every iteration).