### PR TITLE
[flang] Handle namelist group in deconstruct

### DIFF
--- a/flang/include/flang/Optimizer/Support/InternalNames.h
+++ b/flang/include/flang/Optimizer/Support/InternalNames.h
@@ -41,7 +41,8 @@ struct NameUniquer {
     INTRINSIC_TYPE_DESC,
     PROCEDURE,
     TYPE_DESC,
-    VARIABLE
+    VARIABLE,
+    NAMELIST_GROUP
   };
 
   /// Components of an unparsed unique name

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -288,6 +288,10 @@ fir::NameUniquer::deconstruct(llvm::StringRef uniq) {
         else
           kinds.push_back(readInt(uniq, i, i + 1, end));
         break;
+      case 'G':
+        nk = NameKind::NAMELIST_GROUP;
+        name = readName(uniq, i, i + 1, end);
+        break;
 
       default:
         assert(false && "unknown uniquing code");

--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -208,6 +208,11 @@ TEST(InternalNamesTest, complexdeconstructTest) {
   expectedNameKind = NameKind::DISPATCH_TABLE;
   expectedComponents = {{}, {}, "t", {}};
   validateDeconstructedName(actual, expectedNameKind, expectedComponents);
+
+  actual = NameUniquer::deconstruct("_QFmstartGmpitop");
+  expectedNameKind = NameKind::NAMELIST_GROUP;
+  expectedComponents = {{}, {"mstart"}, "mpitop", {}};
+  validateDeconstructedName(actual, expectedNameKind, expectedComponents);
 }
 
 TEST(InternalNamesTest, needExternalNameMangling) {
@@ -217,6 +222,8 @@ TEST(InternalNamesTest, needExternalNameMangling) {
   ASSERT_FALSE(NameUniquer::needExternalNameMangling(""));
   ASSERT_FALSE(NameUniquer::needExternalNameMangling("_QDTmytypeK2K8K18"));
   ASSERT_FALSE(NameUniquer::needExternalNameMangling("exit_"));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling("_QFfooEx"));
+  ASSERT_FALSE(NameUniquer::needExternalNameMangling("_QFmstartGmpitop"));
   ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QPfoo"));
   ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QPbar"));
   ASSERT_TRUE(NameUniquer::needExternalNameMangling("_QBa"));


### PR DESCRIPTION
For some reason the `G` was not handle in the deconstruct function. The mangler uses it for namelist group. The assertion in deconstruct was triggered in one of the test run by Steve. 