### PR TITLE
[fir] Lower full global initialization with dense attribute

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -458,7 +458,7 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
     static constexpr Extent getUnknownExtent() { return -1; }
 
     // Get the number of elements.
-    unsigned getNumElements() const;
+    size_t getNumElements() const;
   }];
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -456,6 +456,9 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
 
     // The value `-1` represents an unknown extent for a dimension
     static constexpr Extent getUnknownExtent() { return -1; }
+
+    // Get the number of elements.
+    unsigned getNumElements() const;
   }];
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -458,7 +458,7 @@ def fir_SequenceType : FIR_Type<"Sequence", "array"> {
     static constexpr Extent getUnknownExtent() { return -1; }
 
     // Get the number of elements.
-    size_t getNumElements() const;
+    std::size_t getNumElements() const;
   }];
 }
 

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -995,6 +995,8 @@ void fir::InsertOnRangeOp::build(mlir::OpBuilder &builder,
 
 /// Range bounds must be nonnegative, and the range must not be empty.
 static mlir::LogicalResult verify(fir::InsertOnRangeOp op) {
+  assert(op.coor().size() >= 2 && op.coor().size() % 2 == 0 
+      && "Uneven number of values in ranges");
   bool rangeIsKnownToBeNonempty = false;
   for (auto i = op.coor().end(), b = op.coor().begin(); i != b;) {
     int64_t ub = (*--i).cast<IntegerAttr>().getInt();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -995,8 +995,8 @@ void fir::InsertOnRangeOp::build(mlir::OpBuilder &builder,
 
 /// Range bounds must be nonnegative, and the range must not be empty.
 static mlir::LogicalResult verify(fir::InsertOnRangeOp op) {
-  assert(op.coor().size() >= 2 && op.coor().size() % 2 == 0 
-      && "Uneven number of values in ranges");
+  if (op.coor().size() < 2 || op.coor().size() % 2 != 0)
+    return op.emitOpError("has uneven number of values in ranges");
   bool rangeIsKnownToBeNonempty = false;
   for (auto i = op.coor().end(), b = op.coor().begin(); i != b;) {
     int64_t ub = (*--i).cast<IntegerAttr>().getInt();

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -818,14 +818,14 @@ bool fir::SequenceType::hasConstantInterior() const {
 
 size_t fir::SequenceType::getNumElements() const {
   if (hasUnknownShape())
-    return -1;
+    return getUnknownExtent();
 
   size_t numElements = 1;
   for (auto extent : getShape()) {
     if (extent != getUnknownExtent())
       numElements = numElements * extent;
     else
-      return -1;
+      return getUnknownExtent();
   }
   return numElements;
 }

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -816,11 +816,11 @@ bool fir::SequenceType::hasConstantInterior() const {
   return true;
 }
 
-unsigned fir::SequenceType::getNumElements() const {
+size_t fir::SequenceType::getNumElements() const {
   if (hasUnknownShape())
     return -1;
 
-  unsigned numElements = 1;
+  size_t numElements = 1;
   for (auto extent : getShape()) {
     if (extent != getUnknownExtent())
       numElements = numElements * extent;

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -816,6 +816,20 @@ bool fir::SequenceType::hasConstantInterior() const {
   return true;
 }
 
+unsigned fir::SequenceType::getNumElements() const {
+  if (hasUnknownShape())
+    return -1;
+
+  unsigned numElements = 1;
+  for (auto extent : getShape()) {
+    if (extent != getUnknownExtent())
+      numElements = numElements * extent;
+    else
+      return -1;
+  }
+  return numElements;
+}
+
 mlir::LogicalResult fir::SequenceType::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
     llvm::ArrayRef<int64_t> shape, mlir::Type eleTy,

--- a/flang/test/Fir/global-initialization.fir
+++ b/flang/test/Fir/global-initialization.fir
@@ -61,5 +61,9 @@ fir.global internal @_QElookforme : !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.
 // CHECK:   [[CST1:%.*]] = llvm.mlir.constant(52 : i32) : i32
 // CHECK:   [[STRUCT:%.*]] = llvm.mlir.undef : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)>
 // CHECK:   [[ARR1:%.*]] = llvm.mlir.undef : !llvm.array<500 x i32>
-
+// CHECK:   [[DENSE1:%.*]] = llvm.mlir.constant(dense<2> : vector<500xi32>) : !llvm.array<500 x i32>
+// CHECK:   [[STRUCT1:%.*]] = llvm.insertvalue [[DENSE1]], [[STRUCT]][0 : i32] : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)>
+// CHECK:   [[DENSE2:%.*]] = llvm.mlir.constant(dense<52> : vector<500xi32>) : !llvm.array<500 x i32>
+// CHECK:   [[STRUCT2:%.*]] = llvm.insertvalue [[DENSE2]], [[STRUCT1]][1 : i32] : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)>
+// CHECK:   llvm.return [[STRUCT2]] : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)>
 // CHECK: }

--- a/flang/test/Fir/global-initialization.fir
+++ b/flang/test/Fir/global-initialization.fir
@@ -1,0 +1,65 @@
+// RUN: tco --fir-to-llvm-ir %s | FileCheck %s
+
+fir.global internal @_QEmask : !fir.array<32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32xi32>
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 31 : index] : (!fir.array<32xi32>, i32) -> !fir.array<32xi32>
+  fir.has_value %2 : !fir.array<32xi32>
+}
+
+// CHECK: llvm.mlir.global internal @_QEmask() : !llvm.array<32 x i32> {
+// CHECK:   [[VAL0:%.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:   [[VAL1:%.*]] = llvm.mlir.undef : !llvm.array<32 x i32>
+// CHECK:   [[VAL2:%.*]] = llvm.mlir.constant(dense<1> : vector<32xi32>) : !llvm.array<32 x i32>
+// CHECK:   llvm.return [[VAL2]] : !llvm.array<32 x i32>
+// CHECK: }
+
+fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32x32xi32>
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 31 : index, 0 : index, 31 : index] : (!fir.array<32x32xi32>, i32) -> !fir.array<32x32xi32>
+  fir.has_value %2 : !fir.array<32x32xi32>
+}
+
+// CHECK: llvm.mlir.global internal @_QEmultiarray() : !llvm.array<32 x array<32 x i32>> {
+// CHECK:   [[VAL0:%.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:   [[VAL1:%.*]] = llvm.mlir.undef : !llvm.array<32 x array<32 x i32>>
+// CHECK:   [[VAL2:%.*]] = llvm.mlir.constant(dense<1> : vector<32x32xi32>) : !llvm.array<32 x array<32 x i32>>
+// CHECK:   llvm.return [[VAL2]] : !llvm.array<32 x array<32 x i32>>
+// CHECK: }
+
+fir.global internal @_QEmasklogical : !fir.array<32768x!fir.logical<4>> {
+  %true = constant true
+  %0 = fir.undefined !fir.array<32768x!fir.logical<4>>
+  %1 = fir.convert %true : (i1) -> !fir.logical<4>
+  %2 = fir.insert_on_range %0, %1, [0 : index, 32767 : index] : (!fir.array<32768x!fir.logical<4>>, !fir.logical<4>) -> !fir.array<32768x!fir.logical<4>>
+  fir.has_value %2 : !fir.array<32768x!fir.logical<4>>
+}
+
+// CHECK: llvm.mlir.global internal @_QEmasklogical() : !llvm.array<32768 x i32> {
+// CHECK:   [[VAL0:%.*]] = llvm.mlir.constant(true) : i1
+// CHECK:   [[VAL1:%.*]] = llvm.mlir.undef : !llvm.array<32768 x i32>
+// CHECK:   [[VAL2:%.*]] = llvm.sext [[VAL0]] : i1 to i32
+// CHECK:   [[VAL3:%.*]] = llvm.mlir.constant(dense<true> : vector<32768xi1>) : !llvm.array<32768 x i32>
+// CHECK:   llvm.return [[VAL3]] : !llvm.array<32768 x i32>
+// CHECK: }
+
+fir.global internal @_QElookforme : !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}> {
+  %c2_i32 = constant 2 : i32
+  %c52_i32 = constant 52 : i32
+  %0 = fir.undefined !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>
+  %1 = fir.undefined !fir.array<500xi32>
+  %2 = fir.insert_on_range %1, %c2_i32, [0 : index, 499 : index] : (!fir.array<500xi32>, i32) -> !fir.array<500xi32>
+  %3 = fir.insert_value %0, %2, ["i", !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>] :(!fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>, !fir.array<500xi32>) -> !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>
+  %4 = fir.insert_on_range %1, %c52_i32, [0 : index, 499 : index] : (!fir.array<500xi32>, i32) -> !fir.array<500xi32>
+  %5 = fir.insert_value %3, %4, ["j", !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>] : (!fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>, !fir.array<500xi32>) -> !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>
+  fir.has_value %5 : !fir.type<_QTt{i:!fir.array<500xi32>,j:!fir.array<500xi32>}>
+}
+
+// CHECK: llvm.mlir.global internal @_QElookforme() : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)> {
+// CHECK:   [[CST0:%.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:   [[CST1:%.*]] = llvm.mlir.constant(52 : i32) : i32
+// CHECK:   [[STRUCT:%.*]] = llvm.mlir.undef : !llvm.struct<"_QTt", (array<500 x i32>, array<500 x i32>)>
+// CHECK:   [[ARR1:%.*]] = llvm.mlir.undef : !llvm.array<500 x i32>
+
+// CHECK: }

--- a/flang/test/Fir/global.fir
+++ b/flang/test/Fir/global.fir
@@ -32,3 +32,28 @@ fir.global @str1 : !fir.char<1,6> {
   %1 = fir.string_lit "Hello!"(6) : !fir.char<1,6>
   fir.has_value %1 : !fir.char<1,6>
 }
+
+// CHECK: @_QEmask = internal global [32 x i32] [i32 1, i32 1
+fir.global internal @_QEmask : !fir.array<32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32xi32>
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 31 : index] : (!fir.array<32xi32>, i32) -> !fir.array<32xi32>
+  fir.has_value %2 : !fir.array<32xi32>
+}
+
+// CHECK: @_QEmultiarray = internal global [32 x [32 x i32]]
+fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32x32xi32>
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 31 : index, 0 : index, 31 : index] : (!fir.array<32x32xi32>, i32) -> !fir.array<32x32xi32>
+  fir.has_value %2 : !fir.array<32x32xi32>
+}
+
+// CHECK: @_QEmasklogical = internal global [32768 x i32] [i32 -1, i32 -1,
+fir.global internal @_QEmasklogical : !fir.array<32768x!fir.logical<4>> {
+  %true = constant true
+  %0 = fir.undefined !fir.array<32768x!fir.logical<4>>
+  %1 = fir.convert %true : (i1) -> !fir.logical<4>
+  %2 = fir.insert_on_range %0, %1, [0 : index, 32767 : index] : (!fir.array<32768x!fir.logical<4>>, !fir.logical<4>) -> !fir.array<32768x!fir.logical<4>>
+  fir.has_value %2 : !fir.array<32768x!fir.logical<4>>
+}

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -498,3 +498,23 @@ func @ugly_char_convert() {
   fir.char_convert %2 for %2 to %3 : !fir.ref<!fir.char<1>>, !fir.ref<!fir.char<1>>, !fir.ref<!fir.array<?x!fir.char<2,?>>>
   return
 }
+
+// -----
+
+fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32x32xi32>
+  // expected-error@+1 {{'fir.insert_on_range' op has uneven number of values in ranges}}
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 31 : index, 0 : index] : (!fir.array<32x32xi32>, i32) -> !fir.array<32x32xi32>
+  fir.has_value %2 : !fir.array<32x32xi32>
+}
+
+// -----
+
+fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
+  %c0_i32 = constant 1 : i32
+  %0 = fir.undefined !fir.array<32x32xi32>
+  // expected-error@+1 {{'fir.insert_on_range' op has uneven number of values in ranges}}
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index] : (!fir.array<32x32xi32>, i32) -> !fir.array<32x32xi32>
+  fir.has_value %2 : !fir.array<32x32xi32>
+}


### PR DESCRIPTION
Translation to LLVM IR can take long time if large arrays are initialzed using `insert_value`. Instead we can translate full initialization with a dense attribute and processing time is not noticeable. 

This behavior was described in issue #888. 