### PR TITLE
Add line information to some fatal errors to help debugging

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1680,15 +1680,11 @@ public:
     // Explicitly map statement function host associated symbols to their
     // parent scope lowered symbol box.
     for (const Fortran::semantics::SymbolRef &sym :
-         Fortran::evaluate::CollectSymbols(*details.stmtFunction())) {
+         Fortran::evaluate::CollectSymbols(*details.stmtFunction()))
       if (const auto *details =
-              sym->detailsIf<Fortran::semantics::HostAssocDetails>()) {
-        if (!symMap.lookupSymbol(*sym)) {
-          symMap.addSymbol(
-              *sym, symMap.lookupSymbol(details->symbol()).toExtendedValue());
-        }
-      }
-    }
+              sym->detailsIf<Fortran::semantics::HostAssocDetails>())
+        if (!symMap.lookupSymbol(*sym))
+          symMap.addSymbol(*sym, gen(details->symbol()));
 
     auto result = genval(details.stmtFunction().value());
     LLVM_DEBUG(llvm::dbgs() << "stmt-function: " << result << '\n');

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2216,7 +2216,7 @@ struct CoordinateOpConversion
   }
 
   int64_t getIntValue(mlir::Value val) const {
-    if (val)
+    if (val) {
       if (auto defop = val.getDefiningOp()) {
         if (auto constOp = dyn_cast<mlir::ConstantIntOp>(defop))
           return constOp.getValue();
@@ -2224,7 +2224,9 @@ struct CoordinateOpConversion
           if (auto attr = llConstOp.value().dyn_cast<mlir::IntegerAttr>())
             return attr.getValue().getSExtValue();
       }
-    llvm_unreachable("must be a constant");
+      fir::emitFatalError(val.getLoc(), "must be a constant");
+    }
+    llvm_unreachable("must not be null value");
   }
 }; // namespace
 


### PR DESCRIPTION
This also had the benefit to slightly simplify the genStmtFunctionRef lowering code by using gen(Sym) that already produces nice error messages.