### PR TITLE
Ps cherry pick extents

### DIFF
--- a/flang/test/Evaluate/folding21.f90
+++ b/flang/test/Evaluate/folding21.f90
@@ -1,0 +1,35 @@
+! RUN: %S/test_folding.sh %s %t %flang_fc1
+! REQUIRES: shell
+! Check array sizes with varying extents, including extents where the upper
+! bound is less than the lower bound
+module m
+ contains
+  subroutine s1(a,b)
+    real nada1(-2:-1)    ! size =  2
+    real nada2(-1:-1)    ! size =  1
+    real nada3( 0:-1)    ! size =  0
+    real nada4( 1:-1)    ! size =  0
+    real nada5( 2:-1)    ! size =  0
+    real nada6( 3:-1)    ! size =  0
+    real nada7( 5, 3:-1) ! size =  0
+    real nada8( -1)      ! size =  0
+
+    integer, parameter :: size1 = size(nada1)
+    integer, parameter :: size2 = size(nada2)
+    integer, parameter :: size3 = size(nada3)
+    integer, parameter :: size4 = size(nada4)
+    integer, parameter :: size5 = size(nada5)
+    integer, parameter :: size6 = size(nada6)
+    integer, parameter :: size7 = size(nada7)
+    integer, parameter :: size8 = size(nada8)
+
+    logical, parameter :: test_size_1 = size1 == 2
+    logical, parameter :: test_size_2 = size2 == 1
+    logical, parameter :: test_size_3 = size3 == 0
+    logical, parameter :: test_size_4 = size4 == 0
+    logical, parameter :: test_size_5 = size5 == 0
+    logical, parameter :: test_size_6 = size6 == 0
+    logical, parameter :: test_size_7 = size7 == 0
+    logical, parameter :: test_size_8 = size8 == 0
+  end subroutine
+end module

--- a/flang/test/Lower/forall.f90
+++ b/flang/test/Lower/forall.f90
@@ -657,11 +657,7 @@ subroutine test_forall_with_array_assignment(a,b)
   ! CHECK: %[[VAL_3:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_4:.*]] = fir.array_load %[[a]](%[[VAL_3]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK-DAG: %[[VAL_6:.*]] = constant 64 : i64
-  ! CHECK-DAG: %[[VAL_7:.*]] = constant 1 : i64
-  ! CHECK-DAG: %[[VAL_8:.*]] = subi %[[VAL_6]], %{{.*}} : i64
-  ! CHECK-DAG: %[[VAL_9:.*]] = constant 1 : i64
-  ! CHECK: %[[VAL_10:.*]] = addi %[[VAL_8]], %{{.*}} : i64
-  ! CHECK: %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i64) -> index
+  ! CHECK: %[[VAL_11:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
   ! CHECK: %[[VAL_12:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_13:.*]] = fir.array_load %[[b]](%[[VAL_12]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK-DAG: %[[VAL_15:.*]] = constant 1 : index
@@ -717,11 +713,7 @@ subroutine test_nested_forall_where(a,b)
   ! CHECK: %[[VAL_5:.*]] = fir.alloca i32 {adapt.valuebyref, uniq_name = "i"}
   ! CHECK: %[[VAL_6:.*]] = fir.array_load %[[a]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK-DAG: %[[VAL_8:.*]] = constant 100 : i64
-  ! CHECK-DAG: %[[VAL_9:.*]] = constant 1 : i64
-  ! CHECK-DAG: %[[VAL_10:.*]] = subi %[[VAL_8]], %{{.*}} : i64
-  ! CHECK-DAG: %[[VAL_11:.*]] = constant 1 : i64
-  ! CHECK: %[[VAL_12:.*]] = addi %[[VAL_10]], %{{.*}} : i64
-  ! CHECK: %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
+  ! CHECK: %[[VAL_13:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
   ! CHECK: %[[VAL_14:.*]] = fir.array_load %[[b]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK-DAG: %[[VAL_16:.*]] = constant 3.140000e+00 : f32
   ! CHECK-DAG: %[[VAL_17:.*]] = constant 1 : i32
@@ -930,11 +922,7 @@ subroutine test_nested_forall_where(a,b)
      elsewhere
   ! CHECK: %[[YAL_45:.*]] = fir.array_load %[[a]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK-DAG: %[[YAL_46:.*]] = constant 100 : i64
-  ! CHECK-DAG: %[[YAL_47:.*]] = constant 1 : i64
-  ! CHECK-DAG: %[[YAL_48:.*]] = subi %[[YAL_46]], %{{.*}} : i64
-  ! CHECK-DAG: %[[YAL_49:.*]] = constant 1 : i64
-  ! CHECK: %[[YAL_50:.*]] = addi %[[YAL_48]], %{{.*}} : i64
-  ! CHECK: %[[YAL_51:.*]] = fir.convert %[[YAL_50]] : (i64) -> index
+  ! CHECK: %[[YAL_51:.*]] = fir.convert %[[YAL_46]] : (i64) -> index
   ! CHECK: %[[YAL_52:.*]] = fir.array_load %[[b]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK-DAG: %[[YAL_53:.*]] = constant 1 : index
   ! CHECK-DAG: %[[YAL_54:.*]] = constant 0 : index
@@ -1031,11 +1019,7 @@ subroutine test_forall_with_slice(i1,i2)
   ! CHECK: %[[VAL_4:.*]] = fir.alloca !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>> {bindc_name = "a", uniq_name = "_QFtest_forall_with_sliceEa"}
   ! CHECK: %[[VAL_5:.*]] = fir.shape %[[VAL_2]], %[[VAL_3]] : (index, index) -> !fir.shape<2>
   ! CHECK: %[[VAL_6:.*]] = fir.array_load %[[VAL_4]](%[[VAL_5]]) : (!fir.ref<!fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>>, !fir.shape<2>) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>
-  ! CHECK-DAG: %[[VAL_7:.*]] = constant 1 : i64
-  ! CHECK-DAG: %[[VAL_8:.*]] = constant 5 : i64
-  ! CHECK-DAG: %[[VAL_9:.*]] = constant 15 : i64
-  ! CHECK-DAG: %[[VAL_10:.*]] = subi %[[VAL_9]], %[[VAL_8]] : i64
-  ! CHECK: %[[VAL_11:.*]] = addi %[[VAL_10]], %[[VAL_7]] : i64
+  ! CHECK: %[[VAL_11:.*]] = constant 11 : i64
   ! CHECK: %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
   ! CHECK: %[[VAL_13:.*]] = constant 1 : index
   ! CHECK: %[[VAL_14:.*]] = constant 1 : index


### PR DESCRIPTION
The pull request contains two commits -- one from the front end changes that were merged as part of https://reviews.llvm.org/D107832, and the other commit which fixes lowering test failures.  These test failures were caused by the fact that the first commit makes the front end do constant folding on extent expressions.  This means that the expressions being lowered are now different as is the generated IR.