### PR TITLE
[flang] Add lowering stubs for OpenMP/OpenACC declarative constructs

### DIFF
--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -16,6 +16,7 @@
 namespace Fortran {
 namespace parser {
 struct OpenACCConstruct;
+struct OpenACCDeclarativeConstruct;
 } // namespace parser
 
 namespace lower {
@@ -28,6 +29,9 @@ struct Evaluation;
 
 void genOpenACCConstruct(AbstractConverter &, pft::Evaluation &,
                          const parser::OpenACCConstruct &);
+void genOpenACCDeclarativeConstruct(
+    AbstractConverter &, pft::Evaluation &,
+    const parser::OpenACCDeclarativeConstruct &);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/include/flang/Lower/OpenMP.h
+++ b/flang/include/flang/Lower/OpenMP.h
@@ -18,6 +18,7 @@
 namespace Fortran {
 namespace parser {
 struct OpenMPConstruct;
+struct OpenMPDeclarativeConstruct;
 struct OmpEndLoopDirective;
 struct OmpClauseList;
 } // namespace parser
@@ -32,6 +33,8 @@ struct Evaluation;
 
 void genOpenMPConstruct(AbstractConverter &, pft::Evaluation &,
                         const parser::OpenMPConstruct &);
+void genOpenMPDeclarativeConstruct(AbstractConverter &, pft::Evaluation &,
+                                   const parser::OpenMPDeclarativeConstruct &);
 
 int64_t getCollapseValue(const Fortran::parser::OmpClauseList &clauseList);
 

--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -134,7 +134,9 @@ using Constructs =
 
 using Directives =
     std::tuple<parser::CompilerDirective, parser::OpenACCConstruct,
-               parser::OpenMPConstruct, parser::OmpEndLoopDirective>;
+               parser::OpenMPConstruct, parser::OmpEndLoopDirective,
+               parser::OpenMPDeclarativeConstruct,
+               parser::OpenACCDeclarativeConstruct>;
 
 template <typename A>
 static constexpr bool isActionStmt{common::HasMember<A, ActionStmts>};

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1359,6 +1359,14 @@ private:
     builder->restoreInsertionPoint(insertPt);
   }
 
+  void genFIR(const Fortran::parser::OpenACCDeclarativeConstruct &accDecl) {
+    auto insertPt = builder->saveInsertionPoint();
+    genOpenACCDeclarativeConstruct(*this, getEval(), accDecl);
+    for (auto &e : getEval().getNestedEvaluations())
+      genFIR(e);
+    builder->restoreInsertionPoint(insertPt);
+  }
+
   void genFIR(const Fortran::parser::OpenMPConstruct &omp) {
     auto insertPt = builder->saveInsertionPoint();
     localSymbols.pushScope();
@@ -1388,6 +1396,14 @@ private:
     for (auto &e : curEval->getNestedEvaluations())
       genFIR(e);
     localSymbols.popScope();
+    builder->restoreInsertionPoint(insertPt);
+  }
+
+  void genFIR(const Fortran::parser::OpenMPDeclarativeConstruct &ompDecl) {
+    auto insertPt = builder->saveInsertionPoint();
+    genOpenMPDeclarativeConstruct(*this, getEval(), ompDecl);
+    for (auto &e : getEval().getNestedEvaluations())
+      genFIR(e);
     builder->restoreInsertionPoint(insertPt);
   }
 

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -1022,11 +1022,6 @@ void Fortran::lower::genOpenACCConstruct(
                   &standaloneConstruct) {
             genACC(converter, eval, standaloneConstruct);
           },
-          [&](const Fortran::parser::OpenACCRoutineConstruct
-                  &routineConstruct) {
-            TODO(converter.genLocation(),
-                 "OpenACC Routine construct not lowered yet!");
-          },
           [&](const Fortran::parser::OpenACCCacheConstruct &cacheConstruct) {
             TODO(converter.genLocation(),
                  "OpenACC Cache construct not lowered yet!");
@@ -1040,4 +1035,25 @@ void Fortran::lower::genOpenACCConstruct(
           },
       },
       accConstruct.u);
+}
+
+void Fortran::lower::genOpenACCDeclarativeConstruct(
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::lower::pft::Evaluation &eval,
+    const Fortran::parser::OpenACCDeclarativeConstruct &accDeclConstruct) {
+
+  std::visit(
+      common::visitors{
+          [&](const Fortran::parser::OpenACCStandaloneDeclarativeConstruct
+                  &standaloneDeclarativeConstruct) {
+            TODO(converter.genLocation(),
+                 "OpenACC Standalone Declarative construct not lowered yet!");
+          },
+          [&](const Fortran::parser::OpenACCRoutineConstruct
+                  &routineConstruct) {
+            TODO(converter.genLocation(),
+                 "OpenACC Routine construct not lowered yet!");
+          },
+      },
+      accDeclConstruct.u);
 }

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -632,3 +632,35 @@ void Fortran::lower::genOpenMPConstruct(
       },
       ompConstruct.u);
 }
