### PR TITLE
Jpr update equivalence handling

### DIFF
--- a/flang/include/flang/Evaluate/initial-image.h
+++ b/flang/include/flang/Evaluate/initial-image.h
@@ -30,6 +30,7 @@ public:
   };
 
   explicit InitialImage(std::size_t bytes) : data_(bytes) {}
+  InitialImage(InitialImage &&that) = default;
 
   std::size_t size() const { return data_.size(); }
 
@@ -93,19 +94,17 @@ public:
 
   void AddPointer(ConstantSubscript, const Expr<SomeType> &);
 
-  void Incorporate(ConstantSubscript, const InitialImage &);
+  void Incorporate(ConstantSubscript toOffset, const InitialImage &from,
+      ConstantSubscript fromOffset, ConstantSubscript bytes);
 
   // Conversions to constant initializers
   std::optional<Expr<SomeType>> AsConstant(FoldingContext &,
       const DynamicType &, const ConstantSubscripts &,
       ConstantSubscript offset = 0) const;
-  std::optional<Expr<SomeType>> AsConstantDataPointer(
-      const DynamicType &, ConstantSubscript offset = 0) const;
-  const ProcedureDesignator &AsConstantProcPointer(
+  std::optional<Expr<SomeType>> AsConstantPointer(
       ConstantSubscript offset = 0) const;
 
   friend class AsConstantHelper;
-  friend class AsConstantDataPointerHelper;
 
 private:
   std::vector<char> data_;

--- a/flang/include/flang/Semantics/scope.h
+++ b/flang/include/flang/Semantics/scope.h
@@ -41,6 +41,8 @@ struct EquivalenceObject {
       std::optional<ConstantSubscript> substringStart, parser::CharBlock source)
       : symbol{symbol}, subscripts{subscripts},
         substringStart{substringStart}, source{source} {}
+  explicit EquivalenceObject(Symbol &symbol)
+      : symbol{symbol}, source{symbol.name()} {}
 
   bool operator==(const EquivalenceObject &) const;
   bool operator<(const EquivalenceObject &) const;

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -497,6 +497,7 @@ public:
       LocalityShared, // named in SHARED locality-spec
       InDataStmt, // initialized in a DATA statement
       InNamelist, // flag is set if the symbol is in Namelist statement
+      CompilerCreated,
       // OpenACC data-sharing attribute
       AccPrivate, AccFirstPrivate, AccShared,
       // OpenACC data-mapping attribute
@@ -782,7 +783,7 @@ struct SymbolAddressCompare {
   }
 };
 
-// Symbol comparison is based on the order of cooked source
+// Symbol comparison is usually based on the order of cooked source
 // stream creation and, when both are from the same cooked source,
 // their positions in that cooked source stream.
 // Don't use this comparator or OrderedSymbolSet to hold
@@ -794,12 +795,17 @@ struct SymbolSourcePositionCompare {
   bool operator()(const MutableSymbolRef &, const MutableSymbolRef &) const;
 };
 
+struct SymbolOffsetCompare {
+  bool operator()(const SymbolRef &, const SymbolRef &) const;
+  bool operator()(const MutableSymbolRef &, const MutableSymbolRef &) const;
+};
+
 using UnorderedSymbolSet = std::set<SymbolRef, SymbolAddressCompare>;
-using OrderedSymbolSet = std::set<SymbolRef, SymbolSourcePositionCompare>;
+using SourceOrderedSymbolSet = std::set<SymbolRef, SymbolSourcePositionCompare>;
 
 template <typename A>
