### PR TITLE
Implement pointer assignment in FORALL context.

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -134,12 +134,29 @@ void createAnyMaskedArrayAssignment(
     ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
     SymMap &symMap, StatementContext &stmtCtx);
 
+/// In the context of a FORALL, a pointer assignment is allowed. The pointer
+/// assignment can be elementwise on an array of pointers. The bounds
+/// expressions as well as the component path may contain references to the
+/// concurrent control variables. The explicit iteration space must be defined.
+void createAnyArrayPointerAssignment(
+    AbstractConverter &converter, const evaluate::Expr<evaluate::SomeType> &lhs,
+    const evaluate::Expr<evaluate::SomeType> &rhs,
+    const evaluate::Assignment::BoundsSpec &bounds,
+    ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
+    SymMap &symMap);
+/// Support the bounds remapping flavor of pointer assignment.
+void createAnyArrayPointerAssignment(
+    AbstractConverter &converter, const evaluate::Expr<evaluate::SomeType> &lhs,
+    const evaluate::Expr<evaluate::SomeType> &rhs,
+    const evaluate::Assignment::BoundsRemapping &bounds,
+    ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
+    SymMap &symMap);
+
 /// Lower an assignment to an allocatable array, allocating the array if
 /// it is not allocated yet or reallocation it if it does not conform
 /// with the right hand side.
 void createAllocatableArrayAssignment(
-    AbstractConverter &converter,
-    const evaluate::Expr<evaluate::SomeType> &lhs,
+    AbstractConverter &converter, const evaluate::Expr<evaluate::SomeType> &lhs,
     const evaluate::Expr<evaluate::SomeType> &rhs,
     ExplicitIterSpace &explicitIterSpace, ImplicitIterSpace &implicitIterSpace,
     SymMap &symMap, StatementContext &stmtCtx);

--- a/flang/include/flang/Lower/Support/Utils.h
+++ b/flang/include/flang/Lower/Support/Utils.h
@@ -16,6 +16,7 @@
 #include "flang/Common/indirection.h"
 #include "flang/Optimizer/Support/Utils.h"
 #include "flang/Parser/char-block.h"
+#include "flang/Semantics/tools.h"
 #include "llvm/ADT/StringRef.h"
 
 //===----------------------------------------------------------------------===//
