### PR TITLE
Implement FORALL with allocatables.

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -34,8 +34,8 @@ class ShapeOp;
 namespace Fortran::lower {
 
 class AbstractConverter;
-class IterationSpaceExpr;
-class MaskExpr;
+class ExplicitIterSpace;
+class ImplicitIterSpace;
 class StatementContext;
 class SymMap;
 
@@ -100,7 +100,11 @@ void createSomeArrayAssignment(AbstractConverter &converter,
                                const fir::ExtendedValue &rhs, SymMap &symMap,
                                StatementContext &stmtCtx);
 
-/// Lower an array assignment expression with masking expression(s).
+/// Common entry point for both explicit iteration spaces and implicit iteration
+/// spaces with masks.
+///
+/// For an implicit iteration space with masking, lowers an array assignment
+/// expression with masking expression(s).
 ///
 /// 1. Evaluate the lhs to determine the rank and how to form the ArrayLoad
 /// (e.g., if there is a slicing op).
@@ -112,14 +116,10 @@ void createSomeArrayAssignment(AbstractConverter &converter,
 /// 5. Evaluate the elemental expression, threading the results.
 /// 6. Copy the resulting array back with ArrayMergeStore to the lhs as
 /// determined per step 1.
-void createMaskedArrayAssignment(AbstractConverter &converter,
-                                 const evaluate::Expr<evaluate::SomeType> &lhs,
-                                 const evaluate::Expr<evaluate::SomeType> &rhs,
-                                 MaskExpr &masks, SymMap &symMap,
-                                 StatementContext &stmtCtx);
-
-/// Lower a scalar or array assignment expression with a user-defined iteration
-/// space and possibly with masking expression(s).
+///
+/// For an explicit iteration space, lower a scalar or array assignment
+/// expression with a user-defined iteration space and possibly with masking
+/// expression(s).
 ///
 /// If the expression is scalar, then the assignment is an array assignment but
 /// the array accesses are explicitly defined by the user and not implied for
@@ -128,19 +128,20 @@ void createMaskedArrayAssignment(AbstractConverter &converter,
 /// If the expression has rank, then the assignment has a combined user-defined
 /// iteration space as well as a inner (subordinate) implied iteration
 /// space. The implied iteration space may include WHERE conditions, `masks`.
-void createExplicitIterationSpaceArrayAssignment(
+void createAnyMaskedArrayAssignment(
     AbstractConverter &converter, const evaluate::Expr<evaluate::SomeType> &lhs,
     const evaluate::Expr<evaluate::SomeType> &rhs,
-    IterationSpaceExpr &iterSpace, MaskExpr &masks, SymMap &symMap,
-    StatementContext &stmtCtx);
+    ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
+    SymMap &symMap, StatementContext &stmtCtx);
 
 /// Lower an assignment to an allocatable array, allocating the array if
 /// it is not allocated yet or reallocation it if it does not conform
 /// with the right hand side.
 void createAllocatableArrayAssignment(
     AbstractConverter &converter, const fir::MutableBoxValue &lhs,
-    const evaluate::Expr<evaluate::SomeType> &rhs, SymMap &symMap,
-    StatementContext &stmtCtx);
+    const evaluate::Expr<evaluate::SomeType> &rhs,
+    ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
+    SymMap &symMap, StatementContext &stmtCtx);
 
 /// Lower an array expression with "parallel" semantics. Such a rhs expression
 /// is fully evaluated prior to being assigned back to a temporary array.

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -13,7 +13,7 @@
 #include "flang/Lower/ConvertExpr.h"
 #include "BuiltinModules.h"
 #include "ConvertVariable.h"
-#include "MaskExpr.h"
+#include "IterationSpace.h"
 #include "RTBuilder.h"
 #include "StatementContext.h"
 #include "flang/Common/default-kinds.h"
@@ -2497,41 +2497,24 @@ public:
   }
 
   //===--------------------------------------------------------------------===//
-  // WHERE array assignment
-  //===--------------------------------------------------------------------===//
-
-  /// Entry point for masked array assignment, Fortran's WHERE. This has the
-  /// same semantics as ordinary array assignment except that the RHS is a
-  /// projected array value based on the mask condition(s).
-  static void lowerMaskedArrayAssignment(
-      Fortran::lower::AbstractConverter &converter,
-      Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
-      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &lhs,
-      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
-      Fortran::lower::MaskExpr &masks) {
-    ArrayExprLowering ael{converter, stmtCtx, symMap,
-                          ConstituentSemantics::CopyInCopyOut, &masks};
-    ael.lowerArrayAssignment(lhs, rhs);
-  }
-
-  //===--------------------------------------------------------------------===//
-  // FORALL assignment and FORALL+WHERE array assignment
+  // WHERE array assignment, FORALL assignment, and FORALL+WHERE array
+  // assignment
   //===--------------------------------------------------------------------===//
 
   /// Entry point for array assignment when the iteration space is explicitly
-  /// defined, Fortran's FORALL. This may also include a masked assignment,
-  /// either via the FORALL specification or a WHERE inside the FORALL. This has
-  /// the same semantics as an ordinary masked array assignment except that the
-  /// iteration space and access expressions are explicitly defined by the user.
-  static void lowerExplicitIterSpaceArrayAssignment(
+  /// defined (Fortran's FORALL) with or without masks, and/or the implied
+  /// iteration space involves masks (Fortran's WHERE). Both contexts (explicit
+  /// space and implicit space with masks) may be present.
+  static void lowerAnyMaskedArrayAssignment(
       Fortran::lower::AbstractConverter &converter,
       Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &lhs,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
-      Fortran::lower::IterationSpaceExpr &iters,
-      Fortran::lower::MaskExpr &masks) {
+      Fortran::lower::ExplicitIterSpace &explicitSpace,
+      Fortran::lower::ImplicitIterSpace &implicitSpace) {
     ArrayExprLowering ael(converter, stmtCtx, symMap,
-                          ConstituentSemantics::CopyInCopyOut, &iters, &masks);
+                          ConstituentSemantics::CopyInCopyOut, &explicitSpace,
+                          &implicitSpace);
     ael.lowerArrayAssignment(lhs, rhs);
   }
 
@@ -2544,15 +2527,20 @@ public:
       Fortran::lower::AbstractConverter &converter,
       Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
       const fir::MutableBoxValue &lhs,
-      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs) {
-    // The allocatable must take lower bounds from the expr if reallocated.
-    // An expr has lbounds only if it is an array symbol or component.
+      const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
+      Fortran::lower::ExplicitIterSpace &explicitSpace,
+      Fortran::lower::ImplicitIterSpace &implicitSpace) {
     ArrayExprLowering ael(converter, stmtCtx, symMap,
-                          ConstituentSemantics::CopyInCopyOut);
+                          ConstituentSemantics::CopyInCopyOut, &explicitSpace,
+                          &implicitSpace);
     ael.lowerAllocatableArrayAssignment(lhs, rhs);
   }
 
   /// Assignment to allocatable array.