+
+void Fortran::lower::genOpenMPDeclarativeConstruct(
+    Fortran::lower::AbstractConverter &converter,
+    Fortran::lower::pft::Evaluation &eval,
+    const Fortran::parser::OpenMPDeclarativeConstruct &ompDeclConstruct) {
+
+  std::visit(
+      common::visitors{
+          [&](const Fortran::parser::OpenMPDeclarativeAllocate
+                  &declarativeAllocate) {
+            TODO(converter.getCurrentLocation(), "OpenMPDeclarativeAllocate");
+          },
+          [&](const Fortran::parser::OpenMPDeclareReductionConstruct
+                  &declareReductionConstruct) {
+            TODO(converter.getCurrentLocation(),
+                 "OpenMPDeclareReductionConstruct");
+          },
+          [&](const Fortran::parser::OpenMPDeclareSimdConstruct
+                  &declareSimdConstruct) {
+            TODO(converter.getCurrentLocation(), "OpenMPDeclareSimdConstruct");
+          },
+          [&](const Fortran::parser::OpenMPDeclareTargetConstruct
+                  &declareTargetConstruct) {
+            TODO(converter.getCurrentLocation(),
+                 "OpenMPDeclareTargetConstruct");
+          },
+          [&](const Fortran::parser::OpenMPThreadprivate &threadprivate) {
+            TODO(converter.getCurrentLocation(), "OpenMPThreadprivate");
+          },
+      },
+      ompDeclConstruct.u);
+}

--- a/flang/test/Lower/OpenACC/acc-declare.f90
+++ b/flang/test/Lower/OpenACC/acc-declare.f90
@@ -1,0 +1,9 @@
+! This test checks lowering of OpenACC declare Directive.
+! XFAIL: *
+! RUN: %bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+
+program main
+  real, dimension(10) :: aa, bb
+
+  !$acc declare present(aa, bb)
+end

--- a/flang/test/Lower/OpenACC/acc-routine.f90
+++ b/flang/test/Lower/OpenACC/acc-routine.f90
@@ -1,0 +1,11 @@
+! This test checks lowering of OpenACC routine Directive.
+! XFAIL: *
+! RUN: %bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+
+program main
+  !$acc routine(sub) seq
+contains
+  subroutine sub(a)
+    real :: a(:)
+  end
+end

--- a/flang/test/Lower/OpenMP/omp-declarative-allocate.f90
+++ b/flang/test/Lower/OpenMP/omp-declarative-allocate.f90
@@ -1,0 +1,10 @@
+! This test checks lowering of OpenMP allocate Directive.
+! XFAIL: *
+! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+program main
+  integer :: x, y
+
+  !$omp allocate(x, y)
+end

--- a/flang/test/Lower/OpenMP/omp-declare-reduction.f90
+++ b/flang/test/Lower/OpenMP/omp-declare-reduction.f90
@@ -1,0 +1,10 @@
+! This test checks lowering of OpenMP declare reduction Directive.
+! XFAIL: *
+! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+subroutine declare_red()
+  integer :: my_var
+  !$omp declare reduction (my_red : integer : omp_out = omp_in) initializer (omp_priv = 0)
+  my_var = 0
+end subroutine declare_red

--- a/flang/test/Lower/OpenMP/omp-declare-simd.f90
+++ b/flang/test/Lower/OpenMP/omp-declare-simd.f90
@@ -1,0 +1,11 @@
+! This test checks lowering of OpenMP declare simd Directive.
+! XFAIL: *
+! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+subroutine sub(x, y)
+  real, intent(inout) :: x, y
+
+  !$omp declare simd(sub) aligned(x)
+  x = 3.14 + y
+end

--- a/flang/test/Lower/OpenMP/omp-declare-target.f90
+++ b/flang/test/Lower/OpenMP/omp-declare-target.f90
@@ -1,0 +1,12 @@
+! This test checks lowering of OpenMP declare target Directive.
+! XFAIL: *
+! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+module mod1
+contains
+  subroutine sub()
+    integer :: x, y
+    !$omp declare target
+  end
+end module

--- a/flang/test/Lower/OpenMP/omp-threadprivate.f90
+++ b/flang/test/Lower/OpenMP/omp-threadprivate.f90
@@ -1,0 +1,10 @@
+! This test checks lowering of OpenMP threadprivate Directive.
+! XFAIL: *
+! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
+! RUN:   FileCheck %s --check-prefix=FIRDialect
+
+program main
+  integer, save :: x, y
+
+  !$omp threadprivate(x, y)
+end


### PR DESCRIPTION
This patch provides the basic infrastructure for lowering declarative constructs for OpenMP and OpenACC.

Could anyone please take a look if I should add `OpenMPDeclarativeConstruct` and `OpenACCDeclarativeConstruct` in `Directives` definition? In this way, they are added in `evaluationList` of `Fortran::lower::pft::FunctionLikeUnit` and the lowering function is emited by `genFIR`. The declarative constructs should be in the front of `evaluationList` before any execution statements. I think the lowering function for OpenMP/OpenACC declarative construct can be emitted in `startNewFunction` after creating variables or `genFIR`. Emiting in `genFIR` do not need extra code fix.

Or could anyone provide one more better design to add `OpenMPDeclarativeConstruct` and `OpenACCDeclarativeConstruct`?