### PR TITLE
[Flang] Fix build failure on MacOS

### DIFF
--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -38,7 +38,7 @@ using preferred_implementation = int;
 // This is the fallback implementation, which should work everywhere.
 template <typename Unused = void> double GetCpuTime(fallback_implementation) {
   std::clock_t timestamp{std::clock()};
-  if (timestamp != std::clock_t{-1}) {
+  if (timestamp != static_cast<std::clock_t>(-1)) {
     return static_cast<double>(timestamp) / CLOCKS_PER_SEC;
   }
 


### PR DESCRIPTION
std::clock_t can be an unsigned value on some platforms like MacOS and
therefore needs a cast when initializing an std::clock_t value with -1.

Reviewed By: klausler

Differential Revision: https://reviews.llvm.org/D107972