+  ///
+  /// The semantics are reverse that of a "regular" array assignment. The rhs
+  /// defines the iteration space of the computation and the lhs is
+  /// resized/reallocated to fit if necessary.
   void lowerAllocatableArrayAssignment(
       const fir::MutableBoxValue &mutableBox,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs) {
@@ -2575,6 +2563,8 @@ public:
         mutableBox.isDerivedWithLengthParameters())
       TODO(loc, "gather rhs length parameters in assignment to allocatable");
 
+    // The allocatable must take lower bounds from the expr if reallocated.
+    // An expr has lbounds only if it is an array symbol or component.
     llvm::SmallVector<mlir::Value> lbounds;
     // takeLboundsIfRealloc is only true iff the rhs is a single dataref.
     const bool takeLboundsIfRealloc =
@@ -2883,7 +2873,7 @@ public:
   /// 3. Return the temporary array and the shape op that describes it.
   Fortran::lower::MaskAddrAndShape
   genExplicitMaskExpr(Fortran::lower::FrontEndExpr fex) {
-    using FESymbol = Fortran::lower::IterationSpaceExpr::FrontEndSymbol;
+    using FESymbol = Fortran::lower::ExplicitIterSpace::FrontEndSymbol;
     assert(explicitSpace);
     auto loc = getLoc();
 
@@ -3125,7 +3115,7 @@ public:
 
   std::pair<llvm::SmallVector<mlir::Value>, fir::DoLoopOp>
   genExplicitLoopsForWhereMasks(fir::ArrayLoadOp resLd) {
-    using FESymbol = Fortran::lower::IterationSpaceExpr::FrontEndSymbol;
+    using FESymbol = Fortran::lower::ExplicitIterSpace::FrontEndSymbol;
     assert(explicitSpace && "must be a FORALL context");
     auto loc = getLoc();
     auto idxTy = builder.getIndexType();
@@ -4251,9 +4241,11 @@ public:
         x.u);
   }
 
