### PR TITLE
[flang] Move runtime API headers to flang/include/flang/Runtime

### DIFF
--- a/flang/docs/tutorials/addingIntrinsics.md
+++ b/flang/docs/tutorials/addingIntrinsics.md
@@ -342,7 +342,7 @@ void fir::runtime::genTrim(fir::FirOpBuilder &builder,
 The key point is `getRuntimeFunc<mkRTKey(Trim)>(loc, builder)` that builds the FIR signature for the runtime
 function automatically. The name passed to `mkRTKey` must be the same as the one inside `RTNAME` when declaring
 the function in the runtime headers. The runtime header must be included in the current file to use `getRuntimeFunc<>`
-(note the `#include "../../runtime/character.h"` at the top of the file). So at least the runtime API must be designed before adding
+(note the `#include "flang/Runtime/character.h"` at the top of the file). So at least the runtime API must be designed before adding
 the support in lowering.
 
 Then, the source file name and line number are lowered from the current location so that they can be passed to the runtime.

--- a/flang/include/flang/Evaluate/pgmath.h.inc
+++ b/flang/include/flang/Evaluate/pgmath.h.inc
@@ -1,4 +1,4 @@
-//===-- runtime/pgmath.h.inc -------------------------------===//
+//===-- include/flang/Evaluate/pgmath.h.inc -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Runtime/allocatable.h
+++ b/flang/include/flang/Runtime/allocatable.h
@@ -1,4 +1,4 @@
-//===-- runtime/allocatable.h -----------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/allocatable.h ---------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,8 +11,8 @@
 #ifndef FORTRAN_RUNTIME_ALLOCATABLE_H_
 #define FORTRAN_RUNTIME_ALLOCATABLE_H_
 
-#include "descriptor.h"
-#include "entry-names.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 

--- a/flang/include/flang/Runtime/assign.h
+++ b/flang/include/flang/Runtime/assign.h
@@ -1,4 +1,4 @@
-//===-- runtime/assign.h --------------------------------------------------===//
+//===-- include/flang/Runtime/assign.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -20,10 +20,10 @@
 // need not be handled here in the runtime; ditto for type conversions on
 // intrinsic assignments.
 
-#ifndef FLANG_RUNTIME_ASSIGN_H_
-#define FLANG_RUNTIME_ASSIGN_H_
+#ifndef FORTRAN_RUNTIME_ASSIGN_H_
+#define FORTRAN_RUNTIME_ASSIGN_H_
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 class Descriptor;
@@ -42,4 +42,4 @@ void RTNAME(Assign)(Descriptor &to, const Descriptor &from,
     const char *sourceFile = nullptr, int sourceLine = 0);
 } // extern "C"
 } // namespace Fortran::runtime
-#endif // FLANG_RUNTIME_ASSIGN_H_
+#endif // FORTRAN_RUNTIME_ASSIGN_H_

--- a/flang/include/flang/Runtime/c-or-cpp.h
+++ b/flang/include/flang/Runtime/c-or-cpp.h
@@ -1,4 +1,4 @@
-//===-- runtime/c-or-cpp.h --------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/c-or-cpp.h ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Runtime/character.h
+++ b/flang/include/flang/Runtime/character.h
@@ -1,4 +1,4 @@
-//===-- runtime/character.h -------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/character.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 
 #ifndef FORTRAN_RUNTIME_CHARACTER_H_
 #define FORTRAN_RUNTIME_CHARACTER_H_
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 #include <cstddef>
 
 namespace Fortran::runtime {

--- a/flang/include/flang/Runtime/command.h
+++ b/flang/include/flang/Runtime/command.h
@@ -1,4 +1,4 @@
-//===-- runtime/command.h ---------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/command.h -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,8 @@
 #ifndef FORTRAN_RUNTIME_COMMAND_H_
 #define FORTRAN_RUNTIME_COMMAND_H_
 
-#include "cpp-type.h"
-#include "entry-names.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 class Descriptor;

--- a/flang/include/flang/Runtime/cpp-type.h
+++ b/flang/include/flang/Runtime/cpp-type.h
@@ -1,4 +1,4 @@
-//===-- runtime/cpp-type.h --------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/cpp-type.h ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Runtime/derived-api.h
+++ b/flang/include/flang/Runtime/derived-api.h
@@ -1,4 +1,4 @@
-//===-- runtime/derived-api.h ---------------------------------------------===//
+//===-- include/flang/Runtime/derived-api.h ---------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,10 +12,10 @@
 // local variables.  Whole allocatable assignment should use AllocatableAssign()
 // instead of this Assign().
 
-#ifndef FLANG_RUNTIME_DERIVED_API_H_
-#define FLANG_RUNTIME_DERIVED_API_H_
+#ifndef FORTRAN_RUNTIME_DERIVED_API_H_
+#define FORTRAN_RUNTIME_DERIVED_API_H_
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 class Descriptor;
@@ -40,4 +40,4 @@ void RTNAME(Assign)(const Descriptor &, const Descriptor &,
 
 } // extern "C"
 } // namespace Fortran::runtime
-#endif // FLANG_RUNTIME_DERIVED_API_H_
+#endif // FORTRAN_RUNTIME_DERIVED_API_H_

--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -1,4 +1,4 @@
-//===-- runtime/descriptor.h ------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/descriptor.h ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -18,9 +18,9 @@
 // User C code is welcome to depend on that ISO_Fortran_binding.h file,
 // but should never reference this internal header.
 
-#include "memory.h"
-#include "type-code.h"
 #include "flang/ISO_Fortran_binding.h"
+#include "flang/Runtime/memory.h"
+#include "flang/Runtime/type-code.h"
 #include <cassert>
 #include <cinttypes>
 #include <cstddef>

