### PR TITLE
[fir] Update symbol table after external name mangling

### DIFF
--- a/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
@@ -51,7 +51,8 @@ public:
       auto result =
           fir::NameUniquer::deconstruct(callee.getValue().getRootReference());
       if (fir::NameUniquer::isExternalFacingUniquedName(result))
-        op.calleeAttr(SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
+        op.calleeAttr(
+            SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
     }
     rewriter.finalizeRootUpdate(op);
     return success();
@@ -105,9 +106,9 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     auto result = fir::NameUniquer::deconstruct(op.symbol().getRootReference());
     if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
-      auto newNameAttr = rewriter.getSymbolRefAttr(mangleExternalName(result));
+      auto newName = rewriter.getSymbolRefAttr(mangleExternalName(result));
       rewriter.replaceOpWithNewOp<fir::AddrOfOp>(op, op.resTy().getType(),
-                                                 newNameAttr);
+                                                 newName);
     }
     return success();
   }
@@ -125,8 +126,8 @@ public:
     auto result =
         fir::NameUniquer::deconstruct(op.funcname().getRootReference());
     if (fir::NameUniquer::isExternalFacingUniquedName(result))
-      op.funcnameAttr(SymbolRefAttr::get(op.getContext(), 
-          mangleExternalName(result)));
+      op.funcnameAttr(
+          SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
     rewriter.finalizeRootUpdate(op);
     return success();
   }

--- a/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
@@ -50,11 +50,8 @@ public:
     if (callee.hasValue()) {
       auto result =
           fir::NameUniquer::deconstruct(callee.getValue().getRootReference());
-      if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
-        auto newName = mangleExternalName(result);
-        op.calleeAttr(SymbolRefAttr::get(op.getContext(), newName));
-        SymbolTable::setSymbolName(op, newName);
-      }
+      if (fir::NameUniquer::isExternalFacingUniquedName(result))
+        op.calleeAttr(SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
     }
     rewriter.finalizeRootUpdate(op);
     return success();
@@ -108,11 +105,9 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     auto result = fir::NameUniquer::deconstruct(op.symbol().getRootReference());
     if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
-      auto newName = mangleExternalName(result);
       auto newNameAttr = rewriter.getSymbolRefAttr(mangleExternalName(result));
       rewriter.replaceOpWithNewOp<fir::AddrOfOp>(op, op.resTy().getType(),
                                                  newNameAttr);
-      SymbolTable::setSymbolName(op, newName);
     }
     return success();
   }
@@ -129,11 +124,9 @@ public:
     rewriter.startRootUpdate(op);
     auto result =
         fir::NameUniquer::deconstruct(op.funcname().getRootReference());
-    if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
-      auto newName = mangleExternalName(result);
-      op.funcnameAttr(SymbolRefAttr::get(op.getContext(), newName));
-      SymbolTable::setSymbolName(op, newName);
-    }
+    if (fir::NameUniquer::isExternalFacingUniquedName(result))
+      op.funcnameAttr(SymbolRefAttr::get(op.getContext(), 
+          mangleExternalName(result)));
     rewriter.finalizeRootUpdate(op);
     return success();
   }

--- a/flang/test/Fir/external-mangling-emboxproc.fir
+++ b/flang/test/Fir/external-mangling-emboxproc.fir
@@ -1,0 +1,10 @@
+// RUN: fir-opt --external-name-interop %s | FileCheck %s
+// RUN: tco --external-name-interop %s | FileCheck %s
+
+func @_QPfoo() {  
+  %e6 = fir.alloca tuple<i32,f64>
+  %0 = fir.emboxproc @_QPfoo_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>  
+  return
+}
+
+// CHECK: %{{.*}}= fir.emboxproc @foo_impl_

--- a/flang/test/Fir/external-mangling-emboxproc.fir
+++ b/flang/test/Fir/external-mangling-emboxproc.fir
@@ -6,5 +6,6 @@ func @_QPfoo() {
   %0 = fir.emboxproc @_QPfoo_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>  
   return
 }
+func private @_QPfoo_impl(!fir.ref<i32>)
 
 // CHECK: %{{.*}}= fir.emboxproc @foo_impl_

--- a/flang/test/Fir/external-mangling.fir
+++ b/flang/test/Fir/external-mangling.fir
@@ -1,6 +1,6 @@
 // RUN: fir-opt --external-name-interop %s | FileCheck %s
 // RUN: tco --external-name-interop %s | FileCheck %s