-  template <typename A>
-  std::pair<CC, mlir::Type> raiseBase(const A &x) {
+  std::pair<CC, mlir::Type> raiseBase(const Fortran::semantics::SymbolRef &x) {
     return {genarr(x), raiseBaseType(x)};
+  }
+  std::pair<CC, mlir::Type> raiseBase(const Fortran::evaluate::Component &x) {
+    return {genComponent(x), raiseBaseType(x)};
   }
   template <typename A>
   std::pair<CC, mlir::Type> raiseRankedBase(const A &x) {
@@ -4313,8 +4305,7 @@ public:
                 auto [fopt2, ty2] = raiseRankedBase(s);
                 return {fopt2, ty2, false, true};
               }
-              auto [fopt2, ty2] = raiseBase(s);
-              return {fopt2, ty2, false, false};
+              return {llvm::None, mlir::Type{}, false, false};
             },
             [&](const Fortran::evaluate::CoarrayRef &) -> RaiseRT {
               TODO(getLoc(), "coarray reference");
@@ -4340,6 +4331,50 @@ public:
       return {fopt2, ty2, ranked, true};
     }
     return {fopt, ty, inrank, ranked};
+  }
+  RaiseRT
+  raiseToArray(const Fortran::evaluate::ArrayRef &x,
+               llvm::ArrayRef<const Fortran::semantics::Symbol *> ctrlSet) {
+    const auto &base = x.base();
+    auto accessUsesControlVariable = [&]() {
+      for (const auto &subs : x.subscript())
+        if (auto *intExpr =
+                std::get_if<Fortran::evaluate::IndirectSubscriptIntegerExpr>(
+                    &subs.u)) {
+          if (symbolSetsIntersect(
+                  ctrlSet, Fortran::evaluate::CollectSymbols(intExpr->value())))
+            return true;
+        } else {
+          // Subscript is a triplet, so x.Rank() should have been
+          // greater than zero.
+          llvm_unreachable("front end reported the rank of this "
+                           "component 0 but it has triple notation");
+        }
+      return false;
+    };
+    return raiseSubscript(
+        [&]() -> RaiseRT {
+          if (base.IsSymbol()) {
+            auto &sym = base.GetFirstSymbol();
+            if (x.Rank() > 0 || accessUsesControlVariable()) {
+              auto [fopt2, ty2] = raiseBase(sym);
+              return RaiseRT{fopt2, fir::unwrapSequenceType(ty2), false,
+                             x.Rank() > 0};
+            }
+            return RaiseRT{llvm::None, mlir::Type{}, false, false};
+          }
+          // Otherwise, it's a component.
+          auto [fopt, ty, inrank, ranked] =
+              raiseToArray(base.GetComponent(), ctrlSet);
+          if (fopt.hasValue())
+            return RaiseRT{fopt, ty, inrank, ranked};
+          if (x.Rank() > 0 || accessUsesControlVariable()) {
+            auto [fopt2, ty2] = raiseBase(base.GetComponent());
+            return RaiseRT{fopt2, ty2, inrank, x.Rank() > 0};
+          }
+          return RaiseRT{fopt, ty, inrank, ranked};
+        }(),
+        x);
   }
   RaiseRT raiseSubscript(const RaiseRT &tup,
                          const Fortran::evaluate::ArrayRef &x) {
@@ -4453,51 +4488,6 @@ public:
                      prevRanked, ranked};
     }
     return tup;
