### PR TITLE
Ensure used module variables are mapped when lowering internal procedures.

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -740,6 +740,16 @@ static parser::CharBlock stmtSourceLoc(const T &stmt) {
   return stmt.visit(common::visitors{[](const auto &x) { return x.source; }});
 }
 
+/// Get the first PFT ancestor node that has type ParentType.
+template <typename ParentType, typename A>
+ParentType *getAncestor(A &node) {
+  if (auto *seekedParent = node.parent.template getIf<ParentType>())
+    return seekedParent;
+  return node.parent.visit(common::visitors{
+      [](Program &p) -> ParentType * { return nullptr; },
+      [](auto &p) -> ParentType * { return getAncestor<ParentType>(p); }});
+}
+
 } // namespace Fortran::lower::pft
 
 namespace Fortran::lower {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6181,6 +6181,7 @@ void ResolveNamesVisitor::HandleProcedureName(
   } else if (CheckUseError(name)) {
     // error was reported
   } else {
+    auto &nonUltimateSymbol = *symbol;
     symbol = &Resolve(name, symbol)->GetUltimate();
     bool convertedToProcEntity{ConvertToProcEntity(*symbol)};
     if (convertedToProcEntity && !symbol->attrs().test(Attr::EXTERNAL) &&
@@ -6205,8 +6206,10 @@ void ResolveNamesVisitor::HandleProcedureName(
       // a mis-parsed array references that will be fixed later. Ensure that if
       // this is a symbol from a host procedure, a symbol with HostAssocDetails
       // is created for the current scope.
-      if (IsUplevelReference(*symbol)) {
-        MakeHostAssocSymbol(name, *symbol);
+      // Operate on non ultimate symbol so that HostAssocDetails are also
+      // created for symbols used associated in the host procedure.
+      if (IsUplevelReference(nonUltimateSymbol)) {
+        MakeHostAssocSymbol(name, nonUltimateSymbol);
       }
     } else if (symbol->test(Symbol::Flag::Implicit)) {
       Say(name,
@@ -6607,7 +6610,8 @@ bool ResolveNamesVisitor::Pre(const parser::PointerAssignmentStmt &x) {
       // If the name is known because it is an object entity from a host
       // procedure, create a host associated symbol.
       if (Symbol * symbol{name->symbol}; symbol &&
-          symbol->has<ObjectEntityDetails>() && IsUplevelReference(*symbol)) {
+          symbol->GetUltimate().has<ObjectEntityDetails>() &&
+          IsUplevelReference(*symbol)) {
         MakeHostAssocSymbol(*name, *symbol);
       }
       return false;

--- a/flang/test/Lower/module-and-internal-proc.f90
+++ b/flang/test/Lower/module-and-internal-proc.f90
@@ -1,0 +1,39 @@
+! Test that module data access are lowered correctly in the different
+! procedure contexts.
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module parent
+  integer :: i
+contains
+! Test simple access to the module data
+! CHECK-LABEL: func @_QMparentPtest1
+subroutine test1()
+  ! CHECK: fir.address_of(@_QMparentEi) : !fir.ref<i32>
+  print *, i
+end subroutine
+
+! Test access to the module data inside an internal procedure where the
+! host is defined inside the module.
+subroutine test2()
+  call test2internal()
+  contains
+  ! CHECK-LABEL: func @_QMparentFtest2Ptest2internal()
+  subroutine test2internal()
+    ! CHECK: fir.address_of(@_QMparentEi) : !fir.ref<i32>
+    print *, i
+  end subroutine
+end subroutine
+end module
+
+! Test access to the module data inside an internal procedure where the
+! host is using the module.
+subroutine test3()
+  use parent
+  call test3internal()
+  contains
+  ! CHECK-LABEL: func @_QFtest3Ptest3internal()
+  subroutine test3internal()
+    ! CHECK: fir.address_of(@_QMparentEi) : !fir.ref<i32>
+    print *, i
+  end subroutine
+end subroutine

--- a/flang/test/Semantics/symbol03.f90
+++ b/flang/test/Semantics/symbol03.f90
@@ -54,3 +54,49 @@ contains
   p => x
  end subroutine
 end subroutine
+
+! Test host associated symbols are also created for symbols that are use
+! associated in the host.
+
+!DEF: /m1 Module
+module m1
+ !DEF: /m1/x PUBLIC ObjectEntity REAL(4)
+ real x(100,100)
+ !DEF: /m1/x_target PUBLIC, TARGET ObjectEntity REAL(4)
+ real, target :: x_target
+end module
+
+!DEF: /s_use (Subroutine) Subprogram
+subroutine s_use
+ !REF: /m1
+ use :: m1
+ !DEF: /s_use/x Use REAL(4)
+ print *, x
+ !DEF: /s_use/s1 (Subroutine) Subprogram
+ call s1
+contains
+ !REF: /s_use/s1
+ subroutine s1
+  !DEF: /s_use/s1/x HostAssoc REAL(4)
+  print *, x(10,10)
+ end subroutine
+end subroutine
+
+!DEF: /sb_use (Subroutine) Subprogram
+subroutine sb_use
+ !REF: /m1
+ use :: m1
+ !DEF: /sb_use/x_target TARGET Use REAL(4)
+ print *, x_target
+ !DEF: /sb_use/s1 (Subroutine) Subprogram
+ call s1
+contains
+ !REF: /sb_use/s1
+ subroutine s1
+  !DEF: /sb_use/s1/p POINTER ObjectEntity REAL(4)
+  real, pointer :: p
+  !REF: /sb_use/s1/p
+  !DEF: /sb_use/s1/x_target TARGET HostAssoc REAL(4)
+  p => x_target
+ end subroutine
+end subroutine


### PR DESCRIPTION
Fixes #941 and similar issues.

When an internal procedure is defined inside a module procedure, it may access the module variables. These accesses are not materialized by associated symbols in the internal procedure scope, so lowering must instantiate all the parent module variables before lowering the internal procedure so that any reference to the module symbols can be resolved as it is done with module procedures currently. Unused instantiation are later discarded by dead code elimination.
This is done by improving the PFT infrastructure to easily look for ModuleLikeUnit ancestors of a FunctionLikeUnit.

Also update the case where the internal procedure is not in a module procedure but simply in a procedure that uses module variables. This case compiled and worked, but the module variable was passed via the host tuple when it can simply be instantiated directly from the module address inside the internal procedure.

Finally, a front-end fix was required in the case where module variables used in the host procedure are referenced inside the internal procedure in mis-parsed array-ref. A previous similar front-end fix did not account for the module variable case. This fixed was already review and merged in LLVM and is simply cherry-picked here.