-// RUN: tco --external-name-interop %s | tco | FileCheck %s --check-prefix=LLVMIR
+// RUN: tco --external-name-interop %s | tco --fir-to-llvm-ir | FileCheck %s --check-prefix=LLVMIR
 
 func @_QPfoo() {  
   %c0 = constant 0 : index
@@ -14,8 +14,6 @@ func @_QPfoo() {
   %7 = fir.convert %6 : (!fir.ref<i8>) -> !fir.ref<f32>
   fir.call @_QPbar(%3) : (!fir.ref<i32>) -> ()
   fir.call @_QPbar2(%7) : (!fir.ref<f32>) -> ()
-  %e6 = fir.alloca tuple<i32,f64>
-  %8 = fir.emboxproc @_QPfoo_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
   return
 }
 fir.global common @_QBa(dense<0> : vector<4xi8>) : !fir.array<4xi8>
@@ -28,15 +26,16 @@ func private @_QPbar2(!fir.ref<f32>)
 // CHECK: %{{.*}} = fir.address_of(@__BLNK__) : !fir.ref<!fir.array<4xi8>>
 // CHECK: fir.call @bar_
 // CHECK: fir.call @bar2_
-// CHECK: %{{.*}}= fir.emboxproc @foo_impl_
 // CHECK: fir.global common @a_(dense<0> : vector<4xi8>) : !fir.array<4xi8>
 // CHECK: fir.global common @__BLNK__(dense<0> : vector<4xi8>) : !fir.array<4xi8>
 // CHECK: func private @bar_(!fir.ref<i32>)
 
-// LLVMIR: @a_ = common global [4 x i8] zeroinitializer
-// LLVMIR: @__BLNK__ = common global [4 x i8] zeroinitializer
-// LLVMIR: define void @foo_()
-// LLVMIR: call void @bar_(
-// LLVMIR: call void @bar2_(
-// LLVMIR: declare void @bar_(
-// LLVMIR: declare void @bar2_(
+// LLVMIR: %{{.*}} = llvm.mlir.addressof @a_ : !llvm.ptr<array<4 x i8>>
+// LLVMIR: %{{.*}} = llvm.mlir.addressof @__BLNK__ : !llvm.ptr<array<4 x i8>>
+// LLVMIR: llvm.call @bar_(%{{.*}}) {sym_name = "bar_"} : (!llvm.ptr<i32>) -> ()
+// LLVMIR: llvm.call @bar2_(%{{.*}}) {sym_name = "bar2_"} : (!llvm.ptr<f32>) -> ()
+
+// LLVMIR: llvm.mlir.global common @a_(dense<0> : vector<4xi8>) : !llvm.array<4 x i8>
+// LLVMIR: llvm.mlir.global common @__BLNK__(dense<0> : vector<4xi8>) : !llvm.array<4 x i8>
+// LLVMIR: llvm.func @bar_(!llvm.ptr<i32>) attributes {sym_visibility = "private"}
+// LLVMIR: llvm.func @bar2_(!llvm.ptr<f32>) attributes {sym_visibility = "private"}

--- a/flang/test/Fir/external-mangling.fir
+++ b/flang/test/Fir/external-mangling.fir
@@ -32,8 +32,8 @@ func private @_QPbar2(!fir.ref<f32>)
 
 // LLVMIR: %{{.*}} = llvm.mlir.addressof @a_ : !llvm.ptr<array<4 x i8>>
 // LLVMIR: %{{.*}} = llvm.mlir.addressof @__BLNK__ : !llvm.ptr<array<4 x i8>>
-// LLVMIR: llvm.call @bar_(%{{.*}}) {sym_name = "bar_"} : (!llvm.ptr<i32>) -> ()
-// LLVMIR: llvm.call @bar2_(%{{.*}}) {sym_name = "bar2_"} : (!llvm.ptr<f32>) -> ()
+// LLVMIR: llvm.call @bar_(%{{.*}}) : (!llvm.ptr<i32>) -> ()
+// LLVMIR: llvm.call @bar2_(%{{.*}}) : (!llvm.ptr<f32>) -> ()
 
 // LLVMIR: llvm.mlir.global common @a_(dense<0> : vector<4xi8>) : !llvm.array<4 x i8>
 // LLVMIR: llvm.mlir.global common @__BLNK__(dense<0> : vector<4xi8>) : !llvm.array<4 x i8>


### PR DESCRIPTION
External name mangling pass was missing to update the symbol table which was triggering some error later in the LLVM IR dialect. 