--- a/flang/include/flang/Runtime/entry-names.h
+++ b/flang/include/flang/Runtime/entry-names.h
@@ -1,4 +1,4 @@
-/*===-- runtime/entry-names.h ---------------------------------------*- C -*-===
+/*===-- include/flang/Runtime/entry-names.h -------------------------*- C -*-=//
  *
  * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
  * See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Runtime/io-api.h
+++ b/flang/include/flang/Runtime/io-api.h
@@ -1,4 +1,4 @@
-//===-- runtime/io-api.h ----------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/io-api.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,8 +11,8 @@
 #ifndef FORTRAN_RUNTIME_IO_API_H_
 #define FORTRAN_RUNTIME_IO_API_H_
 
-#include "entry-names.h"
-#include "iostat.h"
+#include "flang/Runtime/entry-names.h"
+#include "flang/Runtime/iostat.h"
 #include <cinttypes>
 #include <cstddef>
 

--- a/flang/include/flang/Runtime/iostat.h
+++ b/flang/include/flang/Runtime/iostat.h
@@ -1,4 +1,4 @@
-//===-- runtime/iostat.h ----------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/iostat.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 
 #ifndef FORTRAN_RUNTIME_IOSTAT_H_
 #define FORTRAN_RUNTIME_IOSTAT_H_
-#include "magic-numbers.h"
+#include "flang/Runtime/magic-numbers.h"
 namespace Fortran::runtime::io {
 
 // The value of IOSTAT= is zero when no error, end-of-record,

--- a/flang/include/flang/Runtime/magic-numbers.h
+++ b/flang/include/flang/Runtime/magic-numbers.h
@@ -1,10 +1,10 @@
-#if 0 /*===-- runtime/magic-numbers.h -----------------------------------===*/
+#if 0 /*===-- include/flang/Runtime/magic-numbers.h -----------------------===*/
 /*
  * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
  * See https://llvm.org/LICENSE.txt for license information.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
- *===--------------------------------------------------------------------===*/
+ *===----------------------------------------------------------------------===*/
 #endif
 #if 0
 This header can be included into both Fortran and C.

--- a/flang/include/flang/Runtime/main.h
+++ b/flang/include/flang/Runtime/main.h
@@ -1,4 +1,4 @@
-//===-- runtime/main.h ------------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/main.h ----------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,8 @@
 #ifndef FORTRAN_RUNTIME_MAIN_H_
 #define FORTRAN_RUNTIME_MAIN_H_
 
-#include "c-or-cpp.h"
-#include "entry-names.h"
+#include "flang/Runtime/c-or-cpp.h"
+#include "flang/Runtime/entry-names.h"
 
 FORTRAN_EXTERN_C_BEGIN
 void RTNAME(ProgramStart)(int, const char *[], const char *[]);

