### PR TITLE
[NFC] Unify headers in lib/Lower and lib/Optimizer

### DIFF
--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -1,4 +1,4 @@
-//===-- CallInterface.cpp -- Procedure call interface ------*- C++ -*-===//
+//===-- CallInterface.cpp -- Procedure call interface ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -1,4 +1,4 @@
-//===-- SymbolMap.cpp -------------------------------------------*- C++ -*-===//
+//===-- SymbolMap.cpp -----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -1,4 +1,4 @@
-//===-- BoxValue.cpp -------------------------------------------*- C++ -*-===//
+//===-- BoxValue.cpp ------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -1,4 +1,4 @@
-//===- AbstractResult.cpp - Conversion of Abstract Function Result    ---*-===//
+//===- AbstractResult.cpp - Conversion of Abstract Function Result --------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
@@ -1,4 +1,4 @@
-//===- CharacterConversion.cpp -- convert between character encodings ---*-===//
+//===- CharacterConversion.cpp -- convert between character encodings -----===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Optimizer/Transforms/FirLoopResultOpt.cpp
+++ b/flang/lib/Optimizer/Transforms/FirLoopResultOpt.cpp
@@ -1,4 +1,4 @@
-//===- FirLoopResultOpt.cpp - Optimization pass for fir loops    ------ -*-===//
+//===- FirLoopResultOpt.cpp - Optimization pass for fir loops -------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Optimizer/Transforms/MemDataFlowOpt.cpp
+++ b/flang/lib/Optimizer/Transforms/MemDataFlowOpt.cpp
@@ -1,4 +1,4 @@
-//===- MemRefDataFlowOpt.cpp - Memory DataFlow Optimization pass ------ -*-===//
+//===- MemRefDataFlowOpt.cpp - Memory DataFlow Optimization pass ----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Some of the `.cpp` files in `lib/Lower` and `lib/Optimizer` have residual * from EMACS tag. Since this is not necessary for cpp files this PR just use the same header for all files. 

https://llvm.org/docs/CodingStandards.html#file-headers