### PR TITLE
Fix a character constant mangling bug

### DIFF
--- a/flang/include/flang/Lower/Mangler.h
+++ b/flang/include/flang/Lower/Mangler.h
@@ -79,7 +79,7 @@ mangleArrayLiteral(const Fortran::evaluate::Constant<Fortran::evaluate::Type<
                        Fortran::common::TypeCategory::Character, KIND>> &x) {
   return mangleArrayLiteral(
       reinterpret_cast<const uint8_t *>(x.values().data()),
-      x.values().size() * sizeof(x.values()[0]) * x.LEN(), x.shape(),
+      x.values().size() * sizeof(x.values()[0]), x.shape(),
       Fortran::common::TypeCategory::Character, KIND, x.LEN());
 }
 

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -30,11 +30,29 @@ subroutine issue(c1, c2)
   c1 = c2
 end subroutine
 
+! CHECK-LABEL: func @_QQmain
 program p
   character(4) :: c1(3)
   character(4) :: c2(3) = ["abcd", "    ", "    "]
   print *, c2
   call issue(c1, c2)
   print *, c1
+  call charlit
 end program p
 
+! CHECK-LABEL: func @_QPcharlit
+subroutine charlit
+  ! CHECK: fir.address_of(@_QQro.4x3xc1.1636b396a657de68ffb870a885ac44b4) : !fir.ref<!fir.array<4x!fir.char<1,3>>>
+  print*, ['AA ', 'MM ', 'MM ', 'ZZ ']
+  print*, ['AA ', 'MM ', 'MM ', 'ZZ ']
+  print*, ['AA ', 'MM ', 'MM ', 'ZZ ']
+end
+
+! CHECK: fir.global internal @_QQro.4x3xc1.1636b396a657de68ffb870a885ac44b4 constant : !fir.array<4x!fir.char<1,3>>
+! CHECK: AA
+! CHECK: MM
+! CHECK: ZZ
+! CHECK-NOT: fir.global internal @_QQro.4x3xc1
+! CHECK-NOT: AA
+! CHECK-NOT: MM
+! CHECK-NOT: ZZ


### PR DESCRIPTION
The hash portion of a character constant name is currently derived by
hashing over a multiple of the actual character constant length, rather
than the actual length.  Incorporating arbitrary "garbage" characters
in the hash value generation will not usually be a correctness issue
because the resulting "invalid" hash name will be used for both the
value definition and any references to it.  However, beyond wasting
compile time, it can create duplicate constants rather than reusing
a single constant.