-  }
-  RaiseRT
-  raiseToArray(const Fortran::evaluate::ArrayRef &x,
-               llvm::ArrayRef<const Fortran::semantics::Symbol *> ctrlSet) {
-    const auto &base = x.base();
-    return raiseSubscript(
-        [&]() -> RaiseRT {
-          if (base.IsSymbol()) {
-            auto &sym = base.GetFirstSymbol();
-            auto [fopt2, ty2] = raiseBase(sym);
-            return RaiseRT{fopt2, fir::unwrapSequenceType(ty2), false,
-                           x.Rank() > 0};
-          }
-          auto [fopt, ty, inrank, ranked] =
-              raiseToArray(base.GetComponent(), ctrlSet);
-          if (fopt.hasValue())
-            return RaiseRT{fopt, ty, inrank, ranked};
-          if (x.Rank() > 0) {
-            auto [fopt2, ty2] = raiseBase(x);
-            return RaiseRT{fopt2, ty2, false, true};
-          }
-          auto accessUsesControlVariable = [&]() {
-            for (const auto &subs : x.subscript())
-              if (auto *intExpr = std::get_if<
-                      Fortran::evaluate::IndirectSubscriptIntegerExpr>(
-                      &subs.u)) {
-                if (symbolSetsIntersect(
-                        ctrlSet,
-                        Fortran::evaluate::CollectSymbols(intExpr->value())))
-                  return true;
-              } else {
-                // Subscript is a triplet, so x.Rank() should have been
-                // greater than zero.
-                llvm_unreachable("front end reported the rank of this "
-                                 "component 0 but it has triple notation");
-              }
-            return false;
-          };
-          if (accessUsesControlVariable()) {
-            auto [fopt2, ty2] = raiseBase(base.GetComponent());
-            return RaiseRT{fopt2, ty2, false, false};
-          }
-          return RaiseRT{fopt, ty, inrank, ranked};
-        }(),
-        x);
   }
 
   /// Get all the explicit (user-defined) control symbols.
@@ -4761,10 +4751,13 @@ public:
     return arrTy;
   }
 
+  /// Lower a component path with rank or raise it from a scalar expression to
+  /// have array semantics.
   /// Example: <code>array%baz%qux%waldo</code>
   CC genarr(const Fortran::evaluate::Component &x) {
-    if (explicitSpace)
-      return raiseToArray(x);
+    return explicitSpace ? raiseToArray(x) : genComponent(x);
+  }
+  CC genComponent(const Fortran::evaluate::Component &x) {
     ComponentCollection cmptData;
     auto tup = buildComponentsPath(cmptData, x);
     auto lambda = genSlicePath(std::get<ExtValue>(tup), cmptData.trips,
@@ -5400,19 +5393,13 @@ private:
                              Fortran::lower::StatementContext &stmtCtx,
                              Fortran::lower::SymMap &symMap,
                              ConstituentSemantics sem,
-                             Fortran::lower::MaskExpr *masks)
-      : converter{converter}, builder{converter.getFirOpBuilder()},
-        stmtCtx{stmtCtx}, symMap{symMap}, masks{masks}, semant{sem} {}
-
-  explicit ArrayExprLowering(Fortran::lower::AbstractConverter &converter,
-                             Fortran::lower::StatementContext &stmtCtx,
-                             Fortran::lower::SymMap &symMap,
-                             ConstituentSemantics sem,
-                             Fortran::lower::IterationSpaceExpr *iters,
-                             Fortran::lower::MaskExpr *masks)
+                             Fortran::lower::ExplicitIterSpace *expSpace,
+                             Fortran::lower::ImplicitIterSpace *impSpace)
       : converter{converter}, builder{converter.getFirOpBuilder()},
         stmtCtx{stmtCtx}, symMap{symMap},
