### PR TITLE
[flang][fir] Add external name mangling pass

### DIFF
--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -125,6 +125,13 @@ struct NameUniquer {
   static std::pair<NameKind, DeconstructedName>
   deconstruct(llvm::StringRef uniquedName);
 
+  /// Check if the name is an external facing name.
+  static bool isExternalFacingUniquedName(
+      const std::pair<NameKind, DeconstructedName> &deconstructResult);
+
+  /// Check whether the name should be re-mangle with external ABI convention.
+  static bool needExternalNameMangling(llvm::StringRef uniquedName);
+
 private:
   static std::string intAsString(std::int64_t i);
   static std::string doKind(std::int64_t kind);

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -35,6 +35,7 @@ std::unique_ptr<mlir::Pass> createFirToCfgPass();
 std::unique_ptr<mlir::Pass> createArrayValueCopyPass();
 std::unique_ptr<mlir::Pass> createAbstractResultOptPass();
 std::unique_ptr<mlir::Pass> createCharacterConversionPass();
+std::unique_ptr<mlir::Pass> createExternalNameConversionPass();
 
 /// A pass to convert the FIR dialect from "Mem-SSA" form to "Reg-SSA" form.
 /// This pass is a port of LLVM's mem2reg pass, but modified for the FIR dialect

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -179,4 +179,13 @@ def CharacterConversion : Pass<"character-conversion"> {
   ];
 }
 
+def ExternalNameConversion : Pass<"external-name-interop", "mlir::ModuleOp"> {
+  let summary = "Convert name for external interoperability";
+  let description = [{
+    Demangle FIR internal name and mangle them for external interoperability.
+  }];
+  let constructor = "::fir::createExternalNameConversionPass()";
+  let dependentDialects = [ "fir::FIROpsDialect", "mlir::LLVM::LLVMDialect" ];
+}
+
 #endif // FORTRAN_OPTIMIZER_TRANSFORMS_FIR_PASSES

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -185,7 +185,10 @@ def ExternalNameConversion : Pass<"external-name-interop", "mlir::ModuleOp"> {
     Demangle FIR internal name and mangle them for external interoperability.
   }];
   let constructor = "::fir::createExternalNameConversionPass()";
-  let dependentDialects = [ "fir::FIROpsDialect", "mlir::LLVM::LLVMDialect" ];
+  let dependentDialects = [ 
+    "fir::FIROpsDialect", "mlir::LLVM::LLVMDialect", 
+    "mlir::acc::OpenACCDialect", "mlir::omp::OpenMPDialect" 
+  ];
 }
 
 #endif // FORTRAN_OPTIMIZER_TRANSFORMS_FIR_PASSES

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -298,3 +298,18 @@ fir::NameUniquer::deconstruct(llvm::StringRef uniq) {
   }
   return {NameKind::NOT_UNIQUED, DeconstructedName(uniq)};
 }
