### PR TITLE
[NFC] move LiteralNameHelper to remove front-end dependency in FIRBuilder

### DIFF
--- a/flang/include/flang/Lower/FIRBuilder.h
+++ b/flang/include/flang/Lower/FIRBuilder.h
@@ -16,8 +16,6 @@
 #ifndef FORTRAN_LOWER_FIRBUILDER_H
 #define FORTRAN_LOWER_FIRBUILDER_H
 
-#include "flang/Common/reference.h"
-#include "flang/Evaluate/expression.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/KindMapping.h"
@@ -394,62 +392,6 @@ fir::ExtendedValue createStringLiteral(FirOpBuilder &, mlir::Location,
 /// Unique a compiler generated identifier. A short prefix should be provided
 /// to hint at the origin of the identifier.
 std::string uniqueCGIdent(llvm::StringRef prefix, llvm::StringRef name);
-
-/// Generate a unique name for a typed literal constant value.
-class LiteralNameHelper {
-public:
-  template <int KIND>
-  explicit LiteralNameHelper(
-      const Fortran::evaluate::Constant<Fortran::evaluate::Type<
-          Fortran::common::TypeCategory::Character, KIND>> &x) {
-    setTypeId(x.shape(), "c", std::to_string(KIND), x.LEN());
-    const auto &values = x.values();
-    address = (const uint8_t *)values.data();
-    size = values.size() * sizeof(values[0]);
-  }
-  template <Fortran::common::TypeCategory TC, int KIND>
-  explicit LiteralNameHelper(
-      const Fortran::evaluate::Constant<Fortran::evaluate::Type<TC, KIND>> &x) {
-    if constexpr (TC == Fortran::common::TypeCategory::Integer)
-      setTypeId(x.shape(), "i", std::to_string(KIND));
-    else if constexpr (TC == Fortran::common::TypeCategory::Real)
-      setTypeId(x.shape(), "r", std::to_string(KIND));
-    else if constexpr (TC == Fortran::common::TypeCategory::Complex)
-      setTypeId(x.shape(), "z", std::to_string(KIND));
-    else if constexpr (TC == Fortran::common::TypeCategory::Logical)
-      setTypeId(x.shape(), "l", std::to_string(KIND));
-    else
-      llvm_unreachable("invalid type category");
-    const auto &values = x.values();
-    address = (const uint8_t *)values.data();
-    size = values.size() * sizeof(values[0]);
-  }
-  explicit LiteralNameHelper(
-      const Fortran::evaluate::Constant<Fortran::evaluate::SomeDerived> &x) {
-    // FIXME: Replace "DT" with the (fully qualified) type name.
-    setTypeId(x.shape(), "dt", ".DT");
-    const auto &values = x.values();
-    address = (const uint8_t *)values.data();
-    size = values.size() * sizeof(values[0]);
-  }
-
-  std::string getName(Fortran::lower::FirOpBuilder &builder);
-
-private:
-  void setTypeId(const Fortran::evaluate::ConstantSubscripts &shape,
-                 const std::string &tag, const std::string &kind,
-                 Fortran::common::ConstantSubscript charLen = -1) {
-    for (auto extent : shape)
-      typeId.append(std::to_string(extent)).append("x");
-    if (charLen >= 0)
-      typeId.append(std::to_string(charLen)).append("x");
-    typeId.append(tag).append(kind);
-  }
-
-  std::string typeId{};
-  const uint8_t *address;
-  size_t size;
-};
 
 /// Lowers the extents from the sequence type to Values.
 /// Any unknown extents are lowered to undefined values.

--- a/flang/include/flang/Lower/Mangler.h
+++ b/flang/include/flang/Lower/Mangler.h
@@ -13,6 +13,7 @@
 #ifndef FORTRAN_LOWER_MANGLER_H
 #define FORTRAN_LOWER_MANGLER_H
 
+#include "flang/Evaluate/expression.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/StringRef.h"
 #include <string>
@@ -57,6 +58,38 @@ std::string mangleName(const semantics::DerivedTypeSpec &);
 
 /// Recover the bare name of the original symbol from an internal name.
 std::string demangleName(llvm::StringRef name);
+
+std::string
+mangleArrayLiteral(const uint8_t *addr, size_t size,
+                   const Fortran::evaluate::ConstantSubscripts &shape,
+                   Fortran::common::TypeCategory cat, int kind = 0,
+                   Fortran::common::ConstantSubscript charLen = -1);
+
+template <Fortran::common::TypeCategory TC, int KIND>
+std::string mangleArrayLiteral(
+    const Fortran::evaluate::Constant<Fortran::evaluate::Type<TC, KIND>> &x) {
+  return mangleArrayLiteral(
+      reinterpret_cast<const uint8_t *>(x.values().data()),
+      x.values().size() * sizeof(x.values()[0]), x.shape(), TC, KIND);
+}
+
+template <int KIND>
+std::string
+mangleArrayLiteral(const Fortran::evaluate::Constant<Fortran::evaluate::Type<
+                       Fortran::common::TypeCategory::Character, KIND>> &x) {
+  return mangleArrayLiteral(
+      reinterpret_cast<const uint8_t *>(x.values().data()),
+      x.values().size() * sizeof(x.values()[0]) * x.LEN(), x.shape(),
+      Fortran::common::TypeCategory::Character, KIND, x.LEN());
+}
+
+inline std::string mangleArrayLiteral(
+    const Fortran::evaluate::Constant<Fortran::evaluate::SomeDerived> &x) {
+  return mangleArrayLiteral(
+      reinterpret_cast<const uint8_t *>(x.values().data()),
+      x.values().size() * sizeof(x.values()[0]), x.shape(),
+      Fortran::common::TypeCategory::Derived);
+}
 
 } // namespace lower::mangle
 } // namespace Fortran

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -30,6 +30,7 @@
 #include "flang/Lower/ComplexExpr.h"
 #include "flang/Lower/ConvertType.h"
 #include "flang/Lower/IntrinsicCall.h"