-        explicitSpace{iters}, masks{masks}, semant{sem} {}
+        explicitSpace(expSpace->empty() ? nullptr : expSpace),
+        masks(expSpace->empty() && impSpace->empty() ? nullptr : impSpace),
+        semant{sem} {}
 
   mlir::Location getLoc() { return converter.getCurrentLocation(); }
 
@@ -5460,12 +5447,12 @@ private:
   llvm::SmallVector<mlir::Value> slicePath;
   /// If there is a user-defined iteration space, explicitShape will hold the
   /// information from the front end.
-  Fortran::lower::IterationSpaceExpr *explicitSpace = nullptr;
+  Fortran::lower::ExplicitIterSpace *explicitSpace = nullptr;
   /// Even in an explicitly defined iteration space, one can have an
   /// assignment with rank > 0 and thus an implied shape on a component in the
   /// path.
   llvm::SmallVector<mlir::Value> explicitImpliedShape;
-  Fortran::lower::MaskExpr *masks = nullptr;
+  Fortran::lower::ImplicitIterSpace *masks = nullptr;
   ConstituentSemantics semant = ConstituentSemantics::RefTransparent;
   bool inSlice = false;
   // Does the lhs, if any, must take lbounds from rhs if lhs is reallocated ?
@@ -5525,45 +5512,36 @@ void Fortran::lower::createSomeArrayAssignment(
   ArrayExprLowering::lowerArrayAssignment(converter, symMap, stmtCtx, lhs, rhs);
 }
 