--- a/flang/include/flang/Runtime/matmul.h
+++ b/flang/include/flang/Runtime/matmul.h
@@ -1,4 +1,4 @@
-//===-- runtime/matmul.h ----------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/matmul.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,7 +10,7 @@
 
 #ifndef FORTRAN_RUNTIME_MATMUL_H_
 #define FORTRAN_RUNTIME_MATMUL_H_
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 namespace Fortran::runtime {
 class Descriptor;
 extern "C" {

--- a/flang/include/flang/Runtime/memory.h
+++ b/flang/include/flang/Runtime/memory.h
@@ -1,4 +1,4 @@
-//===-- runtime/memory.h ----------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/memory.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Runtime/misc-intrinsic.h
+++ b/flang/include/flang/Runtime/misc-intrinsic.h
@@ -1,4 +1,4 @@
-//===-- runtime/misc-intrinsic.h --------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/misc-intrinsic.h ------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 #ifndef FORTRAN_RUNTIME_MISC_INTRINSIC_H_
 #define FORTRAN_RUNTIME_MISC_INTRINSIC_H_
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 #include <cstdint>
 
 namespace Fortran::runtime {

--- a/flang/include/flang/Runtime/numeric.h
+++ b/flang/include/flang/Runtime/numeric.h
@@ -1,4 +1,4 @@
-//===-- runtime/numeric.h ---------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/numeric.h -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,8 +12,8 @@
 #ifndef FORTRAN_RUNTIME_NUMERIC_H_
 #define FORTRAN_RUNTIME_NUMERIC_H_
 
-#include "cpp-type.h"
-#include "entry-names.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 extern "C" {

--- a/flang/include/flang/Runtime/pointer.h
+++ b/flang/include/flang/Runtime/pointer.h
@@ -1,4 +1,4 @@
-//===-- runtime/pointer.h ---------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/pointer.h -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,8 +12,8 @@
 #ifndef FORTRAN_RUNTIME_POINTER_H_
 #define FORTRAN_RUNTIME_POINTER_H_
 
-#include "descriptor.h"
-#include "entry-names.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 extern "C" {

--- a/flang/include/flang/Runtime/random.h
+++ b/flang/include/flang/Runtime/random.h
@@ -1,4 +1,4 @@
-//===-- runtime/random.h --------------------------------------------------===//
+//===-- include/flang/Runtime/random.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,7 +8,7 @@
 
 // Intrinsic subroutines RANDOM_INIT, RANDOM_NUMBER, and RANDOM_SEED.
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 #include <cstdint>
 
 namespace Fortran::runtime {

--- a/flang/include/flang/Runtime/reduction.h
+++ b/flang/include/flang/Runtime/reduction.h
@@ -1,4 +1,4 @@
-//===-- runtime/reduction.h -------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/reduction.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,9 +11,9 @@
 #ifndef FORTRAN_RUNTIME_REDUCTION_H_
 #define FORTRAN_RUNTIME_REDUCTION_H_
 
-#include "descriptor.h"
-#include "entry-names.h"
 #include "flang/Common/uint128.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/entry-names.h"
 #include <complex>
 #include <cstdint>
 

--- a/flang/include/flang/Runtime/stop.h
+++ b/flang/include/flang/Runtime/stop.h
@@ -1,4 +1,4 @@
-//===-- runtime/stop.h ------------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/stop.h ----------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,8 @@
 #ifndef FORTRAN_RUNTIME_STOP_H_
 #define FORTRAN_RUNTIME_STOP_H_
 
-#include "c-or-cpp.h"
-#include "entry-names.h"
+#include "flang/Runtime/c-or-cpp.h"
+#include "flang/Runtime/entry-names.h"
 #include <stdlib.h>
 
 FORTRAN_EXTERN_C_BEGIN

--- a/flang/include/flang/Runtime/time-intrinsic.h
+++ b/flang/include/flang/Runtime/time-intrinsic.h
@@ -1,4 +1,4 @@
-//===-- runtime/time-intrinsic.h --------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/time-intrinsic.h ------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,8 +12,8 @@
 #ifndef FORTRAN_RUNTIME_TIME_INTRINSIC_H_
 #define FORTRAN_RUNTIME_TIME_INTRINSIC_H_
 
-#include "cpp-type.h"
-#include "entry-names.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/entry-names.h"
 
 namespace Fortran::runtime {
 

--- a/flang/include/flang/Runtime/transformational.h
+++ b/flang/include/flang/Runtime/transformational.h
@@ -1,4 +1,4 @@
-//===-- runtime/transformational.h ------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/transformational.h ----------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -17,9 +17,9 @@
 #ifndef FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
 #define FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
 
-#include "descriptor.h"
-#include "entry-names.h"
-#include "memory.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/entry-names.h"
+#include "flang/Runtime/memory.h"
 
 namespace Fortran::runtime {
 

--- a/flang/include/flang/Runtime/type-code.h
+++ b/flang/include/flang/Runtime/type-code.h
@@ -1,4 +1,4 @@
-//===-- runtime/type-code.h -------------------------------------*- C++ -*-===//
+//===-- include/flang/Runtime/type-code.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -287,7 +287,7 @@ struct HostRuntimeLibrary<std::complex<HostT>, LibraryVersion::Libm> {
 // First declare all libpgmaths functions
 #define PGMATH_LINKING
 #define PGMATH_DECLARE
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
 
 #define REAL_FOLDER(name, func) \
   FolderFactory<decltype(&func), &func>::Create(#name)
@@ -295,7 +295,7 @@ template <> struct HostRuntimeLibrary<float, LibraryVersion::PgmathFast> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_FAST
 #define PGMATH_USE_S(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
@@ -304,7 +304,7 @@ template <> struct HostRuntimeLibrary<double, LibraryVersion::PgmathFast> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_FAST
 #define PGMATH_USE_D(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
@@ -313,7 +313,7 @@ template <> struct HostRuntimeLibrary<float, LibraryVersion::PgmathRelaxed> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_RELAXED
 #define PGMATH_USE_S(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
@@ -322,7 +322,7 @@ template <> struct HostRuntimeLibrary<double, LibraryVersion::PgmathRelaxed> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_RELAXED
 #define PGMATH_USE_D(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
@@ -331,7 +331,7 @@ template <> struct HostRuntimeLibrary<float, LibraryVersion::PgmathPrecise> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_PRECISE
 #define PGMATH_USE_S(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
@@ -340,7 +340,7 @@ template <> struct HostRuntimeLibrary<double, LibraryVersion::PgmathPrecise> {
   static constexpr HostRuntimeFunction table[]{
 #define PGMATH_PRECISE
 #define PGMATH_USE_D(name, func) REAL_FOLDER(name, func),
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
   };
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -11,8 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Allocatable.h"
-#include "../runtime/allocatable.h"
-#include "../runtime/pointer.h"
 #include "StatementContext.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Lower/AbstractConverter.h"
@@ -25,6 +23,8 @@
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Parser/parse-tree.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/pointer.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Semantics/type.h"
 #include "llvm/Support/CommandLine.h"

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Bridge.h"
-#include "../../runtime/iostat.h"
 #include "ConvertVariable.h"
 #include "IterationSpace.h"
 #include "StatementContext.h"
@@ -41,6 +40,7 @@
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "flang/Parser/parse-tree.h"
+#include "flang/Runtime/iostat.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/PatternMatch.h"

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -10,13 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "flang/Lower/IO.h"
-#include "../../runtime/io-api.h"
 #include "ConvertVariable.h"
 #include "StatementContext.h"
 #include "flang/Lower/Allocatable.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/ConvertExpr.h"
+#include "flang/Lower/IO.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Runtime.h"
 #include "flang/Lower/Support/Utils.h"
@@ -27,14 +26,12 @@
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
 #include "flang/Optimizer/Support/FIRContext.h"
 #include "flang/Parser/parse-tree.h"
+#include "flang/Runtime/io-api.h"
 #include "flang/Semantics/tools.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "flang-lower-io"
-
-// List the runtime headers we want to be able to dissect
-#include "../../runtime/io-api.h"
 
 // Define additional runtime type models specific to IO.
 namespace fir::runtime {

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -41,7 +41,7 @@
 #define DEBUG_TYPE "flang-lower-intrinsic"
 
 #define PGMATH_DECLARE
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
 
 /// This file implements lowering of Fortran intrinsic procedures.
 /// Intrinsics are lowered to a mix of FIR and MLIR operations as
@@ -901,17 +901,17 @@ struct RuntimeFunction {
 static constexpr RuntimeFunction pgmathFast[] = {
 #define PGMATH_FAST
 #define PGMATH_USE_ALL_TYPES(name, func) RUNTIME_STATIC_DESCRIPTION(name, func)
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
 };
 static constexpr RuntimeFunction pgmathRelaxed[] = {
 #define PGMATH_RELAXED
 #define PGMATH_USE_ALL_TYPES(name, func) RUNTIME_STATIC_DESCRIPTION(name, func)
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
 };
 static constexpr RuntimeFunction pgmathPrecise[] = {
 #define PGMATH_PRECISE
 #define PGMATH_USE_ALL_TYPES(name, func) RUNTIME_STATIC_DESCRIPTION(name, func)
-#include "../runtime/pgmath.h.inc"
+#include "flang/Evaluate/pgmath.h.inc"
 };
 
 static mlir::FunctionType genF32F32FuncType(mlir::MLIRContext *context) {

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -7,17 +7,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Lower/Runtime.h"
-#include "../../runtime/misc-intrinsic.h"
-#include "../runtime/pointer.h"
-#include "../runtime/random.h"
-#include "../runtime/stop.h"
-#include "../runtime/time-intrinsic.h"
 #include "StatementContext.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
 #include "flang/Parser/parse-tree.h"
+#include "flang/Runtime/misc-intrinsic.h"
+#include "flang/Runtime/pointer.h"
+#include "flang/Runtime/random.h"
+#include "flang/Runtime/stop.h"
+#include "flang/Runtime/time-intrinsic.h"
 #include "flang/Semantics/tools.h"
 #include "llvm/Support/Debug.h"
 

--- a/flang/lib/Optimizer/Builder/Runtime/Assign.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Assign.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Assign.h"
-#include "../../../runtime/assign.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/assign.h"
 
 using namespace Fortran::runtime;
 

--- a/flang/lib/Optimizer/Builder/Runtime/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Character.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Character.h"
-#include "../../../runtime/character.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/character.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace Fortran::runtime;

--- a/flang/lib/Optimizer/Builder/Runtime/Derived.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Derived.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Derived.h"
-#include "../../../runtime/derived-api.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/derived-api.h"
 
 using namespace Fortran::runtime;
 

--- a/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Numeric.h"
-#include "../../../runtime/numeric.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/numeric.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace Fortran::runtime;

--- a/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Reduction.h"
-#include "../../../runtime/reduction.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/reduction.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace Fortran::runtime;

--- a/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
@@ -8,13 +8,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Transformational.h"
-#include "../../../runtime/matmul.h"
-#include "../../../runtime/transformational.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/matmul.h"
+#include "flang/Runtime/transformational.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 using namespace Fortran::runtime;

--- a/flang/lib/Optimizer/CodeGen/DescriptorModel.h
+++ b/flang/lib/Optimizer/CodeGen/DescriptorModel.h
@@ -9,8 +9,8 @@
 #ifndef OPTIMIZER_DESCRIPTOR_MODEL_H
 #define OPTIMIZER_DESCRIPTOR_MODEL_H
 
-#include "../runtime/descriptor.h"
 #include "flang/ISO_Fortran_binding.h"
+#include "flang/Runtime/descriptor.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <tuple>

--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "compute-offsets.h"
-#include "../../runtime/descriptor.h"
 #include "flang/Evaluate/fold-designator.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/shape.h"
 #include "flang/Evaluate/type.h"
+#include "flang/Runtime/descriptor.h"
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/symbol.h"

--- a/flang/module/iso_fortran_env.f90
+++ b/flang/module/iso_fortran_env.f90
@@ -9,7 +9,7 @@
 ! See Fortran 2018, clause 16.10.2
 ! TODO: These are placeholder values so that some tests can be run.
 
-include '../runtime/magic-numbers.h' ! for IOSTAT= error/end code values
+include '../include/flang/Runtime/magic-numbers.h' ! for IOSTAT= error/end code values
 
 module iso_fortran_env
 

--- a/flang/runtime/Fortran_main.c
+++ b/flang/runtime/Fortran_main.c
@@ -1,5 +1,5 @@
-#include "main.h"
-#include "stop.h"
+#include "flang/Runtime/main.h"
+#include "flang/Runtime/stop.h"
 
 /* main entry into PROGRAM */
 void _QQmain();

--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -9,8 +9,8 @@
 // Implements the required interoperability API from ISO_Fortran_binding.h
 // as specified in section 18.5.5 of Fortran 2018.
 
-#include "../include/flang/ISO_Fortran_binding.h"
-#include "descriptor.h"
+#include "flang/ISO_Fortran_binding.h"
+#include "flang/Runtime/descriptor.h"
 #include <cstdlib>
 
 namespace Fortran::ISO {

--- a/flang/runtime/allocatable.cpp
+++ b/flang/runtime/allocatable.cpp
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "allocatable.h"
-#include "assign.h"
+#include "flang/Runtime/allocatable.h"
 #include "derived.h"
 #include "stat.h"
 #include "terminator.h"
 #include "type-info.h"
+#include "flang/Runtime/assign.h"
 
 namespace Fortran::runtime {
 extern "C" {

--- a/flang/runtime/assign.cpp
+++ b/flang/runtime/assign.cpp
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "assign.h"
+#include "flang/Runtime/assign.h"
 #include "derived.h"
-#include "descriptor.h"
 #include "stat.h"
 #include "terminator.h"
 #include "type-info.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/buffer.h
+++ b/flang/runtime/buffer.h
@@ -12,7 +12,7 @@
 #define FORTRAN_RUNTIME_BUFFER_H_
 
 #include "io-error.h"
-#include "memory.h"
+#include "flang/Runtime/memory.h"
 #include <algorithm>
 #include <cinttypes>
 #include <cstring>

--- a/flang/runtime/character.cpp
+++ b/flang/runtime/character.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "character.h"
-#include "cpp-type.h"
-#include "descriptor.h"
+#include "flang/Runtime/character.h"
 #include "terminator.h"
 #include "tools.h"
 #include "flang/Common/bit-population-count.h"
 #include "flang/Common/uint128.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <cstring>
 

--- a/flang/runtime/complex-reduction.h
+++ b/flang/runtime/complex-reduction.h
@@ -15,7 +15,7 @@
 #ifndef FORTRAN_RUNTIME_COMPLEX_REDUCTION_H_
 #define FORTRAN_RUNTIME_COMPLEX_REDUCTION_H_
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 #include <complex.h>
 
 struct CppDescriptor; /* dummy type name for Fortran::runtime::Descriptor */

--- a/flang/runtime/copy.cpp
+++ b/flang/runtime/copy.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "copy.h"
-#include "allocatable.h"
-#include "descriptor.h"
 #include "terminator.h"
 #include "type-info.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/descriptor.h"
 #include <cstring>
 
 namespace Fortran::runtime {

--- a/flang/runtime/copy.h
+++ b/flang/runtime/copy.h
@@ -1,4 +1,4 @@
-//===-- runtime/copy.h -----------------------------------------*- C++ -*-===//
+//===-- runtime/copy.h ------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,7 +12,7 @@
 #ifndef FORTRAN_RUNTIME_COPY_H_
 #define FORTRAN_RUNTIME_COPY_H_
 
-#include "descriptor.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/derived-api.cpp
+++ b/flang/runtime/derived-api.cpp
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "derived-api.h"
+#include "flang/Runtime/derived-api.h"
 #include "derived.h"
-#include "descriptor.h"
 #include "terminator.h"
 #include "type-info.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/derived.cpp
+++ b/flang/runtime/derived.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "derived.h"
-#include "descriptor.h"
 #include "stat.h"
 #include "terminator.h"
 #include "type-info.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/derived.h
+++ b/flang/runtime/derived.h
@@ -8,8 +8,8 @@
 
 // Internal runtime utilities for derived type operations.
 
-#ifndef FLANG_RUNTIME_DERIVED_H_
-#define FLANG_RUNTIME_DERIVED_H_
+#ifndef FORTRAN_RUNTIME_DERIVED_H_
+#define FORTRAN_RUNTIME_DERIVED_H_
 
 namespace Fortran::runtime::typeInfo {
 class DerivedType;
@@ -32,4 +32,4 @@ void Finalize(const Descriptor &, const typeInfo::DerivedType &derived);
 void Destroy(const Descriptor &, bool finalize, const typeInfo::DerivedType &);
 
 } // namespace Fortran::runtime
-#endif // FLANG_RUNTIME_DERIVED_H_
+#endif // FORTRAN_RUNTIME_DERIVED_H_

--- a/flang/runtime/descriptor-io.h
+++ b/flang/runtime/descriptor-io.h
@@ -14,8 +14,6 @@
 // some scalar I/O data transfer APIs could be changed to bypass their use
 // of descriptors in the future for better efficiency.)
 
-#include "cpp-type.h"
-#include "descriptor.h"
 #include "edit-input.h"
 #include "edit-output.h"
 #include "io-stmt.h"
@@ -23,6 +21,8 @@
 #include "type-info.h"
 #include "unit.h"
 #include "flang/Common/uint128.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime::io::descr {
 template <typename A>

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "descriptor.h"
+#include "flang/Runtime/descriptor.h"
 #include "derived.h"
 #include "memory.h"
 #include "stat.h"

--- a/flang/runtime/dot-product.cpp
+++ b/flang/runtime/dot-product.cpp
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "cpp-type.h"
-#include "descriptor.h"
-#include "reduction.h"
 #include "terminator.h"
 #include "tools.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/reduction.h"
 #include <cinttypes>
 
 namespace Fortran::runtime {

--- a/flang/runtime/extrema.cpp
+++ b/flang/runtime/extrema.cpp
@@ -10,10 +10,10 @@
 // and shapes and (for MAXLOC & MINLOC) result integer kinds.  Also implements
 // NORM2 using common infrastructure.
 
-#include "character.h"
 #include "reduction-templates.h"
-#include "reduction.h"
 #include "flang/Common/long-double.h"
+#include "flang/Runtime/character.h"
+#include "flang/Runtime/reduction.h"
 #include <algorithm>
 #include <cinttypes>
 #include <cmath>

--- a/flang/runtime/file.cpp
+++ b/flang/runtime/file.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "file.h"
-#include "magic-numbers.h"
-#include "memory.h"
+#include "flang/Runtime/magic-numbers.h"
+#include "flang/Runtime/memory.h"
 #include <algorithm>
 #include <cerrno>
 #include <cstring>

--- a/flang/runtime/file.h
+++ b/flang/runtime/file.h
@@ -12,7 +12,7 @@
 #define FORTRAN_RUNTIME_FILE_H_
 
 #include "io-error.h"
-#include "memory.h"
+#include "flang/Runtime/memory.h"
 #include <cinttypes>
 #include <optional>
 

--- a/flang/runtime/findloc.cpp
+++ b/flang/runtime/findloc.cpp
@@ -9,10 +9,10 @@
 // Implements FINDLOC for all required operand types and shapes and result
 // integer kinds.
 
-#include "character.h"
 #include "reduction-templates.h"
-#include "reduction.h"
 #include "flang/Common/long-double.h"
+#include "flang/Runtime/character.h"
+#include "flang/Runtime/reduction.h"
 #include <cinttypes>
 #include <complex>
 

--- a/flang/runtime/format-implementation.h
+++ b/flang/runtime/format-implementation.h
@@ -13,9 +13,9 @@
 
 #include "format.h"
 #include "io-stmt.h"
-#include "main.h"
 #include "flang/Common/format.h"
 #include "flang/Decimal/decimal.h"
+#include "flang/Runtime/main.h"
 #include <algorithm>
 #include <limits>
 

--- a/flang/runtime/internal-unit.cpp
+++ b/flang/runtime/internal-unit.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "internal-unit.h"
-#include "descriptor.h"
 #include "io-error.h"
+#include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <type_traits>
 

--- a/flang/runtime/internal-unit.h
+++ b/flang/runtime/internal-unit.h
@@ -12,7 +12,7 @@
 #define FORTRAN_RUNTIME_IO_INTERNAL_UNIT_H_
 
 #include "connection.h"
-#include "descriptor.h"
+#include "flang/Runtime/descriptor.h"
 #include <cinttypes>
 #include <type_traits>
 

--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -8,18 +8,18 @@
 
 // Implements the I/O statement API
 
-#include "io-api.h"
+#include "flang/Runtime/io-api.h"
 #include "descriptor-io.h"
-#include "descriptor.h"
 #include "edit-input.h"
 #include "edit-output.h"
 #include "environment.h"
 #include "format.h"
 #include "io-stmt.h"
-#include "memory.h"
 #include "terminator.h"
 #include "tools.h"
 #include "unit.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/memory.h"
 #include <cstdlib>
 #include <memory>
 

--- a/flang/runtime/io-error.cpp
+++ b/flang/runtime/io-error.cpp
@@ -8,8 +8,8 @@
 
 #include "io-error.h"
 #include "config.h"
-#include "magic-numbers.h"
 #include "tools.h"
+#include "flang/Runtime/magic-numbers.h"
 #include <cerrno>
 #include <cstdarg>
 #include <cstdio>

--- a/flang/runtime/io-error.h
+++ b/flang/runtime/io-error.h
@@ -15,9 +15,9 @@
 #ifndef FORTRAN_RUNTIME_IO_ERROR_H_
 #define FORTRAN_RUNTIME_IO_ERROR_H_
 
-#include "iostat.h"
-#include "memory.h"
 #include "terminator.h"
+#include "flang/Runtime/iostat.h"
+#include "flang/Runtime/memory.h"
 #include <cinttypes>
 
 namespace Fortran::runtime::io {

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -9,9 +9,9 @@
 #include "io-stmt.h"
 #include "connection.h"
 #include "format.h"
-#include "memory.h"
 #include "tools.h"
 #include "unit.h"
+#include "flang/Runtime/memory.h"
 #include <algorithm>
 #include <cstdio>
 #include <cstring>

--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -12,12 +12,12 @@
 #define FORTRAN_RUNTIME_IO_STMT_H_
 
 #include "connection.h"
-#include "descriptor.h"
 #include "file.h"
 #include "format.h"
 #include "internal-unit.h"
-#include "io-api.h"
 #include "io-error.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/io-api.h"
 #include <functional>
 #include <type_traits>
 #include <variant>

--- a/flang/runtime/iostat.cpp
+++ b/flang/runtime/iostat.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "iostat.h"
+#include "flang/Runtime/iostat.h"
 
 namespace Fortran::runtime::io {
 const char *IostatErrorString(int iostat) {

--- a/flang/runtime/main.cpp
+++ b/flang/runtime/main.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "main.h"
+#include "flang/Runtime/main.h"
 #include "environment.h"
 #include "terminator.h"
 #include <cfenv>

--- a/flang/runtime/matmul.cpp
+++ b/flang/runtime/matmul.cpp
@@ -19,11 +19,11 @@
 //
 // Places where BLAS routines could be called are marked as TODO items.
 
-#include "matmul.h"
-#include "cpp-type.h"
-#include "descriptor.h"
+#include "flang/Runtime/matmul.h"
 #include "terminator.h"
 #include "tools.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/memory.cpp
+++ b/flang/runtime/memory.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "memory.h"
+#include "flang/Runtime/memory.h"
 #include "terminator.h"
 #include <cstdlib>
 

--- a/flang/runtime/misc-intrinsic.cpp
+++ b/flang/runtime/misc-intrinsic.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "misc-intrinsic.h"
-#include "descriptor.h"
+#include "flang/Runtime/misc-intrinsic.h"
 #include "terminator.h"
+#include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <cstring>
 

--- a/flang/runtime/namelist.cpp
+++ b/flang/runtime/namelist.cpp
@@ -8,8 +8,8 @@
 
 #include "namelist.h"
 #include "descriptor-io.h"
-#include "io-api.h"
 #include "io-stmt.h"
+#include "flang/Runtime/io-api.h"
 #include <cstring>
 #include <limits>
 

--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "numeric.h"
+#include "flang/Runtime/numeric.h"
 #include "flang/Common/long-double.h"
 #include <climits>
 #include <cmath>

--- a/flang/runtime/pointer.cpp
+++ b/flang/runtime/pointer.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "pointer.h"
+#include "flang/Runtime/pointer.h"
 #include "derived.h"
 #include "stat.h"
 #include "terminator.h"

--- a/flang/runtime/product.cpp
+++ b/flang/runtime/product.cpp
@@ -9,8 +9,8 @@
 // Implements PRODUCT for all required operand types and shapes.
 
 #include "reduction-templates.h"
-#include "reduction.h"
 #include "flang/Common/long-double.h"
+#include "flang/Runtime/reduction.h"
 #include <cinttypes>
 #include <complex>
 

--- a/flang/runtime/random.cpp
+++ b/flang/runtime/random.cpp
@@ -9,12 +9,12 @@
 // Implements the intrinsic subroutines RANDOM_INIT, RANDOM_NUMBER, and
 // RANDOM_SEED.
 
-#include "random.h"
-#include "cpp-type.h"
-#include "descriptor.h"
+#include "flang/Runtime/random.h"
 #include "lock.h"
 #include "flang/Common/leading-zero-bit-count.h"
 #include "flang/Common/uint128.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>

--- a/flang/runtime/reduction-templates.h
+++ b/flang/runtime/reduction-templates.h
@@ -21,10 +21,10 @@
 #ifndef FORTRAN_RUNTIME_REDUCTION_TEMPLATES_H_
 #define FORTRAN_RUNTIME_REDUCTION_TEMPLATES_H_
 
-#include "cpp-type.h"
-#include "descriptor.h"
 #include "terminator.h"
 #include "tools.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/reduction.cpp
+++ b/flang/runtime/reduction.cpp
@@ -12,10 +12,8 @@
 // DOT_PRODUCT, FINDLOC, MATMUL, SUM, and PRODUCT are in their own eponymous
 // source files.
 // NORM2, MAXLOC, MINLOC, MAXVAL, and MINVAL are in extrema.cpp.
-//
-// TODO: IALL, IANY
 
-#include "reduction.h"
+#include "flang/Runtime/reduction.h"
 #include "reduction-templates.h"
 #include <cinttypes>
 

--- a/flang/runtime/stat.cpp
+++ b/flang/runtime/stat.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "stat.h"
-#include "descriptor.h"
 #include "terminator.h"
+#include "flang/Runtime/descriptor.h"
 
 namespace Fortran::runtime {
 const char *StatErrorString(int stat) {

--- a/flang/runtime/stat.h
+++ b/flang/runtime/stat.h
@@ -11,8 +11,8 @@
 
 #ifndef FORTRAN_RUNTIME_STAT_H_
 #define FORTRAN_RUNTIME_STAT_H_
-#include "magic-numbers.h"
 #include "flang/ISO_Fortran_binding.h"
+#include "flang/Runtime/magic-numbers.h"
 namespace Fortran::runtime {
 
 class Descriptor;

--- a/flang/runtime/stop.cpp
+++ b/flang/runtime/stop.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "stop.h"
+#include "flang/Runtime/stop.h"
 #include "file.h"
 #include "io-error.h"
 #include "terminator.h"

--- a/flang/runtime/sum.cpp
+++ b/flang/runtime/sum.cpp
@@ -13,8 +13,8 @@
 // (basically the same as manual "double-double").
 
 #include "reduction-templates.h"
-#include "reduction.h"
 #include "flang/Common/long-double.h"
+#include "flang/Runtime/reduction.h"
 #include <cinttypes>
 #include <complex>
 

--- a/flang/runtime/terminator.h
+++ b/flang/runtime/terminator.h
@@ -11,7 +11,7 @@
 #ifndef FORTRAN_RUNTIME_TERMINATOR_H_
 #define FORTRAN_RUNTIME_TERMINATOR_H_
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 #include <cstdarg>
 
 namespace Fortran::runtime {

--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -8,11 +8,10 @@
 
 // Implements time-related intrinsic subroutines.
 
-#include "time-intrinsic.h"
-
-#include "descriptor.h"
+#include "flang/Runtime/time-intrinsic.h"
 #include "terminator.h"
 #include "tools.h"
+#include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>

--- a/flang/runtime/tools.h
+++ b/flang/runtime/tools.h
@@ -9,11 +9,11 @@
 #ifndef FORTRAN_RUNTIME_TOOLS_H_
 #define FORTRAN_RUNTIME_TOOLS_H_
 
-#include "cpp-type.h"
-#include "descriptor.h"
-#include "memory.h"
 #include "terminator.h"
 #include "flang/Common/long-double.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/memory.h"
 #include <functional>
 #include <map>
 #include <type_traits>

--- a/flang/runtime/transformational.cpp
+++ b/flang/runtime/transformational.cpp
@@ -16,7 +16,7 @@
 // work with arbitrary lower bounds.  This may be technically an extension
 // of the standard but it more likely to conform with its intent.
 
-#include "transformational.h"
+#include "flang/Runtime/transformational.h"
 #include "copy.h"
 #include "terminator.h"
 #include "tools.h"

--- a/flang/runtime/type-code.cpp
+++ b/flang/runtime/type-code.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "type-code.h"
+#include "flang/Runtime/type-code.h"
 
 namespace Fortran::runtime {
 

--- a/flang/runtime/type-info.h
+++ b/flang/runtime/type-info.h
@@ -12,10 +12,10 @@
 // A C++ perspective of the derived type description schemata in
 // flang/module/__fortran_type_info.f90.
 
-#include "descriptor.h"
 #include "terminator.h"
 #include "flang/Common/Fortran.h"
 #include "flang/Common/bit-population-count.h"
+#include "flang/Runtime/descriptor.h"
 #include <cinttypes>
 #include <memory>
 #include <optional>

--- a/flang/runtime/unit-map.h
+++ b/flang/runtime/unit-map.h
@@ -13,8 +13,8 @@
 #define FORTRAN_RUNTIME_UNIT_MAP_H_
 
 #include "lock.h"
-#include "memory.h"
 #include "unit.h"
+#include "flang/Runtime/memory.h"
 #include <cstdlib>
 
 namespace Fortran::runtime::io {

--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -18,8 +18,8 @@
 #include "io-error.h"
 #include "io-stmt.h"
 #include "lock.h"
-#include "memory.h"
 #include "terminator.h"
+#include "flang/Runtime/memory.h"
 #include <cstdlib>
 #include <cstring>
 #include <optional>

--- a/flang/test/Runtime/no-cpp-dep.c
+++ b/flang/test/Runtime/no-cpp-dep.c
@@ -5,10 +5,10 @@ a C compiler.
 
 REQUIRES: c-compiler
 
-RUN: %cc -std=c90 %s -I%runtimeincludes %libruntime %libdecimal -o /dev/null
+RUN: %cc -std=c90 %s -I%include %libruntime %libdecimal -o /dev/null
 */
 
-#include "entry-names.h"
+#include "flang/Runtime/entry-names.h"
 
 /*
 Manually add declarations for the runtime functions that we want to make sure

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -108,16 +108,16 @@ else:
 if config.cc:
     libruntime = os.path.join(config.flang_lib_dir, 'libFortranRuntime.a')
     libdecimal = os.path.join(config.flang_lib_dir, 'libFortranDecimal.a')
-    includes = os.path.join(config.flang_src_dir, 'runtime')
+    include = os.path.join(config.flang_src_dir, 'include')
 
-    if os.path.isfile(libruntime) and os.path.isfile(libdecimal) and os.path.isdir(includes):
+    if os.path.isfile(libruntime) and os.path.isfile(libdecimal) and os.path.isdir(include):
         config.available_features.add('c-compiler')
         tools.append(ToolSubst('%cc', command=config.cc, unresolved='fatal'))
         tools.append(ToolSubst('%libruntime', command=libruntime,
             unresolved='fatal'))
         tools.append(ToolSubst('%libdecimal', command=libdecimal,
             unresolved='fatal'))
-        tools.append(ToolSubst('%runtimeincludes', command=includes,
+        tools.append(ToolSubst('%include', command=include,
             unresolved='fatal'))
 
 if config.flang_standalone_build:

--- a/flang/unittests/Evaluate/ISO-Fortran-binding.cpp
+++ b/flang/unittests/Evaluate/ISO-Fortran-binding.cpp
@@ -1,6 +1,6 @@
 #include "testing.h"
-#include "../../include/flang/ISO_Fortran_binding.h"
-#include "../../runtime/descriptor.h"
+#include "flang/ISO_Fortran_binding.h"
+#include "flang/Runtime/descriptor.h"
 #include "llvm/Support/raw_ostream.h"
 #include <type_traits>
 

--- a/flang/unittests/Evaluate/reshape.cpp
+++ b/flang/unittests/Evaluate/reshape.cpp
@@ -1,6 +1,6 @@
 #include "testing.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/transformational.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/transformational.h"
 #include <cinttypes>
 
 using namespace Fortran::common;

--- a/flang/unittests/Runtime/external-hello.cpp
+++ b/flang/unittests/Runtime/external-hello.cpp
@@ -1,6 +1,6 @@
-#include "../../runtime/io-api.h"
-#include "../../runtime/main.h"
-#include "../../runtime/stop.h"
+#include "flang/Runtime/io-api.h"
+#include "flang/Runtime/main.h"
+#include "flang/Runtime/stop.h"
 #include <cstring>
 #include <limits>
 

--- a/flang/unittests/Runtime/external-io.cpp
+++ b/flang/unittests/Runtime/external-io.cpp
@@ -1,9 +1,9 @@
 // Sanity test for all external I/O modes
 
 #include "testing.h"
-#include "../../runtime/io-api.h"
-#include "../../runtime/main.h"
-#include "../../runtime/stop.h"
+#include "flang/Runtime/io-api.h"
+#include "flang/Runtime/main.h"
+#include "flang/Runtime/stop.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstring>
 

--- a/flang/unittests/RuntimeGTest/CharacterTest.cpp
+++ b/flang/unittests/RuntimeGTest/CharacterTest.cpp
@@ -9,8 +9,8 @@
 // Basic sanity tests of CHARACTER API; exhaustive testing will be done
 // in Fortran.
 
-#include "../../runtime/character.h"
-#include "../../runtime/descriptor.h"
+#include "flang/Runtime/character.h"
+#include "flang/Runtime/descriptor.h"
 #include "gtest/gtest.h"
 #include <cstring>
 #include <functional>

--- a/flang/unittests/RuntimeGTest/ListInputTest.cpp
+++ b/flang/unittests/RuntimeGTest/ListInputTest.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "CrashHandlerFixture.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/io-api.h"
 #include "../../runtime/io-error.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/io-api.h"
 
 using namespace Fortran::runtime;
 using namespace Fortran::runtime::io;

--- a/flang/unittests/RuntimeGTest/Matmul.cpp
+++ b/flang/unittests/RuntimeGTest/Matmul.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../runtime/matmul.h"
+#include "flang/Runtime/matmul.h"
 #include "gtest/gtest.h"
 #include "tools.h"
-#include "../../runtime/allocatable.h"
-#include "../../runtime/cpp-type.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/type-code.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/type-code.h"
 
 using namespace Fortran::runtime;
 using Fortran::common::TypeCategory;

--- a/flang/unittests/RuntimeGTest/MiscIntrinsic.cpp
+++ b/flang/unittests/RuntimeGTest/MiscIntrinsic.cpp
@@ -8,10 +8,10 @@
 
 #include "gtest/gtest.h"
 #include "tools.h"
-#include "../../runtime/allocatable.h"
-#include "../../runtime/cpp-type.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/misc-intrinsic.h"
+#include "flang/Runtime//misc-intrinsic.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
 
 using namespace Fortran::runtime;
 

--- a/flang/unittests/RuntimeGTest/Namelist.cpp
+++ b/flang/unittests/RuntimeGTest/Namelist.cpp
@@ -9,8 +9,8 @@
 #include "../../runtime/namelist.h"
 #include "CrashHandlerFixture.h"
 #include "tools.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/io-api.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/io-api.h"
 #include <algorithm>
 #include <cinttypes>
 #include <complex>

--- a/flang/unittests/RuntimeGTest/Numeric.cpp
+++ b/flang/unittests/RuntimeGTest/Numeric.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../runtime/numeric.h"
+#include "flang/Runtime/numeric.h"
 #include "gtest/gtest.h"
 #include <cmath>
 #include <limits>

--- a/flang/unittests/RuntimeGTest/NumericalFormatTest.cpp
+++ b/flang/unittests/RuntimeGTest/NumericalFormatTest.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "CrashHandlerFixture.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/io-api.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/io-api.h"
 #include <algorithm>
 #include <array>
 #include <cstring>

--- a/flang/unittests/RuntimeGTest/Random.cpp
+++ b/flang/unittests/RuntimeGTest/Random.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../runtime/random.h"
+#include "flang/Runtime//random.h"
 #include "gtest/gtest.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/type-code.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/type-code.h"
 #include <cmath>
 
 using namespace Fortran::runtime;

--- a/flang/unittests/RuntimeGTest/Reduction.cpp
+++ b/flang/unittests/RuntimeGTest/Reduction.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../runtime/reduction.h"
+#include "flang/Runtime/reduction.h"
 #include "gtest/gtest.h"
 #include "tools.h"
-#include "../../runtime/allocatable.h"
-#include "../../runtime/cpp-type.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/type-code.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/type-code.h"
 #include <cstdint>
 #include <cstring>
 #include <string>

--- a/flang/unittests/RuntimeGTest/RuntimeCrashTest.cpp
+++ b/flang/unittests/RuntimeGTest/RuntimeCrashTest.cpp
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 #include "CrashHandlerFixture.h"
-#include "../../runtime/io-api.h"
 #include "../../runtime/terminator.h"
+#include "flang/Runtime/io-api.h"
 #include <gtest/gtest.h>
 
 using namespace Fortran::runtime;

--- a/flang/unittests/RuntimeGTest/Time.cpp
+++ b/flang/unittests/RuntimeGTest/Time.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gtest/gtest.h"
-#include "../../runtime/time-intrinsic.h"
+#include "flang/Runtime/time-intrinsic.h"
 #include <algorithm>
 #include <cctype>
 #include <charconv>

--- a/flang/unittests/RuntimeGTest/Transformational.cpp
+++ b/flang/unittests/RuntimeGTest/Transformational.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../runtime/transformational.h"
+#include "flang/Runtime/transformational.h"
 #include "gtest/gtest.h"
 #include "tools.h"
-#include "../../runtime/type-code.h"
+#include "flang/Runtime/type-code.h"
 
 using namespace Fortran::runtime;
 using Fortran::common::TypeCategory;

--- a/flang/unittests/RuntimeGTest/tools.h
+++ b/flang/unittests/RuntimeGTest/tools.h
@@ -10,10 +10,10 @@
 #define FORTRAN_UNITTESTS_RUNTIME_TOOLS_H_
 
 #include "gtest/gtest.h"
-#include "../../runtime/allocatable.h"
-#include "../../runtime/cpp-type.h"
-#include "../../runtime/descriptor.h"
-#include "../../runtime/type-code.h"
+#include "flang/Runtime/allocatable.h"
+#include "flang/Runtime/cpp-type.h"
+#include "flang/Runtime/descriptor.h"
+#include "flang/Runtime/type-code.h"
 #include <cstdint>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
This commit cherry-picks the change that Peter made in llvm-project and
makes additional changes to account for the differences between fir-dev
and llvm-project.

Here's the original message from Peter's change in Phabricator in
llvm-project:

Move the closure of the subset of flang/runtime/*.h header files that
are referenced by source files outside flang/runtime (apart from unit tests)
into a new directory (flang/include/flang/Runtime) so that relative
include paths into ../runtime need not be used.

flang/runtime/pgmath.h.inc is moved to flang/include/flang/Evaluate;
it's not used by the runtime.

Differential Revision: https://reviews.llvm.org/D109107