### PR TITLE
Handle zero sized equivalence in lowering

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1393,10 +1393,15 @@ struct SymbolDependenceDepth {
       LLVM_DEBUG(llvm::dbgs() << "symbol: " << ultimate << '\n');
       LLVM_DEBUG(llvm::dbgs() << "scope: " << scope << '\n');
       auto off = ultimate.offset();
+      auto symSize = ultimate.size();
       for (auto &v : stores) {
         if (&v.getOwningScope() == &scope) {
-          auto bot = std::get<0>(v.interval);
-          if (off >= bot && off < bot + std::get<1>(v.interval))
+          auto intervalOff = std::get<0>(v.interval);
+          auto intervalSize = std::get<1>(v.interval);
+          if (off >= intervalOff && off < intervalOff + intervalSize)
+            return &v;
+          // Zero sized symbol in zero sized equivalence.
+          if (off == intervalOff && symSize == 0)
             return &v;
         }
       }

--- a/flang/test/Lower/common-block.f90
+++ b/flang/test/Lower/common-block.f90
@@ -5,6 +5,7 @@
 ! CHECK: @_QBy = common global [12 x i8] zeroinitializer
 ! CHECK: @_QBz = global { i32, [4 x i8], float } { i32 42, [4 x i8] undef, float 3.000000e+00 }
 ! CHECK: @_QBrien = common global [1 x i8] zeroinitializer
+! CHECK: @_QBwith_empty_equiv = common global [8 x i8] zeroinitializer
 
 ! CHECK-LABEL: _QPs0
 subroutine s0
@@ -63,3 +64,10 @@ subroutine s5
   real r(1:0)
   common /rien/ r
 end subroutine s5
+
+! CHECK-LABEL: _QPs6
+subroutine s6
+  real r1(1:0), r2(1:0), x, y
+  common /with_empty_equiv/ x, r1, y
+  equivalence(r1, r2)
+end subroutine s6


### PR DESCRIPTION
The interval of zero sized equivalence storage looks like `[i, i[`, so when looking for an interval where `i` belongs, the PFT analysis was crashing.

Accept `[i, i[` to be the right interval of null sized symbol starting at i.

This broke ch14egs that used to pass because we were previously building the intervals as `[i, max(i+1, j)[`.