@@ -35,6 +36,13 @@ const A &removeIndirection(const A &a) {
 template <typename A>
 const A &removeIndirection(const Fortran::common::Indirection<A> &a) {
   return a.value();
+}
+
+/// Clone subexpression and wrap it as a generic `Fortran::evaluate::Expr`.
+template <typename A>
+static Fortran::evaluate::Expr<Fortran::evaluate::SomeType>
+toEvExpr(const A &x) {
+  return Fortran::evaluate::AsGenericExpr(Fortran::common::Clone(x));
 }
 
 #endif // FORTRAN_LOWER_SUPPORT_UTILS_H

--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -410,8 +410,6 @@ public:
                    ProcBoxValue, BoxValue, MutableBoxValue>;
 
   ExtendedValue() : box{UnboxedValue{}} {}
-  ExtendedValue(const ExtendedValue &) = default;
-  ExtendedValue(ExtendedValue &&) = default;
   template <typename A, typename = std::enable_if_t<
                             !std::is_same_v<std::decay_t<A>, ExtendedValue>>>
   constexpr ExtendedValue(A &&a) : box{std::forward<A>(a)} {

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -420,7 +420,6 @@ mlir::Value locationToLineNo(fir::FirOpBuilder &, mlir::Location, mlir::Type);
 /// the component.
 fir::ExtendedValue componentToExtendedValue(fir::FirOpBuilder &builder,
                                             mlir::Location loc,
-                                            const fir::ExtendedValue &obj,
                                             mlir::Value component);
 
 } // namespace fir::factory

--- a/flang/include/flang/Optimizer/Builder/MutableBox.h
+++ b/flang/include/flang/Optimizer/Builder/MutableBox.h
@@ -45,15 +45,15 @@ mlir::Value createUnallocatedBox(fir::FirOpBuilder &builder, mlir::Location loc,
 /// The created MutableBoxValue wraps a fir.ref<fir.box<fir.heap<type>>> and is
 /// initialized to unallocated/diassociated status. An optional name can be
 /// given to the created !fir.ref<fir.box>.
-fir::MutableBoxValue createTempMutableBox(fir::FirOpBuilder &, mlir::Location,
-                                          mlir::Type type,
+fir::MutableBoxValue createTempMutableBox(fir::FirOpBuilder &builder,
+                                          mlir::Location loc, mlir::Type type,
                                           llvm::StringRef name = {});
 
 /// Update a MutableBoxValue to describe entity \p source (that must be in
 /// memory). If \lbounds is not empty, it is used to defined the MutableBoxValue
 /// lower bounds, otherwise, the lower bounds from \p source are used.
-void associateMutableBox(fir::FirOpBuilder &, mlir::Location,
-                         const fir::MutableBoxValue &,
+void associateMutableBox(fir::FirOpBuilder &builder, mlir::Location loc,
+                         const fir::MutableBoxValue &box,
                          const fir::ExtendedValue &source,
                          mlir::ValueRange lbounds);
 
@@ -61,8 +61,9 @@ void associateMutableBox(fir::FirOpBuilder &, mlir::Location,
 /// memory) with a new array layout given by \p lbounds and \p ubounds.
 /// \p source must be known to be contiguous at compile time, or it must have
 /// rank 1 (constraint from Fortran 2018 standard 10.2.2.3 point 9).
-void associateMutableBoxWithRemap(fir::FirOpBuilder &, mlir::Location,
-                                  const fir::MutableBoxValue &,
+void associateMutableBoxWithRemap(fir::FirOpBuilder &builder,
+                                  mlir::Location loc,
+                                  const fir::MutableBoxValue &box,
                                   const fir::ExtendedValue &source,
                                   mlir::ValueRange lbounds,
                                   mlir::ValueRange ubounds);
@@ -71,8 +72,8 @@ void associateMutableBoxWithRemap(fir::FirOpBuilder &, mlir::Location,
 /// disassociated/unallocated. Nothing is done with the entity that was
 /// previously associated/allocated. The function generates code that sets the
 /// address field of the MutableBoxValue to zero.
-void disassociateMutableBox(fir::FirOpBuilder &, mlir::Location,
-                            const fir::MutableBoxValue &);
+void disassociateMutableBox(fir::FirOpBuilder &builder, mlir::Location loc,
+                            const fir::MutableBoxValue &box);
 
 /// Generate code to conditionally reallocate a MutableBoxValue with a new
 /// shape, lower bounds, and length parameters if it is unallocated or if its
@@ -85,14 +86,15 @@ void disassociateMutableBox(fir::FirOpBuilder &, mlir::Location,
 /// parameter mismatch can trigger a reallocation. See Fortran 10.2.1.3 point 3
 /// that this function is implementing for more details. The polymorphic
 /// requirements are not yet covered by this function.
-void genReallocIfNeeded(fir::FirOpBuilder &, mlir::Location,
-                        const fir::MutableBoxValue &, mlir::ValueRange lbounds,
-                        mlir::ValueRange shape, mlir::ValueRange lengthParams);
+void genReallocIfNeeded(fir::FirOpBuilder &builder, mlir::Location loc,
+                        const fir::MutableBoxValue &box,
+                        mlir::ValueRange lbounds, mlir::ValueRange shape,
+                        mlir::ValueRange lengthParams);
 
 /// Finalize a mutable box if it is allocated or associated. This includes both
 /// calling the finalizer, if any, and deallocating the storage.
-void genFinalization(fir::FirOpBuilder &, mlir::Location,
-                     const fir::MutableBoxValue &);
+void genFinalization(fir::FirOpBuilder &builder, mlir::Location loc,
+                     const fir::MutableBoxValue &box);
 
 void genInlinedAllocation(fir::FirOpBuilder &builder, mlir::Location loc,
                           const fir::MutableBoxValue &box,
@@ -106,28 +108,30 @@ void genInlinedDeallocate(fir::FirOpBuilder &builder, mlir::Location loc,
 /// When the MutableBoxValue was passed as a fir.ref<fir.box> to a call that may
 /// have modified it, update the MutableBoxValue according to the
 /// fir.ref<fir.box> value.
-void syncMutableBoxFromIRBox(fir::FirOpBuilder &, mlir::Location,
-                             const fir::MutableBoxValue &);
+void syncMutableBoxFromIRBox(fir::FirOpBuilder &builder, mlir::Location loc,
+                             const fir::MutableBoxValue &box);
 
 /// Read all mutable properties into a normal symbol box.
 /// It is OK to call this on unassociated/unallocated boxes but any use of the
 /// resulting values will be undefined (only the base address will be guaranteed
 /// to be null).
-fir::ExtendedValue genMutableBoxRead(fir::FirOpBuilder &, mlir::Location,
-                                     const fir::MutableBoxValue &,
+fir::ExtendedValue genMutableBoxRead(fir::FirOpBuilder &builder,
+                                     mlir::Location loc,
+                                     const fir::MutableBoxValue &box,
                                      bool mayBePolymorphic = true);
 
 /// Returns the fir.ref<fir.box<T>> of a MutableBoxValue filled with the current
 /// association / allocation properties. If the fir.ref<fir.box> already exists
 /// and is-up to date, this is a no-op, otherwise, code will be generated to
 /// fill the it.
-mlir::Value getMutableIRBox(fir::FirOpBuilder &, mlir::Location,
-                            const fir::MutableBoxValue &);
+mlir::Value getMutableIRBox(fir::FirOpBuilder &builder, mlir::Location loc,
+                            const fir::MutableBoxValue &box);
 
 /// Generate allocation or association status test and returns the resulting
 /// i1. This is testing this for a valid/non-null base address value.
-mlir::Value genIsAllocatedOrAssociatedTest(fir::FirOpBuilder &, mlir::Location,
-                                           const fir::MutableBoxValue &);
+mlir::Value genIsAllocatedOrAssociatedTest(fir::FirOpBuilder &builder,
+                                           mlir::Location loc,
+                                           const fir::MutableBoxValue &box);
 
 } // namespace fir::factory
 

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -66,7 +66,9 @@ bool isa_ref_type(mlir::Type t);
 bool isa_passbyref_type(mlir::Type t);
 
 /// Is `t` a boxed type?
-bool isa_box_type(mlir::Type t);
+inline bool isa_box_type(mlir::Type t) {
+  return t.isa<BoxType>() || t.isa<BoxCharType>() || t.isa<BoxProcType>();
+}
 
 /// Is `t` a type that can conform to be pass-by-reference? Depending on the
 /// context, these types may simply demote to pass-by-reference or a reference
@@ -75,8 +77,14 @@ inline bool conformsWithPassByRef(mlir::Type t) {
   return isa_ref_type(t) || isa_box_type(t);
 }
 
+/// Is `t` a derived (record) type?
+inline bool isa_derived(mlir::Type t) { return t.isa<fir::RecordType>(); }
+
 /// Is `t` a FIR dialect aggregate type?
-bool isa_aggregate(mlir::Type t);
+inline bool isa_aggregate(mlir::Type t) {
+  return t.isa<SequenceType>() || fir::isa_derived(t) ||
+         t.isa<mlir::TupleType>();
+}
 
 /// Extract the `Type` pointed to from a FIR memory reference type. If `t` is
 /// not a memory reference type, then returns a null `Type`.
@@ -126,9 +134,6 @@ inline bool isa_char_string(mlir::Type t) {
     return ct.getLen() != fir::CharacterType::singleton();
   return false;
 }
-
-/// Is `t` a derived (record) type?
-inline bool isa_derived(mlir::Type t) { return t.isa<fir::RecordType>(); }
 
 /// Is `t` a box type for which it is not possible to deduce the box size?
 /// It is not possible to deduce the size of a box that describes an entity

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -5121,6 +5121,8 @@ public:
         if (auto eleTy = fir::dyn_cast_ptrEleTy(box.getType()))
           if (!eleTy.isa<fir::BoxType>()) {
             // `box` is not boxed. Embox it now.
+            // FIXME: createBox isn't correct here. We want to create a boxed
+            // POINTER instead.
             box = builder.createBox(loc, box);
           }
         return arraySectionElementToExtendedValue(builder, loc, extMemref, box,
@@ -5826,7 +5828,7 @@ private:
   /// Array appears in a context where it must be boxed.
   bool isBoxValue() { return semant == ConstituentSemantics::BoxValue; }
 
-  /// Data referemce is to a box or value to be boxed.
+  /// Data reference is to a box or value to be boxed.
   bool isBoxValueEle() {
     return semant == ConstituentSemantics::BoxValueElement;
   }

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -674,8 +674,7 @@ fir::factory::createExtents(fir::FirOpBuilder &builder, mlir::Location loc,
 }
 
 fir::ExtendedValue fir::factory::componentToExtendedValue(
-    fir::FirOpBuilder &builder, mlir::Location loc,
-    const fir::ExtendedValue &obj, mlir::Value component) {
+    fir::FirOpBuilder &builder, mlir::Location loc, mlir::Value component) {
   auto fieldTy = component.getType();
   if (auto ty = fir::dyn_cast_ptrEleTy(fieldTy))
     fieldTy = ty;

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -673,6 +673,20 @@ fir::factory::createExtents(fir::FirOpBuilder &builder, mlir::Location loc,
   return extents;
 }
 
+// FIXME: This needs some work. To correctly determine the extended value of a
+// component, one needs the base object, its type, and its type parameters. (An
+// alternative would be to provide an already computed address of the final
+// component rather than the base object's address, the point being the result
+// will require the address of the final component to create the extended
+// value.) One further needs the full path of components being applied. One
+// needs to apply type-based expressions to type parameters along this said
+// path. (See applyPathToType for a type-only derivation.) Finally, one needs to
+// compose the extended value of the terminal component, including all of its
+// parameters: array lower bounds expressions, extents, type parameters, etc.
+// Any of these properties may be deferred until runtime in Fortran. This
+// operation may therefore generate a sizeable block of IR, including calls to
+// type-based helper functions, so caching the result of this operation in the
+// client would be advised as well.
 fir::ExtendedValue fir::factory::componentToExtendedValue(
     fir::FirOpBuilder &builder, mlir::Location loc, mlir::Value component) {
   auto fieldTy = component.getType();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -314,7 +314,9 @@ static mlir::Type adjustedElementType(mlir::Type t) {
     auto eleTy = ty.getEleTy();
     if (fir::isa_char(eleTy))
       return eleTy;
-    if (eleTy.isa<fir::RecordType>())
+    if (fir::isa_derived(eleTy))
+      return eleTy;
+    if (eleTy.isa<fir::SequenceType>())
       return eleTy;
   }
   return t;

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -203,18 +203,9 @@ bool isa_ref_type(mlir::Type t) {
          t.isa<fir::LLVMPointerType>();
 }
 
-bool isa_box_type(mlir::Type t) {
-  return t.isa<BoxType>() || t.isa<BoxCharType>() || t.isa<BoxProcType>();
-}
-
 bool isa_passbyref_type(mlir::Type t) {
   return t.isa<ReferenceType>() || isa_box_type(t) ||
          t.isa<mlir::FunctionType>();
-}
-
-bool isa_aggregate(mlir::Type t) {
-  return t.isa<SequenceType>() || t.isa<RecordType>() ||
-         t.isa<mlir::TupleType>();
 }
 
 mlir::Type dyn_cast_ptrEleTy(mlir::Type t) {

--- a/flang/test/Lower/forall-2.f90
+++ b/flang/test/Lower/forall-2.f90
@@ -15,7 +15,20 @@ subroutine implied_iters_allocatable(a1)
 end subroutine implied_iters_allocatable
 
 ! CHECK-LABEL: func @_QPforall_pointer_assign(
+! CHECK-SAME: %[[arg0:[^:]*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>,
+! CHECK-SAME: %[[arg1:[^:]*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>> {fir.target},
+! CHECK-SAME: %[[arg2:[^:]*]]: !fir.ref<i32>, %[[arg3:[^:]*]]: !fir.ref<i32>) {
 subroutine forall_pointer_assign(ap, at, ii, ij)
+  ! CHECK-NEXT: %[[VAL_0:.*]] = fir.alloca i32 {adapt.valuebyref, uniq_name = "i"}
+  ! CHECK: %[[VAL_1:.*]] = fir.array_load %[[arg0]] : (!fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>) -> !fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK: %[[VAL_3:.*]] = fir.array_load %[[arg1]] : (!fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>>) -> !fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>
+  ! CHECK: %[[VAL_5:.*]] = fir.load %[[arg2]] : !fir.ref<i32>
+  ! CHECK: %[[VAL_7:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+  ! CHECK: %[[VAL_8:.*]] = fir.load %[[arg3]] : !fir.ref<i32>
+  ! CHECK: %[[VAL_10:.*]] = fir.convert %[[VAL_8]] : (i32) -> index
+  ! CHECK: %[[VAL_11:.*]] = constant 8 : i32
+  ! CHECK: %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (i32) -> index
+
   type t
      real, pointer :: ptr(:)
   end type t
@@ -23,12 +36,32 @@ subroutine forall_pointer_assign(ap, at, ii, ij)
      real :: targ(20)
   end type u
   type(t) :: ap(:)
-  type(u) :: at(:)
+  type(u), target :: at(:)
   integer :: ii, ij
 
+  ! CHECK: %[[V_0:.*]] = fir.do_loop %[[V_1:.*]] = %[[VAL_7]] to %[[VAL_10]] step %[[VAL_12]] unordered iter_args(%[[VAL_2:.*]] = %[[VAL_1]]) -> (!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) {
+  ! CHECK: %[[V_3:.*]] = fir.convert %[[V_1]] : (index) -> i32
+  ! CHECK: fir.store %[[V_3]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[VAL_4:.*]] = fir.field_index targ, !fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>
+  ! CHECK-DAG: %[[VAL_5:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK-DAG: %[[VAL_6:.*]] = constant 4 : i32
+  ! CHECK: %[[VAL_7:.*]] = subi %[[VAL_5]], %[[VAL_6]] : i32
+  ! CHECK: %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> i64
+  ! CHECK: %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
+  ! CHECK: %[[VAL_10:.*]] = fir.array_fetch %[[VAL_3]], %[[VAL_9]], %[[VAL_4]] : (!fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>, index, !fir.field) -> !fir.ref<!fir.array<20xf32>>
+  ! CHECK: %[[VAL_11:.*]] = fir.embox %[[VAL_10]] : (!fir.ref<!fir.array<20xf32>>) -> !fir.box<!fir.array<20xf32>>
+  ! CHECK: %[[VAL_12:.*]] = fir.field_index ptr, !fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK: %[[VAL_13:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK: %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> i64
+  ! CHECK: %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i64) -> index
+  ! CHECK: %[[VAL_16:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.array<20xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  ! CHECK: %[[VAL_17:.*]] = fir.array_update %[[VAL_2]], %[[VAL_16]], %[[VAL_15]], %[[VAL_12]] : (!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>, index, !fir.field) -> !fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK: fir.result %[[VAL_17]] : !fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
   forall (i = ii:ij:8)
-  !  ap(i)%ptr => at(i-4)%targ
+     ap(i)%ptr => at(i-4)%targ
   end forall
+  ! CHECK: }
+  ! CHECK: fir.array_merge_store %[[VAL_1]], %[[V_0]] to %[[arg0]] : !fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>
   ! CHECK: return
 end subroutine forall_pointer_assign
 


### PR DESCRIPTION
This does not fix tests using substring operations.