### PR TITLE
Process block data programs early

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -106,34 +106,47 @@ using IncrementLoopNestInfo = llvm::SmallVector<IncrementLoopInfo>;
 
 namespace {
 
-/// Walk over the pre-FIR tree (PFT) and lower it to the FIR dialect of MLIR.
-///
-/// After building the PFT, the FirConverter processes that representation
-/// and lowers it to the FIR executable representation.
+/// Create a pre-FIR tree (PFT) from the parse tree, then traverse it to
+/// generate the FIR dialect of MLIR.
 class FirConverter : public Fortran::lower::AbstractConverter {
 public:
   explicit FirConverter(Fortran::lower::LoweringBridge &bridge)
       : bridge{bridge}, foldingContext{bridge.createFoldingContext()} {}
   virtual ~FirConverter() = default;
 
-  /// Convert the PFT to FIR
+  /// Convert the PFT to FIR.
   void run(Fortran::lower::pft::Program &pft) {
-    // Declare mlir::FuncOp for all the FunctionLikeUnit defined in the PFT
-    // before lowering any function bodies so that the definition signatures
-    // prevail on call spot signatures.
-    declareFunctions(pft);
+    // Preliminary translation pass.
+    //  - Declare all functions that have definitions so that definition
+    //    signatures prevail over call site signatures.
+    //  - Define module variables so they are available before lowering any
+    //    function that may use them.
+    //  - Translate block data programs so that common block definitions with
+    //    data initializations take precedence over other definitions.
+    for (auto &u : pft.getUnits()) {
+      std::visit(
+          Fortran::common::visitors{
+              [&](Fortran::lower::pft::FunctionLikeUnit &f) {
+                declareFunction(f);
+              },
+              [&](Fortran::lower::pft::ModuleLikeUnit &m) {
+                lowerModuleVariables(m);
+                for (auto &f : m.nestedFunctions)
+                  declareFunction(f);
+              },
+              [&](Fortran::lower::pft::BlockDataUnit &b) { lowerBlockData(b); },
+              [&](Fortran::lower::pft::CompilerDirectiveUnit &d) {},
+          },
+          u);
+    }
 
-    // Define variables of the modules defined in this program. This is done
-    // first to ensure they are defined before lowering any function that may
-    // use them.
-    lowerModuleVariables(pft);
-    // do translation
+    // Primary translation pass.
     for (auto &u : pft.getUnits()) {
       std::visit(
           Fortran::common::visitors{
               [&](Fortran::lower::pft::FunctionLikeUnit &f) { lowerFunc(f); },
               [&](Fortran::lower::pft::ModuleLikeUnit &m) { lowerMod(m); },
-              [&](Fortran::lower::pft::BlockDataUnit &b) { lowerBlockData(b); },
+              [&](Fortran::lower::pft::BlockDataUnit &b) {},
               [&](Fortran::lower::pft::CompilerDirectiveUnit &d) {
                 setCurrentPosition(
                     d.get<Fortran::parser::CompilerDirective>().source);
@@ -142,29 +155,6 @@ public:
               },
           },
           u);
-    }
-  }
-
-  /// Declare mlir::FuncOp for all the FunctionLikeUnit defined in the PFT
-  /// without any other side-effects.
-  void declareFunctions(Fortran::lower::pft::Program &pft) {
-    for (auto &u : pft.getUnits()) {
-      std::visit(Fortran::common::visitors{
-                     [&](Fortran::lower::pft::FunctionLikeUnit &f) {
-                       declareFunction(f);
-                     },
-                     [&](Fortran::lower::pft::ModuleLikeUnit &m) {
-                       for (auto &f : m.nestedFunctions)
-                         declareFunction(f);
-                     },
-                     [&](Fortran::lower::pft::BlockDataUnit &) {
-                       // No functions defined in block data.
-                     },
-                     [&](Fortran::lower::pft::CompilerDirectiveUnit &) {
-                       // No functions defined.
-                     },
-                 },
-                 u);
     }
   }
 
@@ -225,22 +215,6 @@ public:
         LLVM_DEBUG(llvm::dbgs() << "host associated symbol " << sym << '\n');
         escapees.insert(escapingSym);
       }
-    }
-  }
-
-  /// Loop through modules defined in this file to generate the fir::globalOp
-  /// for module variables.
-  void lowerModuleVariables(Fortran::lower::pft::Program &pft) {
-    for (auto &u : pft.getUnits()) {
-      std::visit(Fortran::common::visitors{
-                     [&](Fortran::lower::pft::ModuleLikeUnit &m) {
-                       lowerModuleVariables(m);
-                     },
-                     [](auto &) {
-                       // Not a module, so no processing needed here.
-                     },
-                 },
-                 u);
     }
   }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -106,8 +106,7 @@ using IncrementLoopNestInfo = llvm::SmallVector<IncrementLoopInfo>;
 
 namespace {
 
-/// Create a pre-FIR tree (PFT) from the parse tree, then traverse it to
-/// generate the FIR dialect of MLIR.
+/// Traverse the pre-FIR tree (PFT) to generate the FIR dialect of MLIR.
 class FirConverter : public Fortran::lower::AbstractConverter {
 public:
   explicit FirConverter(Fortran::lower::LoweringBridge &bridge)

--- a/flang/test/Lower/allocatable-globals.f90
+++ b/flang/test/Lower/allocatable-globals.f90
@@ -3,6 +3,12 @@
 
 ! Test global allocatable definition lowering
 
+! CHECK-LABEL: fir.global linkonce @_QMmod_allocatablesEc : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {
+  ! CHECK-DAG: %[[modcNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,10>>>
+  ! CHECK-DAG: %[[modcShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[modcInitBox:.*]] = fir.embox %[[modcNullAddr]](%[[modcShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+  ! CHECK: fir.has_value %[[modcInitBox]] : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
+
 module mod_allocatables
   character(10), allocatable :: c(:)
 end module
@@ -31,12 +37,6 @@ subroutine test_globals()
   allocate(gx, gy(20, 30), gc3, gc4(40, 50))
   allocate(character(15):: gc1, gc2(60, 70))
 end subroutine
-
-! CHECK-LABEL: fir.global linkonce @_QMmod_allocatablesEc : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {
-  ! CHECK-DAG: %[[modcNullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,10>>>
-  ! CHECK-DAG: %[[modcShape:.*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK: %[[modcInitBox:.*]] = fir.embox %[[modcNullAddr]](%[[modcShape]]) : (!fir.heap<!fir.array<?x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
-  ! CHECK: fir.has_value %[[modcInitBox]] : !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>
 
 ! CHECK-LABEL: fir.global internal @_QFtest_globalsEgc1 : !fir.box<!fir.heap<!fir.char<1,?>>>
   ! CHECK-DAG: %[[gc1NullAddr:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>

--- a/flang/test/Lower/array-constructor-1.f90
+++ b/flang/test/Lower/array-constructor-1.f90
@@ -5,7 +5,7 @@ module units
 contains
   ! CHECK-LABEL: _QMunitsPis_preconnected_unit
   logical function is_preconnected_unit(u)
-  ! CHECK: [[units_ssa:%[0-9]+]] = fir.address_of([[units_value:.*]]) : !fir.ref<!fir.array<3xi32>>
+  ! CHECK: [[units_ssa:%[0-9]+]] = fir.address_of(@_QMunitsECpreconnected_unit) : !fir.ref<!fir.array<3xi32>>
     integer :: u
     integer :: i
     is_preconnected_unit = .true.
@@ -40,8 +40,6 @@ program prog
   call check_units
   call zero
 end
-
-! CHECK: fir.global linkonce [[units_value]] constant : !fir.array<3xi32>
 
 ! CHECK: fir.global internal @_QFzeroECa constant : !fir.array<0x!fir.complex<4>>
 ! CHECK:   %0 = fir.undefined !fir.array<0x!fir.complex<4>>

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -76,6 +76,26 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   
 end subroutine s
 
+! CHECK: %[[VAL_1:.*]] = constant 1.000000e+00 : f32
+! CHECK: %[[VAL_2:.*]] = constant 2.400000e+00 : f32
+! CHECK: %[[VAL_3:.*]] = constant 0.000000e+00 : f32
+! CHECK: %[[VAL_4:.*]] = fir.undefined tuple<!fir.array<5x5xf32>>
+! CHECK: %[[VAL_5:.*]] = fir.undefined !fir.array<5x5xf32>
+! CHECK: %[[VAL_6:.*]] = fir.insert_on_range %[[VAL_5]], %[[VAL_1]], [0 : index, 1 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_7:.*]] = fir.insert_on_range %[[VAL_6]], %[[VAL_3]], [2 : index, 4 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_8:.*]] = fir.insert_on_range %[[VAL_7]], %[[VAL_1]], [0 : index, 1 : index, 1 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_9:.*]] = fir.insert_value %[[VAL_8]], %[[VAL_3]], [2 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_2]], [3 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_11:.*]] = fir.insert_value %[[VAL_10]], %[[VAL_3]], [4 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_12:.*]] = fir.insert_on_range %[[VAL_11]], %[[VAL_1]], [0 : index, 1 : index, 2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_13:.*]] = fir.insert_value %[[VAL_12]], %[[VAL_3]], [2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_14:.*]] = fir.insert_value %[[VAL_13]], %[[VAL_2]], [3 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_15:.*]] = fir.insert_on_range %[[VAL_14]], %[[VAL_3]], [4 : index, 2 : index, 2 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_16:.*]] = fir.insert_value %[[VAL_15]], %[[VAL_2]], [3 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_17:.*]] = fir.insert_on_range %[[VAL_16]], %[[VAL_3]], [4 : index, 4 : index, 3 : index, 4 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
+! CHECK: %[[VAL_18:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_17]], [0 : index] : (tuple<!fir.array<5x5xf32>>, !fir.array<5x5xf32>) -> tuple<!fir.array<5x5xf32>>
+! CHECK: fir.has_value %[[VAL_18]] : tuple<!fir.array<5x5xf32>>
+
 ! CHECK-LABEL range
 subroutine range()
   ! Compile-time initalized arrays
@@ -129,25 +149,6 @@ subroutine rangeGlobal()
 end subroutine rangeGlobal
 
 block data
-   ! CHECK: %[[VAL_223:.*]] = constant 1.000000e+00 : f32
-   ! CHECK: %[[VAL_224:.*]] = constant 2.400000e+00 : f32
-   ! CHECK: %[[VAL_225:.*]] = constant 0.000000e+00 : f32
-   ! CHECK: %[[VAL_226:.*]] = fir.undefined tuple<!fir.array<5x5xf32>>
-   ! CHECK: %[[VAL_227:.*]] = fir.undefined !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_228:.*]] = fir.insert_on_range %[[VAL_227]], %[[VAL_223]], [0 : index, 1 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_229:.*]] = fir.insert_on_range %[[VAL_228]], %[[VAL_225]], [2 : index, 4 : index, 0 : index, 0 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_230:.*]] = fir.insert_on_range %[[VAL_229]], %[[VAL_223]], [0 : index, 1 : index, 1 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_231:.*]] = fir.insert_value %[[VAL_230]], %[[VAL_225]], [2 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_232:.*]] = fir.insert_value %[[VAL_231]], %[[VAL_224]], [3 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_233:.*]] = fir.insert_value %[[VAL_232]], %[[VAL_225]], [4 : index, 1 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_234:.*]] = fir.insert_on_range %[[VAL_233]], %[[VAL_223]], [0 : index, 1 : index, 2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_235:.*]] = fir.insert_value %[[VAL_234]], %[[VAL_225]], [2 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_236:.*]] = fir.insert_value %[[VAL_235]], %[[VAL_224]], [3 : index, 2 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_237:.*]] = fir.insert_on_range %[[VAL_236]], %[[VAL_225]], [4 : index, 2 : index, 2 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_238:.*]] = fir.insert_value %[[VAL_237]], %[[VAL_224]], [3 : index, 3 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_239:.*]] = fir.insert_on_range %[[VAL_238]], %[[VAL_225]], [4 : index, 4 : index, 3 : index, 4 : index] : (!fir.array<5x5xf32>, f32) -> !fir.array<5x5xf32>
-   ! CHECK: %[[VAL_240:.*]] = fir.insert_value %[[VAL_226]], %[[VAL_239]], [0 : index] : (tuple<!fir.array<5x5xf32>>, !fir.array<5x5xf32>) -> tuple<!fir.array<5x5xf32>>
-   ! CHECK: fir.has_value %[[VAL_240]] : tuple<!fir.array<5x5xf32>>
   real(selected_real_kind(6)) :: x(5,5)
   common /block/ x
   data x(1,1), x(2,1), x(3,1) / 1, 1, 0 /

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -14,7 +14,6 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   integer a6(6:i,j:*)
   real a7(i:70,7:j,k:80)
 
- 
   ! CHECK-LABEL: BeginExternalListOutput
   ! CHECK-DAG: fir.load %arg3 :
   ! CHECK-DAG: %[[i1:.*]] = subi %{{.*}}, %[[one:c1.*]] :
@@ -76,6 +75,7 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   
 end subroutine s
 
+! CHECK-LABEL: fir.global @_QBblock
 ! CHECK: %[[VAL_1:.*]] = constant 1.000000e+00 : f32
 ! CHECK: %[[VAL_2:.*]] = constant 2.400000e+00 : f32
 ! CHECK: %[[VAL_3:.*]] = constant 0.000000e+00 : f32


### PR DESCRIPTION
Block data programs may initialize common block data, so process them
in a preliminary pass (along with function declarations and module
variables) to give them precedence over other common block declarations.