### PR TITLE
Lower derived array assignments and improve derived scalar assignments

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -39,6 +39,9 @@ class FirOpBuilder : public mlir::OpBuilder {
 public:
   explicit FirOpBuilder(mlir::Operation *op, const fir::KindMapping &kindMap)
       : OpBuilder{op}, kindMap{kindMap} {}
+  explicit FirOpBuilder(mlir::OpBuilder &builder,
+                        const fir::KindMapping &kindMap)
+      : OpBuilder{builder}, kindMap{kindMap} {}
 
   /// Get the current Region of the insertion point.
   mlir::Region &getRegion() { return *getBlock()->getParent(); }
@@ -422,6 +425,12 @@ fir::ExtendedValue componentToExtendedValue(fir::FirOpBuilder &builder,
                                             mlir::Location loc,
                                             mlir::Value component);
 
+/// Assign \p rhs to \p lhs. Both \p rhs and \p lhs must be scalar derived
+/// types. The assignment follows Fortran intrinsic assignment semantic for
+/// derived types (10.2.1.3 point 13).
+void genRecordAssignment(fir::FirOpBuilder &builder, mlir::Location loc,
+                         const fir::ExtendedValue &lhs,
+                         const fir::ExtendedValue &rhs);
 } // namespace fir::factory
 
 #endif // FORTRAN_OPTIMIZER_BUILDER_FIRBUILDER_H

--- a/flang/include/flang/Optimizer/Runtime/Assign.h
+++ b/flang/include/flang/Optimizer/Runtime/Assign.h
@@ -1,0 +1,32 @@
+//===-- Assign.h - generate assignment runtime API calls     ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_RUNTIME_ASSIGN_H
+#define FORTRAN_OPTIMIZER_RUNTIME_ASSIGN_H
+
+namespace mlir {
+class Value;
+class Location;
+} // namespace mlir
+
+namespace fir {
+class FirOpBuilder;
+}
+
+namespace fir::runtime {
+
+/// Generate runtime call to assign \p sourceBox to \p destBox.
+/// \p destBox must be a fir.ref<fir.box<T>> and \p sourceBox a fir.box<T>.
+/// \p destBox Fortran descriptor may be modified if destBox is an allocatable
+/// according to Fortran allocatable assignment rules, otherwise it is not
+/// modified.
+void genAssign(fir::FirOpBuilder &builder, mlir::Location loc,
+               mlir::Value destBox, mlir::Value sourceBox);
+
+} // namespace fir::runtime
+#endif // FORTRAN_OPTIMIZER_RUNTIME_ASSIGN_H

--- a/flang/lib/Optimizer/Runtime/Assign.cpp
+++ b/flang/lib/Optimizer/Runtime/Assign.cpp
@@ -1,0 +1,26 @@
+//===-- Assign.cpp -- generate assignment runtime API calls ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Runtime/Assign.h"
+#include "../../../runtime/assign.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Runtime/RTBuilder.h"
+
+using namespace Fortran::runtime;
+
+void fir::runtime::genAssign(fir::FirOpBuilder &builder, mlir::Location loc,
+                             mlir::Value destBox, mlir::Value sourceBox) {
+  auto func = fir::runtime::getRuntimeFunc<mkRTKey(Assign)>(loc, builder);
+  auto fTy = func.getType();
+  auto sourceFile = fir::factory::locationToFilename(builder, loc);
+  auto sourceLine =
+      fir::factory::locationToLineNo(builder, loc, fTy.getInput(3));
+  auto args = fir::runtime::createArguments(builder, loc, fTy, destBox,
+                                            sourceBox, sourceFile, sourceLine);
+  builder.create<fir::CallOp>(loc, func, args);
+}

