### PR TITLE
Use name of an equivalence member in local aggregate alloca

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -661,9 +661,9 @@ instantiateAggregateStore(Fortran::lower::AbstractConverter &converter,
   auto &builder = converter.getFirOpBuilder();
   auto i8Ty = builder.getIntegerType(8);
   auto loc = converter.getCurrentLocation();
+  auto aggName = mangleGlobalAggregateStore(var.getAggregateStore());
   if (var.isGlobal()) {
     // The scope of this aggregate is this procedure.
-    auto aggName = mangleGlobalAggregateStore(var.getAggregateStore());
     fir::GlobalOp global = builder.getNamedGlobal(aggName);
     if (!global) {
       auto &aggregate = var.getAggregateStore();
@@ -696,7 +696,7 @@ instantiateAggregateStore(Fortran::lower::AbstractConverter &converter,
   fir::SequenceType::Shape shape(1, size);
   auto seqTy = fir::SequenceType::get(shape, i8Ty);
   auto local =
-      builder.allocateLocal(loc, seqTy, ".aggtmp", "", llvm::None, llvm::None,
+      builder.allocateLocal(loc, seqTy, aggName, "", llvm::None, llvm::None,
                             /*target=*/false);
   insertAggregateStore(storeMap, var, local);
 }

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -4,7 +4,7 @@
 SUBROUTINE s1
   INTEGER i
   REAL r
-  ! CHECK: = fir.alloca !fir.array<4xi8>
+  ! CHECK: = fir.alloca !fir.array<4xi8> {uniq_name = "_QFs1Ei"}
   EQUIVALENCE (r,i)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
   ! CHECK: %[[iloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i32>


### PR DESCRIPTION
".aggtmp" was used as the "uniq_name" in equivalence, but was not uniq at all. Use the mangled name of one the equivalence member instead. The member symbol that gives its name to the local equivalence storage is the first in lexicographical order (just like for global aggregate).