### PR TITLE
Fix fir.coordinate_of op use with char<kind,?> types.

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1481,7 +1481,6 @@ public:
           delta = builder.create<mlir::MulIOp>(loc, delta, ext);
         ++dim;
       }
-#if 1
       if (fir::factory::CharacterExprHelper::isCharacterScalar(refTy)) {
         auto chTy = fir::factory::CharacterExprHelper::getCharacterType(refTy);
         if (fir::characterWithDynamicLen(chTy)) {
@@ -1493,7 +1492,6 @@ public:
           base = builder.createConvert(loc, seqRefTy, base);
         }
       }
-#endif
       return builder.create<fir::CoordinateOp>(
           loc, refTy, base, llvm::ArrayRef<mlir::Value>{total});
     };

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1481,6 +1481,19 @@ public:
           delta = builder.create<mlir::MulIOp>(loc, delta, ext);
         ++dim;
       }
+#if 1
+      if (fir::factory::CharacterExprHelper::isCharacterScalar(refTy)) {
+        auto chTy = fir::factory::CharacterExprHelper::getCharacterType(refTy);
+        if (fir::characterWithDynamicLen(chTy)) {
+          auto ctx = builder.getContext();
+          auto kind = fir::factory::CharacterExprHelper::getCharacterKind(chTy);
+          auto singleTy = fir::CharacterType::getSingleton(ctx, kind);
+          refTy = builder.getRefType(singleTy);
+          auto seqRefTy = builder.getRefType(builder.getVarLenSeqTy(singleTy));
+          base = builder.createConvert(loc, seqRefTy, base);
+        }
+      }
+#endif
       return builder.create<fir::CoordinateOp>(
           loc, refTy, base, llvm::ArrayRef<mlir::Value>{total});
     };

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1481,6 +1481,7 @@ public:
           delta = builder.create<mlir::MulIOp>(loc, delta, ext);
         ++dim;
       }
+      auto origRefTy = refTy;
       if (fir::factory::CharacterExprHelper::isCharacterScalar(refTy)) {
         auto chTy = fir::factory::CharacterExprHelper::getCharacterType(refTy);
         if (fir::characterWithDynamicLen(chTy)) {
@@ -1492,8 +1493,10 @@ public:
           base = builder.createConvert(loc, seqRefTy, base);
         }
       }
-      return builder.create<fir::CoordinateOp>(
+      auto coor = builder.create<fir::CoordinateOp>(
           loc, refTy, base, llvm::ArrayRef<mlir::Value>{total});
+      // Convert to expected, original type after address arithmetic.
+      return builder.createConvert(loc, origRefTy, coor);
     };
     return array.match(
         [&](const fir::ArrayBoxValue &arr) -> ExtValue {

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -26,9 +26,8 @@ static fir::CharacterType recoverCharacterType(mlir::Type type) {
   if (auto boxType = type.dyn_cast<fir::BoxCharType>())
     return boxType.getEleTy();
   while (true) {
-    if (auto pointedType = fir::dyn_cast_ptrEleTy(type))
-      type = pointedType;
-    else if (auto boxTy = type.dyn_cast<fir::BoxType>())
+    type = fir::unwrapRefType(type);
+    if (auto boxTy = type.dyn_cast<fir::BoxType>())
       type = boxTy.getEleTy();
     else
       break;
@@ -643,15 +642,11 @@ bool fir::factory::CharacterExprHelper::isCharacterLiteral(mlir::Type type) {
 bool fir::factory::CharacterExprHelper::isCharacterScalar(mlir::Type type) {
   if (type.isa<fir::BoxCharType>())
     return true;
-  if (auto pointedType = fir::dyn_cast_ptrEleTy(type))
-    type = pointedType;
+  type = fir::unwrapRefType(type);
   if (auto boxTy = type.dyn_cast<fir::BoxType>())
     type = boxTy.getEleTy();
-  if (auto pointedType = fir::dyn_cast_ptrEleTy(type))
-    type = pointedType;
-  if (auto seqType = type.dyn_cast<fir::SequenceType>())
-    return false;
-  return fir::isa_char(type);
+  type = fir::unwrapRefType(type);
+  return !type.isa<fir::SequenceType>() && fir::isa_char(type);
 }
 
 fir::KindTy

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -249,8 +249,10 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK: %[[sub:.*]] = subi %[[c7]], %[[dims]]#0 : index 
   ! CHECK: %[[mul:.*]] = muli %[[len]], %[[sub]] : index 
   ! CHECK: %[[offset:.*]] = addi %[[mul]], %c0{{.*}} : index
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cast]], %[[offset]]
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: %[[cnvt:.*]] = fir.convert %[[cast]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cnvt]], %[[offset]]
+  ! CHECK: %[[cnvt:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cnvt]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(a1_0%p(7))
 
@@ -267,8 +269,10 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK: %[[sub:.*]] = subi %[[c7]], %[[dims]]#0 : index 
   ! CHECK: %[[mul:.*]] = muli %[[len]], %[[sub]] : index 
   ! CHECK: %[[offset:.*]] = addi %[[mul]], %c0{{.*}} : index
-  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cast]], %[[offset]]
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]]
+  ! CHECK: %[[cnvt:.*]] = fir.convert %[[cast]]
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cnvt]], %[[offset]]
+  ! CHECK: %[[cnvt:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cnvt]], %[[len]]
   ! CHECK: fir.call @_QPtakes_char_scalar(%[[boxchar]])
   call takes_char_scalar(a1_1(5)%p(7))
 


### PR DESCRIPTION
The coordinate_of op requires a constant sized type, so it will not work
correctly if used with fir.char with unknown length. The code was
already computing the correct offsets from runtime values, but the type
was not being converted resulting in internal errors in code gen.