--- a/flang/lib/Optimizer/Runtime/CMakeLists.txt
+++ b/flang/lib/Optimizer/Runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_flang_library(FIRRuntime
+  Assign.cpp
   Character.cpp
   Derived.cpp
   Numeric.cpp

--- a/flang/test/Lower/array-derived-assignments.f90
+++ b/flang/test/Lower/array-derived-assignments.f90
@@ -1,0 +1,77 @@
+! Test derived type assignment lowering inside array expression
+! RUN: bbc %s -o - | FileCheck %s
+
+module array_derived_assign
+  type simple_copy
+    integer :: i
+    character(10) :: c(20)
+    real, pointer :: p(:)
+  end type
+  type deep_copy
+    integer :: i
+    real, allocatable :: a(:)
+  end type
+contains
+
+! Simple copies are implemented inline.
+! CHECK-LABEL: func @_QMarray_derived_assignPtest_simple_copy(
+! CHECK-SAME: %[[T1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>,
+! CHECK-SAME: %[[T2:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>) {
+subroutine test_simple_copy(t1, t2)
+  type(simple_copy) :: t1(10), t2(10)
+! CHECK-DAG:   %[[VAL_0:.*]] = constant 10 : index
+! CHECK-DAG:   %[[VAL_1:.*]] = constant 0 : index
+! CHECK-DAG:   %[[VAL_2:.*]] = constant 1 : index
+! CHECK:   %[[VAL_3:.*]] = fir.shape %[[VAL_0]] : (index) -> !fir.shape<1>
+! CHECK:   br ^bb1(%[[VAL_1]], %[[VAL_0]] : index, index)
+! CHECK: ^bb1(%[[VAL_4:.*]]: index, %[[VAL_5:.*]]: index):
+! CHECK:   %[[VAL_6:.*]] = cmpi sgt, %[[VAL_5]], %[[VAL_1]] : index
+! CHECK:   cond_br %[[VAL_6]], ^bb2, ^bb3
+! CHECK: ^bb2:
+! CHECK:   %[[VAL_7:.*]] = addi %[[VAL_4]], %[[VAL_2]] : index
+! CHECK:   %[[VAL_8:.*]] = fir.array_coor %[[T2:.*]](%[[VAL_3]]) %[[VAL_7]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>
+! CHECK:   %[[VAL_10:.*]] = fir.array_coor %[[T1:.*]](%[[VAL_3]]) %[[VAL_7]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>
+! CHECK:   %[[VAL_12:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>
+! CHECK:   fir.store %[[VAL_12]] to %[[VAL_10]] : !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{{.*}}>>
+! CHECK:   %[[VAL_13:.*]] = subi %[[VAL_5]], %[[VAL_2]] : index
+! CHECK:   br ^bb1(%[[VAL_7]], %[[VAL_13]] : index, index)
+! CHECK: ^bb3:
+! CHECK:   return
+  t1 = t2
+end subroutine
+
+! Types require more complex assignments are passed to the runtime
+! CHECK-LABEL: func @_QMarray_derived_assignPtest_deep_copy(
+! CHECK-SAME: %[[T1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>,
+! CHECK-SAME: %[[T2:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>) {
+subroutine test_deep_copy(t1, t2)
+  type(deep_copy) :: t1(10), t2(10)
+! CHECK-DAG:   %[[VAL_15:.*]] = constant 10 : index
+! CHECK-DAG:   %[[VAL_16:.*]] = constant 0 : index
+! CHECK-DAG:   %[[VAL_17:.*]] = constant 1 : index
+! CHECK:   %[[VAL_18:.*]] = fir.alloca !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>> {uniq_name = ""}
+! CHECK:   %[[VAL_19:.*]] = fir.shape %[[VAL_15]] : (index) -> !fir.shape<1>
+! CHECK:   br ^bb1(%[[VAL_16]], %[[VAL_15]] : index, index)
+! CHECK: ^bb1(%[[VAL_20:.*]]: index, %[[VAL_21:.*]]: index):
+! CHECK:   %[[VAL_22:.*]] = cmpi sgt, %[[VAL_21]], %[[VAL_16]] : index
+! CHECK:   cond_br %[[VAL_22]], ^bb2, ^bb3
+! CHECK: ^bb2:
+! CHECK:   %[[VAL_23:.*]] = addi %[[VAL_20]], %[[VAL_17]] : index
+! CHECK:   %[[VAL_24:.*]] = fir.array_coor %[[T2:.*]](%[[VAL_19]]) %[[VAL_23]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>
+! CHECK:   %[[VAL_26:.*]] = fir.array_coor %[[T1:.*]](%[[VAL_19]]) %[[VAL_23]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>
+! CHECK:   %[[VAL_28:.*]] = fir.embox %[[VAL_26]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>
+! CHECK:   %[[VAL_29:.*]] = fir.embox %[[VAL_24]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>
+! CHECK:   fir.store %[[VAL_28]] to %[[VAL_18]] : !fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>>
+! CHECK:   %[[VAL_30:.*]] = fir.address_of({{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:   %[[VAL_31:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:   %[[VAL_32:.*]] = fir.convert %[[VAL_29]] : (!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{{.*}}>>) -> !fir.box<none>
+! CHECK:   %[[VAL_33:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:   %[[VAL_34:.*]] = fir.call @_FortranAAssign(%[[VAL_31]], %[[VAL_32]], %[[VAL_33]], %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+! CHECK:   %[[VAL_35:.*]] = subi %[[VAL_21]], %[[VAL_17]] : index
+! CHECK:   br ^bb1(%[[VAL_23]], %[[VAL_35]] : index, index)
+! CHECK: ^bb3:
+! CHECK:   return
+  t1 = t2
+end subroutine
+  
+end module

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -11,16 +11,9 @@ subroutine test1
   type(t) :: t1, t2
   ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et1"}
   ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et2"}
-  ! CHECK-DAG: %[[a:.*]] = fir.field_index a, !fir.type<_QFtest1Tt{a:i32,b:i32}>
-  ! CHECK: %[[ac:.*]] = fir.coordinate_of %[[t2]], %[[a]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[ad:.*]] = fir.coordinate_of %[[t1]], %[[a]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[ld:.*]] = fir.load %[[ac]] : !fir.ref<i32>
-  ! CHECK: fir.store %[[ld]] to %[[ad]] : !fir.ref<i32>
-  ! CHECK: %[[b:.*]] = fir.field_index b, !fir.type<_QFtest1Tt{a:i32,b:i32}>
-  ! CHECK: %[[bc:.*]] = fir.coordinate_of %[[t2]], %[[b]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[bd:.*]] = fir.coordinate_of %[[t1]], %[[b]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[ld:.*]] = fir.load %[[bc]] : !fir.ref<i32>
-  ! CHECK: fir.store %[[ld]] to %[[bd]] : !fir.ref<i32>
+
+  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest1Tt{{.*}}>
+  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest1Tt{{.*}}>
   t1 = t2
 end subroutine test1
 
@@ -77,21 +70,8 @@ subroutine test3
   ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et1"}
   ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et2"}
 
-  ! CHECK: %[[mc:.*]] = fir.field_index m_c, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
-  ! CHECK: %[[t2x:.*]] = fir.coordinate_of %[[t2]], %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
-  ! CHECK: %[[t1x:.*]] = fir.coordinate_of %[[t1]], %[[mc]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
-  ! CHECK-DAG: %[[one:.*]] = constant 1
-  ! CHECK: %[[count:.*]] = muli %[[one]], %
-  ! CHECK: constant false
-  ! CHECK: %[[dst:.*]] = fir.convert %[[t1x]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
-  ! CHECK: %[[src:.*]] = fir.convert %[[t2x]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
-  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[dst]], %[[src]], %[[count]], %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
-
-
-  ! CHECK: %[[mi:.*]] = fir.field_index m_i, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
-  ! CHECK: %[[mip:.*]] = fir.coordinate_of %[[t1]], %[[mi]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[ii:.*]] = fir.load
-  ! CHECK: fir.store %[[ii]] to %[[mip]] : !fir.ref<i32>
+  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest3Tt{{.*}}>
+  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest3Tt{{.*}}>
   t1 = t2
   ! CHECK: return
 end subroutine test3
@@ -105,18 +85,9 @@ subroutine test_array_comp(t1, t2)
      integer :: m_i
   end type t
   type(t) :: t1, t2
-  ! CHECK: %[[xfield:.*]] = fir.field_index m_x, !fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>
-  ! CHECK-DAG: %[[x2coor:.*]] = fir.coordinate_of %[[t2]], %[[xfield]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.array<10xf32>>
-  ! CHECK-DAG: %[[x1coor:.*]] = fir.coordinate_of %[[t1]], %[[xfield]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.array<10xf32>>
-  ! CHECK-DAG: %[[x1load:.*]] = fir.array_load %[[x1coor]](%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
-  ! CHECK-DAG: %[[x2load:.*]] = fir.array_load %[[x2coor]](%{{.*}}) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
-  ! CHECK: %[[loop:.*]] = fir.do_loop %[[idx:.*]] = %c0{{.*}} to %{{.*}} step %c1{{.*}} iter_args(%[[res:.*]] = %[[x1load]]) -> (!fir.array<10xf32>) {
-  ! CHECK:   %[[fetch:.*]] = fir.array_fetch %[[x2load]], %[[idx]] : (!fir.array<10xf32>, index) -> f32
-  ! CHECK:   %[[update:.*]] = fir.array_update %[[res]], %[[fetch]], %[[idx]] : (!fir.array<10xf32>, f32, index) -> !fir.array<10xf32>
-  ! CHECK:   fir.result %[[update]] : !fir.array<10xf32>
-  ! CHECK: fir.array_merge_store %[[x1load]], %[[loop]] to %[[x1coor]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>
 
-  ! CHECK: fir.field_index m_i, !fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>
+  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest_array_compTt{{.*}}>
+  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest_array_compTt{{.*}}>
   t1 = t2
 end subroutine
 
@@ -129,13 +100,9 @@ subroutine test_ptr_comp(t1, t2)
      integer :: m_i
   end type t
   type(t) :: t1, t2
-  ! CHECK: %[[ptrfield:.*]] = fir.field_index ptr, !fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>
-  ! CHECK-DAG: %[[ptr2coor:.*]] = fir.coordinate_of %[[t2]], %[[ptrfield]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
-  ! CHECK: %[[ptr1coor:.*]] = fir.coordinate_of %[[t1]], %[[ptrfield]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
-  ! CHECK-DAG: %[[ptr:.*]] = fir.load %[[ptr2coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
-  ! CHECK: fir.store %[[ptr]] to %[[ptr1coor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
 
-  ! CHECK: fir.field_index m_i, !fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>
+  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest_ptr_compTt{{.*}}>
+  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest_ptr_compTt{{.*}}>
   t1 = t2
 end subroutine
 
@@ -146,13 +113,77 @@ subroutine test_box_assign(t1, t2)
   type t
      integer :: i
   end type t
+  ! Note: the implementation of this case is not optimal, the runtime call is overkill, but right now
+  ! lowering is conservative with derived type pointers because it does not make a difference between the
+  ! polymorphic and non polymorphic ones at the FIR level.
   type(t), pointer :: t1, t2
+  ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>
   ! CHECK: %[[t2Load:.*]] = fir.load %[[t2]] : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>
   ! CHECK: %[[t1Load:.*]] = fir.load %[[t1]] : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>
-  ! CHECK: %[[ifield:.*]] = fir.field_index i, !fir.type<_QFtest_box_assignTt{i:i32}>
-  ! CHECK: %[[t2Coor:.*]] = fir.coordinate_of %[[t2Load]], %[[ifield]] : (!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[t1Coor:.*]] = fir.coordinate_of %[[t1Load]], %[[ifield]] : (!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>, !fir.field) -> !fir.ref<i32>
-  ! CHECK: %[[val:.*]] = fir.load %[[t2Coor]] : !fir.ref<i32>
-  ! CHECK: fir.store %[[val]] to %[[t1Coor]] : !fir.ref<i32>
+  ! CHECK: fir.store %[[t1Load]] to %[[tmpBox]] : !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>
+  ! CHECK: %[[lhs:.*]] = fir.convert %[[tmpBox]] : (!fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: %[[rhs:.*]] = fir.convert %[[t2Load]] : (!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAAssign(%[[lhs]], %[[rhs]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none
   t1 = t2
 end subroutine
+
+! CHECK-LABEL: func @_QPtest_alloc_comp(
+! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>,
+! CHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>)
+subroutine test_alloc_comp(t1, t2)
+! Test that derived type assignment with allocatable components are using the
+! runtime to handle the deep copy.
+  type t
+    real, allocatable :: x(:, :)
+    integer :: i
+  end type
+  type(t) :: t1, t2
+  ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>
+  ! CHECK: %[[t1Box:.*]] = fir.embox %[[t1]] : (!fir.ref<!fir.type<_QFtest_alloc_compTt{{.*}}>>) -> !fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>
+  ! CHECK: %[[t2Box:.*]] = fir.embox %[[t2]] : (!fir.ref<!fir.type<_QFtest_alloc_compTt{{.*}}>>) -> !fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>
+  ! CHECK: fir.store %[[t1Box]] to %[[tmpBox]] : !fir.ref<!fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>>
+  ! CHECK: %[[lhs:.*]] = fir.convert %[[tmpBox]] : (!fir.ref<!fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>>) -> !fir.ref<!fir.box<none>>
+  ! CHECK: %[[rhs:.*]] = fir.convert %[[t2Box]] : (!fir.box<!fir.type<_QFtest_alloc_compTt{{.*}}>>) -> !fir.box<none>
+  ! CHECK: fir.call @_FortranAAssign(%[[lhs]], %[[rhs]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+  t1 = t2
+end subroutine
+
+module component_with_user_def_assign
+  type t0
+    integer :: i
+    integer :: j
+  contains
+    procedure :: user_def
+    generic :: assignment(=) => user_def
+  end type
+  interface
+  subroutine user_def(other, self)
+    import t0
+    class(t0), intent(out) :: other
+    class(t0), intent(in) :: self
+  end subroutine
+  end interface
+
+  ! Assignments of type(t) must call the user defined assignment for component a.
+  ! Currently this is delegated to the runtime.
+  type t
+    type(t0) :: a
+    integer :: i
+  end type
+
+contains
+  ! CHECK-LABEL: func @_QMcomponent_with_user_def_assignPtest(
+  ! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>,
+  ! CHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>)
+  subroutine test(t1, t2)
+    type(t) :: t1, t2
+    ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>
+    ! CHECK: %[[t1Box:.*]] = fir.embox %[[t1]] : (!fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>) -> !fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>
+    ! CHECK: %[[t2Box:.*]] = fir.embox %[[t2]] : (!fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>) -> !fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>
+    ! CHECK: fir.store %[[t1Box]] to %[[tmpBox]] : !fir.ref<!fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>>
+    ! CHECK: %[[lhs:.*]] = fir.convert %[[tmpBox]] : (!fir.ref<!fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>>) -> !fir.ref<!fir.box<none>>
+    ! CHECK: %[[rhs:.*]] = fir.convert %[[t2Box]] : (!fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>) -> !fir.box<none>
+    ! CHECK: fir.call @_FortranAAssign(%[[lhs]], %[[rhs]], %{{.*}}, %{{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none
+    t1 = t2
+  end subroutine
+end module


### PR DESCRIPTION
Move the `genRecordAssignment` scalar assignment helper in fir::factory so
that it can be used for the array case in ArrayCopyValue.cpp.

Simplify `genRecordAssignment` to only lower as inline code the cases where
a mem copy can be done to implement the derive type assignment (that is
when their are no allocatable component, automatic component, or
component requiring a user defined assignment calls). For the rest, use
the runtime genAssign() that handles deep copies and user defined
assignments.

For the inline version, instead of working component by component, and
using the array expression framework for array components, simply emit a
derived type load + store. This is OK since the derived types assigned
inlined have constant size. LLVM transform this into element by element
assignment of llvm.memmove itself (opt --memcpyopt inserts memmove calls).

This allows implementing the simple cases inlined without depending on
the array expression framework (which is not possible during the
ArrayCopyValue pass), or manually creating llvm.memmove, which would
require inserting a fir.sizeof of to compute the byte size for the
memmove.

This patch side effect is to eliminate the TODO for allocatable component
and the FIXME for derived type component that may have user defined assignment
in the scalar case (since this is now delegated to the runtime).