### PR TITLE
Cherry pick non advancing IO runtime fix and add TODO for Size= specifier

### DIFF
--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "flang/Lower/IO.h"
 #include "ConvertVariable.h"
 #include "StatementContext.h"
 #include "flang/Lower/Allocatable.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/ConvertExpr.h"
-#include "flang/Lower/IO.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Runtime.h"
 #include "flang/Lower/Support/Utils.h"
@@ -946,12 +946,22 @@ mlir::Value genIOOption<Fortran::parser::IoControlSpec::Pos>(
     const Fortran::parser::IoControlSpec::Pos &spec) {
   return genIntIOOption<mkIOKey(SetPos)>(converter, loc, cookie, stmtCtx, spec);
 }
+
 template <>
 mlir::Value genIOOption<Fortran::parser::IoControlSpec::Rec>(
     Fortran::lower::AbstractConverter &converter, mlir::Location loc,
     mlir::Value cookie, Fortran::lower::StatementContext &stmtCtx,
     const Fortran::parser::IoControlSpec::Rec &spec) {
   return genIntIOOption<mkIOKey(SetRec)>(converter, loc, cookie, stmtCtx, spec);
+}
+
+template <>
+mlir::Value genIOOption<Fortran::parser::IoControlSpec::Size>(
+    Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+    mlir::Value cookie, Fortran::lower::StatementContext &,
+    const Fortran::parser::IoControlSpec::Size &) {
+  // Runtime GetSize is not implemented yet.
+  TODO(loc, "SIZE= specifier in a data transfer statement");
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -402,7 +402,7 @@ bool ExternalFileUnit::BeginReadingRecord(IoErrorHandler &handler) {
 void ExternalFileUnit::FinishReadingRecord(IoErrorHandler &handler) {
   RUNTIME_CHECK(handler, direction_ == Direction::Input && beganReadingRecord_);
   beganReadingRecord_ = false;
-  if (handler.InError()) {
+  if (handler.InError() && handler.GetIoStat() != IostatEor) {
     // avoid bogus crashes in END/ERR circumstances
   } else if (access == Access::Sequential) {
     RUNTIME_CHECK(handler, recordLength.has_value());


### PR DESCRIPTION
Runtime for SIZE= specifier is not yet implemented, and its interface is most likely wrong (integer argument should be a reference), so just add a TODO in lowering to avoid silent bugs for now.