### PR TITLE
Cherry pick all flang commits from LLVM since last cherry-picking

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -58,6 +58,11 @@ write(buffer,*,delim="QUOTE") quotes
 print "('>',a10,'<')", buffer
 end
 ```
+* The name of the control variable in an implied DO loop in an array
+  constructor or DATA statement has a scope over the value-list only,
+  not the bounds of the implied DO loop.  It is not advisable to use
+  an object of the same name as the index variable in a bounds
+  expression, but it will work, instead of being needlessly undefined.
 
 ## Extensions, deletions, and legacy features supported by default
 

--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -203,12 +203,6 @@ protected:
     GetContext().actualClauses.push_back(type);
   }
 
-  void EnterSIMDNest() { simdNest_++; }
-
-  void ExitSIMDNest() { simdNest_--; }
-
-  int GetSIMDNest() { return simdNest_; }
-
   // Check if the given clause is present in the current context
   const PC *FindClause(C type) {
     auto it{GetContext().clauseInfo.find(type)};
@@ -320,7 +314,6 @@ protected:
       directiveClausesMap_;
 
   std::string ClauseSetToString(const common::EnumSet<C, ClauseEnumSize> set);
-  int simdNest_{0};
 };
 
 template <typename D, typename C, typename PC, std::size_t ClauseEnumSize>

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -981,8 +981,6 @@ void OmpStructureChecker::CheckCancellationNest(
         eligibleCancellation = true;
       }
       break;
-    default:
-      break;
     }
     if (!eligibleCancellation) {
       context_.Say(source,
@@ -1027,8 +1025,6 @@ void OmpStructureChecker::CheckCancellationNest(
           ContextDirectiveAsFortran(),
           parser::ToUpperCaseLetters(
               parser::OmpCancelType::EnumToString(type)));
-      break;
-    default:
       break;
     }
   }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -285,7 +285,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPConstruct &x) {
   // called individually for each construct.  Therefore a
   // dirContext_ size `1` means the current construct is nested
   if (dirContext_.size() >= 1) {
-    if (GetSIMDNest() > 0) {
+    if (GetDirectiveNest(SIMDNest) > 0) {
       CheckSIMDNest(x);
     }
   }
@@ -306,7 +306,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
 
   PushContextAndClauseSets(beginDir.source, beginDir.v);
   if (llvm::omp::simdSet.test(GetContext().directive)) {
-    EnterSIMDNest();
+    EnterDirectiveNest(SIMDNest);
   }
 
   if (beginDir.v == llvm::omp::Directive::OMPD_do) {
@@ -585,7 +585,7 @@ void OmpStructureChecker::CheckDistLinear(
 
 void OmpStructureChecker::Leave(const parser::OpenMPLoopConstruct &) {
   if (llvm::omp::simdSet.test(GetContext().directive)) {
-    ExitSIMDNest();
+    ExitDirectiveNest(SIMDNest);
   }
   dirContext_.pop_back();
 }
@@ -625,11 +625,35 @@ void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
     if (GetContext().directive == llvm::omp::Directive::OMPD_master) {
       CheckMasterNesting(x);
     }
+    // A teams region can only be strictly nested within the implicit parallel
+    // region or a target region.
+    if (GetContext().directive == llvm::omp::Directive::OMPD_teams &&
+        GetContextParent().directive != llvm::omp::Directive::OMPD_target) {
+      context_.Say(parser::FindSourceLocation(x),
+          "%s region can only be strictly nested within the implicit parallel "
+          "region or TARGET region"_err_en_US,
+          ContextDirectiveAsFortran());
+    }
+    // If a teams construct is nested within a target construct, that target
+    // construct must contain no statements, declarations or directives outside
+    // of the teams construct.
+    if (GetContext().directive == llvm::omp::Directive::OMPD_teams &&
+        GetContextParent().directive == llvm::omp::Directive::OMPD_target &&
+        !GetDirectiveNest(TargetBlockOnlyTeams)) {
+      context_.Say(GetContextParent().directiveSource,
+          "TARGET construct with nested TEAMS region contains statements or "
+          "directives outside of the TEAMS construct"_err_en_US);
+    }
   }
 
   CheckNoBranching(block, beginDir.v, beginDir.source);
 
   switch (beginDir.v) {
+  case llvm::omp::Directive::OMPD_target:
+    if (CheckTargetBlockOnlyTeams(block)) {
+      EnterDirectiveNest(TargetBlockOnlyTeams);
+    }
+    break;
   case llvm::omp::OMPD_workshare:
   case llvm::omp::OMPD_parallel_workshare:
     CheckWorkshareBlockStmts(block, beginDir.source);
@@ -683,6 +707,9 @@ void OmpStructureChecker::CheckIfDoOrderedClause(
 }
 
 void OmpStructureChecker::Leave(const parser::OpenMPBlockConstruct &) {
+  if (GetDirectiveNest(TargetBlockOnlyTeams)) {
+    ExitDirectiveNest(TargetBlockOnlyTeams);
+  }
   dirContext_.pop_back();
 }
 
@@ -1917,6 +1944,30 @@ void OmpStructureChecker::CheckPrivateSymbolsInOuterCxt(
       }
     }
   }
+}
+
+bool OmpStructureChecker::CheckTargetBlockOnlyTeams(
+    const parser::Block &block) {
+  bool nestedTeams{false};
+  auto it{block.begin()};
+
+  if (const auto *ompConstruct{parser::Unwrap<parser::OpenMPConstruct>(*it)}) {
+    if (const auto *ompBlockConstruct{
+            std::get_if<parser::OpenMPBlockConstruct>(&ompConstruct->u)}) {
+      const auto &beginBlockDir{
+          std::get<parser::OmpBeginBlockDirective>(ompBlockConstruct->t)};
+      const auto &beginDir{
+          std::get<parser::OmpBlockDirective>(beginBlockDir.t)};
+      if (beginDir.v == llvm::omp::Directive::OMPD_teams) {
+        nestedTeams = true;
+      }
+    }
+  }
+
+  if (nestedTeams && ++it == block.end()) {
+    return true;
+  }
+  return false;
 }
 
 void OmpStructureChecker::CheckWorkshareBlockStmts(

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -218,6 +218,7 @@ private:
   void SetLoopInfo(const parser::OpenMPLoopConstruct &x);
   void CheckIsLoopIvPartOfClause(
       llvmOmpClause clause, const parser::OmpObjectList &ompObjectList);
+  bool CheckTargetBlockOnlyTeams(const parser::Block &);
   void CheckWorkshareBlockStmts(const parser::Block &, parser::CharBlock);
 
   void CheckLoopItrVariableIsInt(const parser::OpenMPLoopConstruct &x);
@@ -248,6 +249,12 @@ private:
   void CheckPredefinedAllocatorRestriction(
       const parser::CharBlock &source, const parser::Name &name);
   bool isPredefinedAllocator{false};
+  void EnterDirectiveNest(const int index) { directiveNest_[index]++; }
+  void ExitDirectiveNest(const int index) { directiveNest_[index]--; }
+  int GetDirectiveNest(const int index) { return directiveNest_[index]; }
+
+  enum directiveNestType { SIMDNest, TargetBlockOnlyTeams, LastType };
+  int directiveNest_[LastType + 1] = {0};
 };
 } // namespace Fortran::semantics
 #endif // FORTRAN_SEMANTICS_CHECK_OMP_STRUCTURE_H_

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -226,6 +226,7 @@ private:
   void CheckCycleConstraints(const parser::OpenMPLoopConstruct &x);
   void CheckDistLinear(const parser::OpenMPLoopConstruct &x);
   void CheckSIMDNest(const parser::OpenMPConstruct &x);
+  void CheckTargetNest(const parser::OpenMPConstruct &x);
   void CheckCancellationNest(
       const parser::CharBlock &source, const parser::OmpCancelType::Type &type);
   std::int64_t GetOrdCollapseLevel(const parser::OpenMPLoopConstruct &x);
@@ -253,7 +254,12 @@ private:
   void ExitDirectiveNest(const int index) { directiveNest_[index]--; }
   int GetDirectiveNest(const int index) { return directiveNest_[index]; }
 
-  enum directiveNestType { SIMDNest, TargetBlockOnlyTeams, LastType };
+  enum directiveNestType {
+    SIMDNest,
+    TargetBlockOnlyTeams,
+    TargetNest,
+    LastType
+  };
   int directiveNest_[LastType + 1] = {0};
 };
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -225,6 +225,8 @@ private:
   void CheckCycleConstraints(const parser::OpenMPLoopConstruct &x);
   void CheckDistLinear(const parser::OpenMPLoopConstruct &x);
   void CheckSIMDNest(const parser::OpenMPConstruct &x);
+  void CheckCancellationNest(
+      const parser::CharBlock &source, const parser::OmpCancelType::Type &type);
   std::int64_t GetOrdCollapseLevel(const parser::OpenMPLoopConstruct &x);
   void CheckIfDoOrderedClause(const parser::OmpBlockDirective &blkDirectiv);
   bool CheckReductionOperators(const parser::OmpClause::Reduction &);

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -901,11 +901,12 @@ protected:
   // it comes from the entity in the containing scope, or implicit rules.
   // Return pointer to the new symbol, or nullptr on error.
   Symbol *DeclareLocalEntity(const parser::Name &);
-  // Declare a statement entity (e.g., an implied DO loop index).
-  // If there isn't a type specified, implicit rules apply.
-  // Return pointer to the new symbol, or nullptr on error.
-  Symbol *DeclareStatementEntity(
-      const parser::Name &, const std::optional<parser::IntegerTypeSpec> &);
+  // Declare a statement entity (i.e., an implied DO loop index for
+  // a DATA statement or an array constructor).  If there isn't an explict
+  // type specified, implicit rules apply. Return pointer to the new symbol,
+  // or nullptr on error.
+  Symbol *DeclareStatementEntity(const parser::DoVariable &,
+      const std::optional<parser::IntegerTypeSpec> &);
   Symbol &MakeCommonBlockSymbol(const parser::Name &);
   Symbol &MakeCommonBlockSymbol(const std::optional<parser::Name> &);
   bool CheckUseError(const parser::Name &);
@@ -925,6 +926,16 @@ protected:
   bool PassesSharedLocalityChecks(const parser::Name &name, Symbol &symbol);
   Symbol *NoteInterfaceName(const parser::Name &);
   bool IsUplevelReference(const Symbol &);
+
+  std::optional<SourceName> BeginCheckOnIndexUseInOwnBounds(
+      const parser::DoVariable &name) {
+    std::optional<SourceName> result{checkIndexUseInOwnBounds_};
+    checkIndexUseInOwnBounds_ = name.thing.thing.source;
+    return result;
+  }
+  void EndCheckOnIndexUseInOwnBounds(const std::optional<SourceName> &restore) {
+    checkIndexUseInOwnBounds_ = restore;
+  }
 
 private:
   // The attribute corresponding to the statement containing an ObjectDecl
@@ -956,6 +967,9 @@ private:
   } enumerationState_;
   // Set for OldParameterStmt processing
   bool inOldStyleParameterStmt_{false};
+  // Set when walking DATA & array constructor implied DO loop bounds
+  // to warn about use of the implied DO intex therein.
+  std::optional<SourceName> checkIndexUseInOwnBounds_;
 
   bool HandleAttributeStmt(Attr, const std::list<parser::Name> &);
   Symbol &HandleAttributeStmt(Attr, const parser::Name &);
@@ -5009,8 +5023,10 @@ Symbol *DeclarationVisitor::DeclareLocalEntity(const parser::Name &name) {
   return &MakeHostAssocSymbol(name, prev);
 }
 
-Symbol *DeclarationVisitor::DeclareStatementEntity(const parser::Name &name,
+Symbol *DeclarationVisitor::DeclareStatementEntity(
+    const parser::DoVariable &doVar,
     const std::optional<parser::IntegerTypeSpec> &type) {
+  const parser::Name &name{doVar.thing.thing};
   const DeclTypeSpec *declTypeSpec{nullptr};
   if (auto *prev{FindSymbol(name)}) {
     if (prev->owner() == currScope()) {
@@ -5036,7 +5052,9 @@ Symbol *DeclarationVisitor::DeclareStatementEntity(const parser::Name &name,
   } else {
     ApplyImplicitRules(symbol);
   }
-  return Resolve(name, &symbol);
+  Symbol *result{Resolve(name, &symbol)};
+  AnalyzeExpr(context(), doVar); // enforce INTEGER type
+  return result;
 }
 
 // Set the type of an entity or report an error.
@@ -5320,9 +5338,7 @@ bool ConstructVisitor::Pre(const parser::LocalitySpec::Shared &x) {
 
 bool ConstructVisitor::Pre(const parser::AcSpec &x) {
   ProcessTypeSpec(x.type);
-  PushScope(Scope::Kind::ImpliedDos, nullptr);
   Walk(x.values);
-  PopScope();
   return false;
 }
 
@@ -5333,9 +5349,18 @@ bool ConstructVisitor::Pre(const parser::AcImpliedDo &x) {
   auto &control{std::get<parser::AcImpliedDoControl>(x.t)};
   auto &type{std::get<std::optional<parser::IntegerTypeSpec>>(control.t)};
   auto &bounds{std::get<parser::AcImpliedDoControl::Bounds>(control.t)};
+  // F'2018 has the scope of the implied DO variable covering the entire
+  // implied DO production (19.4(5)), which seems wrong in cases where the name
+  // of the implied DO variable appears in one of the bound expressions. Thus
+  // this extension, which shrinks the scope of the variable to exclude the
+  // expressions in the bounds.
+  auto restore{BeginCheckOnIndexUseInOwnBounds(bounds.name)};
+  Walk(bounds.lower);
+  Walk(bounds.upper);
+  Walk(bounds.step);
+  EndCheckOnIndexUseInOwnBounds(restore);
   PushScope(Scope::Kind::ImpliedDos, nullptr);
-  DeclareStatementEntity(bounds.name.thing.thing, type);
-  Walk(bounds);
+  DeclareStatementEntity(bounds.name, type);
   Walk(values);
   PopScope();
   return false;
@@ -5345,9 +5370,21 @@ bool ConstructVisitor::Pre(const parser::DataImpliedDo &x) {
   auto &objects{std::get<std::list<parser::DataIDoObject>>(x.t)};
   auto &type{std::get<std::optional<parser::IntegerTypeSpec>>(x.t)};
   auto &bounds{std::get<parser::DataImpliedDo::Bounds>(x.t)};
-  DeclareStatementEntity(bounds.name.thing.thing, type);
-  Walk(bounds);
+  // See comment in Pre(AcImpliedDo) above.
+  auto restore{BeginCheckOnIndexUseInOwnBounds(bounds.name)};
+  Walk(bounds.lower);
+  Walk(bounds.upper);
+  Walk(bounds.step);
+  EndCheckOnIndexUseInOwnBounds(restore);
+  bool pushScope{currScope().kind() != Scope::Kind::ImpliedDos};
+  if (pushScope) {
+    PushScope(Scope::Kind::ImpliedDos, nullptr);
+  }
+  DeclareStatementEntity(bounds.name, type);
   Walk(objects);
+  if (pushScope) {
+    PopScope();
+  }
   return false;
 }
 
@@ -5886,6 +5923,12 @@ const parser::Name *DeclarationVisitor::ResolveName(const parser::Name &name) {
       ConvertToObjectEntity(*symbol);
       ApplyImplicitRules(*symbol);
     }
+    if (checkIndexUseInOwnBounds_ &&
+        *checkIndexUseInOwnBounds_ == name.source) {
+      Say(name,
+          "Implied DO index '%s' uses an object of the same name in its bounds expressions"_en_US,
+          name.source);
+    }
     return &name;
   }
   if (isImplicitNoneType()) {
@@ -5893,6 +5936,11 @@ const parser::Name *DeclarationVisitor::ResolveName(const parser::Name &name) {
     return nullptr;
   }
   // Create the symbol then ensure it is accessible
+  if (checkIndexUseInOwnBounds_ && *checkIndexUseInOwnBounds_ == name.source) {
+    Say(name,
+        "Implied DO index '%s' uses itself in its own bounds expressions"_err_en_US,
+        name.source);
+  }
   MakeSymbol(InclusiveScope(), name.source, Attrs{});
   auto *symbol{FindSymbol(name)};
   if (!symbol) {

--- a/flang/test/Semantics/array-constr-values.f90
+++ b/flang/test/Semantics/array-constr-values.f90
@@ -58,7 +58,7 @@ subroutine checkC7115()
   real, dimension(10), parameter :: good1 = [(99.9, i = 1, 10)]
   real, dimension(100), parameter :: good2 = [((88.8, i = 1, 10), j = 1, 10)]
   real, dimension(-1:0), parameter :: good3 = [77.7, 66.6]
-  !ERROR: Implied DO index is active in surrounding implied DO loop and may not have the same name
+  !ERROR: Implied DO index 'i' is active in a surrounding implied DO loop and may not have the same name
   real, dimension(100), parameter :: bad = [((88.8, i = 1, 10), i = 1, 10)]
 
   !ERROR: Value of named constant 'bad2' ([INTEGER(4)::(int(j,kind=4),INTEGER(8)::j=1_8,1_8,0_8)]) cannot be computed as a constant value

--- a/flang/test/Semantics/data11.f90
+++ b/flang/test/Semantics/data11.f90
@@ -1,0 +1,9 @@
+! RUN: %flang_fc1 -fsyntax-only -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! CHECK:  Implied DO index 'j' uses an object of the same name in its bounds expressions
+! CHECK: ObjectEntity type: REAL(4) shape: 1_8:5_8 init:[REAL(4)::1._4,2._4,3._4,4._4,5._4]
+! Verify that the scope of a DATA statement implied DO loop index does
+! not include the bounds expressions (language extension, with warning)
+integer, parameter :: j = 5
+real, save :: a(j)
+data (a(j),j=1,j)/1,2,3,4,5/
+end

--- a/flang/test/Semantics/modfile25.f90
+++ b/flang/test/Semantics/modfile25.f90
@@ -39,7 +39,9 @@ end module m1
 ! integer(8),parameter::a1ss(1_8:*)=[INTEGER(8)::3_8]
 ! integer(8),parameter::a1sss(1_8:*)=[INTEGER(8)::1_8]
 ! integer(8),parameter::a1rs(1_8:*)=[INTEGER(8)::3_8,1_8,1_8,1_8]
+! intrinsic::rank
 ! integer(8),parameter::a1n(1_8:*)=[INTEGER(8)::125_8,5_8,5_8]
+! intrinsic::size
 ! integer(8),parameter::a1sn(1_8:*)=[INTEGER(8)::3_8,1_8,1_8]
 ! integer(8),parameter::ac1s(1_8:*)=[INTEGER(8)::1_8]
 ! integer(8),parameter::ac2s(1_8:*)=[INTEGER(8)::3_8]

--- a/flang/test/Semantics/modfile26.f90
+++ b/flang/test/Semantics/modfile26.f90
@@ -66,12 +66,15 @@ end module m1
 !Expect: m1.mod
 !module m1
 !integer(4),parameter::iranges(1_8:*)=[INTEGER(4)::2_4,4_4,9_4,18_4,38_4]
+!intrinsic::range
 !logical(4),parameter::ircheck=.true._4
 !intrinsic::all
 !integer(4),parameter::intpvals(1_8:*)=[INTEGER(4)::0_4,2_4,3_4,4_4,5_4,9_4,10_4,18_4,19_4,38_4,39_4]
 !integer(4),parameter::intpkinds(1_8:*)=[INTEGER(4)::1_4,1_4,2_4,2_4,4_4,4_4,8_4,8_4,16_4,16_4,-1_4]
+!intrinsic::size
 !logical(4),parameter::ipcheck=.true._4
 !integer(4),parameter::realprecs(1_8:*)=[INTEGER(4)::3_4,2_4,6_4,15_4,18_4,33_4]
+!intrinsic::precision
 !logical(4),parameter::rpreccheck=.true._4
 !integer(4),parameter::realpvals(1_8:*)=[INTEGER(4)::0_4,3_4,4_4,6_4,7_4,15_4,16_4,18_4,19_4,33_4,34_4]
 !integer(4),parameter::realpkinds(1_8:*)=[INTEGER(4)::2_4,2_4,4_4,4_4,8_4,8_4,10_4,10_4,16_4,16_4,-1_4]
@@ -82,7 +85,9 @@ end module m1
 !integer(4),parameter::realrkinds(1_8:*)=[INTEGER(4)::2_4,2_4,3_4,3_4,8_4,8_4,10_4,10_4,-2_4]
 !logical(4),parameter::realrcheck=.true._4
 !logical(4),parameter::radixcheck=.true._4
+!intrinsic::radix
 !integer(4),parameter::intdigits(1_8:*)=[INTEGER(4)::7_4,15_4,31_4,63_4,127_4]
+!intrinsic::digits
 !logical(4),parameter::intdigitscheck=.true._4
 !integer(4),parameter::realdigits(1_8:*)=[INTEGER(4)::11_4,8_4,24_4,53_4,64_4,113_4]
 !logical(4),parameter::realdigitscheck=.true._4

--- a/flang/test/Semantics/omp-clause-validity01.f90
+++ b/flang/test/Semantics/omp-clause-validity01.f90
@@ -494,9 +494,6 @@ use omp_lib
   !ERROR: RELAXED clause is not allowed on the FLUSH directive
   !$omp flush relaxed
 
-  !$omp cancel DO
-  !$omp cancellation point parallel
-
 ! 2.13.2 critical Construct
 
   ! !$omp critical (first)

--- a/flang/test/Semantics/omp-firstprivate01.f90
+++ b/flang/test/Semantics/omp-firstprivate01.f90
@@ -12,6 +12,7 @@ program omp_firstprivate
   a = 10
   b = 20
 
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
   !$omp target
   !$omp teams private(a, b)
   !ERROR: FIRSTPRIVATE variable 'a' is PRIVATE in outer context

--- a/flang/test/Semantics/omp-nested-cancel.f90
+++ b/flang/test/Semantics/omp-nested-cancel.f90
@@ -1,0 +1,250 @@
+! RUN: %S/test_errors.sh %s %t %flang -fopenmp
+! REQUIRES: shell
+
+! OpenMP Version 5.0
+! Check OpenMP construct validity for the following directives:
+! 2.18.1 Cancel Construct
+
+program main
+  integer :: i, N = 10
+  real :: a
+
+  !ERROR: CANCEL TASKGROUP directive is not closely nested inside TASK or TASKLOOP
+  !$omp cancel taskgroup
+
+  !ERROR: CANCEL SECTIONS directive is not closely nested inside SECTION or SECTIONS
+  !$omp cancel sections
+
+  !ERROR: CANCEL DO directive is not closely nested inside the construct that matches the DO clause type
+  !$omp cancel do
+
+  !ERROR: CANCEL PARALLEL directive is not closely nested inside the construct that matches the PARALLEL clause type
+  !$omp cancel parallel
+
+  !$omp parallel
+  !$omp sections
+  !$omp cancel sections
+  !$omp section
+  a = 3.14
+  !$omp end sections
+  !$omp end parallel
+
+  !$omp sections
+  !$omp section
+  !$omp cancel sections
+  a = 3.14
+  !$omp end sections
+
+  !$omp parallel
+  !ERROR: With SECTIONS clause, CANCEL construct cannot be closely nested inside PARALLEL construct
+  !$omp cancel sections
+  a = 3.14
+  !$omp end parallel
+
+  !$omp parallel sections
+  !$omp cancel sections
+  a = 3.14
+  !$omp end parallel sections
+
+  !$omp do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end do
+
+  !$omp parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end parallel do
+
+  !$omp target
+  !$omp teams
+  !$omp distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end distribute parallel do
+  !$omp end teams
+  !$omp end target
+
+  !$omp target
+  !$omp teams distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end teams distribute parallel do
+  !$omp end target
+
+  !$omp target teams distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancel do
+  end do
+  !$omp end target parallel do
+
+  !$omp parallel
+  do i = 1, N
+    a = 3.14
+    !ERROR: With DO clause, CANCEL construct cannot be closely nested inside PARALLEL construct
+    !$omp cancel do
+  end do
+  !$omp end parallel
+
+  !$omp parallel
+  do i = 1, N
+    a = 3.14
+    !$omp cancel parallel
+  end do
+  !$omp end parallel
+
+  !$omp target parallel
+  do i = 1, N
+    a = 3.14
+    !$omp cancel parallel
+  end do
+  !$omp end target parallel
+
+  !$omp target parallel do
+  do i = 1, N
+    a = 3.14
+    !ERROR: With PARALLEL clause, CANCEL construct cannot be closely nested inside TARGET PARALLEL DO construct
+    !$omp cancel parallel
+  end do
+  !$omp end target parallel do
+
+  !$omp do
+  do i = 1, N
+    a = 3.14
+    !ERROR: With PARALLEL clause, CANCEL construct cannot be closely nested inside DO construct
+    !$omp cancel parallel
+  end do
+  !$omp end do
+
+contains
+  subroutine sub1()
+    !$omp task
+    !$omp cancel taskgroup
+    a = 3.14
+    !$omp end task
+
+    !$omp taskloop
+    do i = 1, N
+      !$omp parallel
+      !$omp end parallel
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+
+    !$omp taskloop nogroup
+    do i = 1, N
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+
+    !$omp parallel
+    !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+    !$omp cancel taskgroup
+    a = 3.14
+    !$omp end parallel
+
+    !$omp do
+    do i = 1, N
+      !$omp task
+      !$omp cancel taskgroup
+      a = 3.14
+      !$omp end task
+    end do
+    !$omp end do
+
+    !$omp parallel
+    !$omp taskgroup
+    !$omp task
+    !$omp cancel taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end taskgroup
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp task
+    !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+    !$omp cancel taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp do
+    do i = 1, N
+      !$omp task
+      !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+      !$omp cancel taskgroup
+      a = 3.14
+      !$omp end task
+    end do
+    !$omp end do
+    !$omp end parallel
+
+    !$omp target parallel
+    !$omp task
+    !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+    !$omp cancel taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end target parallel
+
+    !$omp parallel
+    !$omp taskloop private(j) nogroup
+    do i = 1, N
+      !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp taskloop
+    do i = 1, N
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp taskgroup
+    !$omp taskloop nogroup
+    do i = 1, N
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end taskgroup
+    !$omp end parallel
+
+    !$omp target parallel
+    !$omp taskloop nogroup
+    do i = 1, N
+      !ERROR: With TASKGROUP clause, CANCEL construct must be closely nested inside TASK or TASKLOOP construct and CANCEL region must be closely nested inside TASKGROUP region
+      !$omp cancel taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end target parallel
+  end subroutine sub1
+
+end program main

--- a/flang/test/Semantics/omp-nested-cancellation-point.f90
+++ b/flang/test/Semantics/omp-nested-cancellation-point.f90
@@ -1,0 +1,250 @@
+! RUN: %S/test_errors.sh %s %t %flang -fopenmp
+! REQUIRES: shell
+
+! OpenMP Version 5.0
+! Check OpenMP construct validity for the following directives:
+! 2.18.2 Cancellation Point Construct
+
+program main
+  integer :: i, N = 10
+  real :: a
+
+  !ERROR: CANCELLATION POINT TASKGROUP directive is not closely nested inside TASK or TASKLOOP
+  !$omp cancellation point taskgroup
+
+  !ERROR: CANCELLATION POINT SECTIONS directive is not closely nested inside SECTION or SECTIONS
+  !$omp cancellation point sections
+
+  !ERROR: CANCELLATION POINT DO directive is not closely nested inside the construct that matches the DO clause type
+  !$omp cancellation point do
+
+  !ERROR: CANCELLATION POINT PARALLEL directive is not closely nested inside the construct that matches the PARALLEL clause type
+  !$omp cancellation point parallel
+
+  !$omp parallel
+  !$omp sections
+  !$omp cancellation point sections
+  !$omp section
+  a = 3.14
+  !$omp end sections
+  !$omp end parallel
+
+  !$omp sections
+  !$omp section
+  !$omp cancellation point sections
+  a = 3.14
+  !$omp end sections
+
+  !$omp parallel
+  !ERROR: With SECTIONS clause, CANCELLATION POINT construct cannot be closely nested inside PARALLEL construct
+  !$omp cancellation point sections
+  a = 3.14
+  !$omp end parallel
+
+  !$omp parallel sections
+  !$omp cancellation point sections
+  a = 3.14
+  !$omp end parallel sections
+
+  !$omp do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end do
+
+  !$omp parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end parallel do
+
+  !$omp target
+  !$omp teams
+  !$omp distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end distribute parallel do
+  !$omp end teams
+  !$omp end target
+
+  !$omp target
+  !$omp teams distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end teams distribute parallel do
+  !$omp end target
+
+  !$omp target teams distribute parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target parallel do
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point do
+  end do
+  !$omp end target parallel do
+
+  !$omp parallel
+  do i = 1, N
+    a = 3.14
+    !ERROR: With DO clause, CANCELLATION POINT construct cannot be closely nested inside PARALLEL construct
+    !$omp cancellation point do
+  end do
+  !$omp end parallel
+
+  !$omp parallel
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point parallel
+  end do
+  !$omp end parallel
+
+  !$omp target parallel
+  do i = 1, N
+    a = 3.14
+    !$omp cancellation point parallel
+  end do
+  !$omp end target parallel
+
+  !$omp target parallel do
+  do i = 1, N
+    a = 3.14
+    !ERROR: With PARALLEL clause, CANCELLATION POINT construct cannot be closely nested inside TARGET PARALLEL DO construct
+    !$omp cancellation point parallel
+  end do
+  !$omp end target parallel do
+
+  !$omp do
+  do i = 1, N
+    a = 3.14
+    !ERROR: With PARALLEL clause, CANCELLATION POINT construct cannot be closely nested inside DO construct
+    !$omp cancellation point parallel
+  end do
+  !$omp end do
+
+contains
+  subroutine sub1()
+    !$omp task
+    !$omp cancellation point taskgroup
+    a = 3.14
+    !$omp end task
+
+    !$omp taskloop
+    do i = 1, N
+      !$omp parallel
+      !$omp end parallel
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+
+    !$omp taskloop nogroup
+    do i = 1, N
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+
+    !$omp parallel
+    !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+    !$omp cancellation point taskgroup
+    a = 3.14
+    !$omp end parallel
+
+    !$omp do
+    do i = 1, N
+      !$omp task
+      !$omp cancellation point taskgroup
+      a = 3.14
+      !$omp end task
+    end do
+    !$omp end do
+
+    !$omp parallel
+    !$omp taskgroup
+    !$omp task
+    !$omp cancellation point taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end taskgroup
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp task
+    !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+    !$omp cancellation point taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp do
+    do i = 1, N
+      !$omp task
+      !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+      !$omp cancellation point taskgroup
+      a = 3.14
+      !$omp end task
+    end do
+    !$omp end do
+    !$omp end parallel
+
+    !$omp target parallel
+    !$omp task
+    !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+    !$omp cancellation point taskgroup
+    a = 3.14
+    !$omp end task
+    !$omp end target parallel
+
+    !$omp parallel
+    !$omp taskloop private(j) nogroup
+    do i = 1, N
+      !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp taskloop
+    do i = 1, N
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end parallel
+
+    !$omp parallel
+    !$omp taskgroup
+    !$omp taskloop nogroup
+    do i = 1, N
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end taskgroup
+    !$omp end parallel
+
+    !$omp target parallel
+    !$omp taskloop nogroup
+    do i = 1, N
+      !ERROR: With TASKGROUP clause, CANCELLATION POINT construct must be closely nested inside TASK or TASKLOOP construct and CANCELLATION POINT region must be closely nested inside TASKGROUP region
+      !$omp cancellation point taskgroup
+      a = 3.14
+    end do
+    !$omp end taskloop
+    !$omp end target parallel
+  end subroutine sub1
+
+end program main

--- a/flang/test/Semantics/omp-nested-master.f90
+++ b/flang/test/Semantics/omp-nested-master.f90
@@ -87,6 +87,7 @@ program omp_nest_master
 
   !$omp ordered
   do i = 1, 10
+    !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
     !$omp teams
     !$omp distribute
     do k =1, 10
@@ -102,6 +103,7 @@ program omp_nest_master
 
   !$omp critical
   do i = 1, 10
+    !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
     !$omp teams
     !$omp distribute
     do k =1, 10
@@ -117,6 +119,7 @@ program omp_nest_master
 
   !$omp taskloop
   do i = 1, 10
+    !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
     !$omp teams
     !$omp distribute
     do k =1, 10
@@ -133,6 +136,7 @@ program omp_nest_master
 
   !$omp task
   do i = 1, 10
+    !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
     !$omp teams
     !$omp distribute
     do k =1, 10

--- a/flang/test/Semantics/omp-nested-simd.f90
+++ b/flang/test/Semantics/omp-nested-simd.f90
@@ -42,6 +42,7 @@ SUBROUTINE NESTED_BAD(N)
       DO J = 1,N
         print *, "Hi"
         !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
+        !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
         !$omp teams 
          DO K = 1,N
         print *, 'Hello'
@@ -64,12 +65,6 @@ SUBROUTINE NESTED_BAD(N)
         K = 2
       end do
       !$omp end task
-      !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
-      !$omp teams 
-      do J = 1, N
-        K = 2
-      end do
-      !$omp end teams
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
       !$omp target 
       do J = 1, N
@@ -103,12 +98,6 @@ SUBROUTINE NESTED_BAD(N)
         K = 2
       end do
       !$omp end task
-      !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
-      !$omp teams 
-      do J = 1, N
-        K = 2
-      end do
-      !$omp end teams
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
       !$omp target 
       do J = 1, N
@@ -144,12 +133,6 @@ SUBROUTINE NESTED_BAD(N)
       end do
       !$omp end task
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
-      !$omp teams 
-      do J = 1, N
-        K = 2
-      end do
-      !$omp end teams
-      !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
       !$omp target 
       do J = 1, N
         K = 2
@@ -183,12 +166,6 @@ SUBROUTINE NESTED_BAD(N)
         K = 2
       end do
       !$omp end task
-      !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
-      !$omp teams 
-      do J = 1, N
-        K = 2
-      end do
-      !$omp end teams
       !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
       !$omp target 
       do J = 1, N

--- a/flang/test/Semantics/omp-nested-target.f90
+++ b/flang/test/Semantics/omp-nested-target.f90
@@ -1,0 +1,54 @@
+! RUN: %S/test_errors.sh %s %t %flang_fc1 -fopenmp
+! REQUIRES: shell
+
+! OpenMP Version 5.0
+! Check OpenMP construct validity for the following directives:
+! 2.12.5 Target Construct
+
+program main
+  integer :: i, j, N = 10
+  real :: a, arrayA(512), arrayB(512), ai(10)
+  real, allocatable :: B(:)
+
+  !$omp target
+  !WARNING: If TARGET UPDATE directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target update from(arrayA) to(arrayB)
+  do i = 1, 512
+    arrayA(i) = arrayB(i)
+  end do
+  !$omp end target
+
+  !$omp parallel
+  !$omp target
+  !$omp parallel
+  !WARNING: If TARGET UPDATE directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target update from(arrayA) to(arrayB)
+  do i = 1, 512
+    arrayA(i) = arrayB(i)
+  end do
+  !$omp end parallel
+  !$omp end target
+  !$omp end parallel
+
+  !$omp target
+  !WARNING: If TARGET DATA directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target data map(to: a)
+  do i = 1, N
+    a = 3.14
+  end do
+  !$omp end target data
+  !$omp end target
+
+  allocate(B(N))
+  !$omp target
+  !WARNING: If TARGET ENTER DATA directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target enter data map(alloc:B)
+  !$omp end target
+
+  !$omp target
+  !WARNING: If TARGET EXIT DATA directive is nested inside TARGET region, the behaviour is unspecified
+  !$omp target exit data map(delete:B)
+  !$omp end target
+  deallocate(B)
+
+end program main

--- a/flang/test/Semantics/omp-nested-teams.f90
+++ b/flang/test/Semantics/omp-nested-teams.f90
@@ -1,0 +1,113 @@
+! RUN: %S/test_errors.sh %s %t %flang -fopenmp
+! REQUIRES: shell
+
+! OpenMP Version 5.0
+! Check OpenMP construct validity for the following directives:
+! 2.7 Teams Construct
+
+program main
+  integer :: i, j, N = 10
+  real :: a, b, c
+
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+
+  !$omp target
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end target
+
+  !$omp target
+  !$omp parallel
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end parallel
+  !$omp end target
+
+  !$omp parallel
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end parallel
+
+  !$omp do
+  do i = 1, N
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  end do
+
+  !$omp master
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end master
+
+  !$omp target parallel
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end target parallel
+
+  !$omp target
+  !$omp teams
+  !ERROR: Only `DISTRIBUTE` or `PARALLEL` regions are allowed to be strictly nested inside `TEAMS` region.
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end teams
+  !$omp end target
+
+  !$omp target teams
+  !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end target teams
+
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
+  !$omp target
+  do i = 1, N
+    !$omp teams
+    a = 3.14
+    !$omp end teams
+  enddo
+  !$omp end target
+
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
+  !$omp target
+  if (i .GT. 1) then
+    if (j .GT. 1) then
+      !$omp teams
+      a = 3.14
+      !$omp end teams
+    end if
+  end if
+  !$omp end target
+
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
+  !$omp target
+  b = 3.14
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  !$omp end target
+
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
+  !$omp target
+  !$omp teams
+  a = 3.14
+  !$omp end teams
+  c = 3.14
+  !$omp end target
+
+end program main

--- a/flang/test/Semantics/resolve106.f90
+++ b/flang/test/Semantics/resolve106.f90
@@ -1,0 +1,5 @@
+!RUN: %flang -fsyntax-only %s 2>&1 | FileCheck %s
+integer, parameter :: j = 10
+! CHECK: Implied DO index 'j' uses an object of the same name in its bounds expressions
+real :: a(10) = [(j, j=1,j)]
+end

--- a/flang/test/Semantics/resolve30.f90
+++ b/flang/test/Semantics/resolve30.f90
@@ -31,9 +31,9 @@ subroutine s3
 end
 
 subroutine s4
-  real :: i, j
+  real :: j
   !ERROR: Must have INTEGER type, but is REAL(4)
-  real :: a(16) = [(i, i=1, 16)]
+  real :: a(16) = [(x, x=1, 16)]
   real :: b(16)
   !ERROR: Must have INTEGER type, but is REAL(4)
   data(b(j), j=1, 16) / 16 * 0.0 /

--- a/flang/test/Semantics/symbol05.f90
+++ b/flang/test/Semantics/symbol05.f90
@@ -49,10 +49,10 @@ subroutine s3
   !DEF: /s3/Block1/t DerivedType
   type :: t
    !DEF: /s3/Block1/t/x ObjectEntity REAL(4)
-   !DEF: /s3/Block1/t/ImpliedDos1/ImpliedDos1/i (Implicit) ObjectEntity INTEGER(4)
+   !DEF: /s3/Block1/t/ImpliedDos1/i (Implicit) ObjectEntity INTEGER(4)
    real :: x(10) = [(i, i=1,10)]
    !DEF: /s3/Block1/t/y ObjectEntity REAL(4)
-   !DEF: /s3/Block1/t/ImpliedDos2/ImpliedDos1/j ObjectEntity INTEGER(8)
+   !DEF: /s3/Block1/t/ImpliedDos2/j ObjectEntity INTEGER(8)
    real :: y(10) = [(j, j=1,10)]
   end type
  end block


### PR DESCRIPTION
Small update since #989 to incorporate the DO loop indic scope extension, a WRITE after BACKSPACE fix and some new OpenMP semantics checks.

Some intermediate commits have already been cherry-picked in #1006 and #1012.

As for previous cherry-picks, this includes all commits done in flang but the one listed below that touch the new driver and require a full rebase with llvm (#1008 is working on bringing the new driver here). The port of symbol test to python is also ignored because it was causing regression in my sandbox that I did not want to investigate until a full rebase.

Latest LLVM commit cherry-picked is b232a88c6fac07a2c4304d156a33664dbbe77a1b.

Ignored commits are:
- 787c443a8da7add81d8ff7d430afcac16a1e4b0c	[flang] Refine output file generation
- 0d1a0f7e8de5a506c0bd409fc27e77fb733f7886	Make test_symbols.py compare files line-by-line
- 316be03ff5968d589fda054d5f03319400b22b38	Revert "[flang] Refine output file generation"
- fd21d1e198e381a2b9e7af1701044462b2d386cd	[flang] Refine output file generation
- dcc6b7b1d5e5a0f9537ce1bf919ac2338bd7ad7b	[OptTable] Refine how `printHelp` treats empty help texts
- 520e5db26a4a9fcb418d9ef2da813155038caade	[flang][driver] Add print function name Plugin example
- 4f21e6aeddc2dbe4ae22aba5b97cae0c50c961f6	[flang][nfc] Tweak the FrontendAction class
- 265a9961d13e78fc1a5f4b478ac9651fcccdf92b	[flang][nfc] Move `Semantics` from `FrontendAction` to `CompilerInstance`
- 5437f2e9a98bec3e546e67903bac49cfc8c0c004	[flang][nfc] Remove `flang-new-driver` from LIT