-OrderedSymbolSet OrderBySourcePosition(const A &container) {
-  OrderedSymbolSet result;
+SourceOrderedSymbolSet OrderBySourcePosition(const A &container) {
+  SourceOrderedSymbolSet result;
   for (SymbolRef x : container) {
     result.emplace(x);
   }

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -56,6 +56,8 @@ const DeclTypeSpec *FindParentTypeSpec(const DeclTypeSpec &);
 const DeclTypeSpec *FindParentTypeSpec(const Scope &);
 const DeclTypeSpec *FindParentTypeSpec(const Symbol &);
 
+const EquivalenceSet *FindEquivalenceSet(const Symbol &);
+
 enum class Tristate { No, Yes, Maybe };
 inline Tristate ToTristate(bool x) { return x ? Tristate::Yes : Tristate::No; }
 
@@ -105,14 +107,13 @@ bool IsEventTypeOrLockType(const DerivedTypeSpec *);
 bool IsOrContainsEventOrLockComponent(const Symbol &);
 bool CanBeTypeBoundProc(const Symbol *);
 // Does a non-PARAMETER symbol have explicit initialization with =value or
-// =>target in its declaration, or optionally in a DATA statement? (Being
+// =>target in its declaration (but not in a DATA statement)? (Being
 // ALLOCATABLE or having a derived type with default component initialization
 // doesn't count; it must be a variable initialization that implies the SAVE
 // attribute, or a derived type component default value.)
-bool IsStaticallyInitialized(const Symbol &, bool ignoreDATAstatements = false);
+bool HasDeclarationInitializer(const Symbol &);
 // Is the symbol explicitly or implicitly initialized in any way?
-bool IsInitialized(const Symbol &, bool ignoreDATAstatements = false,
-    const Symbol *derivedType = nullptr);
+bool IsInitialized(const Symbol &, bool ignoreDATAstatements = false);
 // Is the symbol a component subject to deallocation or finalization?
 bool IsDestructible(const Symbol &, const Symbol *derivedType = nullptr);
 bool HasIntrinsicTypeName(const Symbol &);
@@ -329,6 +330,13 @@ enum class ProcedureDefinitionClass {
 };
 
 ProcedureDefinitionClass ClassifyProcedure(const Symbol &);
+
+// Returns a list of storage associations due to EQUIVALENCE in a
+// scope; each storage association is a list of symbol references
+// in ascending order of scope offset.  Note that the scope may have
+// more EquivalenceSets than this function's result has storage
+// associations; these are closures over equivalences.
+std::list<std::list<SymbolRef>> GetStorageAssociations(const Scope &);
 
 // Derived type component iterator that provides a C++ LegacyForwardIterator
 // iterator over the Ordered, Direct, Ultimate or Potential components of a

--- a/flang/lib/Evaluate/initial-image.cpp
+++ b/flang/lib/Evaluate/initial-image.cpp
@@ -54,11 +54,14 @@ void InitialImage::AddPointer(
   pointers_.emplace(offset, pointer);
 }
 
-void InitialImage::Incorporate(
-    ConstantSubscript offset, const InitialImage &that) {
-  CHECK(that.pointers_.empty()); // pointers are not allowed in EQUIVALENCE
-  CHECK(offset + that.size() <= size());
-  std::memcpy(&data_[offset], &that.data_[0], that.size());
+void InitialImage::Incorporate(ConstantSubscript toOffset,
+    const InitialImage &from, ConstantSubscript fromOffset,
+    ConstantSubscript bytes) {
+  CHECK(from.pointers_.empty()); // pointers are not allowed in EQUIVALENCE
+  CHECK(fromOffset >= 0 && bytes >= 0 &&
+      static_cast<std::size_t>(fromOffset + bytes) <= from.size());
+  CHECK(static_cast<std::size_t>(toOffset + bytes) <= size());
+  std::memcpy(&data_[toOffset], &from.data_[fromOffset], bytes);
 }
 
 // Classes used with common::SearchTypes() to (re)construct Constant<> values
@@ -97,26 +100,31 @@ public:
       const semantics::DerivedTypeSpec &derived{type_.GetDerivedTypeSpec()};
       for (auto iter : DEREF(derived.scope())) {
         const Symbol &component{*iter.second};
-        bool isPointer{IsPointer(component)};
-        if (component.has<semantics::ObjectEntityDetails>() ||
-            component.has<semantics::ProcEntityDetails>()) {
-          auto componentType{DynamicType::From(component)};
-          CHECK(componentType);
+        bool isProcPtr{IsProcedurePointer(component)};
+        if (isProcPtr || component.has<semantics::ObjectEntityDetails>()) {
           auto at{offset_ + component.offset()};
-          if (isPointer) {
+          if (isProcPtr) {
             for (std::size_t j{0}; j < elements; ++j, at += stride) {
-              Result value{image_.AsConstantDataPointer(*componentType, at)};
-              CHECK(value);
-              typedValue[j].emplace(component, std::move(*value));
+              if (Result value{image_.AsConstantPointer(at)}) {
+                typedValue[j].emplace(component, std::move(*value));
+              }
+            }
+          } else if (IsPointer(component)) {
+            for (std::size_t j{0}; j < elements; ++j, at += stride) {
+              if (Result value{image_.AsConstantPointer(at)}) {
+                typedValue[j].emplace(component, std::move(*value));
+              }
             }
           } else {
+            auto componentType{DynamicType::From(component)};
+            CHECK(componentType.has_value());
             auto componentExtents{GetConstantExtents(context_, component)};
-            CHECK(componentExtents);
+            CHECK(componentExtents.has_value());
             for (std::size_t j{0}; j < elements; ++j, at += stride) {
-              Result value{image_.AsConstant(
-                  context_, *componentType, *componentExtents, at)};
-              CHECK(value);
-              typedValue[j].emplace(component, std::move(*value));
+              if (Result value{image_.AsConstant(
+                      context_, *componentType, *componentExtents, at)}) {
+                typedValue[j].emplace(component, std::move(*value));
+              }
             }
           }
         }
@@ -159,45 +167,11 @@ std::optional<Expr<SomeType>> InitialImage::AsConstant(FoldingContext &context,
       AsConstantHelper{context, type, extents, *this, offset});
 }
 
-class AsConstantDataPointerHelper {
-public:
-  using Result = std::optional<Expr<SomeType>>;
-  using Types = AllTypes;
-  AsConstantDataPointerHelper(const DynamicType &type,
-      const InitialImage &image, ConstantSubscript offset = 0)
-      : type_{type}, image_{image}, offset_{offset} {}
-  template <typename T> Result Test() {
-    if (T::category != type_.category()) {
-      return std::nullopt;
-    }
-    if constexpr (T::category != TypeCategory::Derived) {
-      if (T::kind != type_.kind()) {
-        return std::nullopt;
-      }
-    }
-    auto iter{image_.pointers_.find(offset_)};
-    if (iter == image_.pointers_.end()) {
-      return AsGenericExpr(NullPointer{});
-    }
-    return iter->second;
-  }
-
-private:
-  const DynamicType &type_;
-  const InitialImage &image_;
-  ConstantSubscript offset_;
-};
-
-std::optional<Expr<SomeType>> InitialImage::AsConstantDataPointer(
-    const DynamicType &type, ConstantSubscript offset) const {
-  return common::SearchTypes(AsConstantDataPointerHelper{type, *this, offset});
-}
-
-const ProcedureDesignator &InitialImage::AsConstantProcPointer(
+std::optional<Expr<SomeType>> InitialImage::AsConstantPointer(
     ConstantSubscript offset) const {
-  auto iter{pointers_.find(0)};
-  CHECK(iter != pointers_.end());
-  return DEREF(std::get_if<ProcedureDesignator>(&iter->second.u));
+  auto iter{pointers_.find(offset)};
+  return iter == pointers_.end() ? std::optional<Expr<SomeType>>{}
+                                 : iter->second;
 }
 
 } // namespace Fortran::evaluate

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -526,7 +526,7 @@ void CheckHelper::CheckObjectEntity(
     messages_.Say("OPTIONAL attribute may apply only to a dummy "
                   "argument"_err_en_US); // C849
   }
-  if (IsStaticallyInitialized(symbol, true /* ignore DATA inits */)) { // C808
+  if (HasDeclarationInitializer(symbol)) { // C808; ignore DATA initialization
     CheckPointerInitialization(symbol);
     if (IsAutomatic(symbol)) {
       messages_.Say(

--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -38,9 +38,9 @@ private:
   };
   struct SymbolAndOffset {
     SymbolAndOffset(Symbol &s, std::size_t off, const EquivalenceObject &obj)
-        : symbol{&s}, offset{off}, object{&obj} {}
+        : symbol{s}, offset{off}, object{&obj} {}
     SymbolAndOffset(const SymbolAndOffset &) = default;
-    Symbol *symbol;
+    MutableSymbolRef symbol;
     std::size_t offset;
     const EquivalenceObject *object;
   };

--- a/flang/lib/Semantics/data-to-inits.cpp
+++ b/flang/lib/Semantics/data-to-inits.cpp
@@ -20,6 +20,16 @@
 #include "flang/Evaluate/tools.h"
 #include "flang/Semantics/tools.h"
 
+// The job of generating explicit static initializers for objects that don't
+// have them in order to implement default component initialization is now being
+// done in lowering, so don't do it here in semantics; but the code remains here
+// in case we change our minds.
+static constexpr bool makeDefaultInitializationExplicit{false};
+
+// Whether to delete the original "init()" initializers from storage-associated
+// objects and pointers.
+static constexpr bool removeOriginalInits{false};
+
 namespace Fortran::semantics {
 
 // Steps through a list of values in a DATA statement set; implements
@@ -269,8 +279,10 @@ bool DataInitializationCompiler::InitElement(
     }
   }};
   const auto GetImage{[&]() -> evaluate::InitialImage & {
-    auto &symbolInit{inits_.emplace(&symbol, symbol.size()).first->second};
-    symbolInit.inits.emplace_back(offsetSymbol.offset(), offsetSymbol.size());
+    auto iter{inits_.emplace(&symbol, symbol.size())};
+    auto &symbolInit{iter.first->second};
+    symbolInit.initializedRanges.emplace_back(
+        offsetSymbol.offset(), offsetSymbol.size());
     return symbolInit.image;
   }};
   const auto OutOfRangeError{[&]() {
@@ -393,146 +405,422 @@ void AccumulateDataInitializations(DataInitializations &inits,
   }
 }
 
-static bool CombineSomeEquivalencedInits(
-    DataInitializations &inits, evaluate::ExpressionAnalyzer &exprAnalyzer) {
-  auto end{inits.end()};
-  for (auto iter{inits.begin()}; iter != end; ++iter) {
-    const Symbol &symbol{*iter->first};
-    Scope &scope{const_cast<Scope &>(symbol.owner())};
-    if (scope.equivalenceSets().empty()) {
-      continue; // no problem to solve here
-    }
-    const auto *commonBlock{FindCommonBlockContaining(symbol)};
-    // Sweep following DATA initializations in search of overlapping
-    // objects, accumulating into a vector; iterate to a fixed point.
-    std::vector<const Symbol *> conflicts;
-    auto minStart{symbol.offset()};
-    auto maxEnd{symbol.offset() + symbol.size()};
-    std::size_t minElementBytes{1};
-    while (true) {
-      auto prevCount{conflicts.size()};
-      conflicts.clear();
-      for (auto scan{iter}; ++scan != end;) {
-        const Symbol &other{*scan->first};
-        const Scope &otherScope{other.owner()};
-        if (&otherScope == &scope &&
-            FindCommonBlockContaining(other) == commonBlock &&
-            maxEnd > other.offset() &&
-            other.offset() + other.size() > minStart) {
-          // "other" conflicts with "symbol" or another conflict
-          conflicts.push_back(&other);
-          minStart = std::min(minStart, other.offset());
-          maxEnd = std::max(maxEnd, other.offset() + other.size());
+// Looks for default derived type component initialization -- but
+// *not* allocatables.
+static const DerivedTypeSpec *HasDefaultInitialization(const Symbol &symbol) {
+  if (const auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
+    if (object->init().has_value()) {
+      return nullptr; // init is explicit, not default
+    } else if (!object->isDummy() && object->type()) {
+      if (const DerivedTypeSpec * derived{object->type()->AsDerived()}) {
+        DirectComponentIterator directs{*derived};
+        if (std::find_if(
+                directs.begin(), directs.end(), [](const Symbol &component) {
+                  return !IsAllocatable(component) &&
+                      HasDeclarationInitializer(component);
+                })) {
+          return derived;
         }
       }
-      if (conflicts.size() == prevCount) {
-        break;
+    }
+  }
+  return nullptr;
+}
+
+// PopulateWithComponentDefaults() adds initializations to an instance
+// of SymbolDataInitialization containing all of the default component
+// initializers
+
+static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
+    std::size_t offset, const DerivedTypeSpec &derived,
+    evaluate::FoldingContext &foldingContext);
+
+static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
+    std::size_t offset, const DerivedTypeSpec &derived,
+    evaluate::FoldingContext &foldingContext, const Symbol &symbol) {
+  if (auto extents{evaluate::GetConstantExtents(foldingContext, symbol)}) {
+    const Scope &scope{derived.scope() ? *derived.scope()
+                                       : DEREF(derived.typeSymbol().scope())};
+    std::size_t stride{scope.size()};
+    if (std::size_t alignment{scope.alignment().value_or(0)}) {
+      stride = ((stride + alignment - 1) / alignment) * alignment;
+    }
+    for (auto elements{evaluate::GetSize(*extents)}; elements-- > 0;
+         offset += stride) {
+      PopulateWithComponentDefaults(init, offset, derived, foldingContext);
+    }
+  }
+}
+
+// F'2018 19.5.3(10) allows storage-associated default component initialization
+// when the values are identical.
+static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
+    std::size_t offset, const DerivedTypeSpec &derived,
+    evaluate::FoldingContext &foldingContext) {
+  const Scope &scope{
+      derived.scope() ? *derived.scope() : DEREF(derived.typeSymbol().scope())};
+  for (const auto &pair : scope) {
+    const Symbol &component{*pair.second};
+    std::size_t componentOffset{offset + component.offset()};
+    if (const auto *object{component.detailsIf<ObjectEntityDetails>()}) {
+      if (!IsAllocatable(component) && !IsAutomatic(component)) {
+        bool initialized{false};
+        if (object->init()) {
+          initialized = true;
+          if (IsPointer(component)) {
+            if (auto extant{init.image.AsConstantPointer(componentOffset)}) {
+              initialized = !(*extant == *object->init());
+            }
+            if (initialized) {
+              init.image.AddPointer(componentOffset, *object->init());
+            }
+          } else { // data, not pointer
+            if (auto dyType{evaluate::DynamicType::From(component)}) {
+              if (auto extents{evaluate::GetConstantExtents(
+                      foldingContext, component)}) {
+                if (auto extant{init.image.AsConstant(
+                        foldingContext, *dyType, *extents, componentOffset)}) {
+                  initialized = !(*extant == *object->init());
+                }
+              }
+            }
+            if (initialized) {
+              init.image.Add(componentOffset, component.size(), *object->init(),
+                  foldingContext);
+            }
+          }
+        } else if (const DeclTypeSpec * type{component.GetType()}) {
+          if (const DerivedTypeSpec * componentDerived{type->AsDerived()}) {
+            PopulateWithComponentDefaults(init, componentOffset,
+                *componentDerived, foldingContext, component);
+          }
+        }
+        if (initialized) {
+          init.initializedRanges.emplace_back(
+              componentOffset, component.size());
+        }
+      }
+    } else if (const auto *proc{component.detailsIf<ProcEntityDetails>()}) {
+      if (proc->init() && *proc->init()) {
+        SomeExpr procPtrInit{evaluate::ProcedureDesignator{**proc->init()}};
+        auto extant{init.image.AsConstantPointer(componentOffset)};
+        if (!extant || !(*extant == procPtrInit)) {
+          init.initializedRanges.emplace_back(
+              componentOffset, component.size());
+          init.image.AddPointer(componentOffset, std::move(procPtrInit));
+        }
       }
     }
-    if (conflicts.empty()) {
-      continue;
+  }
+}
+
+static bool CheckForOverlappingInitialization(
+    const std::list<SymbolRef> &symbols,
+    SymbolDataInitialization &initialization,
+    evaluate::ExpressionAnalyzer &exprAnalyzer, const std::string &what) {
+  bool result{true};
+  auto &context{exprAnalyzer.GetFoldingContext()};
+  initialization.initializedRanges.sort();
+  ConstantSubscript next{0};
+  for (const auto &range : initialization.initializedRanges) {
+    if (range.start() < next) {
+      result = false; // error: overlap
+      bool hit{false};
+      for (const Symbol &symbol : symbols) {
+        auto offset{range.start() -
+            static_cast<ConstantSubscript>(
+                symbol.offset() - symbols.front()->offset())};
+        if (offset >= 0) {
+          if (auto badDesignator{evaluate::OffsetToDesignator(
+                  context, symbol, offset, range.size())}) {
+            hit = true;
+            exprAnalyzer.Say(symbol.name(),
+                "%s affect '%s' more than once"_err_en_US, what,
+                badDesignator->AsFortran());
+          }
+        }
+      }
+      CHECK(hit);
     }
-    // Compute the minimum common granularity
-    if (auto dyType{evaluate::DynamicType::From(symbol)}) {
-      minElementBytes = evaluate::ToInt64(
-          dyType->MeasureSizeInBytes(exprAnalyzer.GetFoldingContext(), true))
-                            .value_or(1);
+    next = range.start() + range.size();
+    CHECK(next <= static_cast<ConstantSubscript>(initialization.image.size()));
+  }
+  return result;
+}
+
+static void IncorporateExplicitInitialization(
+    SymbolDataInitialization &combined, DataInitializations &inits,
+    const Symbol &symbol, ConstantSubscript firstOffset,
+    evaluate::FoldingContext &foldingContext) {
+  auto iter{inits.find(&symbol)};
+  const auto offset{symbol.offset() - firstOffset};
+  if (iter != inits.end()) { // DATA statement initialization
+    for (const auto &range : iter->second.initializedRanges) {
+      auto at{offset + range.start()};
+      combined.initializedRanges.emplace_back(at, range.size());
+      combined.image.Incorporate(
+          at, iter->second.image, range.start(), range.size());
     }
-    for (const Symbol *s : conflicts) {
-      if (auto dyType{evaluate::DynamicType::From(*s)}) {
-        minElementBytes = std::min<std::size_t>(minElementBytes,
-            evaluate::ToInt64(dyType->MeasureSizeInBytes(
-                                  exprAnalyzer.GetFoldingContext(), true))
-                .value_or(1));
+    if (removeOriginalInits) {
+      inits.erase(iter);
+    }
+  } else { // Declaration initialization
+    Symbol &mutableSymbol{const_cast<Symbol &>(symbol)};
+    if (IsPointer(mutableSymbol)) {
+      if (auto *object{mutableSymbol.detailsIf<ObjectEntityDetails>()}) {
+        if (object->init()) {
+          combined.initializedRanges.emplace_back(offset, mutableSymbol.size());
+          combined.image.AddPointer(offset, *object->init());
+          if (removeOriginalInits) {
+            object->init().reset();
+          }
+        }
+      } else if (auto *proc{mutableSymbol.detailsIf<ProcEntityDetails>()}) {
+        if (proc->init() && *proc->init()) {
+          combined.initializedRanges.emplace_back(offset, mutableSymbol.size());
+          combined.image.AddPointer(
+              offset, SomeExpr{evaluate::ProcedureDesignator{**proc->init()}});
+          if (removeOriginalInits) {
+            proc->init().reset();
+          }
+        }
+      }
+    } else if (auto *object{mutableSymbol.detailsIf<ObjectEntityDetails>()}) {
+      if (!IsNamedConstant(mutableSymbol) && object->init()) {
+        combined.initializedRanges.emplace_back(offset, mutableSymbol.size());
+        combined.image.Add(
+            offset, mutableSymbol.size(), *object->init(), foldingContext);
+        if (removeOriginalInits) {
+          object->init().reset();
+        }
+      }
+    }
+  }
+}
+
+// Finds the size of the smallest element type in a list of
+// storage-associated objects.
+static std::size_t ComputeMinElementBytes(
+    const std::list<SymbolRef> &associated,
+    evaluate::FoldingContext &foldingContext) {
+  std::size_t minElementBytes{1};
+  const Symbol &first{*associated.front()};
+  for (const Symbol &s : associated) {
+    if (auto dyType{evaluate::DynamicType::From(s)}) {
+      auto size{static_cast<std::size_t>(
+          evaluate::ToInt64(dyType->MeasureSizeInBytes(foldingContext, true))
+              .value_or(1))};
+      if (std::size_t alignment{dyType->GetAlignment(foldingContext)}) {
+        size = ((size + alignment - 1) / alignment) * alignment;
+      }
+      if (&s == &first) {
+        minElementBytes = size;
       } else {
-        minElementBytes = 1;
+        minElementBytes = std::min(minElementBytes, size);
+      }
+    } else {
+      minElementBytes = 1;
+    }
+  }
+  return minElementBytes;
+}
+
+// Checks for overlapping initialization errors in a list of
+// storage-associated objects.  Default component initializations
+// are allowed to be overridden by explicit initializations.
+// If the objects are static, save the combined initializer as
+// a compiler-created object that covers all of them.
+static bool CombineEquivalencedInitialization(
+    const std::list<SymbolRef> &associated,
+    evaluate::ExpressionAnalyzer &exprAnalyzer, DataInitializations &inits) {
+  // Compute the minimum common granularity and total size
+  const Symbol &first{*associated.front()};
+  std::size_t maxLimit{0};
+  for (const Symbol &s : associated) {
+    CHECK(s.offset() >= first.offset());
+    auto limit{s.offset() + s.size()};
+    if (limit > maxLimit) {
+      maxLimit = limit;
+    }
+  }
+  auto bytes{static_cast<common::ConstantSubscript>(maxLimit - first.offset())};
+  Scope &scope{const_cast<Scope &>(first.owner())};
+  // Combine the initializations of the associated objects.
+  // Apply all default initializations first.
+  SymbolDataInitialization combined{static_cast<std::size_t>(bytes)};
+  auto &foldingContext{exprAnalyzer.GetFoldingContext()};
+  for (const Symbol &s : associated) {
+    if (!IsNamedConstant(s)) {
+      if (const auto *derived{HasDefaultInitialization(s)}) {
+        PopulateWithComponentDefaults(
+            combined, s.offset() - first.offset(), *derived, foldingContext, s);
       }
     }
-    CHECK(minElementBytes > 0);
-    CHECK((minElementBytes & (minElementBytes - 1)) == 0);
-    auto bytes{static_cast<common::ConstantSubscript>(maxEnd - minStart)};
-    CHECK(bytes % minElementBytes == 0);
-    const DeclTypeSpec &typeSpec{scope.MakeNumericType(
-        TypeCategory::Integer, KindExpr{minElementBytes})};
-    // Combine "symbol" and "conflicts[]" into a compiler array temp
-    // that overlaps all of them, and merge their initial values into
-    // the temp's initializer.
+  }
+  if (!CheckForOverlappingInitialization(associated, combined, exprAnalyzer,
+          "Distinct default component initializations of equivalenced objects"s)) {
+    return false;
+  }
+  // Don't complain about overlap between explicit initializations and
+  // default initializations.
+  combined.initializedRanges.clear();
+  // Now overlay all explicit initializations from DATA statements and
+  // from initializers in declarations.
+  for (const Symbol &symbol : associated) {
+    IncorporateExplicitInitialization(
+        combined, inits, symbol, first.offset(), foldingContext);
+  }
+  if (!CheckForOverlappingInitialization(associated, combined, exprAnalyzer,
+          "Explicit initializations of equivalenced objects"s)) {
+    return false;
+  }
+  // If the items are in static storage, save the final initialization.
+  if (std::find_if(associated.begin(), associated.end(),
+          [](SymbolRef ref) { return IsSaved(*ref); }) != associated.end()) {
+    // Create a compiler array temp that overlaps all the items.
     SourceName name{exprAnalyzer.context().GetTempName(scope)};
     auto emplaced{
         scope.try_emplace(name, Attrs{Attr::SAVE}, ObjectEntityDetails{})};
     CHECK(emplaced.second);
     Symbol &combinedSymbol{*emplaced.first->second};
+    combinedSymbol.set(Symbol::Flag::CompilerCreated);
+    inits.emplace(&combinedSymbol, std::move(combined));
     auto &details{combinedSymbol.get<ObjectEntityDetails>()};
-    combinedSymbol.set_offset(minStart);
+    combinedSymbol.set_offset(first.offset());
     combinedSymbol.set_size(bytes);
+    std::size_t minElementBytes{
+        ComputeMinElementBytes(associated, foldingContext)};
+    if (!evaluate::IsValidKindOfIntrinsicType(
+            TypeCategory::Integer, minElementBytes) ||
+        (bytes % minElementBytes) != 0) {
+      minElementBytes = 1;
+    }
+    const DeclTypeSpec &typeSpec{scope.MakeNumericType(
+        TypeCategory::Integer, KindExpr{minElementBytes})};
     details.set_type(typeSpec);
     ArraySpec arraySpec;
     arraySpec.emplace_back(ShapeSpec::MakeExplicit(Bound{
         bytes / static_cast<common::ConstantSubscript>(minElementBytes)}));
     details.set_shape(arraySpec);
-    if (commonBlock) {
+    if (const auto *commonBlock{FindCommonBlockContaining(first)}) {
       details.set_commonBlock(*commonBlock);
     }
-    // Merge these EQUIVALENCE'd DATA initializations, and remove the
-    // original initializations from the map.
-    auto combinedInit{
-        inits.emplace(&combinedSymbol, static_cast<std::size_t>(bytes))};
-    evaluate::InitialImage &combined{combinedInit.first->second.image};
-    combined.Incorporate(symbol.offset() - minStart, iter->second.image);
-    inits.erase(iter);
-    for (const Symbol *s : conflicts) {
-      auto sIter{inits.find(s)};
-      CHECK(sIter != inits.end());
-      combined.Incorporate(s->offset() - minStart, sIter->second.image);
-      inits.erase(sIter);
-    }
-    return true; // got one
+    // Add an EQUIVALENCE set to the scope so that the new object appears in
+    // the results of GetStorageAssociations().
+    auto &newSet{scope.equivalenceSets().emplace_back()};
+    newSet.emplace_back(combinedSymbol);
+    newSet.emplace_back(const_cast<Symbol &>(first));
   }
-  return false; // no remaining EQUIVALENCE'd DATA initializations
+  return true;
 }
 
-// Converts the initialization image for all the DATA statement appearances of
-// a single symbol into an init() expression in the symbol table entry.
+// When a statically-allocated derived type variable has no explicit
+// initialization, but its type has at least one nonallocatable ultimate
+// component with default initialization, make its initialization explicit.
+[[maybe_unused]] static void MakeDefaultInitializationExplicit(
+    const Scope &scope, const std::list<std::list<SymbolRef>> &associations,
+    evaluate::FoldingContext &foldingContext, DataInitializations &inits) {
+  UnorderedSymbolSet equivalenced;
+  for (const std::list<SymbolRef> &association : associations) {
+    for (const Symbol &symbol : association) {
+      equivalenced.emplace(symbol);
+    }
+  }
+  for (const auto &pair : scope) {
+    const Symbol &symbol{*pair.second};
+    if (!symbol.test(Symbol::Flag::InDataStmt) &&
+        !HasDeclarationInitializer(symbol) && IsSaved(symbol) &&
+        equivalenced.find(symbol) == equivalenced.end()) {
+      // Static object, no local storage association, no explicit initialization
+      if (const DerivedTypeSpec * derived{HasDefaultInitialization(symbol)}) {
+        auto newInitIter{inits.emplace(&symbol, symbol.size())};
+        CHECK(newInitIter.second);
+        auto &newInit{newInitIter.first->second};
+        PopulateWithComponentDefaults(
+            newInit, 0, *derived, foldingContext, symbol);
+      }
+    }
+  }
+}
+
+// Traverses the Scopes to:
+// 1) combine initialization of equivalenced objects, &
+// 2) optionally make initialization explicit for otherwise uninitialized static
+//    objects of derived types with default component initialization
+// Returns false on error.
+static bool ProcessScopes(const Scope &scope,
+    evaluate::ExpressionAnalyzer &exprAnalyzer, DataInitializations &inits) {
+  bool result{true}; // no error
+  switch (scope.kind()) {
+  case Scope::Kind::Global:
+  case Scope::Kind::Module:
+  case Scope::Kind::MainProgram:
+  case Scope::Kind::Subprogram:
+  case Scope::Kind::BlockData:
+  case Scope::Kind::Block: {
+    std::list<std::list<SymbolRef>> associations{GetStorageAssociations(scope)};
+    for (const std::list<SymbolRef> &associated : associations) {
+      if (std::find_if(associated.begin(), associated.end(), [](SymbolRef ref) {
+            return IsInitialized(*ref);
+          }) != associated.end()) {
+        result &=
+            CombineEquivalencedInitialization(associated, exprAnalyzer, inits);
+      }
+    }
+    if constexpr (makeDefaultInitializationExplicit) {
+      MakeDefaultInitializationExplicit(
+          scope, associations, exprAnalyzer.GetFoldingContext(), inits);
+    }
+    for (const Scope &child : scope.children()) {
+      result &= ProcessScopes(child, exprAnalyzer, inits);
+    }
+  } break;
+  default:;
+  }
+  return result;
+}
+
+// Converts the static initialization image for a single symbol with
+// one or more DATA statement appearances.
 void ConstructInitializer(const Symbol &symbol,
     SymbolDataInitialization &initialization,
     evaluate::ExpressionAnalyzer &exprAnalyzer) {
+  std::list<SymbolRef> symbols{symbol};
+  CheckForOverlappingInitialization(
+      symbols, initialization, exprAnalyzer, "DATA statement initializations"s);
   auto &context{exprAnalyzer.GetFoldingContext()};
-  initialization.inits.sort();
-  ConstantSubscript next{0};
-  for (const auto &init : initialization.inits) {
-    if (init.start() < next) {
-      auto badDesignator{evaluate::OffsetToDesignator(
-          context, symbol, init.start(), init.size())};
-      CHECK(badDesignator);
-      exprAnalyzer.Say(symbol.name(),
-          "DATA statement initializations affect '%s' more than once"_err_en_US,
-          badDesignator->AsFortran());
-    }
-    next = init.start() + init.size();
-    CHECK(next <= static_cast<ConstantSubscript>(initialization.image.size()));
-  }
   if (const auto *proc{symbol.detailsIf<ProcEntityDetails>()}) {
     CHECK(IsProcedurePointer(symbol));
-    const auto &procDesignator{initialization.image.AsConstantProcPointer()};
-    CHECK(!procDesignator.GetComponent());
     auto &mutableProc{const_cast<ProcEntityDetails &>(*proc)};
-    mutableProc.set_init(DEREF(procDesignator.GetSymbol()));
-  } else if (const auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
-    if (auto symbolType{evaluate::DynamicType::From(symbol)}) {
-      auto &mutableObject{const_cast<ObjectEntityDetails &>(*object)};
-      if (IsPointer(symbol)) {
-        mutableObject.set_init(
-            initialization.image.AsConstantDataPointer(*symbolType));
+    if (MaybeExpr expr{initialization.image.AsConstantPointer()}) {
+      if (const auto *procDesignator{
+              std::get_if<evaluate::ProcedureDesignator>(&expr->u)}) {
+        CHECK(!procDesignator->GetComponent());
+        mutableProc.set_init(DEREF(procDesignator->GetSymbol()));
       } else {
-        if (auto extents{evaluate::GetConstantExtents(context, symbol)}) {
-          mutableObject.set_init(
-              initialization.image.AsConstant(context, *symbolType, *extents));
-        } else {
-          exprAnalyzer.Say(symbol.name(),
-              "internal: unknown shape for '%s' while constructing initializer from DATA"_err_en_US,
-              symbol.name());
-          return;
-        }
+        CHECK(evaluate::IsNullPointer(*expr));
+        mutableProc.set_init(nullptr);
+      }
+    } else {
+      mutableProc.set_init(nullptr);
+    }
+  } else if (const auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
+    auto &mutableObject{const_cast<ObjectEntityDetails &>(*object)};
+    if (IsPointer(symbol)) {
+      if (auto ptr{initialization.image.AsConstantPointer()}) {
+        mutableObject.set_init(*ptr);
+      } else {
+        mutableObject.set_init(SomeExpr{evaluate::NullPointer{}});
+      }
+    } else if (auto symbolType{evaluate::DynamicType::From(symbol)}) {
+      if (auto extents{evaluate::GetConstantExtents(context, symbol)}) {
+        mutableObject.set_init(
+            initialization.image.AsConstant(context, *symbolType, *extents));
+      } else {
+        exprAnalyzer.Say(symbol.name(),
+            "internal: unknown shape for '%s' while constructing initializer from DATA"_err_en_US,
+            symbol.name());
+        return;
       }
     } else {
       exprAnalyzer.Say(symbol.name(),
@@ -552,10 +840,11 @@ void ConstructInitializer(const Symbol &symbol,
 
 void ConvertToInitializers(
     DataInitializations &inits, evaluate::ExpressionAnalyzer &exprAnalyzer) {
-  while (CombineSomeEquivalencedInits(inits, exprAnalyzer)) {
-  }
-  for (auto &[symbolPtr, initialization] : inits) {
-    ConstructInitializer(*symbolPtr, initialization, exprAnalyzer);
+  if (ProcessScopes(
+          exprAnalyzer.context().globalScope(), exprAnalyzer, inits)) {
+    for (auto &[symbolPtr, initialization] : inits) {
+      ConstructInitializer(*symbolPtr, initialization, exprAnalyzer);
+    }
   }
 }
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/data-to-inits.h
+++ b/flang/lib/Semantics/data-to-inits.h
@@ -28,8 +28,9 @@ class Symbol;
 struct SymbolDataInitialization {
   using Range = common::Interval<common::ConstantSubscript>;
   explicit SymbolDataInitialization(std::size_t bytes) : image{bytes} {}
+  SymbolDataInitialization(SymbolDataInitialization &&) = default;
   evaluate::InitialImage image;
-  std::list<Range> inits;
+  std::list<Range> initializedRanges;
 };
 
 using DataInitializations = std::map<const Symbol *, SymbolDataInitialization>;

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -3756,7 +3756,7 @@ Symbol &DeclarationVisitor::DeclareUnknownEntity(
 
 bool DeclarationVisitor::HasCycle(
     const Symbol &procSymbol, const ProcInterface &interface) {
-  OrderedSymbolSet procsInCycle;
+  SourceOrderedSymbolSet procsInCycle;
   procsInCycle.insert(procSymbol);
   const ProcInterface *thisInterface{&interface};
   bool haveInterface{true};
@@ -5389,7 +5389,7 @@ bool ConstructVisitor::Pre(const parser::DataImpliedDo &x) {
 }
 
 // Sets InDataStmt flag on a variable (or misidentified function) in a DATA
-// statement so that the predicate IsStaticallyInitialized() will be true
+// statement so that the predicate IsInitialized() will be true
 // during semantic analysis before the symbol's initializer is constructed.
 bool ConstructVisitor::Pre(const parser::DataIDoObject &x) {
   std::visit(

--- a/flang/lib/Semantics/runtime-type-info.cpp
+++ b/flang/lib/Semantics/runtime-type-info.cpp
@@ -264,11 +264,11 @@ static SomeExpr SaveNumericPointerTarget(
     object.set_shape(arraySpec);
     object.set_init(evaluate::AsGenericExpr(evaluate::Constant<T>{
         std::move(x), evaluate::ConstantSubscripts{elements}}));
-    const Symbol &symbol{
-        *scope
-             .try_emplace(
-                 name, Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
-             .first->second};
+    Symbol &symbol{*scope
+                        .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
+                            std::move(object))
+                        .first->second};
+    symbol.set(Symbol::Flag::CompilerCreated);
     return evaluate::AsGenericExpr(
         evaluate::Expr<T>{evaluate::Designator<T>{symbol}});
   }
@@ -301,11 +301,11 @@ static SomeExpr SaveDerivedPointerTarget(Scope &scope, SourceName name,
     object.set_init(
         evaluate::AsGenericExpr(evaluate::Constant<evaluate::SomeDerived>{
             derivedType, std::move(x), std::move(shape)}));
-    const Symbol &symbol{
-        *scope
-             .try_emplace(
-                 name, Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
-             .first->second};
+    Symbol &symbol{*scope
+                        .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
+                            std::move(object))
+                        .first->second};
+    symbol.set(Symbol::Flag::CompilerCreated);
     return evaluate::AsGenericExpr(
         evaluate::Designator<evaluate::SomeDerived>{symbol});
   }
@@ -313,11 +313,12 @@ static SomeExpr SaveDerivedPointerTarget(Scope &scope, SourceName name,
 
 static SomeExpr SaveObjectInit(
     Scope &scope, SourceName name, const ObjectEntityDetails &object) {
-  const Symbol &symbol{*scope
-                            .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
-                                ObjectEntityDetails{object})
-                            .first->second};
+  Symbol &symbol{*scope
+                      .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
+                          ObjectEntityDetails{object})
+                      .first->second};
   CHECK(symbol.get<ObjectEntityDetails>().init().has_value());
+  symbol.set(Symbol::Flag::CompilerCreated);
   return evaluate::AsGenericExpr(
       evaluate::Designator<evaluate::SomeDerived>{symbol});
 }
@@ -615,6 +616,7 @@ Symbol &RuntimeTableBuilder::CreateObject(
       Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))};
   CHECK(pair.second);
   Symbol &result{*pair.first->second};
+  result.set(Symbol::Flag::CompilerCreated);
   return result;
 }
 
@@ -638,11 +640,11 @@ SomeExpr RuntimeTableBuilder::SaveNameAsPointerTarget(
   using Ascii = evaluate::Type<TypeCategory::Character, 1>;
   using AsciiExpr = evaluate::Expr<Ascii>;
   object.set_init(evaluate::AsGenericExpr(AsciiExpr{name}));
-  const Symbol &symbol{
-      *scope
-           .try_emplace(SaveObjectName(".n."s + name),
-               Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
-           .first->second};
+  Symbol &symbol{*scope
+                      .try_emplace(SaveObjectName(".n."s + name),
+                          Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
+                      .first->second};
+  symbol.set(Symbol::Flag::CompilerCreated);
   return evaluate::AsGenericExpr(
       AsciiExpr{evaluate::Designator<Ascii>{symbol}});
 }
@@ -819,6 +821,7 @@ bool RuntimeTableBuilder::InitializeDataPointer(
         ".dp."s + distinctName + "."s + symbol.name().ToString())};
     Symbol &ptrDtSym{
         *scope.try_emplace(ptrDtName, Attrs{}, UnknownDetails{}).first->second};
+    ptrDtSym.set(Symbol::Flag::CompilerCreated);
     Scope &ptrDtScope{scope.MakeScope(Scope::Kind::DerivedType, &ptrDtSym)};
     ignoreScopes_.insert(&ptrDtScope);
     ObjectEntityDetails ptrDtObj;

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -680,4 +680,38 @@ bool GenericKind::Is(GenericKind::OtherKind x) const {
   return y && *y == x;
 }
 
+bool SymbolOffsetCompare::operator()(
+    const SymbolRef &x, const SymbolRef &y) const {
+  const Symbol *xCommon{FindCommonBlockContaining(*x)};
+  const Symbol *yCommon{FindCommonBlockContaining(*y)};
+  if (xCommon) {
+    if (yCommon) {
+      const SymbolSourcePositionCompare sourceCmp;
+      if (sourceCmp(*xCommon, *yCommon)) {
+        return true;
+      } else if (sourceCmp(*yCommon, *xCommon)) {
+        return false;
+      } else if (x->offset() == y->offset()) {
+        return x->size() > y->size();
+      } else {
+        return x->offset() < y->offset();
+      }
+    } else {
+      return false;
+    }
+  } else if (yCommon) {
+    return true;
+  } else if (x->offset() == y->offset()) {
+    return x->size() > y->size();
+  } else {
+    return x->offset() < y->offset();
+  }
+  return x->GetSemanticsContext().allCookedSources().Precedes(
+      x->name(), y->name());
+}
+bool SymbolOffsetCompare::operator()(
+    const MutableSymbolRef &x, const MutableSymbolRef &y) const {
+  return (*this)(SymbolRef{*x}, SymbolRef{*y});
+}
+
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/type.cpp
+++ b/flang/lib/Semantics/type.cpp
@@ -179,10 +179,8 @@ bool DerivedTypeSpec::IsForwardReferenced() const {
 
 bool DerivedTypeSpec::HasDefaultInitialization() const {
   DirectComponentIterator components{*this};
-  return bool{std::find_if(
-      components.begin(), components.end(), [&](const Symbol &component) {
-        return IsInitialized(component, false, &typeSymbol());
-      })};
+  return bool{std::find_if(components.begin(), components.end(),
+      [&](const Symbol &component) { return IsInitialized(component); })};
 }
 
 bool DerivedTypeSpec::HasDestruction() const {

--- a/flang/test/Lower/default-initialization-globals.f90
+++ b/flang/test/Lower/default-initialization-globals.f90
@@ -145,15 +145,13 @@ subroutine eqv()
   type(tseq), save :: somet
   integer :: i(2)
   equivalence (somet, i)
-! CHECK-LABEL: fir.global internal @_QFeqvEi : tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>> {
+! CHECK-LABEL: fir.global internal @_QFeqvEi : !fir.array<2xi32> {
   ! CHECK-DAG: %[[VAL_50:.*]] = constant 2 : i32
   ! CHECK-DAG: %[[VAL_51:.*]] = constant 3 : i32
-  ! CHECK: %[[VAL_52:.*]] = fir.undefined tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
-  ! CHECK: %[[VAL_53:.*]] = fir.undefined !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_54:.*]] = fir.insert_value %[[VAL_53]], %[[VAL_50]], ["i", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_55:.*]] = fir.insert_value %[[VAL_54]], %[[VAL_51]], ["j", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_56:.*]] = fir.insert_value %[[VAL_52]], %[[VAL_55]], [0 : index] : (tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>, !fir.type<_QMtinitTtseq{i:i32,j:i32}>) -> tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
-  ! CHECK: fir.has_value %[[VAL_56]] : tuple<!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
+  ! CHECK: %[[VAL_52:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_53:.*]] = fir.insert_value %[[VAL_52]], %[[VAL_50]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_54:.*]] = fir.insert_value %[[VAL_53]], %[[VAL_51]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: fir.has_value %[[VAL_54]] : !fir.array<2xi32>
 end subroutine
 
 subroutine eqv_explicit_init()
@@ -161,32 +159,24 @@ subroutine eqv_explicit_init()
   type(tseq), save :: somet
   integer :: i(2) = [4, 5]
   equivalence (somet, i)
-! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi : tuple<!fir.array<2xi32>> {
+! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi : !fir.array<2xi32> {
   ! CHECK-DAG: %[[VAL_57:.*]] = constant 4 : i32
   ! CHECK-DAG: %[[VAL_58:.*]] = constant 5 : i32
-  ! CHECK: %[[VAL_59:.*]] = fir.undefined tuple<!fir.array<2xi32>>
-  ! CHECK: %[[VAL_60:.*]] = fir.undefined !fir.array<2xi32>
-  ! CHECK: %[[VAL_61:.*]] = fir.insert_value %[[VAL_60]], %[[VAL_57]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_62:.*]] = fir.insert_value %[[VAL_61]], %[[VAL_58]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_63:.*]] = fir.insert_value %[[VAL_59]], %[[VAL_62]], [0 : index] : (tuple<!fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>>
-  ! CHECK: fir.has_value %[[VAL_63]] : tuple<!fir.array<2xi32>>
+  ! CHECK: %[[VAL_59:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_60:.*]] = fir.insert_value %[[VAL_59]], %[[VAL_57]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_61:.*]] = fir.insert_value %[[VAL_60]], %[[VAL_58]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: fir.has_value %[[VAL_61]] : !fir.array<2xi32>
 end subroutine
 
 subroutine eqv_same_default_init()
   use tinit
   type(tseq), save :: somet1(2), somet2
   equivalence (somet1(1), somet2)
-! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 : tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>> {
-  ! CHECK-DAG: %[[VAL_64:.*]] = constant 2 : i32
-  ! CHECK-DAG: %[[VAL_65:.*]] = constant 3 : i32
-  ! CHECK: %[[VAL_66:.*]] = fir.undefined tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
-  ! CHECK: %[[VAL_67:.*]] = fir.undefined !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_68:.*]] = fir.insert_value %[[VAL_67]], %[[VAL_64]], ["i", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_69:.*]] = fir.insert_value %[[VAL_68]], %[[VAL_65]], ["j", !fir.type<_QMtinitTtseq{i:i32,j:i32}>] : (!fir.type<_QMtinitTtseq{i:i32,j:i32}>, i32) -> !fir.type<_QMtinitTtseq{i:i32,j:i32}>
-  ! CHECK: %[[VAL_70:.*]] = fir.undefined !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
-  ! CHECK: %[[VAL_71:.*]] = fir.insert_on_range %[[VAL_70]], %[[VAL_69]], [0 : index, 1 : index] : (!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>, !fir.type<_QMtinitTtseq{i:i32,j:i32}>) -> !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>
-  ! CHECK: %[[VAL_72:.*]] = fir.insert_value %[[VAL_66]], %[[VAL_71]], [0 : index] : (tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>, !fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>) -> tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
-  ! CHECK: fir.has_value %[[VAL_72]] : tuple<!fir.array<2x!fir.type<_QMtinitTtseq{i:i32,j:i32}>>>
+! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 : !fir.array<2xi64> {
+  ! CHECK: %[[VAL_62:.*]] = constant 12884901890 : i64
+  ! CHECK: %[[VAL_63:.*]] = fir.undefined !fir.array<2xi64>
+  ! CHECK: %[[VAL_64:.*]] = fir.insert_on_range %[[VAL_63]], %[[VAL_62]], [0 : index, 1 : index] : (!fir.array<2xi64>, i64) -> !fir.array<2xi64>
+  ! CHECK: fir.has_value %[[VAL_64]] : !fir.array<2xi64>
 end subroutine
 
 subroutine eqv_full_overlaps_with_explicit_init()
@@ -202,37 +192,44 @@ subroutine eqv_full_overlaps_with_explicit_init()
   equivalence (i, link(1))
   equivalence (somet, link(2))
   equivalence (j, link(3))
-! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi : tuple<!fir.array<2xi32>, !fir.array<2xi32>> {
+! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi : !fir.array<4xi32> {
   ! CHECK-DAG: %[[VAL_73:.*]] = constant 5 : i32
   ! CHECK-DAG: %[[VAL_74:.*]] = constant 6 : i32
   ! CHECK-DAG: %[[VAL_75:.*]] = constant 7 : i32
   ! CHECK-DAG: %[[VAL_76:.*]] = constant 8 : i32
-  ! CHECK: %[[VAL_77:.*]] = fir.undefined tuple<!fir.array<2xi32>, !fir.array<2xi32>>
-  ! CHECK: %[[VAL_78:.*]] = fir.undefined !fir.array<2xi32>
-  ! CHECK: %[[VAL_79:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_73]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_80:.*]] = fir.insert_value %[[VAL_79]], %[[VAL_74]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_81:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_80]], [0 : index] : (tuple<!fir.array<2xi32>, !fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>, !fir.array<2xi32>>
-  ! CHECK: %[[VAL_82:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_75]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_83:.*]] = fir.insert_value %[[VAL_82]], %[[VAL_76]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
-  ! CHECK: %[[VAL_84:.*]] = fir.insert_value %[[VAL_81]], %[[VAL_83]], [1 : index] : (tuple<!fir.array<2xi32>, !fir.array<2xi32>>, !fir.array<2xi32>) -> tuple<!fir.array<2xi32>, !fir.array<2xi32>>
-  ! CHECK: fir.has_value %[[VAL_84]] : tuple<!fir.array<2xi32>, !fir.array<2xi32>>
+  ! CHECK-DAG: %[[VAL_77:.*]] = fir.undefined !fir.array<4xi32>
+  ! CHECK-DAG: %[[VAL_78:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_73]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK-DAG: %[[VAL_79:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_74]], [1 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK-DAG: %[[VAL_80:.*]] = fir.insert_value %[[VAL_79]], %[[VAL_75]], [2 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK-DAG: %[[VAL_81:.*]] = fir.insert_value %[[VAL_80]], %[[VAL_76]], [3 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK-DAG: fir.has_value %[[VAL_81]] : !fir.array<4xi32>
 end subroutine
 
-! TODO: possible extension.
-! subroutine eqv_partial_overlaps_with_explicit_init()
-!   use tinit
-!   type(tseq), save :: somet
-!   integer, save :: link(4)
-!   integer :: i(2) = [5, 6]
-!   integer :: j = 7
-!   ! `somet` is only partially covered by explicit init, somet%j default
-!   ! init value should be used in the equiv storage init to match nvfortran,
-!   ! ifort, and nagfor behavior. Currently hits hard TODO. Note that gfortran
-!   ! refuses this code.
-!   !   i(1)=5 | i(2)=6  |    -    |  -
-!   !     -    | somet%i | somet%j |
-!   !     -    |    -    |    -    | j=7
-!   equivalence (i, link(1))
-!   equivalence (somet, link(2))
-!   equivalence (j, link(4))
-! end subroutine
+subroutine eqv_partial_overlaps_with_explicit_init()
+  use tinit
+  type(tseq), save :: somet
+  integer, save :: link(4)
+  integer :: i(2) = [5, 6]
+  integer :: j = 7
+  ! `somet` is only partially covered by explicit init, somet%j default
+  ! init value should be used in the equiv storage init to match nvfortran,
+  ! ifort, and nagfor behavior (gfortran refuses this code). 19.5.3.4 point
+  ! 10 specifies that explicit initialization overrides default initialization.
+  !   i(1)=5 | i(2)=6  |    -    |  -
+  !     -    | somet%i | somet%j |
+  !     -    |    -    |    -    | j=7
+  equivalence (i, link(1))
+  equivalence (somet, link(2))
+  equivalence (j, link(4))
+! CHECK-LABEL: fir.global internal @_QFeqv_partial_overlaps_with_explicit_initEi : !fir.array<4xi32>
+   ! CHECK-DAG: %[[VAL_82:.*]] = constant 5 : i32
+   ! CHECK-DAG: %[[VAL_83:.*]] = constant 6 : i32
+   ! CHECK-DAG: %[[VAL_84:.*]] = constant 3 : i32
+   ! CHECK-DAG: %[[VAL_85:.*]] = constant 7 : i32
+   ! CHECK: %[[VAL_86:.*]] = fir.undefined !fir.array<4xi32>
+   ! CHECK: %[[VAL_87:.*]] = fir.insert_value %[[VAL_86]], %[[VAL_82]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_88:.*]] = fir.insert_value %[[VAL_87]], %[[VAL_83]], [1 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_89:.*]] = fir.insert_value %[[VAL_88]], %[[VAL_84]], [2 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_90:.*]] = fir.insert_value %[[VAL_89]], %[[VAL_85]], [3 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: fir.has_value %[[VAL_90]] : !fir.array<4xi32>
+end subroutine

--- a/flang/test/Lower/equivalence-2.f90
+++ b/flang/test/Lower/equivalence-2.f90
@@ -24,8 +24,7 @@ subroutine test_eq_sets
   DIMENSION Ag(2), Bg(2)
   SAVE Ag, Bg
   EQUIVALENCE (Ag(1), Bg(2))
-  ! CHECK-DAG: %[[agbgStore:.*]] = fir.address_of(@_QFtest_eq_setsEbg) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<8xi8>>>
-  ! CHECK-DAG: %[[agbg:.*]] = fir.convert %[[agbgStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<8xi8>>>) -> !fir.ref<!fir.array<12xi8>>
+  ! CHECK-DAG: %[[agbg:.*]] = fir.address_of(@_QFtest_eq_setsEag) : !fir.ref<!fir.array<12xi8>>
   ! CHECK-DAG: %[[agAddr:.*]] = fir.coordinate_of %[[agbg]], %c4{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
   ! CHECK-DAG: %[[ag:.*]] = fir.convert %[[agAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
   ! CHECK-DAG: %[[bgAddr:.*]] = fir.coordinate_of %[[agbg]], %c0{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
@@ -34,8 +33,7 @@ subroutine test_eq_sets
   DIMENSION Ig(2), Xg(2)
   SAVE Ig, Xg
   EQUIVALENCE (Ig(1), Xg(1))
-  ! CHECK-DAG: %[[igxgStore:.*]] = fir.address_of(@_QFtest_eq_setsEig) : !fir.ref<tuple<!fir.array<8xi8>>>
-  ! CHECK-DAG: %[[igxg:.*]] = fir.convert %[[igxgStore]] : (!fir.ref<tuple<!fir.array<8xi8>>>) -> !fir.ref<!fir.array<8xi8>>
+  ! CHECK-DAG: %[[igxg:.*]] = fir.address_of(@_QFtest_eq_setsEig) : !fir.ref<!fir.array<8xi8>>
   ! CHECK-DAG: %[[igOffset:.*]] = constant 0 : index
   ! CHECK-DAG: %[[igAddr:.*]] = fir.coordinate_of %[[igxg]], %c0{{.*}} : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
   ! CHECK-DAG: %[[ig:.*]] = fir.convert %[[igAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xi32>>
@@ -55,8 +53,7 @@ subroutine eq_and_entry_foo
   DIMENSION :: x(2)
   EQUIVALENCE (x(2), i) 
   call foo1(x, i)
-  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEx) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
-  ! CHECK-DAG: %[[xi:.*]] = fir.convert %[[xiStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>) -> !fir.ref<!fir.array<8xi8>>
+  ! CHECK: %[[xi:.*]] = fir.address_of(@_QFeq_and_entry_fooEi) : !fir.ref<!fir.array<8xi8>>
 
   ! CHECK-DAG: %[[iOffset:.*]] = constant 4 : index
   ! CHECK-DAG: %[[iAddr:.*]] = fir.coordinate_of %[[xi]], %[[iOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
@@ -73,8 +70,7 @@ subroutine eq_and_entry_foo
 end
 
 ! CHECK-LABEL: @_QPeq_and_entry_bar()
-  ! CHECK: %[[xiStore:.*]] = fir.address_of(@_QFeq_and_entry_fooEx) : !fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>
-  ! CHECK-DAG: %[[xi:.*]] = fir.convert %[[xiStore]] : (!fir.ref<tuple<!fir.array<4xi8>, !fir.array<4xi8>>>) -> !fir.ref<!fir.array<8xi8>>
+  ! CHECK: %[[xi:.*]] = fir.address_of(@_QFeq_and_entry_fooEi) : !fir.ref<!fir.array<8xi8>>
 
   ! CHECK-DAG: %[[iOffset:.*]] = constant 4 : index
   ! CHECK-DAG: %[[iAddr:.*]] = fir.coordinate_of %[[xi]], %[[iOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>

--- a/flang/test/Lower/equivalence-static-init.f90
+++ b/flang/test/Lower/equivalence-static-init.f90
@@ -10,13 +10,10 @@ subroutine test_eqv_init
   equivalence (i, link(3))
 end subroutine
 
-! CHECK-LABEL: fir.global internal @_QFtest_eqv_initEj : tuple<i32, !fir.array<4xi8>, i32> {
-  ! CHECK: %[[VAL_0:.*]] = fir.undefined tuple<i32, !fir.array<4xi8>, i32>
-  ! CHECK: %[[VAL_1:.*]] = constant 7 : i32
-  ! CHECK: %[[VAL_2:.*]] = constant 0 : index
-  ! CHECK: %[[VAL_3:.*]] = fir.insert_value %[[VAL_0]], %[[VAL_1]], [0 : index] : (tuple<i32, !fir.array<4xi8>, i32>, i32) -> tuple<i32, !fir.array<4xi8>, i32>
-  ! CHECK: %[[VAL_4:.*]] = constant 5 : i32
-  ! CHECK: %[[VAL_5:.*]] = constant 2 : index
-  ! CHECK: %[[VAL_6:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_4]], [2 : index] : (tuple<i32, !fir.array<4xi8>, i32>, i32) -> tuple<i32, !fir.array<4xi8>, i32>
-  ! CHECK: fir.has_value %[[VAL_6]] : tuple<i32, !fir.array<4xi8>, i32>
-! CHECK }
+! CHECK-LABEL: fir.global internal @_QFtest_eqv_initEi : !fir.array<3xi32> {
+    ! CHECK: %[[VAL_1:.*]] = fir.undefined !fir.array<3xi32>
+    ! CHECK: %[[VAL_2:.*]] = fir.insert_value %0, %c7{{.*}}, [0 : index] : (!fir.array<3xi32>, i32) -> !fir.array<3xi32>
+    ! CHECK: %[[VAL_3:.*]] = fir.insert_value %1, %c0{{.*}}, [1 : index] : (!fir.array<3xi32>, i32) -> !fir.array<3xi32>
+    ! CHECK: %[[VAL_4:.*]] = fir.insert_value %2, %c5{{.*}}, [2 : index] : (!fir.array<3xi32>, i32) -> !fir.array<3xi32>
+    ! CHECK: fir.has_value %[[VAL_4]] : !fir.array<3xi32>
+! CHECK: }

--- a/flang/test/Lower/explicit-interface-results.f90
+++ b/flang/test/Lower/explicit-interface-results.f90
@@ -297,9 +297,8 @@ end module
 ! CHECK-LABEL: func @_QPtest_result_depends_on_equiv_sym
 subroutine test_result_depends_on_equiv_sym()
   use m_with_equiv, only : result_depends_on_equiv_sym
-  ! CHECK: %[[equiv:.*]] = fir.address_of(@_QMm_with_equivEarray) : !fir.ref<tuple<!fir.array<8xi8>, !fir.array<16xi8>>>
-  ! CHECK: %[[cast:.*]] = fir.convert %[[equiv]] : (!fir.ref<tuple<!fir.array<8xi8>, !fir.array<16xi8>>>) -> !fir.ref<!fir.array<24xi8>>
-  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[cast]], %c{{.*}} : (!fir.ref<!fir.array<24xi8>>, index) -> !fir.ref<i8>
+  ! CHECK: %[[equiv:.*]] = fir.address_of(@_QMm_with_equivEarray) : !fir.ref<!fir.array<24xi8>>
+  ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[equiv]], %c{{.*}} : (!fir.ref<!fir.array<24xi8>>, index) -> !fir.ref<i8>
   ! CHECK: %[[l:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i64>
   ! CHECK: %[[load:.*]] = fir.load %[[l]] : !fir.ref<i64>
   ! CHECK: %[[lcast:.*]] = fir.convert %[[load]] : (i64) -> index

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -21,14 +21,13 @@ module modEq1
   real :: y2(10)
   equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
 end module
-! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ex3 : tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>  {
-  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>
-  ! CHECK: fir.has_value %[[undef]] : tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>
-! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey2 : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>> {
-  ! CHECK: %[[undef:.*]] = fir.undefined tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
-  ! CHECK: %[[cst:.*]] = constant 4.200000e+01 : f32
-  ! CHECK: %[[init:.*]] = fir.insert_value %[[undef]], %[[cst]], [1 : index] : (tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>, f32) -> tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
-  ! CHECK: fir.has_value %[[init]] : tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ex1 : !fir.array<76xi8>
+! CHECK-LABEL: fir.global linkonce @_QMmodeq1Ey1 : !fir.array<10xi32> {
+  ! CHECK: %[[undef:.*]] = fir.undefined !fir.array<10xi32>
+  ! CHECK: %[[v1:.*]] = fir.insert_on_range %0, %c0{{.*}}, [0 : index, 3 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
+  ! CHECK: %[[v2:.*]] = fir.insert_value %1, %c1109917696{{.*}}, [4 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
+  ! CHECK: %[[v3:.*]] = fir.insert_on_range %2, %c0{{.*}}, [5 : index, 9 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
+  ! CHECK: fir.has_value %[[v3]] : !fir.array<10xi32>
 
 ! Module defines variable in common block without initializer
 module modCommonNoInit1

--- a/flang/test/Lower/module_use_in_same_file.f90
+++ b/flang/test/Lower/module_use_in_same_file.f90
@@ -43,24 +43,24 @@ module modEq2
 contains
   ! CHECK-LABEL: func @_QMmodeq2Pfoo()
   real function foo()
-    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
-    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<!fir.array<76xi8>>
+    ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<!fir.array<10xi32>>
     foo = x2(1) + y1
   end function
 end module
 ! CHECK-LABEL: func @_QPmodeq2use()
 real function modEq2use()
   use modEq2
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<!fir.array<76xi8>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<!fir.array<10xi32>>
   modEq2use = x2(1) + y1
 end function
 ! Test rename of used equivalence members
 ! CHECK-LABEL: func @_QPmodeq2use_rename()
 real function modEq2use_rename()
   use modEq2, only: renamedx => x2, renamedy => y1
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<!fir.array<76xi8>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<!fir.array<10xi32>>
   modEq2use = renamedx(1) + renamedy
 end function
 
@@ -114,9 +114,9 @@ real function test_no_equiv_conflicts()
   real :: y2l(10)
   save :: x1l, x2l, x3l, y1l, y2l
   equivalence (x1l(1), x2l(5), x3l(10)), (y1l, y2l(5))
-  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEx3l) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEy2l) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex3) : !fir.ref<tuple<!fir.array<20xi8>, !fir.array<16xi8>, !fir.array<40xi8>>>
-  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey2) : !fir.ref<tuple<!fir.array<16xi8>, f32, !fir.array<20xi8>>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEx1l) : !fir.ref<!fir.array<76xi8>>
+  ! CHECK-DAG: fir.address_of(@_QFtest_no_equiv_conflictsEy1l) : !fir.ref<!fir.array<10xi32>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ex1) : !fir.ref<!fir.array<76xi8>>
+  ! CHECK-DAG: fir.address_of(@_QMmodeq2Ey1) : !fir.ref<!fir.array<10xi32>>
   test_no_equiv_conflicts = x2(1) + y1 + x2l(1) + y1l
 end function

--- a/flang/test/Semantics/data12.f90
+++ b/flang/test/Semantics/data12.f90
@@ -1,0 +1,35 @@
+! RUN: %S/test_errors.sh %s %t %flang_fc1
+! REQUIRES: shell
+type :: t1
+  sequence
+  integer :: m = 123
+  integer :: pad
+end type
+type :: t2
+  sequence
+  integer :: n = 123
+  integer :: pad
+end type
+type :: t3
+  sequence
+  integer :: k = 234
+  integer :: pad
+end type
+!ERROR: Distinct default component initializations of equivalenced objects affect 'x1a%m' more than once
+type(t1) :: x1a
+!ERROR: Distinct default component initializations of equivalenced objects affect 'x2a%n' more than once
+type(t2) :: x2a
+!ERROR: Distinct default component initializations of equivalenced objects affect 'x3%k' more than once
+type(t3), save :: x3
+!ERROR: Explicit initializations of equivalenced objects affect 'ja(2_8)' more than once
+!ERROR: Explicit initializations of equivalenced objects affect 'ka(1_8)' more than once
+integer :: ja(2), ka(2)
+data ja/345, 456/
+data ka/456, 567/
+equivalence(x1a, x2a, x3)
+! Same value: no error
+type(t1) :: x1b
+type(t2) :: x2b
+equivalence(x1b, x2b)
+equivalence(ja(2),ka(1))
+end

--- a/flang/test/Semantics/data13.f90
+++ b/flang/test/Semantics/data13.f90
@@ -1,0 +1,32 @@
+! RUN: %flang_fc1 -fsyntax-only -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! Verify that the closure of EQUIVALENCE'd symbols with any DATA
+! initialization produces a combined initializer, with explicit
+! initialization overriding any default component initialization.
+! CHECK: .F18.0, SAVE (CompilerCreated) size=8 offset=0: ObjectEntity type: INTEGER(4) shape: 1_8:2_8 init:[INTEGER(4)::456_4,234_4]
+! CHECK: ja (InDataStmt) size=8 offset=0: ObjectEntity type: INTEGER(4) shape: 1_8:2_8
+! CHECK-NOT: x0, SAVE size=8 offset=8: ObjectEntity type: TYPE(t1) init:t1(m=123_4,n=234_4)
+! CHECK: x1 size=8 offset=16: ObjectEntity type: TYPE(t1) init:t1(m=345_4,n=234_4)
+! CHECK: x2 size=8 offset=0: ObjectEntity type: TYPE(t1)
+! CHECK-NOT: x3a, SAVE size=8 offset=24: ObjectEntity type: TYPE(t3) init:t3(t2=t2(k=567_4),j=0_4)
+! CHECK: x3b size=8 offset=32: ObjectEntity type: TYPE(t3) init:t3(k=567_4,j=678_4)
+! CHECK: Equivalence Sets: (x2,ja(1)) (.F18.0,x2)
+type :: t1
+  sequence
+  integer :: m = 123
+  integer :: n = 234
+end type
+type :: t2
+  integer :: k = 567
+end type
+type, extends(t2) :: t3
+  integer :: j ! uninitialized
+end type
+type(t1), save :: x0 ! not enabled
+type(t1) :: x1 = t1(m=345)
+type(t1) :: x2
+type(t3), save :: x3a ! not enabled
+type(t3) :: x3b = t3(j=678)
+integer :: ja(2)
+equivalence(x2, ja)
+data ja(1)/456/
+end

--- a/flang/test/Semantics/typeinfo01.f90
+++ b/flang/test/Semantics/typeinfo01.f90
@@ -6,10 +6,10 @@ module m01
     integer :: n
   end type
 !CHECK: Module scope: m01
-!CHECK: .c.t1, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.n,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
-!CHECK: .dt.t1, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t1,sizeinbytes=4_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.t1,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .n.n, SAVE, TARGET: ObjectEntity type: CHARACTER(1_8,1) init:"n"
-!CHECK: .n.t1, SAVE, TARGET: ObjectEntity type: CHARACTER(2_8,1) init:"t1"
+!CHECK: .c.t1, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.n,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
+!CHECK: .dt.t1, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t1,sizeinbytes=4_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.t1,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .n.n, SAVE, TARGET (CompilerCreated): ObjectEntity type: CHARACTER(1_8,1) init:"n"
+!CHECK: .n.t1, SAVE, TARGET (CompilerCreated): ObjectEntity type: CHARACTER(2_8,1) init:"t1"
 !CHECK: DerivedType scope: t1
 end module
 
@@ -20,10 +20,10 @@ module m02
   type, extends(parent) :: child
     integer :: cn
   end type
-!CHECK: .c.child, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:1_8 init:[component::component(name=.n.parent,genre=1_1,category=5_1,kind=0_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=.dt.parent,lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.cn,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=4_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
-!CHECK: .c.parent, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.pn,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
-!CHECK: .dt.child, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.child,sizeinbytes=8_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.child,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=1_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .dt.parent, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.parent,sizeinbytes=4_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.parent,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .c.child, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:1_8 init:[component::component(name=.n.parent,genre=1_1,category=5_1,kind=0_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=.dt.parent,lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.cn,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=4_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
+!CHECK: .c.parent, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.pn,genre=1_1,category=0_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
+!CHECK: .dt.child, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.child,sizeinbytes=8_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.child,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=1_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .dt.parent, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.parent,sizeinbytes=4_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.parent,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
 end module
 
 module m03
@@ -32,11 +32,11 @@ module m03
     real(kind=k) :: a
   end type
   type(kpdt(4)) :: x
-!CHECK: .c.kpdt.0, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.a,genre=1_1,category=1_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
-!CHECK: .dt.kpdt, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(name=.n.kpdt,uninstantiated=NULL(),kindparameter=.kp.kpdt,lenparameterkind=NULL())
-!CHECK: .dt.kpdt.0, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.kpdt,sizeinbytes=4_8,uninstantiated=.dt.kpdt,kindparameter=.kp.kpdt.0,lenparameterkind=NULL(),component=.c.kpdt.0,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .kp.kpdt, SAVE, TARGET: ObjectEntity type: INTEGER(8) shape: 0_8:0_8 init:[INTEGER(8)::1_8]
-!CHECK: .kp.kpdt.0, SAVE, TARGET: ObjectEntity type: INTEGER(8) shape: 0_8:0_8 init:[INTEGER(8)::4_8]
+!CHECK: .c.kpdt.0, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.a,genre=1_1,category=1_1,kind=4_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
+!CHECK: .dt.kpdt, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(name=.n.kpdt,uninstantiated=NULL(),kindparameter=.kp.kpdt,lenparameterkind=NULL())
+!CHECK: .dt.kpdt.0, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.kpdt,sizeinbytes=4_8,uninstantiated=.dt.kpdt,kindparameter=.kp.kpdt.0,lenparameterkind=NULL(),component=.c.kpdt.0,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .kp.kpdt, SAVE, TARGET (CompilerCreated): ObjectEntity type: INTEGER(8) shape: 0_8:0_8 init:[INTEGER(8)::1_8]
+!CHECK: .kp.kpdt.0, SAVE, TARGET (CompilerCreated): ObjectEntity type: INTEGER(8) shape: 0_8:0_8 init:[INTEGER(8)::4_8]
 end module
 
 module m04
@@ -49,8 +49,8 @@ module m04
   subroutine s1(x)
     class(tbps), intent(in) :: x
   end subroutine
-!CHECK: .dt.tbps, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.tbps,name=.n.tbps,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .v.tbps, SAVE, TARGET: ObjectEntity type: TYPE(binding) shape: 0_8:1_8 init:[binding::binding(proc=s1,name=.n.b1),binding(proc=s1,name=.n.b2)]
+!CHECK: .dt.tbps, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.tbps,name=.n.tbps,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .v.tbps, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(binding) shape: 0_8:1_8 init:[binding::binding(proc=s1,name=.n.b1),binding(proc=s1,name=.n.b2)]
 end module
 
 module m05
@@ -61,8 +61,8 @@ module m05
   subroutine s1(x)
     class(t), intent(in) :: x
   end subroutine
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=24_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=.p.t,special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=0_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .p.t, SAVE, TARGET: ObjectEntity type: TYPE(procptrcomponent) shape: 0_8:0_8 init:[procptrcomponent::procptrcomponent(name=.n.p1,offset=0_8,initialization=s1)]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=24_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=.p.t,special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=0_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .p.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(procptrcomponent) shape: 0_8:0_8 init:[procptrcomponent::procptrcomponent(name=.n.p1,offset=0_8,initialization=s1)]
 end module
 
 module m06
@@ -84,12 +84,12 @@ module m06
     class(t2), intent(out) :: x
     class(t), intent(in) :: y
   end subroutine
-!CHECK: .c.t2, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.t,genre=1_1,category=5_1,kind=0_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=.dt.t,lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=2_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .dt.t2, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t2,name=.n.t2,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.t2,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=1_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .s.t, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=1_1,isargdescriptorset=3_1,proc=s1)]
-!CHECK: .v.t, SAVE, TARGET: ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s1,name=.n.s1)]
-!CHECK: .v.t2, SAVE, TARGET: ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s2,name=.n.s1)]
+!CHECK: .c.t2, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:0_8 init:[component::component(name=.n.t,genre=1_1,category=5_1,kind=0_1,rank=0_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=.dt.t,lenvalue=NULL(),bounds=NULL(),initialization=NULL())]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=2_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .dt.t2, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t2,name=.n.t2,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=.c.t2,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=1_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .s.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=1_1,isargdescriptorset=3_1,proc=s1)]
+!CHECK: .v.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s1,name=.n.s1)]
+!CHECK: .v.t2, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s2,name=.n.s1)]
 end module
 
 module m07
@@ -103,9 +103,9 @@ module m07
     class(t), intent(out) :: x
     class(t), intent(in) :: y
   end subroutine
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=4_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .s.t, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=2_1,isargdescriptorset=3_1,proc=s1)]
-!CHECK: .v.t, SAVE, TARGET: ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s1,name=.n.s1)]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=4_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .s.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=2_1,isargdescriptorset=3_1,proc=s1)]
+!CHECK: .v.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(binding) shape: 0_8:0_8 init:[binding::binding(proc=s1,name=.n.s1)]
 end module
 
 module m08
@@ -123,8 +123,8 @@ module m08
   impure elemental subroutine s3(x)
     type(t) :: x
   end subroutine
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=3200_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=0_1,nofinalizationneeded=0_1)
-!CHECK: .s.t, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:2_8 init:[specialbinding::specialbinding(which=7_1,isargdescriptorset=0_1,proc=s3),specialbinding(which=10_1,isargdescriptorset=1_1,proc=s1),specialbinding(which=11_1,isargdescriptorset=0_1,proc=s2)]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=3200_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=0_1,nofinalizationneeded=0_1)
+!CHECK: .s.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:2_8 init:[specialbinding::specialbinding(which=7_1,isargdescriptorset=0_1,proc=s3),specialbinding(which=10_1,isargdescriptorset=1_1,proc=s1),specialbinding(which=11_1,isargdescriptorset=0_1,proc=s2)]
 end module
 
 module m09
@@ -165,9 +165,9 @@ module m09
     integer, intent(out) :: iostat
     character(len=*), intent(inout) :: iomsg
   end subroutine
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=120_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .s.t, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:3_8 init:[specialbinding::specialbinding(which=3_1,isargdescriptorset=1_1,proc=rf),specialbinding(which=4_1,isargdescriptorset=1_1,proc=ru),specialbinding(which=5_1,isargdescriptorset=1_1,proc=wf),specialbinding(which=6_1,isargdescriptorset=1_1,proc=wu)]
-!CHECK: .v.t, SAVE, TARGET: ObjectEntity type: TYPE(binding) shape: 0_8:3_8 init:[binding::binding(proc=rf,name=.n.rf),binding(proc=ru,name=.n.ru),binding(proc=wf,name=.n.wf),binding(proc=wu,name=.n.wu)]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=.v.t,name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=120_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .s.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:3_8 init:[specialbinding::specialbinding(which=3_1,isargdescriptorset=1_1,proc=rf),specialbinding(which=4_1,isargdescriptorset=1_1,proc=ru),specialbinding(which=5_1,isargdescriptorset=1_1,proc=wf),specialbinding(which=6_1,isargdescriptorset=1_1,proc=wu)]
+!CHECK: .v.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(binding) shape: 0_8:3_8 init:[binding::binding(proc=rf,name=.n.rf),binding(proc=ru,name=.n.ru),binding(proc=wf,name=.n.wf),binding(proc=wu,name=.n.wu)]
 end module
 
 module m10
@@ -214,8 +214,8 @@ module m10
     integer, intent(out) :: iostat
     character(len=*), intent(inout) :: iomsg
   end subroutine
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=120_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
-!CHECK: .s.t, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:3_8 init:[specialbinding::specialbinding(which=3_1,isargdescriptorset=0_1,proc=rf),specialbinding(which=4_1,isargdescriptorset=0_1,proc=ru),specialbinding(which=5_1,isargdescriptorset=0_1,proc=wf),specialbinding(which=6_1,isargdescriptorset=0_1,proc=wu)]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=0_8,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=NULL(),component=NULL(),procptr=NULL(),special=.s.t,specialbitset=120_4,hasparent=0_1,noinitializationneeded=1_1,nodestructionneeded=1_1,nofinalizationneeded=1_1)
+!CHECK: .s.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:3_8 init:[specialbinding::specialbinding(which=3_1,isargdescriptorset=0_1,proc=rf),specialbinding(which=4_1,isargdescriptorset=0_1,proc=ru),specialbinding(which=5_1,isargdescriptorset=0_1,proc=wf),specialbinding(which=6_1,isargdescriptorset=0_1,proc=wu)]
 end module
 
 module m11
@@ -227,16 +227,16 @@ module m11
     character(len=len) :: chauto
     real :: automatic(len)
   end type
-!CHECK: .dt.t, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(name=.n.t,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=.lpk.t)
-!CHECK: .lpk.t, SAVE, TARGET: ObjectEntity type: INTEGER(1) shape: 0_8:0_8 init:[INTEGER(1)::8_1]
+!CHECK: .dt.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(name=.n.t,uninstantiated=NULL(),kindparameter=NULL(),lenparameterkind=.lpk.t)
+!CHECK: .lpk.t, SAVE, TARGET (CompilerCreated): ObjectEntity type: INTEGER(1) shape: 0_8:0_8 init:[INTEGER(1)::8_1]
  contains
   subroutine s1(x)
-!CHECK: .b.t.1.automatic, SAVE, TARGET: ObjectEntity type: TYPE(value) shape: 0_8:1_8,0_8:0_8 init:reshape([value::value(genre=2_1,value=1_8),value(genre=3_1,value=0_8)],shape=[2,1])
-!CHECK: .c.t.1, SAVE, TARGET: ObjectEntity type: TYPE(component) shape: 0_8:3_8 init:[component::component(name=.n.allocatable,genre=3_1,category=1_1,kind=4_1,rank=1_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.pointer,genre=2_1,category=1_1,kind=4_1,rank=0_1,offset=48_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=.di.t.1.pointer),component(name=.n.chauto,genre=4_1,category=3_1,kind=1_1,rank=0_1,offset=72_8,characterlen=value(genre=3_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.automatic,genre=4_1,category=1_1,kind=4_1,rank=1_1,offset=96_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=.b.t.1.automatic,initialization=NULL())]
-!CHECK: .di.t.1.pointer, SAVE, TARGET: ObjectEntity type: TYPE(.dp.t.1.pointer) init:.dp.t.1.pointer(pointer=target)
-!CHECK: .dp.t.1.pointer: DerivedType components: pointer
-!CHECK: .dt.t.1, SAVE, TARGET: ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=144_8,uninstantiated=.dt.t,kindparameter=NULL(),lenparameterkind=.lpk.t.1,component=.c.t.1,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=0_1,nodestructionneeded=0_1,nofinalizationneeded=1_1)
-!CHECK: .lpk.t.1, SAVE, TARGET: ObjectEntity type: INTEGER(1) shape: 0_8:0_8 init:[INTEGER(1)::8_1]
+!CHECK: .b.t.1.automatic, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(value) shape: 0_8:1_8,0_8:0_8 init:reshape([value::value(genre=2_1,value=1_8),value(genre=3_1,value=0_8)],shape=[2,1])
+!CHECK: .c.t.1, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(component) shape: 0_8:3_8 init:[component::component(name=.n.allocatable,genre=3_1,category=1_1,kind=4_1,rank=1_1,offset=0_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.pointer,genre=2_1,category=1_1,kind=4_1,rank=0_1,offset=48_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=.di.t.1.pointer),component(name=.n.chauto,genre=4_1,category=3_1,kind=1_1,rank=0_1,offset=72_8,characterlen=value(genre=3_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=NULL(),initialization=NULL()),component(name=.n.automatic,genre=4_1,category=1_1,kind=4_1,rank=1_1,offset=96_8,characterlen=value(genre=1_1,value=0_8),derived=NULL(),lenvalue=NULL(),bounds=.b.t.1.automatic,initialization=NULL())]
+!CHECK: .di.t.1.pointer, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(.dp.t.1.pointer) init:.dp.t.1.pointer(pointer=target)
+!CHECK: .dp.t.1.pointer (CompilerCreated): DerivedType components: pointer
+!CHECK: .dt.t.1, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(derivedtype) init:derivedtype(binding=NULL(),name=.n.t,sizeinbytes=144_8,uninstantiated=.dt.t,kindparameter=NULL(),lenparameterkind=.lpk.t.1,component=.c.t.1,procptr=NULL(),special=NULL(),specialbitset=0_4,hasparent=0_1,noinitializationneeded=0_1,nodestructionneeded=0_1,nofinalizationneeded=1_1)
+!CHECK: .lpk.t.1, SAVE, TARGET (CompilerCreated): ObjectEntity type: INTEGER(1) shape: 0_8:0_8 init:[INTEGER(1)::8_1]
 !CHECK: DerivedType scope: .dp.t.1.pointer size=24 alignment=8 instantiation of .dp.t.1.pointer
 !CHECK: pointer, POINTER size=24 offset=0: ObjectEntity type: REAL(4)
     type(t(*)), intent(in) :: x
@@ -248,9 +248,9 @@ module m12
     integer :: n
     integer :: n2
     integer :: n_3
-    ! CHECK: .n.n, SAVE, TARGET: ObjectEntity type: CHARACTER(1_8,1) init:"n"
-    ! CHECK: .n.n2, SAVE, TARGET: ObjectEntity type: CHARACTER(2_8,1) init:"n2"
-    ! CHECK: .n.n_3, SAVE, TARGET: ObjectEntity type: CHARACTER(3_8,1) init:"n_3"
+    ! CHECK: .n.n, SAVE, TARGET (CompilerCreated): ObjectEntity type: CHARACTER(1_8,1) init:"n"
+    ! CHECK: .n.n2, SAVE, TARGET (CompilerCreated): ObjectEntity type: CHARACTER(2_8,1) init:"n2"
+    ! CHECK: .n.n_3, SAVE, TARGET (CompilerCreated): ObjectEntity type: CHARACTER(3_8,1) init:"n_3"
   end type
 end module
 
@@ -260,7 +260,7 @@ module m13
    contains
     procedure :: assign1, assign2
     generic :: assignment(=) => assign1, assign2
-    ! CHECK: .s.t1, SAVE, TARGET: ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=2_1,isargdescriptorset=3_1,proc=assign1)]
+    ! CHECK: .s.t1, SAVE, TARGET (CompilerCreated): ObjectEntity type: TYPE(specialbinding) shape: 0_8:0_8 init:[specialbinding::specialbinding(which=2_1,isargdescriptorset=3_1,proc=assign1)]
   end type
  contains
   impure elemental subroutine assign1(to, from)


### PR DESCRIPTION
Semantics analysis is now doing an analysis of equivalence default and explicit initializations to detect conflicting initializations. This patch cherry-picks the change from LLVM (first commit). The second commit of this patch is what matters here, and contains the related lowering update.

The semantics change allows lowering to re-use semantics tools/results and:

1. Remove the interval analysis and use GetStorageAssociations to
   get a group of symbol that belongs to the same aggregate.

2. Simplify the static equivalence initialization lowering (simply use
   the generated integer array expression with the equivalence initial
   value, that already combines all the equivalence members default and
   explicit initialization).

Functional improvements of this change:
- Fix issue #994.
- Implement the TODOs that was left around explicit and default init overlap support in lowering (last test case of `flang/test/Lower/default-initialization-globals.f90`).
- More safety in general regarding bad init overlaps (lowering was assuming the program was conformant, this is now enforced in semantics).

Side consequences of this change:

1. The aggregate storage names are changed, they now use the first
   member name in alphabetical order. The rational is to cover the
   cases where we need to ensure that the same name is built in
   two different translation unit for a same equivalence. The previous
   naming was relying on a mix of offset and scope order. There is no
   guarantee the scope order is the same in module files.

2. The aggregate storage types are now fir.array<sizexiw> where
   size*w/8 is the equivalence storage size and w is the biggest
   possible storage units given the equivalence member types and
   Fortran storage unit rules.

Common block initialization lowering is not impacted, it simply ignores the new compiler generated symbol that are generated for equivalences in commons.