### PR TITLE
[OpenMP] Fix assertion when array slice is passed as an argument in parallel

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -983,8 +983,23 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
                     mlir::ConversionPatternRewriter &rewriter) const {
     auto thisPt = rewriter.saveInsertionPoint();
     auto *thisBlock = rewriter.getInsertionBlock();
-    auto func = mlir::cast<mlir::LLVM::LLVMFuncOp>(thisBlock->getParentOp());
-    rewriter.setInsertionPointToStart(&func.front());
+    auto op = thisBlock->getParentOp();
+    // Order to find the Op in whose entry block the alloca should be inserted.
+    // The parent Op if it is an LLVM Function Op.
+    // The ancestor OpenMP Op which is outlineable.
+    // The ancestor LLVM Function Op.
+    if (isa<mlir::LLVM::LLVMFuncOp>(op)) {
+      auto func = mlir::cast<mlir::LLVM::LLVMFuncOp>(op);
+      rewriter.setInsertionPointToStart(&func.front());
+    } else if (auto iface =
+                   thisBlock->getParent()
+                       ->getParentOfType<
+                           mlir::omp::OutlineableOpenMPOpInterface>()) {
+      rewriter.setInsertionPointToStart(iface.getAllocaBlock());
+    } else {
+      auto func = op->getParentOfType<mlir::LLVM::LLVMFuncOp>();
+      rewriter.setInsertionPointToStart(&func.front());
+    }
     auto sz = this->genConstantOffset(loc, rewriter, 1);
     auto al = rewriter.create<mlir::LLVM::AllocaOp>(loc, toTy, sz, alignment);
     rewriter.restoreInsertionPoint(thisPt);

--- a/flang/test/Lower/OpenMP/omp-parallel-alloca-fix.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-alloca-fix.f90
@@ -1,0 +1,64 @@
+! This test checks passing an array slice in a parallel region
+
+! RUN: bbc -fopenmp %s -o - | tco 2>&1 | FileCheck %s
+
+! CHECK-LABEL: @_QPsb1..omp_par
+! CHECK-LABEL: omp.par.region1
+! CHECK:   %[[SB1_MAT:.*]] = alloca { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, align 8
+! CHECK:   %[[SB1_MAT1:.*]] = getelementptr { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[SB1_MAT]], i32 0, i32 0
+! CHECK:   %[[SB1_MAT2:.*]] = load i32*, i32** %[[SB1_MAT1]], align 8
+! CHECK:   %[[SB1_MAT3:.*]] = bitcast i32* %[[SB1_MAT2]] to [3 x i32]*
+! CHECK:   call void @_QPouter_src_calc([3 x i32]* %[[SB1_MAT3]])
+
+subroutine sb1
+  IMPLICIT NONE
+  INTEGER, DIMENSION(3, 3) :: mat
+  INTEGER :: k
+
+  !$OMP PARALLEL
+  DO k = 1, 2
+     CALL outer_src_calc (  mat(:,k) )
+  END DO
+  !$OMP END PARALLEL
+end subroutine
+
+! CHECK-LABEL: @_QPsb2..omp_par
+! CHECK-LABEL: omp.par.region1
+! CHECK:   %[[SB2_MAT:.*]] = alloca { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, align 8
+! CHECK:   call i32 @__kmpc_master
+! CHECK:   %[[SB2_MAT1:.*]] = getelementptr { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[SB2_MAT]], i32 0, i32 0
+! CHECK:   %[[SB2_MAT2:.*]] = load i32*, i32** %[[SB2_MAT1]], align 8
+! CHECK:   %[[SB2_MAT3:.*]] = bitcast i32* %[[SB2_MAT2]] to [3 x i32]*
+! CHECK:   call void @_QPouter_src_calc([3 x i32]* %[[SB2_MAT3]])
+subroutine sb2
+  IMPLICIT NONE
+  INTEGER, DIMENSION(3, 3) :: mat
+  INTEGER :: k
+
+  !$OMP PARALLEL
+  !$OMP MASTER
+  DO k = 1, 2
+     CALL outer_src_calc (  mat(:,k) )
+  END DO
+  !$OMP END MASTER
+  !$OMP END PARALLEL
+end subroutine
+
+! CHECK-LABEL: @_QPsb3
+! CHECK:   %[[SB3_MAT:.*]] = alloca { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, align 8
+! CHECK:   call i32 @__kmpc_master
+! CHECK:   %[[SB3_MAT1:.*]] = getelementptr { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[SB3_MAT]], i32 0, i32 0
+! CHECK:   %[[SB3_MAT2:.*]] = load i32*, i32** %[[SB3_MAT1]], align 8
+! CHECK:   %[[SB3_MAT3:.*]] = bitcast i32* %[[SB3_MAT2]] to [3 x i32]*
+! CHECK:   call void @_QPouter_src_calc([3 x i32]* %[[SB3_MAT3]])
+subroutine sb3
+  IMPLICIT NONE
+  INTEGER, DIMENSION(3, 3) :: mat
+  INTEGER :: k
+
+  !$OMP MASTER
+  DO k = 1, 2
+     CALL outer_src_calc (  mat(:,k) )
+  END DO
+  !$OMP END MASTER
+end subroutine


### PR DESCRIPTION
This patch fixes an assertion failure when an array slice is passed in a function argument in a parallel region. The conversion pattern for an operation creates an alloca operation while converting to LLVM Dialect. It expects the parent operation to be an LLVM Function Op. In the presence of OpenMP, the parent operation can be an OpenMP Operation. In this case, we have to either find an Outlineable OpenMP ancestor Op or an ancestor LLVM Function Op to insert the alloca.