### PR TITLE
Lower elemental subroutine calls (outside of user assignment case)

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -186,6 +186,16 @@ createSomeArrayBox(AbstractConverter &converter,
                    const evaluate::Expr<evaluate::SomeType> &expr,
                    SymMap &symMap, StatementContext &stmtCtx);
 
+/// Lower a subroutine call. This handles both elemental and non elemental
+/// subroutines. \p isUserDefAssignment must be set if this is called in the
+/// context of a user defined assignment. For subroutines with alternate
+/// returns, the returned value indicates which label the code should jump to.
+/// The returned value is null otherwise.
+mlir::Value createSubroutineCall(AbstractConverter &converter,
+                                 const evaluate::Expr<evaluate::SomeType> &call,
+                                 SymMap &symMap, StatementContext &stmtCtx,
+                                 bool isUserDefAssignment);
+
 // Attribute for an alloca that is a trivial adaptor for converting a value to
 // pass-by-ref semantics for a VALUE parameter. The optimizer may be able to
 // eliminate these.

--- a/flang/test/Lower/array-elemental-subroutines.f90
+++ b/flang/test/Lower/array-elemental-subroutines.f90
@@ -1,0 +1,64 @@
+! Test lowering of elemental subroutine calls with array arguments
+! RUN: bbc -o - -emit-fir %s | FileCheck %s
+
+! CHECK-LABEL: func @_QPtest_elem_sub(
+! CHECK-SAME:                         %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>,
+! CHECK-SAME:                         %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>,
+! CHECK-SAME:                         %[[VAL_2:.*]]: !fir.ref<i32>,
+! CHECK-SAME:                         %[[VAL_3:.*]]: !fir.ref<!fir.complex<4>>) {
+subroutine test_elem_sub(x, c, i, z)
+  real :: x(:)
+  character(*) :: c(:)
+  integer :: i
+  complex :: z
+  interface
+    elemental subroutine foo(x, c, i, z)
+      real, intent(out) :: x
+      character(*), intent(inout) :: c
+      integer, intent(in) :: i
+      complex, value :: z
+    end subroutine
+  end interface
+
+  call foo(x, c(10:1:-1), i, z)
+  ! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.complex<4> {adapt.valuebyref}
+  ! CHECK:         %[[VAL_5:.*]] = constant 10 : i64
+  ! CHECK:         %[[VAL_6:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_7:.*]] = constant -1 : i64
+  ! CHECK:         %[[VAL_8:.*]] = fir.slice %[[VAL_5]], %[[VAL_6]], %[[VAL_7]] : (i64, i64, i64) -> !fir.slice<1>
+  ! CHECK:         %[[VAL_9:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.complex<4>>
+  ! CHECK:         fir.store %[[VAL_9]] to %[[VAL_4]] : !fir.ref<!fir.complex<4>>
+  ! CHECK:         %[[VAL_10:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_10]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+  ! CHECK:         %[[VAL_12:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_13:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_14:.*]] = subi %[[VAL_11]]#1, %[[VAL_12]] : index
+  ! CHECK:         fir.do_loop %[[VAL_15:.*]] = %[[VAL_13]] to %[[VAL_14]] step %[[VAL_12]] {
+  ! CHECK:           %[[VAL_16:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_17:.*]] = addi %[[VAL_15]], %[[VAL_16]] : index
+  ! CHECK:           %[[VAL_18:.*]] = fir.array_coor %[[VAL_0]] %[[VAL_17]] : (!fir.box<!fir.array<?xf32>>, index) -> !fir.ref<f32>
+  ! CHECK:           %[[VAL_19:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_20:.*]] = addi %[[VAL_15]], %[[VAL_19]] : index
+  ! CHECK:           %[[VAL_21:.*]] = fir.array_coor %[[VAL_1]] {{\[}}%[[VAL_8]]] %[[VAL_20]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>, !fir.slice<1>, index) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK:           %[[VAL_22:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+  ! CHECK:           %[[VAL_23:.*]] = fir.emboxchar %[[VAL_21]], %[[VAL_22]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK:           fir.call @_QPfoo(%[[VAL_18]], %[[VAL_23]], %[[VAL_2]], %[[VAL_4]]) : (!fir.ref<f32>, !fir.boxchar<1>, !fir.ref<i32>, !fir.ref<!fir.complex<4>>) -> ()
+  ! CHECK:         }
+  ! CHECK:         return
+  ! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_elem_sub_no_array_args(
+! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<i32>,
+! CHECK-SAME:                                       %[[VAL_1:.*]]: !fir.ref<i32>) {
+subroutine test_elem_sub_no_array_args(i, j)
+  integer :: i, j
+  interface
+    elemental subroutine bar(i, j)
+      integer, intent(out) :: i
+      integer, intent(in) :: j
+    end subroutine
+  end interface
+  call bar(i, j)
+  ! CHECK:         fir.call @_QPbar(%[[VAL_0]], %[[VAL_1]]) : (!fir.ref<i32>, !fir.ref<i32>) -> ()
+end subroutine

--- a/flang/test/Lower/forall.f90
+++ b/flang/test/Lower/forall.f90
@@ -613,26 +613,26 @@ subroutine test_nested_forall_where(a,b)
   ! CHECK:             %[[VAL_99:.*]] = fir.convert %[[VAL_98]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
   ! CHECK:             %[[VAL_100:.*]] = fir.shape %[[VAL_97]] : (index) -> !fir.shape<1>
   ! CHECK:             %[[VAL_101:.*]] = fir.array_load %[[VAL_99]](%[[VAL_100]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
-  ! CHECK:             %[[VAL_102:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_103:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_104:.*]] = subi %[[VAL_97]], %[[VAL_102]] : index
-  ! CHECK:             %[[VAL_105:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:             %[[VAL_106:.*]] = fir.convert %[[VAL_105]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:             %[[VAL_107:.*]] = fir.convert %[[VAL_106]] : (!fir.heap<!fir.array<?xi8>>) -> i64
-  ! CHECK:             %[[VAL_108:.*]] = constant 0 : i64
-  ! CHECK:             %[[VAL_109:.*]] = cmpi eq, %[[VAL_107]], %[[VAL_108]] : i64
-  ! CHECK:             fir.if %[[VAL_109]] {
-  ! CHECK:               %[[VAL_110:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_97]] {uniq_name = ".lazy.mask"}
-  ! CHECK:               %[[VAL_111:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
-  ! CHECK:               fir.store %[[VAL_110]] to %[[VAL_111]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
-  ! CHECK:               %[[VAL_112:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
-  ! CHECK:               %[[VAL_113:.*]] = constant 0 : index
-  ! CHECK:               %[[VAL_114:.*]] = fir.coordinate_of %[[VAL_112]], %[[VAL_113]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
-  ! CHECK:               fir.store %[[VAL_97]] to %[[VAL_114]] : !fir.ref<index>
-  ! CHECK:               %[[VAL_115:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
-  ! CHECK:               fir.store %[[VAL_112]] to %[[VAL_115]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:             %[[VAL_102:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             %[[VAL_104:.*]] = fir.convert %[[VAL_103]] : (!fir.heap<!fir.array<?xi8>>) -> i64
+  ! CHECK:             %[[VAL_105:.*]] = constant 0 : i64
+  ! CHECK:             %[[VAL_106:.*]] = cmpi eq, %[[VAL_104]], %[[VAL_105]] : i64
+  ! CHECK:             fir.if %[[VAL_106]] {
+  ! CHECK:               %[[VAL_107:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_97]] {uniq_name = ".lazy.mask"}
+  ! CHECK:               %[[VAL_108:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:               fir.store %[[VAL_107]] to %[[VAL_108]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:               %[[VAL_109:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
+  ! CHECK:               %[[VAL_110:.*]] = constant 0 : index
+  ! CHECK:               %[[VAL_111:.*]] = fir.coordinate_of %[[VAL_109]], %[[VAL_110]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
+  ! CHECK:               fir.store %[[VAL_97]] to %[[VAL_111]] : !fir.ref<index>
+  ! CHECK:               %[[VAL_112:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:               fir.store %[[VAL_109]] to %[[VAL_112]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
   ! CHECK:             }
-  ! CHECK:             %[[VAL_116:.*]] = fir.do_loop %[[VAL_117:.*]] = %[[VAL_103]] to %[[VAL_104]] step %[[VAL_102]] unordered iter_args(%[[VAL_118:.*]] = %[[VAL_101]]) -> (!fir.array<?xi8>) {
+  ! CHECK:             %[[VAL_113:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_114:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_115:.*]] = subi %[[VAL_97]], %[[VAL_113]] : index
+  ! CHECK:             %[[VAL_116:.*]] = fir.do_loop %[[VAL_117:.*]] = %[[VAL_114]] to %[[VAL_115]] step %[[VAL_113]] unordered iter_args(%[[VAL_118:.*]] = %[[VAL_101]]) -> (!fir.array<?xi8>) {
   ! CHECK:               %[[VAL_119:.*]] = fir.array_fetch %[[VAL_90]], %[[VAL_117]] : (!fir.array<100xf32>, index) -> f32
   ! CHECK:               %[[VAL_120:.*]] = cmpf ogt, %[[VAL_119]], %[[VAL_91]] : f32
   ! CHECK:               %[[VAL_121:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>

--- a/flang/test/Lower/intrinsic-procedures/mvbits.f90
+++ b/flang/test/Lower/intrinsic-procedures/mvbits.f90
@@ -33,3 +33,47 @@ function mvbits_test(from, frompos, len, to, topos)
   mvbits_test = to
 end
 
+! CHECK-LABEL: func @_QPmvbits_array_test(
+! CHECK-SAME:                             %[[VAL_0:[^:]+]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                             %[[VAL_1:[^:]+]]: !fir.ref<i32>,
+! CHECK-SAME:                             %[[VAL_2:[^:]+]]: !fir.ref<i32>,
+! CHECK-SAME:                             %[[VAL_3:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                             %[[VAL_4:.*]]: !fir.ref<i32>) {
+subroutine mvbits_array_test(from, frompos, len, to, topos)
+  integer :: from(:), frompos, len, to(:), topos
+
+  call mvbits(from, frompos, len, to, topos)
+  ! CHECK:         %[[VAL_5:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+  ! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+  ! CHECK:         %[[VAL_7:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:         %[[VAL_9:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_10:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_9]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+  ! CHECK:         %[[VAL_11:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_12:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_13:.*]] = subi %[[VAL_10]]#1, %[[VAL_11]] : index
+  ! CHECK:         fir.do_loop %[[VAL_14:.*]] = %[[VAL_12]] to %[[VAL_13]] step %[[VAL_11]] {
+  ! CHECK:           %[[VAL_15:.*]] = fir.array_fetch %[[VAL_5]], %[[VAL_14]] : (!fir.array<?xi32>, index) -> i32
+  ! CHECK:           %[[VAL_16:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_17:.*]] = addi %[[VAL_14]], %[[VAL_16]] : index
+  ! CHECK:           %[[VAL_18:.*]] = fir.array_coor %[[VAL_3]] %[[VAL_17]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+  ! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_18]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_20:.*]] = constant 0 : i32
+  ! CHECK:           %[[VAL_21:.*]] = constant -1 : i32
+  ! CHECK:           %[[VAL_22:.*]] = constant 32 : i32
+  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_22]], %[[VAL_7]] : i32
+  ! CHECK:           %[[VAL_24:.*]] = shift_right_unsigned %[[VAL_21]], %[[VAL_23]] : i32
+  ! CHECK:           %[[VAL_25:.*]] = shift_left %[[VAL_24]], %[[VAL_8]] : i32
+  ! CHECK:           %[[VAL_26:.*]] = xor %[[VAL_25]], %[[VAL_21]] : i32
+  ! CHECK:           %[[VAL_27:.*]] = and %[[VAL_26]], %[[VAL_19]] : i32
+  ! CHECK:           %[[VAL_28:.*]] = shift_right_unsigned %[[VAL_15]], %[[VAL_6]] : i32
+  ! CHECK:           %[[VAL_29:.*]] = and %[[VAL_28]], %[[VAL_24]] : i32
+  ! CHECK:           %[[VAL_30:.*]] = shift_left %[[VAL_29]], %[[VAL_8]] : i32
+  ! CHECK:           %[[VAL_31:.*]] = or %[[VAL_27]], %[[VAL_30]] : i32
+  ! CHECK:           %[[VAL_32:.*]] = cmpi eq, %[[VAL_7]], %[[VAL_20]] : i32
+  ! CHECK:           %[[VAL_33:.*]] = select %[[VAL_32]], %[[VAL_19]], %[[VAL_31]] : i32
+  ! CHECK:           fir.store %[[VAL_33]] to %[[VAL_18]] : !fir.ref<i32>
+  ! CHECK:         }
+  ! CHECK:         return
+  ! CHECK:       }
+end subroutine


### PR DESCRIPTION
Use the array lowering framework to lower elemental subroutine.
This required:

- Splitting the part of genIterSpace that creates the
  implicit loops into a new genImplicitLoops function. genIterspace
  deals with the destination and other explicit contexts set-ups that
  do not matter in the subroutine case (there is no destination).
  Other than having no destination, a big difference is that there is
  no threaded innerArg. genImplicitLoops handles this variation.

- Fixing a bug in the iteration shape determination. The code was
  assuming there would always be at least one array_load, which is
  not true if there are only RefTransparent operands. This is always
  true in the subroutine case, but was actually also an issue for things
  like `print *, elem_func(array)` with the previous code (compile crash).
  Add a new ArrayOperands structure to keep track of what matters to
  later deduce the shape of the array expression instead of keeping
  track of array_loads for that purpose.

- Elemental subroutine with intent(out)/intent(inout) arguments must be
  applied "in array element order" (15.8.3). It turns out this is also
  the case for impure elemental functions (10.1.4 p5). Instead of always
  creating loops as "unordered=true" add an unordered field to the ArrayExprLowering
  class. It is set to true by default, but will be set to false if any
  impure elemental function is lowered, or in case of
  intent(out)/intent(inout) arguments in elemental subroutines.

- Last, instead of using createFirExpr to lowering subroutine calls, use
  a new createSubroutineCall that deals with the array/scalar
  dispatching.

A TODO is added for the user defined elemental assignment, because
overlap analysis between RHS/LHS must be done, and this require somehow
plugging this special and very restricted case of elemental calls into
the array_load/array_update/array_merge framework or some ad-hoc
lowering.

Note: some dead code in the code that became genImplicitLoops is removed here (FORALL refactoring leftover ?). The loop bounds are now evaluated after the ccPrelude mask due to the genImplicitLoops code move, hence the forall lit test change.