### PR TITLE
[OpenMP] Add support for lowering Critical Construct

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3590,17 +3590,19 @@ struct OpenMPDeclarativeConstruct {
       u;
 };
 
-// 2.13.2 CRITICAL [Name] <block> END CRITICAL [Name]
 struct OmpCriticalDirective {
   TUPLE_CLASS_BOILERPLATE(OmpCriticalDirective);
   CharBlock source;
-  std::tuple<Verbatim, std::optional<Name>, std::optional<OmpClause>> t;
+  std::tuple<Verbatim, std::optional<Name>, OmpClauseList> t;
 };
 struct OmpEndCriticalDirective {
   TUPLE_CLASS_BOILERPLATE(OmpEndCriticalDirective);
   CharBlock source;
   std::tuple<Verbatim, std::optional<Name>> t;
 };
+// [OMP-5.0] 2.17.1 CRITICAL [(Name) [[,] hint(hint-expression)]]
+//                  <block>
+//                  END CRITICAL [Name]
 struct OpenMPCriticalConstruct {
   TUPLE_CLASS_BOILERPLATE(OpenMPCriticalConstruct);
   std::tuple<OmpCriticalDirective, Block, OmpEndCriticalDirective> t;

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -660,14 +660,13 @@ void Fortran::lower::genOpenMPConstruct(
                 return firOpBuilder.create<mlir::omp::CriticalOp>(
                     currentLocation, FlatSymbolRefAttr(), hint);
               } else {
-                auto type = fir::CharacterType::get(firOpBuilder.getContext(),
-                                                    1, name.size());
-                auto global = firOpBuilder.getNamedGlobal(name);
+		auto module = firOpBuilder.getModule();
+		mlir::OpBuilder modBuilder(module.getBodyRegion());
+		auto global = module.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
                 if (!global)
-                  global = firOpBuilder.createGlobalConstant(currentLocation,
-                                                             type, name);
+                  global = modBuilder.create<mlir::omp::CriticalDeclareOp>(currentLocation, name);
                 return firOpBuilder.create<mlir::omp::CriticalOp>(
-                    currentLocation, global.getSymbol(), hint);
+                    currentLocation, firOpBuilder.getSymbolRefAttr(global.sym_name()), hint);
               }
             }();
             createBodyOfOp<omp::CriticalOp>(criticalOp, converter,

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -593,6 +593,51 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
                                 &wsLoopOpClauseList, iv);
 }
 
