### PR TITLE
[OpenMP] Fixes for schedule modifier

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -364,9 +364,12 @@ getScheduleModifiers(const Fortran::parser::OmpScheduleClause &x) {
       const auto &modType2 = std::get<
           std::optional<Fortran::parser::OmpScheduleModifier::Modifier2>>(
           modifier->t);
-      if (modType2->v.v !=
-          Fortran::parser::OmpScheduleModifierType::ModType::Simd)
+      if (modType2 &&
+          modType2->v.v !=
+              Fortran::parser::OmpScheduleModifierType::ModType::Simd)
         return translateModifier(modType2->v);
+
+      return mlir::omp::ScheduleModifier::none;
     }
 
     return translateModifier(modType1.v);
@@ -390,8 +393,8 @@ getSIMDModifier(const Fortran::parser::OmpScheduleClause &x) {
     const auto &modType2 = std::get<
         std::optional<Fortran::parser::OmpScheduleModifier::Modifier2>>(
         modifier->t);
-    if (modType2->v.v ==
-        Fortran::parser::OmpScheduleModifierType::ModType::Simd)
+    if (modType2 && modType2->v.v ==
+                        Fortran::parser::OmpScheduleModifierType::ModType::Simd)
       return mlir::omp::ScheduleModifier::simd;
   }
   return mlir::omp::ScheduleModifier::none;


### PR DESCRIPTION
Check the existence of modType2 variable before accessing its contents. Have seen some non-deterministic behaviour without this fix. Also added a return `none` in a particular case.

Originally part of the following PRs. Pulling it out for ease of review, approval and merge.
https://github.com/flang-compiler/f18-llvm-project/pull/975
https://github.com/flang-compiler/f18-llvm-project/pull/928