+
+bool fir::NameUniquer::isExternalFacingUniquedName(
+    const std::pair<fir::NameUniquer::NameKind,
+                    fir::NameUniquer::DeconstructedName> &deconstructResult) {
+  return (deconstructResult.first == NameKind::PROCEDURE ||
+          deconstructResult.first == NameKind::COMMON) &&
+         deconstructResult.second.modules.empty() &&
+         !deconstructResult.second.host;
+}
+
+bool fir::NameUniquer::needExternalNameMangling(llvm::StringRef uniquedName) {
+  auto result = fir::NameUniquer::deconstruct(uniquedName);
+  return result.first != fir::NameUniquer::NameKind::NOT_UNIQUED &&
+         fir::NameUniquer::isExternalFacingUniquedName(result);
+}

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_flang_library(FIRTransforms
   CharacterConversion.cpp
   ControlFlowConverter.cpp
   CSE.cpp
+  ExternalNameConversion.cpp
   FirLoopResultOpt.cpp
   MemDataFlowOpt.cpp
   MemToReg.cpp

--- a/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
@@ -1,0 +1,184 @@
+//===- ExternalNameConversion.cpp -- convert name with external convention ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Support/InternalNames.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+//===----------------------------------------------------------------------===//
+// Helper functions
+//===----------------------------------------------------------------------===//
+
+/// Mangle the name with gfortran convention.
+std::string
+mangleExternalName(const std::pair<fir::NameUniquer::NameKind,
+                                   fir::NameUniquer::DeconstructedName>
+                       result) {
+  if (result.first == fir::NameUniquer::NameKind::COMMON &&
+      result.second.name.empty())
+    return "__BLNK__";
+  return result.second.name + "_";
+}
+
+//===----------------------------------------------------------------------===//
+// Rewrite patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MangleNameOnCallOp : public mlir::OpRewritePattern<fir::CallOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(fir::CallOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.startRootUpdate(op);
+    auto callee = op.callee();
+    if (callee.hasValue()) {
+      auto result =
+          fir::NameUniquer::deconstruct(callee.getValue().getRootReference());
+      if (fir::NameUniquer::isExternalFacingUniquedName(result))
+        op.calleeAttr(
+            SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
+    }
+    rewriter.finalizeRootUpdate(op);
+    return success();
+  }
+};
+
+struct MangleNameOnFuncOp : public mlir::OpRewritePattern<mlir::FuncOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::FuncOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.startRootUpdate(op);
+    auto result = fir::NameUniquer::deconstruct(op.sym_name());
+    if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
+      op.sym_nameAttr(rewriter.getStringAttr(mangleExternalName(result)));
+    }
+    rewriter.finalizeRootUpdate(op);
+    return success();
+  }
+};
+
+struct MangleNameForCommonBlock : public mlir::OpRewritePattern<fir::GlobalOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(fir::GlobalOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.startRootUpdate(op);
+    auto result = fir::NameUniquer::deconstruct(op.symref().getRootReference());
+    if (fir::NameUniquer::isExternalFacingUniquedName(result))
+      op.symrefAttr(mlir::SymbolRefAttr::get(op.getContext(),
+                                             mangleExternalName(result)));
+    rewriter.finalizeRootUpdate(op);
+    return success();
+  }
+};
+
+struct MangleNameOnAddrOfOp : public mlir::OpRewritePattern<fir::AddrOfOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(fir::AddrOfOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto result = fir::NameUniquer::deconstruct(op.symbol().getRootReference());
+    if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
+      auto newName = rewriter.getSymbolRefAttr(mangleExternalName(result));
+      rewriter.replaceOpWithNewOp<fir::AddrOfOp>(op, op.resTy().getType(),
+                                                 newName);
+    }
+    return success();
+  }
+};
+
+struct MangleNameOnEmboxProcOp
+    : public mlir::OpRewritePattern<fir::EmboxProcOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(fir::EmboxProcOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.startRootUpdate(op);
+    auto result =
+        fir::NameUniquer::deconstruct(op.funcname().getRootReference());
+    if (fir::NameUniquer::isExternalFacingUniquedName(result))
+      op.funcnameAttr(
+          SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
+    rewriter.finalizeRootUpdate(op);
+    return success();
+  }
+};
+
+class ExternalNameConversionPass
+    : public fir::ExternalNameConversionBase<ExternalNameConversionPass> {
+public:
+  mlir::ModuleOp getModule() { return getOperation(); }
+  void runOnOperation() override;
+};
+} // namespace
+
+void ExternalNameConversionPass::runOnOperation() {
+  auto op = getOperation();
+  auto *context = &getContext();
+
+  mlir::OwningRewritePatternList patterns(context);
+  patterns.insert<MangleNameOnCallOp, MangleNameOnCallOp, MangleNameOnFuncOp,
+                  MangleNameForCommonBlock, MangleNameOnAddrOfOp,
+                  MangleNameOnEmboxProcOp>(context);
+
+  ConversionTarget target(*context);
+  target.addLegalDialect<fir::FIROpsDialect, LLVM::LLVMDialect,
+                         acc::OpenACCDialect, omp::OpenMPDialect>();
+
+  target.addDynamicallyLegalOp<fir::CallOp>([](fir::CallOp op) {
+    if (op.callee().hasValue())
+      return !fir::NameUniquer::needExternalNameMangling(
+          op.callee().getValue().getRootReference());
+    return true;
+  });
+
+  target.addDynamicallyLegalOp<mlir::FuncOp>([](mlir::FuncOp op) {
+    return !fir::NameUniquer::needExternalNameMangling(op.sym_name());
+  });
+
+  target.addDynamicallyLegalOp<fir::GlobalOp>([](fir::GlobalOp op) {
+    return !fir::NameUniquer::needExternalNameMangling(
+        op.symref().getRootReference());
+  });
+
+  target.addDynamicallyLegalOp<fir::AddrOfOp>([](fir::AddrOfOp op) {
+    return !fir::NameUniquer::needExternalNameMangling(
+        op.symbol().getRootReference());
+  });
+
+  target.addDynamicallyLegalOp<fir::EmboxProcOp>([](fir::EmboxProcOp op) {
+    return !fir::NameUniquer::needExternalNameMangling(
+        op.funcname().getRootReference());
+  });
+
+  if (failed(applyPartialConversion(op, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> fir::createExternalNameConversionPass() {
+  return std::make_unique<ExternalNameConversionPass>();
+}

--- a/flang/lib/Optimizer/Transforms/PassDetail.h
+++ b/flang/lib/Optimizer/Transforms/PassDetail.h
@@ -11,6 +11,7 @@
 
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Pass/Pass.h"

--- a/flang/lib/Optimizer/Transforms/PassDetail.h
+++ b/flang/lib/Optimizer/Transforms/PassDetail.h
@@ -12,6 +12,8 @@
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Pass/Pass.h"

--- a/flang/test/Fir/external-mangling.fir
+++ b/flang/test/Fir/external-mangling.fir
@@ -1,0 +1,42 @@
+// RUN: fir-opt --external-name-interop %s | FileCheck %s
+// RUN: tco --external-name-interop %s | FileCheck %s
+// RUN: tco --external-name-interop %s | tco | FileCheck %s --check-prefix=LLVMIR
+
+func @_QPfoo() {  
+  %c0 = constant 0 : index
+  %0 = fir.address_of(@_QBa) : !fir.ref<!fir.array<4xi8>>
+  %1 = fir.convert %0 : (!fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<?xi8>>
+  %2 = fir.coordinate_of %1, %c0 : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+  %3 = fir.convert %2 : (!fir.ref<i8>) -> !fir.ref<i32>
+  %4 = fir.address_of(@_QB) : !fir.ref<!fir.array<4xi8>>
+  %5 = fir.convert %4 : (!fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<?xi8>>
+  %6 = fir.coordinate_of %5, %c0 : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+  %7 = fir.convert %6 : (!fir.ref<i8>) -> !fir.ref<f32>
+  fir.call @_QPbar(%3) : (!fir.ref<i32>) -> ()
+  fir.call @_QPbar2(%7) : (!fir.ref<f32>) -> ()
+  %e6 = fir.alloca tuple<i32,f64>
+  %8 = fir.emboxproc @_QPfoo_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
+  return
+}
+fir.global common @_QBa(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+fir.global common @_QB(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+func private @_QPbar(!fir.ref<i32>)
+func private @_QPbar2(!fir.ref<f32>)
+
+// CHECK: func @foo_
+// CHECK: %{{.*}} = fir.address_of(@a_) : !fir.ref<!fir.array<4xi8>>
+// CHECK: %{{.*}} = fir.address_of(@__BLNK__) : !fir.ref<!fir.array<4xi8>>
+// CHECK: fir.call @bar_
+// CHECK: fir.call @bar2_
+// CHECK: %{{.*}}= fir.emboxproc @foo_impl_
+// CHECK: fir.global common @a_(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+// CHECK: fir.global common @__BLNK__(dense<0> : vector<4xi8>) : !fir.array<4xi8>
+// CHECK: func private @bar_(!fir.ref<i32>)
+
+// LLVMIR: @a_ = common global [4 x i8] zeroinitializer
+// LLVMIR: @__BLNK__ = common global [4 x i8] zeroinitializer
+// LLVMIR: define void @foo_()
+// LLVMIR: call void @bar_(
+// LLVMIR: call void @bar2_(
+// LLVMIR: declare void @bar_(
+// LLVMIR: declare void @bar2_(

--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -210,4 +210,36 @@ TEST(InternalNamesTest, complexdeconstructTest) {
   validateDeconstructedName(actual, expectedNameKind, expectedComponents);
 }
 
+TEST(InternalNamesTest, needExternalNameMangling) {
+  ASSERT_FALSE(
+      NameUniquer::needExternalNameMangling("_QMmodSs1modSs2modFsubPfun"));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling("omp_num_thread"));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling(""));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling("_QDTmytypeK2K8K18"));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling("exit_"));
+  ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QPfoo"));
+  ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QPbar"));
+  ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QBa"));
+}
+
+TEST(InternalNamesTest, isExternalFacingUniquedName) {
+  std::pair result = NameUniquer::deconstruct("_QMmodSs1modSs2modFsubPfun");
+
+  ASSERT_FALSE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("omp_num_thread");
+  ASSERT_FALSE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("");
+  ASSERT_FALSE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("_QDTmytypeK2K8K18");
+  ASSERT_FALSE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("exit_");
+  ASSERT_FALSE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("_QPfoo");
+  ASSERT_TRUE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("_QPbar");
+  ASSERT_TRUE(NameUniquer::isExternalFacingUniquedName(result));
+  result = NameUniquer::deconstruct("_QBa");
+  ASSERT_TRUE(NameUniquer::isExternalFacingUniquedName(result));
+}
+
 // main() from gtest_main


### PR DESCRIPTION
The patch add a new pass called `ExternalNameConversion`. It converts the FIR internal name with the gfortran external name convention. 

The pass is not applied by default in `tco`. 