+static void
+genOMP(Fortran::lower::AbstractConverter &converter,
+       const Fortran::parser::OpenMPCriticalConstruct &criticalConstruct) {
+  auto &firOpBuilder = converter.getFirOpBuilder();
+  auto currentLocation = converter.getCurrentLocation();
+  std::string name;
+  const Fortran::parser::OmpCriticalDirective &cd =
+      std::get<Fortran::parser::OmpCriticalDirective>(criticalConstruct.t);
+  if (std::get<std::optional<Fortran::parser::Name>>(cd.t).has_value()) {
+    name =
+        std::get<std::optional<Fortran::parser::Name>>(cd.t).value().ToString();
+  }
+
+  mlir::omp::SyncHintKindAttr hint;
+  const auto &clauseList = std::get<Fortran::parser::OmpClauseList>(cd.t);
+  for (const auto &clause : clauseList.v)
+    if (auto hintClause =
+            std::get_if<Fortran::parser::OmpClause::Hint>(&clause.u)) {
+      const auto *expr = Fortran::semantics::GetExpr(hintClause->v);
+      const auto hintValue = Fortran::evaluate::ToInt64(*expr);
+      hint = mlir::omp::SyncHintKindAttr::get(
+          firOpBuilder.getContext(),
+          mlir::omp::symbolizeSyncHintKind(*hintValue).getValue());
+      break;
+    }
+
+  mlir::omp::CriticalOp criticalOp = [&]() -> mlir::omp::CriticalOp {
+    if (name.empty()) {
+      return firOpBuilder.create<mlir::omp::CriticalOp>(
+          currentLocation, FlatSymbolRefAttr(), hint);
+    } else {
+      auto module = firOpBuilder.getModule();
+      mlir::OpBuilder modBuilder(module.getBodyRegion());
+      auto global = module.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
+      if (!global)
+        global = modBuilder.create<mlir::omp::CriticalDeclareOp>(
+            currentLocation, name);
+      return firOpBuilder.create<mlir::omp::CriticalOp>(
+          currentLocation, firOpBuilder.getSymbolRefAttr(global.sym_name()),
+          hint);
+    }
+  }();
+  createBodyOfOp<omp::CriticalOp>(criticalOp, converter, currentLocation);
+}
+
 void Fortran::lower::genOpenMPConstruct(
     Fortran::lower::AbstractConverter &converter,
     Fortran::lower::pft::Evaluation &eval,
@@ -626,52 +671,7 @@ void Fortran::lower::genOpenMPConstruct(
             TODO(converter.getCurrentLocation(), "OpenMPAtomicConstruct");
           },
           [&](const Fortran::parser::OpenMPCriticalConstruct
-                  &criticalConstruct) {
-            auto &firOpBuilder = converter.getFirOpBuilder();
-            auto currentLocation = converter.getCurrentLocation();
-            std::string name;
-            const Fortran::parser::OmpCriticalDirective &cd =
-                std::get<Fortran::parser::OmpCriticalDirective>(
-                    criticalConstruct.t);
-            if (std::get<std::optional<Fortran::parser::Name>>(cd.t)
-                    .has_value()) {
-              name = std::get<std::optional<Fortran::parser::Name>>(cd.t)
-                         .value()
-                         .ToString();
-            }
-
-            mlir::omp::SyncHintKindAttr hint;
-            const auto &clauseList =
-                std::get<Fortran::parser::OmpClauseList>(cd.t);
-            for (const auto &clause : clauseList.v)
-              if (auto hintClause =
-                      std::get_if<Fortran::parser::OmpClause::Hint>(
-                          &clause.u)) {
-                const auto *expr = Fortran::semantics::GetExpr(hintClause->v);
-                const auto hintValue = Fortran::evaluate::ToInt64(*expr);
-                hint = mlir::omp::SyncHintKindAttr::get(
-                    firOpBuilder.getContext(),
-                    mlir::omp::symbolizeSyncHintKind(*hintValue).getValue());
-                break;
-              }
-
-            mlir::omp::CriticalOp criticalOp = [&]() -> mlir::omp::CriticalOp {
-              if (name.empty()) {
-                return firOpBuilder.create<mlir::omp::CriticalOp>(
-                    currentLocation, FlatSymbolRefAttr(), hint);
-              } else {
-		auto module = firOpBuilder.getModule();
-		mlir::OpBuilder modBuilder(module.getBodyRegion());
-		auto global = module.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
-                if (!global)
-                  global = modBuilder.create<mlir::omp::CriticalDeclareOp>(currentLocation, name);
-                return firOpBuilder.create<mlir::omp::CriticalOp>(
-                    currentLocation, firOpBuilder.getSymbolRefAttr(global.sym_name()), hint);
-              }
-            }();
-            createBodyOfOp<omp::CriticalOp>(criticalOp, converter,
-                                            currentLocation);
-          },
+                  &criticalConstruct) { genOMP(converter, criticalConstruct); },
       },
       ompConstruct.u);
 }

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -467,7 +467,7 @@ TYPE_PARSER(startOmpLine >>
         verbatim("END CRITICAL"_tok), maybe(parenthesized(name)))) /
         endOmpLine)
 TYPE_PARSER(sourced(construct<OmpCriticalDirective>(verbatim("CRITICAL"_tok),
-                maybe(parenthesized(name)), maybe(Parser<OmpClause>{}))) /
+                maybe(parenthesized(name)), Parser<OmpClauseList>{})) /
     endOmpLine)
 
 TYPE_PARSER(construct<OpenMPCriticalConstruct>(

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2287,7 +2287,7 @@ public:
     BeginOpenMP();
     Word("!$OMP CRITICAL");
     Walk(" (", std::get<std::optional<Name>>(x.t), ")");
-    Walk(std::get<std::optional<OmpClause>>(x.t));
+    Walk(std::get<OmpClauseList>(x.t));
     Put("\n");
     EndOpenMP();
   }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -308,7 +308,7 @@ public:
   bool Pre(const parser::OpenMPSectionsConstruct &);
   void Post(const parser::OpenMPSectionsConstruct &) { PopContext(); }
 
-  bool Pre(const parser::OpenMPCriticalConstruct &);
+  bool Pre(const parser::OpenMPCriticalConstruct &x);
   void Post(const parser::OpenMPCriticalConstruct &) { PopContext(); }
 
   bool Pre(const parser::OpenMPDeclareSimdConstruct &x) {
@@ -1332,8 +1332,18 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPSectionsConstruct &x) {
 }
 
 bool OmpAttributeVisitor::Pre(const parser::OpenMPCriticalConstruct &x) {
-  const auto &criticalDir{std::get<parser::OmpCriticalDirective>(x.t)};
-  PushContext(criticalDir.source, llvm::omp::Directive::OMPD_critical);
+  const auto &beginCriticalDir{std::get<parser::OmpCriticalDirective>(x.t)};
+  const auto &endCriticalDir{std::get<parser::OmpEndCriticalDirective>(x.t)};
+  PushContext(beginCriticalDir.source, llvm::omp::Directive::OMPD_critical);
+
+  if (const auto &criticalName{
+          std::get<std::optional<parser::Name>>(beginCriticalDir.t)}) {
+    ResolveOmpName(*criticalName, Symbol::Flag::OmpCriticalLock);
+  }
+  if (const auto &endCriticalName{
+          std::get<std::optional<parser::Name>>(endCriticalDir.t)}) {
+    ResolveOmpName(*endCriticalName, Symbol::Flag::OmpCriticalLock);
+  }
   return true;
 }
 
@@ -1454,6 +1464,12 @@ void OmpAttributeVisitor::ResolveOmpName(
         AddToContextObjectWithDSA(*resolvedSymbol, ompFlag);
       }
     }