-void Fortran::lower::createMaskedArrayAssignment(
+void Fortran::lower::createAnyMaskedArrayAssignment(
     Fortran::lower::AbstractConverter &converter,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &lhs,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
-    Fortran::lower::MaskExpr &masks, Fortran::lower::SymMap &symMap,
-    Fortran::lower::StatementContext &stmtCtx) {
+    Fortran::lower::ExplicitIterSpace &explicitSpace,
+    Fortran::lower::ImplicitIterSpace &implicitSpace,
+    Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx) {
   LLVM_DEBUG(lhs.AsFortran(llvm::dbgs() << "onto array: ") << '\n';
              rhs.AsFortran(llvm::dbgs() << "assign expression: ")
-             << " given mask conditions\n"
-             << masks << '\n';);
-  ArrayExprLowering::lowerMaskedArrayAssignment(converter, symMap, stmtCtx, lhs,
-                                                rhs, masks);
-}
-
-void Fortran::lower::createExplicitIterationSpaceArrayAssignment(
-    Fortran::lower::AbstractConverter &converter,
-    const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &lhs,
-    const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
-    Fortran::lower::IterationSpaceExpr &iterSpace,
-    Fortran::lower::MaskExpr &masks, Fortran::lower::SymMap &symMap,
-    Fortran::lower::StatementContext &stmtCtx) {
-  LLVM_DEBUG(lhs.AsFortran(llvm::dbgs() << "onto array: ") << '\n';
-             rhs.AsFortran(llvm::dbgs() << "assign expression: ")
-             << " given iteration space:\n"
-             << iterSpace << "\n and mask conditions:\n"
-             << masks << '\n';);
-  ArrayExprLowering::lowerExplicitIterSpaceArrayAssignment(
-      converter, symMap, stmtCtx, lhs, rhs, iterSpace, masks);
+             << " given the explicit iteration space:\n"
+             << explicitSpace << "\n and implied mask conditions:\n"
+             << implicitSpace << '\n';);
+  ArrayExprLowering::lowerAnyMaskedArrayAssignment(
+      converter, symMap, stmtCtx, lhs, rhs, explicitSpace, implicitSpace);
 }
 
 void Fortran::lower::createAllocatableArrayAssignment(
     Fortran::lower::AbstractConverter &converter,
     const fir::MutableBoxValue &lhs,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &rhs,
+    Fortran::lower::ExplicitIterSpace &explicitSpace,
+    Fortran::lower::ImplicitIterSpace &implicitSpace,
     Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx) {
-  LLVM_DEBUG(llvm::dbgs() << "onto array: " << lhs << '\n';
-             rhs.AsFortran(llvm::dbgs() << "assign expression: ") << '\n';);
-  ArrayExprLowering::lowerAllocatableArrayAssignment(converter, symMap, stmtCtx,
-                                                     lhs, rhs);
+  LLVM_DEBUG(llvm::dbgs() << "defining array: " << lhs << '\n';
+             rhs.AsFortran(llvm::dbgs() << "assign expression: ")
+             << " given the explicit iteration space:\n"
+             << explicitSpace << "\n and implied mask conditions:\n"
+             << implicitSpace << '\n';);
+  ArrayExprLowering::lowerAllocatableArrayAssignment(
+      converter, symMap, stmtCtx, lhs, rhs, explicitSpace, implicitSpace);
 }
 
 fir::ExtendedValue Fortran::lower::createSomeArrayTempValue(

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SymbolMap.h"
-#include "MaskExpr.h"
+#include "IterationSpace.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/Support/Debug.h"
 
@@ -290,7 +290,7 @@ bool fir::BoxValue::verify() const {
 
 llvm::raw_ostream &
 Fortran::lower::operator<<(llvm::raw_ostream &s,
-                           const Fortran::lower::MaskExpr &e) {
+                           const Fortran::lower::ImplicitIterSpace &e) {
   for (auto &xs : e.getMasks()) {
     s << "{ ";
     for (auto &x : xs)
@@ -302,7 +302,7 @@ Fortran::lower::operator<<(llvm::raw_ostream &s,
 
 llvm::raw_ostream &
 Fortran::lower::operator<<(llvm::raw_ostream &s,
-                           const Fortran::lower::IterationSpaceExpr &e) {
+                           const Fortran::lower::ExplicitIterSpace &e) {
   for (auto &xs : e.dims()) {
     s << "{ ";
     for (auto &x : xs.first) {
@@ -322,8 +322,10 @@ Fortran::lower::operator<<(llvm::raw_ostream &s,
   return s;
 }
 
-void Fortran::lower::MaskExpr::dump() const { llvm::errs() << *this << '\n'; }
+void Fortran::lower::ImplicitIterSpace::dump() const {
+  llvm::errs() << *this << '\n';
+}
 
-void Fortran::lower::IterationSpaceExpr::dump() const {
+void Fortran::lower::ExplicitIterSpace::dump() const {
   llvm::errs() << *this << '\n';
 }

--- a/flang/test/Lower/forall.f90
+++ b/flang/test/Lower/forall.f90
@@ -1165,3 +1165,101 @@ subroutine test_forall_with_ranked_dimension
   ! CHECK: fir.array_merge_store %[[VAL_5]], %[[V_0]] to %[[VAL_3]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, !fir.ref<!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>>
   ! CHECK: return
 end subroutine test_forall_with_ranked_dimension
+
+! CHECK-LABEL: func @_QPforall_with_allocatable(
+! CHECK-SAME: %[[arg0:[^:]*]]: !fir.box<!fir.array<?xf32>>) {
+subroutine forall_with_allocatable(a1)
+  real :: a1(:)
+  real, allocatable :: arr(:)
+  ! CHECK: %[[VAL_0:.*]] = fir.alloca i32 {adapt.valuebyref, uniq_name = "i"}
+  ! CHECK: %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {bindc_name = "arr", uniq_name = "_QFforall_with_allocatableEarr"}
+  ! CHECK: %[[VAL_2:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {uniq_name = "_QFforall_with_allocatableEarr.addr"}
+  ! CHECK: %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFforall_with_allocatableEarr.lb0"}
+  ! CHECK: %[[VAL_4:.*]] = fir.alloca index {uniq_name = "_QFforall_with_allocatableEarr.ext0"}
+  ! CHECK: %[[VAL_5:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+  ! CHECK: fir.store %[[VAL_5]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK: %[[VAL_6:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+  ! CHECK: %[[VAL_7:.*]] = fir.load %[[VAL_4]] : !fir.ref<index>
+  ! CHECK: %[[VAL_8:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+  ! CHECK: %[[VAL_9:.*]] = fir.shape_shift %[[VAL_6]], %[[VAL_7]] : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[VAL_10:.*]] = fir.array_load %[[VAL_8]](%[[VAL_9]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.array<?xf32>
+  ! CHECK: %[[VAL_11:.*]] = fir.array_load %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  ! CHECK: %[[VAL_13:.*]] = constant 5 : i32
+  ! CHECK: %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> index
+  ! CHECK: %[[VAL_15:.*]] = constant 15 : i32
+  ! CHECK: %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> index
+  ! CHECK: %[[VAL_17:.*]] = constant 1 : index
+
+  ! CHECK: %[[V_0:.*]] = fir.do_loop %[[V_1:.*]] = %[[VAL_14]] to %[[VAL_16]] step %[[VAL_17]] unordered iter_args(%[[V_2:.*]] = %[[VAL_10]]) -> (!fir.array<?xf32>) {
+  ! CHECK: %[[V_3:.*]] = fir.convert %[[V_1]] : (index) -> i32
+  ! CHECK: fir.store %[[V_3]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_4:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_5:.*]] = fir.convert %[[V_4]] : (i32) -> i64
+  ! CHECK: %[[V_6:.*]] = fir.convert %[[V_5]] : (i64) -> index
+  ! CHECK: %[[V_7:.*]] = fir.array_fetch %[[VAL_11]], %[[V_6]] : (!fir.array<?xf32>, index) -> f32
+  ! CHECK: %[[V_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_9:.*]] = fir.convert %[[V_8]] : (i32) -> i64
+  ! CHECK: %[[V_10:.*]] = fir.convert %[[V_9]] : (i64) -> index
+  ! CHECK: %[[V_11:.*]] = fir.array_update %[[V_2]], %[[V_7]], %[[V_10]] : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+  ! CHECK: fir.result %[[V_11]] : !fir.array<?xf32>
+  forall (i=5:15)
+     arr(i) = a1(i)
+  end forall
+  ! CHECK: }
+  ! CHECK: fir.array_merge_store %[[VAL_10]], %[[V_0]] to %[[VAL_8]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.heap<!fir.array<?xf32>>
+  ! CHECK: return
+end subroutine forall_with_allocatable
+
+! CHECK-LABEL: func @_QPforall_with_allocatable2(
+! CHECK-SAME: %[[arg0:[^:]*]]: !fir.box<!fir.array<?xf32>>) {
+subroutine forall_with_allocatable2(a1)
+  ! CHECK: %[[VAL_0:.*]] = fir.alloca i32 {adapt.valuebyref, uniq_name = "i"}
+  ! CHECK: %[[VAL_1:.*]] = fir.alloca !fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "thing", uniq_name = "_QFforall_with_allocatable2Ething"}
+  ! CHECK: %[[VAL_2:.*]] = fir.embox %[[VAL_1]] : (!fir.ref<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[VAL_3:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]+}}>>
+  ! CHECK: %[[VAL_4:.*]] = constant {{[0-9]+}} : i32
+  ! CHECK: %[[VAL_5:.*]] = fir.convert %[[VAL_2]] : (!fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
+  ! CHECK: %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
+  ! CHECK: %[[VAL_7:.*]] = fir.call @_FortranAInitialize(%[[VAL_5]], %[[VAL_6]], %[[VAL_4]]) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
+  ! CHECK: %[[VAL_8:.*]] = fir.field_index arr, !fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
+  ! CHECK: %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_8]] : (!fir.ref<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[VAL_10:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+  ! CHECK: %[[VAL_11:.*]] = constant 0 : index
+  ! CHECK: %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_10]], %[[VAL_11]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+  ! CHECK: %[[VAL_13:.*]] = fir.box_addr %[[VAL_10]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+  ! CHECK: %[[VAL_14:.*]] = fir.shape_shift %[[VAL_12]]#0, %[[VAL_12]]#1 : (index, index) -> !fir.shapeshift<1>
+  ! CHECK: %[[VAL_15:.*]] = constant 1 : index
+  ! CHECK: %[[VAL_16:.*]] = fir.slice %[[VAL_12]]#0, %[[VAL_12]]#1, %[[VAL_15]] : (index, index, index) -> !fir.slice<1>
+  ! CHECK: %[[VAL_17:.*]] = fir.array_load %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_16]]] : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>, !fir.slice<1>) -> !fir.array<?xf32>
+  ! CHECK: %[[VAL_18:.*]] = fir.array_load %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  ! CHECK: %[[VAL_20:.*]] = constant 5 : i32
+  ! CHECK: %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i32) -> index
+  ! CHECK: %[[VAL_22:.*]] = constant 15 : i32
+  ! CHECK: %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i32) -> index
+  ! CHECK: %[[VAL_24:.*]] = constant 1 : index
+  real :: a1(:)
+  type t
+     integer :: i
+     real, allocatable :: arr(:)
+  end type t
+  type(t) :: thing
+
+  ! CHECK: %[[V_0:.*]] = fir.do_loop %[[V_1:.*]] = %[[VAL_21]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[V_2:.*]] = %[[VAL_17]]) -> (!fir.array<?xf32>) {
+  ! CHECK: %[[V_3:.*]] = fir.convert %[[V_1]] : (index) -> i32
+  ! CHECK: fir.store %[[V_3]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_4:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_5:.*]] = fir.convert %[[V_4]] : (i32) -> i64
+  ! CHECK: %[[V_6:.*]] = fir.convert %[[V_5]] : (i64) -> index
+  ! CHECK: %[[V_7:.*]] = fir.array_fetch %[[VAL_18]], %[[V_6]] : (!fir.array<?xf32>, index) -> f32
+  ! CHECK: %[[V_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[V_9:.*]] = fir.convert %[[V_8]] : (i32) -> i64
+  ! CHECK: %[[V_10:.*]] = fir.convert %[[V_9]] : (i64) -> index
+  ! CHECK: %[[V_11:.*]] = fir.array_update %[[V_2]], %[[V_7]], %[[V_10]] : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+  ! CHECK: fir.result %[[V_11]] : !fir.array<?xf32>
+  ! CHECK: }
+  forall (i=5:15)
+     thing%arr(i) = a1(i)
+  end forall
+  ! CHECK: fir.array_merge_store %[[VAL_17]], %[[V_0]] to %[[VAL_13]]{{\[}}%[[VAL_16]]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.heap<!fir.array<?xf32>>, !fir.slice<1>
+  ! CHECK: return
+end subroutine forall_with_allocatable2


### PR DESCRIPTION
This also includes some renaming to keep implicit and explicit iteration
spaces more clearly distinct.