### PR TITLE
Cherry pick system clock implementation patch from phabricator

### DIFF
--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -106,6 +106,58 @@ count_t GetSystemClockCountMax(fallback_implementation) {
   return std::min(std::numeric_limits<std::clock_t>::max(),
       std::numeric_limits<count_t>::max());
 }
+
+constexpr count_t NSECS_PER_SEC{1'000'000'000};
+
+// POSIX implementation using clock_gettime. This is only enabled if
+// clock_gettime is available.
+template <typename T = int, typename U = struct timespec>
+count_t GetSystemClockCount(preferred_implementation,
+    // We need some dummy parameters to pass to decltype(clock_gettime).
+    T ClockId = 0, U *Timespec = nullptr,
+    decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
+#if defined CLOCK_THREAD_CPUTIME_ID
+#define CLOCKID CLOCK_THREAD_CPUTIME_ID
+#elif defined CLOCK_PROCESS_CPUTIME_ID
+#define CLOCKID CLOCK_PROCESS_CPUTIME_ID
+#elif defined CLOCK_MONOTONIC
+#define CLOCKID CLOCK_MONOTONIC
+#else
+#define CLOCKID CLOCK_REALTIME
+#endif
+  struct timespec tspec;
+  if (clock_gettime(CLOCKID, &tspec) != 0) {
+    // Return -HUGE() to represent failure.
+    return -std::numeric_limits<count_t>::max();
+  }
+
+  // Wrap around to avoid overflows.
+  constexpr count_t max_secs{
+      std::numeric_limits<count_t>::max() / NSECS_PER_SEC};
+  count_t wrapped_secs{tspec.tv_sec % max_secs};
+
+  // At this point, wrapped_secs < max_secs, and max_secs has already been
+  // truncated by the division. Therefore, we should still have enough room to
+  // add tv_nsec, since it is < NSECS_PER_SEC.
+  return tspec.tv_nsec + wrapped_secs * NSECS_PER_SEC;
+}
+
+template <typename T = int, typename U = struct timespec>
+count_t GetSystemClockCountRate(preferred_implementation,
+    // We need some dummy parameters to pass to decltype(clock_gettime).
+    T ClockId = 0, U *Timespec = nullptr,
+    decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
+  return NSECS_PER_SEC;
+}
+
+template <typename T = int, typename U = struct timespec>
+count_t GetSystemClockCountMax(preferred_implementation,
+    // We need some dummy parameters to pass to decltype(clock_gettime).
+    T ClockId = 0, U *Timespec = nullptr,
+    decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
+  count_t max_secs{std::numeric_limits<count_t>::max() / NSECS_PER_SEC};
+  return max_secs * NSECS_PER_SEC - 1;
+}
 } // anonymous namespace
 
 namespace Fortran::runtime {

--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -13,6 +13,8 @@
 #include <ctime>
 
 // CPU_TIME (Fortran 2018 16.9.57)
+// SYSTEM_CLOCK (Fortran 2018 16.9.168)
+//
 // We can use std::clock() from the <ctime> header as a fallback implementation
 // that should be available everywhere. This may not provide the best resolution
 // and is particularly troublesome on (some?) POSIX systems where CLOCKS_PER_SEC
@@ -68,11 +70,59 @@ double GetCpuTime(preferred_implementation,
   // Return some negative value to represent failure.
   return -1.0;
 }
+
+using count_t =
+    Fortran::runtime::CppTypeFor<Fortran::common::TypeCategory::Integer, 8>;
+
+// This is the fallback implementation, which should work everywhere. Note that
+// in general we can't recover after std::clock has reached its maximum value.
+template <typename Unused = void>
+count_t GetSystemClockCount(fallback_implementation) {
+  std::clock_t timestamp{std::clock()};
+  if (timestamp == static_cast<std::clock_t>(-1)) {
+    // Return -HUGE() to represent failure.
+    return -std::numeric_limits<count_t>::max();
+  }
+
+  // If our return type is large enough to hold any value returned by
+  // std::clock, our work is done. Otherwise, we have to wrap around.
+  static constexpr auto max{std::numeric_limits<count_t>::max()};
+  if constexpr (max <= std::numeric_limits<count_t>::max()) {
+    return static_cast<count_t>(timestamp);
+  } else {
+    // Since std::clock_t could be a floating point type, we can't just use the
+    // % operator, so we have to wrap around manually.
+    return static_cast<count_t>(timestamp - max * std::floor(timestamp / max));
+  }
+}
+
+template <typename Unused = void>
+count_t GetSystemClockCountRate(fallback_implementation) {
+  return CLOCKS_PER_SEC;
+}
+
+template <typename Unused = void>
+count_t GetSystemClockCountMax(fallback_implementation) {
+  return std::min(std::numeric_limits<std::clock_t>::max(),
+      std::numeric_limits<count_t>::max());
+}
 } // anonymous namespace
 
 namespace Fortran::runtime {
 extern "C" {
 
 double RTNAME(CpuTime)() { return GetCpuTime(0); }
+
+CppTypeFor<TypeCategory::Integer, 8> RTNAME(SystemClockCount)() {
+  return GetSystemClockCount(0);
+}
+
+CppTypeFor<TypeCategory::Integer, 8> RTNAME(SystemClockCountRate)() {
+  return GetSystemClockCountRate(0);
+}
+
+CppTypeFor<TypeCategory::Integer, 8> RTNAME(SystemClockCountMax)() {
+  return GetSystemClockCountMax(0);
+}
 } // extern "C"
 } // namespace Fortran::runtime

--- a/flang/unittests/RuntimeGTest/Time.cpp
+++ b/flang/unittests/RuntimeGTest/Time.cpp
@@ -26,3 +26,33 @@ TEST(TimeIntrinsics, CpuTime) {
     ASSERT_GE(end, start);
   }
 }
+
+using count_t = CppTypeFor<TypeCategory::Integer, 8>;
+
+TEST(TimeIntrinsics, SystemClock) {
+  // We can't really test that we get the "right" result for SYSTEM_CLOCK, but
+  // we can have a smoke test to see that we get something reasonable on the
+  // platforms where we expect to support it.
+
+  // The value of the count rate and max will vary by platform, but they should
+  // always be strictly positive if we have a working implementation of
+  // SYSTEM_CLOCK.
+  EXPECT_GT(RTNAME(SystemClockCountRate)(), 0);
+
+  count_t max{RTNAME(SystemClockCountMax)()};
+  EXPECT_GT(max, 0);
+
+  count_t start{RTNAME(SystemClockCount)()};
+  EXPECT_GE(start, 0);
+  EXPECT_LE(start, max);
+
+  // Loop until we get a different value from SystemClockCount. If we don't get
+  // one before we time out, then we should probably look into an implementation
+  // for SystemClokcCount with a better timer resolution on this platform.
+  for (count_t end = start; end == start; end = RTNAME(SystemClockCount)()) {
+    EXPECT_GE(end, 0);
+    EXPECT_LE(end, max);
+
+    EXPECT_GE(end, start);
+  }
+}


### PR DESCRIPTION
Cherry-picks:
- https://reviews.llvm.org/D105969
- https://reviews.llvm.org/D105970

The phabricator reviews cannot be merged in LLVM currently because this would break the Windows builds and Diana is on vacation.

I am assuming the windows build issue is OK in fir-dev, and we want to move along with testing. I'll revert and replace by the actual piece of work once it is merged in LLVM.