+  } else if (ompFlag == Symbol::Flag::OmpCriticalLock) {
+    // Create a new symbol.
+    const auto pair{GetContext().scope.try_emplace(
+        name.source, Attrs{}, UnknownDetails{})};
+    CHECK(pair.second);
+    name.symbol = &pair.first->second.get();
   }
 }
 

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -24,9 +24,16 @@ program mn
 !LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var)
 !$OMP END CRITICAL(help)
 
-! Just to test that the same name can be used again
-!$OMP CRITICAL(help) HINT(omp_lock_hint_contended)
+! Test that the same name can be used again
+! Also test with the zero hint expression
+!FIRDialect: omp.critical(@help) hint(none)
+!LLVMIRDialect: omp.critical(@help) hint(none)
+!LLVMIR: call void @__kmpc_critical_with_hint({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var, i32 0)
+!$OMP CRITICAL(help) HINT(omp_lock_hint_none)
         x = x - y
+!FIRDialect: omp.terminator
+!LLVMIRDialect: omp.terminator
+!LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var)
 !$OMP END CRITICAL(help)
 
 !FIRDialect: omp.critical

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -1,0 +1,37 @@
+! This test checks lowering of OpenMP Critical Directive.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp %s -o - | \
+! RUN:   tco --disable-llvm --print-ir-after=fir-to-llvm-ir 2>&1 | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco | FileCheck %s --check-prefix=LLVMIR
+
+
+program mn
+        use omp_lib
+        integer :: x, y
+!FIRDialect: omp.critical(@help) hint(contended)
+!LLVMIRDialect: omp.critical(@help) hint(contended)
+!LLVMIR: call void @__kmpc_critical_with_hint({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var, i32 2)
+!$OMP CRITICAL(help) HINT(omp_lock_hint_contended)
+        x = x + y
+!FIRDialect: omp.terminator
+!LLVMIRDialect: omp.terminator
+!LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var)
+!$OMP END CRITICAL(help)
+
+!FIRDialect: omp.critical
+!LLVMIRDialect: omp.critical
+!LLVMIR: call void @__kmpc_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}_.var)
+!$OMP CRITICAL
+        y = x + y
+!FIRDialect: omp.terminator
+!LLVMIRDialect: omp.terminator
+!LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}_.var)
+!$OMP END CRITICAL
+end program
+
+!FIRDialect: fir.global @help constant : !fir.char<1,4>
+!LLVMIRDialect: llvm.mlir.global external constant @help() : !llvm.array<4 x i8>

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -12,6 +12,8 @@
 program mn
         use omp_lib
         integer :: x, y