+#include "flang/Lower/Mangler.h"
 #include "flang/Lower/Runtime.h"
 #include "flang/Lower/Support/Utils.h"
 #include "flang/Lower/Todo.h"
@@ -3946,7 +3947,7 @@ public:
     auto loc = getLoc();
     auto idxTy = builder.getIndexType();
     auto arrTy = converter.genType(toEvExpr(x));
-    auto globalName = Fortran::lower::LiteralNameHelper{x}.getName(builder);
+    std::string globalName = Fortran::lower::mangle::mangleArrayLiteral(x);
     auto global = builder.getNamedGlobal(globalName);
     if (!global) {
       global = builder.createGlobalConstant(

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -15,9 +15,11 @@
 #include "flang/Semantics/tools.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/MD5.h"
 
 // recursively build the vector of module scopes
 static void moduleNames(const Fortran::semantics::Scope &scope,
@@ -162,6 +164,52 @@ std::string Fortran::lower::mangle::mangleName(
 std::string Fortran::lower::mangle::demangleName(llvm::StringRef name) {
   auto result = fir::NameUniquer::deconstruct(name);
   return result.second.name;
+}
+
+//===----------------------------------------------------------------------===//
+// Array Literals Mangling
+//===----------------------------------------------------------------------===//
+
+static std::string typeToString(Fortran::common::TypeCategory cat, int kind) {
+  switch (cat) {
+  case Fortran::common::TypeCategory::Integer:
+    return "i" + std::to_string(kind);
+  case Fortran::common::TypeCategory::Real:
+    return "r" + std::to_string(kind);
+  case Fortran::common::TypeCategory::Complex:
+    return "z" + std::to_string(kind);
+  case Fortran::common::TypeCategory::Logical:
+    return "l" + std::to_string(kind);
+  case Fortran::common::TypeCategory::Character:
+    return "c" + std::to_string(kind);
+  case Fortran::common::TypeCategory::Derived:
+    // FIXME: Replace "DT" with the (fully qualified) type name.
+    return "dt.DT";
+  }
+  llvm_unreachable("bad TypeCategory");
+}
+
+std::string Fortran::lower::mangle::mangleArrayLiteral(
+    const uint8_t *addr, size_t size,
+    const Fortran::evaluate::ConstantSubscripts &shape,
+    Fortran::common::TypeCategory cat, int kind,
+    Fortran::common::ConstantSubscript charLen) {
+  std::string typeId = "";
+  for (auto extent : shape)
+    typeId.append(std::to_string(extent)).append("x");
+  if (charLen >= 0)
+    typeId.append(std::to_string(charLen)).append("x");
+  typeId.append(typeToString(cat, kind));
+  auto name = fir::NameUniquer::doGenerated("ro."s.append(typeId).append("."));
+  if (!size)
+    return name += "null";
+  llvm::MD5 hashValue{};
+  hashValue.update(llvm::ArrayRef<uint8_t>{addr, size});
+  llvm::MD5::MD5Result hashResult;
+  hashValue.final(hashResult);
+  llvm::SmallString<32> hashString;
+  llvm::MD5::stringifyResult(hashResult, hashString);
+  return name += hashString.c_str();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
I am planning to move FirOpBuilder class in `lib/Optimzier/`. This is an initial NFC to remove lib/Evaluate and lib/Semantics dependencies from FIRBuilder.[h,cpp].  

The main change is the move of the `LiteralNameHelper` class that works on evaluate::Constant into Mangler.[h,cpp]. I slightly modified the API to makes this a `mangleArrayLitteral` function instead of a class.

The remaining piece is to clean/split CharacterExpr, ComplexExpr.h, and Allocatable.h from front-end data structures (some FirOpBuilder tools depend on these structures), or to make those member function Fortran::lower::xxx function.