### PR TITLE
[OpenMP] Add support for Lowering Ordered Threads Directive

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -410,6 +410,21 @@ genOMP(Fortran::lower::AbstractConverter &converter,
     auto currentLocation = converter.getCurrentLocation();
     auto masterOp = firOpBuilder.create<mlir::omp::MasterOp>(currentLocation);
     createBodyOfOp<omp::MasterOp>(masterOp, converter, currentLocation, eval);
+  } else if (blockDirective.v == llvm::omp::OMPD_ordered) {
+    auto &firOpBuilder = converter.getFirOpBuilder();
+    auto currentLocation = converter.getCurrentLocation();
+    mlir::Attribute simdClauseOperand;
+    auto orderedOp = firOpBuilder.create<mlir::omp::OrderedRegionOp>(
+        currentLocation, simdClauseOperand.dyn_cast_or_null<UnitAttr>());
+    const auto &clauseList =
+        std::get<Fortran::parser::OmpClauseList>(beginBlockDirective.t);
+    for (const auto &clause : clauseList.v) {
+      if (std::get_if<Fortran::parser::OmpClause::Simd>(&clause.u)) {
+        TODO(currentLocation, "OpenMP ORDERED SIMD");
+      }
+    }
+    createBodyOfOp<omp::OrderedRegionOp>(orderedOp, converter, currentLocation,
+                                         eval);
   }
 }
 

--- a/flang/test/Lower/OpenMP/omp-ordered-threads.f90
+++ b/flang/test/Lower/OpenMP/omp-ordered-threads.f90
@@ -1,0 +1,42 @@
+! This test checks lowering of OpenMP ordered directive with threads Clause.
+! Without clause in ordered direcitve, it behaves as if threads clause is
+! specified.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco --disable-llvm --print-ir-after=fir-to-llvm-ir 2>&1 | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | tco | FileCheck %s --check-prefix=LLVMIR
+
+program ordered
+        integer :: i
+        integer :: a(20)
+
+!FIRDialect: omp.ordered_region  {
+!LLVMIRDialect: omp.ordered_region  {
+!LLVMIR: [[TMP0:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB0:[0-9]+]]), !dbg !{{.*}}
+!LLVMIR-NEXT: call void @__kmpc_ordered(%struct.ident_t* @[[GLOB0]], i32 [[TMP0]]), !dbg !{{.*}}
+!$OMP ORDERED
+        a(i) = a(i-1) + 1
+!FIRDialect:   omp.terminator
+!FIRDialect-NEXT: }
+!LLVMIRDialect:   omp.terminator
+!LLVMIRDialect-NEXT: }
+!LLVMIR: call void @__kmpc_end_ordered(%struct.ident_t* @[[GLOB0]], i32 [[TMP0]]), !dbg !{{.*}}
+!$OMP END ORDERED
+
+!FIRDialect: omp.ordered_region  {
+!LLVMIRDialect: omp.ordered_region  {
+!LLVMIR: [[TMP1:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]]), !dbg !{{.*}}
+!LLVMIR-NEXT: call void @__kmpc_ordered(%struct.ident_t* @[[GLOB1]], i32 [[TMP1]]), !dbg !{{.*}}
+!$OMP ORDERED THREADS
+        a(i) = a(i-1) + 1
+!FIRDialect:   omp.terminator
+!FIRDialect-NEXT: }
+!LLVMIRDialect:   omp.terminator
+!LLVMIRDialect-NEXT: }
+!LLVMIR: call void @__kmpc_end_ordered(%struct.ident_t* @[[GLOB1]], i32 [[TMP1]]), !dbg !{{.*}}
+!LLVMIR-NEXT: ret void, !dbg !{{.*}}
+!$OMP END ORDERED
+
+end


### PR DESCRIPTION
This patch supports lowering parse-tree to MLIR for ordered threads directive. Ordered threads directive must work together with ordered clause without parameter specified in wsloop directive. They are tested and results are correct. The lowering work for ordered clause without parameter specified in wsloop directive will be in another patch in upstream.

For ordered simd directive, LLVM middle-end optimization passes still do not support it yet.

For ordered depend directive. the lowering work will be in another patch after tested together with the implementation of ordered clause with parameter specified in wsloop directive.