+!FIRDialect: omp.critical.declare @help
+!LLVMDialect: omp.critical.declare @help
 !FIRDialect: omp.critical(@help) hint(contended)
 !LLVMIRDialect: omp.critical(@help) hint(contended)
 !LLVMIR: call void @__kmpc_critical_with_hint({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var, i32 2)
@@ -37,6 +39,3 @@ program mn
 !LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}_.var)
 !$OMP END CRITICAL
 end program
-
-!FIRDialect: fir.global @help constant : !fir.char<1,4>
-!LLVMIRDialect: llvm.mlir.global external constant @help() : !llvm.array<4 x i8>

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -22,6 +22,11 @@ program mn
 !LLVMIR: call void @__kmpc_end_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}help.var)
 !$OMP END CRITICAL(help)
 
+! Just to test that the same name can be used again
+!$OMP CRITICAL(help) HINT(omp_lock_hint_contended)
+        x = x - y
+!$OMP END CRITICAL(help)
+
 !FIRDialect: omp.critical
 !LLVMIRDialect: omp.critical
 !LLVMIR: call void @__kmpc_critical({{.*}}, {{.*}}, {{.*}} @{{.*}}_.var)

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -452,7 +452,7 @@ def OMP_Single : Directive<"single"> {
 }
 def OMP_Master : Directive<"master"> {}
 def OMP_Critical : Directive<"critical"> {
-  let allowedClauses = [
+  let allowedOnceClauses = [
     VersionedClause<OMPC_Hint>
   ];
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -305,8 +305,6 @@ convertOmpCritical(Operation &opInst, llvm::IRBuilderBase &builder,
     hint =
         llvm::ConstantInt::get(llvm::Type::getInt32Ty(llvmContext),
                                static_cast<int>(criticalOp.hint().getValue()));
-  } else {
-    hint = llvm::ConstantInt::get(llvm::Type::getInt32Ty(llvmContext), 0);
   }
   builder.restoreIP(moduleTranslation.getOpenMPBuilder()->createCritical(
       ompLoc, bodyGenCB, finiCB, criticalOp.name().getValueOr(""), hint));

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -564,6 +564,16 @@ llvm.func @omp_critical(%x : !llvm.ptr<i32>, %xval : i32) -> () {
     omp.terminator
   }
   // CHECK: call void @__kmpc_end_critical({{.*}}critical_user_mutex.var{{.*}})
+
+  // CHECK: call void @__kmpc_critical_with_hint({{.*}}critical_user_mutex.var{{.*}}, i32 0)
+  // CHECK: br label %omp.critical.region
+  // CHECK: omp.critical.region
+  omp.critical(@mutex) hint(none) {
+  // CHECK: store
+    llvm.store %xval, %x : !llvm.ptr<i32>
+    omp.terminator
+  }
+  // CHECK: call void @__kmpc_end_critical({{.*}}critical_user_mutex.var{{.*}})
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -545,7 +545,7 @@ omp.critical.declare @mutex
 
 // CHECK-LABEL: @omp_critical
 llvm.func @omp_critical(%x : !llvm.ptr<i32>, %xval : i32) -> () {
-  // CHECK: call void @__kmpc_critical_with_hint({{.*}}critical_user_.var{{.*}}, i32 0)
+  // CHECK: call void @__kmpc_critical({{.*}}critical_user_.var{{.*}})
   // CHECK: br label %omp.critical.region
   // CHECK: omp.critical.region
   omp.critical {


### PR DESCRIPTION
The patch adds lowering for the Critical Construct.

The patch uses some code from @Sameeranjoshi's patch https://reviews.llvm.org/D93051. 