### PR TITLE
Lower elemental user defined assignment

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -205,7 +205,9 @@ createSomeArrayBox(AbstractConverter &converter,
 /// returns, the returned value indicates which label the code should jump to.
 /// The returned value is null otherwise.
 mlir::Value createSubroutineCall(AbstractConverter &converter,
-                                 const evaluate::Expr<evaluate::SomeType> &call,
+                                 const evaluate::ProcedureRef &call,
+                                 ExplicitIterSpace &explicitIterSpace,
+                                 ImplicitIterSpace &implicitIterSpace,
                                  SymMap &symMap, StatementContext &stmtCtx,
                                  bool isUserDefAssignment);
 

--- a/flang/include/flang/Optimizer/Builder/Character.h
+++ b/flang/include/flang/Optimizer/Builder/Character.h
@@ -153,6 +153,12 @@ public:
   /// Returns integer value held in a character singleton.
   mlir::Value extractCodeFromSingleton(mlir::Value singleton);
 
+  /// Create a value for the length of a character based on its memory reference
+  /// that may be a boxchar, box or !fir.[ptr|ref|heap]<fir.char<kind, len>>. If
+  /// the memref is a simple address and the length is not constant in type, the
+  /// returned length will be empty.
+  mlir::Value getLength(mlir::Value memref);
+
   /// Compute length given a fir.box describing a character entity.
   /// It adjusts the length from the number of bytes per the descriptor
   /// to the number of characters per the Fortran KIND.

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1479,6 +1479,64 @@ def fir_ArrayUpdateOp : fir_Op<"array_update", [AttrSizedOperandSegments,
   let verifier = "return ::verify(*this);";
 }
 
+def fir_ArrayModifyOp : fir_Op<"array_modify", [AttrSizedOperandSegments,
+    NoSideEffect]> {
+  let summary = "Get an address for an array value to modify it.";
+
+  let description = [{
+    Modify the value of an element in an array value through actions done
+    on the returned address. A new array value is also
+    returned where all element values of the input array are identical except
+    for the selected element which is the value after the modification done
+    on the element address.
+
+    ```fortran
+      real :: a(n)
+      ...
+      ! Elemental user defined assignment from type(SomeType) to real.
+      a = value_of_some_type
+    ```
+
+    One can use `fir.array_modify` to update the (implied) value of `a(i)`
+    in an array expression as shown above.
+
+    ```mlir
+      %s = fir.shape %n : (index) -> !fir.shape<1>
+      // Load the entire array 'a'.
+      %v = fir.array_load %a(%s) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
+      // Update the value of one of the array value's elements with a user
+      // defined assignment from %rhs.
+      %new = fir.do_loop %i = ... (%inner = %v) {
+        %rhs = ...
+        %addr, %r = fir.array_modify %inner, %i, %j : (!fir.array<?xf32>,  index) -> fir.ref<f32>, !fir.array<?xf32>
+        fir.call @user_def_assign(%addr, %rhs) (fir.ref<f32>, fir.ref<!fir.type<SomeType>>) -> ()
+        fir.result %r : !fir.ref<!fir.array<?xf32>>
+      }
+      fir.array_merge_store %v, %new to %a : !fir.ref<!fir.array<?xf32>>
+    ```
+
+    An array value modification behaves as if a mapping function from the indices
+    to the new value has been added, replacing the previous mapping. These
+    mappings can be added to the ssa-value, but will not be materialized in
+    memory until the `fir.array_merge_store` is performed.
+  }];
+
+  let arguments = (ins
+    fir_SequenceType:$sequence,
+    Variadic<AnyCoordinateType>:$indices,
+    Variadic<AnyIntegerType>:$typeparams
+  );
+
+  let results = (outs fir_ReferenceType, fir_SequenceType);
+
+  let assemblyFormat = [{
+    $sequence `,` $indices (`typeparams` $typeparams^)? attr-dict
+      `:` functional-type(operands, results)
+  }];
+
+  let verifier = [{ return ::verify(*this); }];
+}
+
 def fir_ArrayMergeStoreOp : fir_Op<"array_merge_store",
     [AttrSizedOperandSegments]> {
   let summary = "Store merged array value to memory.";

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -661,9 +661,9 @@ private:
     setCurrentPosition(stmt.v.source);
     assert(stmt.typedCall && "Call was not analyzed");
     // Call statement lowering shares code with function call lowering.
-    Fortran::semantics::SomeExpr expr{*stmt.typedCall};
     auto res = Fortran::lower::createSubroutineCall(
-        *this, expr, localSymbols, stmtCtx, /*isUserDefAssignment=*/false);
+        *this, *stmt.typedCall, explicitIterSpace, implicitIterSpace,
+        localSymbols, stmtCtx, /*isUserDefAssignment=*/false);
     if (!res)
       return; // "Normal" subroutine call.
     // Call with alternate return specifiers.
@@ -1941,18 +1941,12 @@ private:
             // [2] User defined assignment. If the context is a scalar
             // expression then call the procedure.
             [&](const Fortran::evaluate::ProcedureRef &procRef) {
-              if (implicitIterationSpace())
-                TODO(loc, "user defined assignment within WHERE");
-
-              Fortran::semantics::SomeExpr expr{procRef};
               auto &ctx = explicitIterationSpace()
                               ? explicitIterSpace.stmtContext()
                               : stmtCtx;
               Fortran::lower::createSubroutineCall(
-                  *this, expr, localSymbols, ctx, /*isUserDefAssignment=*/true);
-              if (explicitIterationSpace())
-                builder->create<fir::ResultOp>(
-                    loc, explicitIterSpace.getInnerArgs());
+                  *this, procRef, explicitIterSpace, implicitIterSpace,
+                  localSymbols, ctx, /*isUserDefAssignment=*/true);
             },
 
             // [3] Pointer assignment with possibly empty bounds-spec. R1035: a
@@ -2595,8 +2589,24 @@ private:
     explicitIterSpace.exprBase(&e, LHS);
   }
   void analyzeExplicitSpace(const Fortran::evaluate::Assignment *assign) {
-    analyzeExplicitSpace</*LHS=*/true>(assign->lhs);
-    analyzeExplicitSpace(assign->rhs);
+    auto analyzeAssign = [&](const Fortran::lower::SomeExpr &lhs,
+                             const Fortran::lower::SomeExpr &rhs) {
+      analyzeExplicitSpace</*LHS=*/true>(lhs);
+      analyzeExplicitSpace(rhs);
+    };
+    std::visit(
+        Fortran::common::visitors{
+            [&](const Fortran::evaluate::ProcedureRef &procRef) {
+              // Ensure the procRef expressions are the one being visited.
+              assert(procRef.arguments().size() == 2);
+              const auto *lhs = procRef.arguments()[0].value().UnwrapExpr();
+              const auto *rhs = procRef.arguments()[1].value().UnwrapExpr();
+              assert(lhs && rhs &&
+                     "user defined assignment arguments must be expressions");
+              analyzeAssign(*lhs, *rhs);
+            },
+            [&](const auto &) { analyzeAssign(assign->lhs, assign->rhs); }},
+        assign->u);
     explicitIterSpace.endAssign();
   }
   void analyzeExplicitSpace(const Fortran::parser::ForallAssignmentStmt &stmt) {

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -705,3 +705,19 @@ fir::factory::CharacterExprHelper::readLengthFromBox(mlir::Value box) {
   }
   return size;
 }
+
+mlir::Value fir::factory::CharacterExprHelper::getLength(mlir::Value memref) {
+  auto memrefType = memref.getType();
+  auto charType = recoverCharacterType(memrefType);
+  assert(charType && "must be a character type");
+  if (charType.hasConstantLen())
+    return builder.createIntegerConstant(loc, builder.getCharacterLengthType(),
+                                         charType.getLen());
+  if (memrefType.isa<fir::BoxType>())
+    return readLengthFromBox(memref);
+  if (memrefType.isa<fir::BoxCharType>())
+    return createUnboxChar(memref).second;
+
+  // Length cannot be deduced from memref.
+  return {};
+}

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -500,6 +500,18 @@ static mlir::LogicalResult verify(fir::ArrayUpdateOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// ArrayModifyOp
+//===----------------------------------------------------------------------===//
+
+static mlir::LogicalResult verify(fir::ArrayModifyOp op) {
+  auto arrTy = op.sequence().getType().cast<fir::SequenceType>();
+  auto indSize = op.indices().size();
+  if (indSize < arrTy.getDimension())
+    return op.emitOpError("number of indices must match array dimension");
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // BoxAddrOp
 //===----------------------------------------------------------------------===//
 

--- a/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
+++ b/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
@@ -101,80 +101,134 @@ private:
 };
 } // namespace
 
-// Recursively trace operands to find all array operations relating to the
-// values merged.
-static void populateSets(llvm::SmallVectorImpl<mlir::Operation *> &reach,
-                         llvm::SmallPtrSetImpl<mlir::Value> &visited,
-                         mlir::Value val) {
-  if (!val || visited.contains(val))
-    return;
-  visited.insert(val);
+namespace {
 
-  if (auto *op = val.getDefiningOp()) {
-    // `val` is defined by an Op, process the defining Op.
-    // If `val` is defined by a region containing Op, we want to drill down and
-    // through that Op's region(s).
-    LLVM_DEBUG(llvm::dbgs() << "popset: " << val << '\n');
+/// Helper class to collect all array operations that produced an array value.
+class ReachCollector {
+public:
+  ReachCollector(llvm::SmallVectorImpl<mlir::Operation *> &reach,
+                 mlir::Region *loopRegion)
+      : reach{reach}, loopRegion{loopRegion} {}
+
+  // Recursively trace operands to find all array operations relating to the
+  // values merged.
+  void collectArrayAccessFrom(mlir::Value val) {
+    if (!val || visited.contains(val))
+      return;
+    visited.insert(val);
+
+    if (auto *op = val.getDefiningOp()) {
+      // `val` is defined by an Op, process the defining Op.
+      // If `val` is defined by a region containing Op, we want to drill down
+      // and through that Op's region(s).
+      LLVM_DEBUG(llvm::dbgs() << "popset: " << val << '\n');
+      auto popFn = [&](auto rop) {
+        auto resNum = val.cast<mlir::OpResult>().getResultNumber();
+        llvm::SmallVector<mlir::Value> results;
+        rop.resultToSourceOps(results, resNum);
+        for (auto u : results)
+          collectArrayAccessFrom(u);
+      };
+      if (auto rop = mlir::dyn_cast<DoLoopOp>(op)) {
+        popFn(rop);
+        return;
+      }
+      if (auto rop = mlir::dyn_cast<IterWhileOp>(op)) {
+        popFn(rop);
+        return;
+      }
+      if (auto rop = mlir::dyn_cast<fir::IfOp>(op)) {
+        popFn(rop);
+        return;
+      }
+
+      if (mlir::isa<fir::AllocaOp, fir::AllocMemOp>(op))
+        // Look for any stores inside the loops, and collect an array operation
+        // that produced the value being stored to it.
+        for (auto user : op->getUsers())
+          if (auto store = mlir::dyn_cast<fir::StoreOp>(user))
+            if (opIsInsideLoops(store))
+              collectArrayAccessFrom(store.value());
+
+      // Otherwise, Op does not contain a region so just chase its operands.
+      if (mlir::isa<ArrayLoadOp, ArrayUpdateOp, ArrayModifyOp, ArrayFetchOp>(
+              op)) {
+        LLVM_DEBUG(llvm::dbgs() << "add " << *op << " to reachable set\n");
+        reach.emplace_back(op);
+      }
+      // Array modify assignment is performed on the result. So the analysis
+      // must look at the what is done with the result.
+      if (mlir::isa<ArrayModifyOp>(op))
+        for (auto user : op->getResult(0).getUsers())
+          followUsers(user);
+
+      for (auto u : op->getOperands())
+        collectArrayAccessFrom(u);
+      return;
+    }
+
+    // Process a block argument.
+    auto ba = val.cast<mlir::BlockArgument>();
+    auto *parent = ba.getOwner()->getParentOp();
+    // If inside an Op holding a region, the block argument corresponds to an
+    // argument passed to the containing Op.
     auto popFn = [&](auto rop) {
-      auto resNum = val.cast<mlir::OpResult>().getResultNumber();
-      llvm::SmallVector<mlir::Value> results;
-      rop.resultToSourceOps(results, resNum);
-      for (auto u : results)
-        populateSets(reach, visited, u);
+      collectArrayAccessFrom(rop.blockArgToSourceOp(ba.getArgNumber()));
     };
-    if (auto rop = mlir::dyn_cast<DoLoopOp>(op)) {
+    if (auto rop = mlir::dyn_cast<DoLoopOp>(parent)) {
       popFn(rop);
       return;
     }
-    if (auto rop = mlir::dyn_cast<IterWhileOp>(op)) {
+    if (auto rop = mlir::dyn_cast<IterWhileOp>(parent)) {
       popFn(rop);
       return;
     }
-    if (auto rop = mlir::dyn_cast<fir::IfOp>(op)) {
-      popFn(rop);
-      return;
+    // Otherwise, a block argument is provided via the pred blocks.
+    for (auto *pred : ba.getOwner()->getPredecessors()) {
+      auto u = pred->getTerminator()->getOperand(ba.getArgNumber());
+      collectArrayAccessFrom(u);
     }
-
-    // Otherwise, Op does not contain a region so just chase its operands.
-    if (mlir::isa<ArrayLoadOp, ArrayUpdateOp, ArrayFetchOp>(op)) {
-      LLVM_DEBUG(llvm::dbgs() << "add " << *op << " to reachable set\n");
-      reach.emplace_back(op);
-    }
-    for (auto u : op->getOperands())
-      populateSets(reach, visited, u);
-    return;
   }
 
-  // Process a block argument.
-  auto ba = val.cast<mlir::BlockArgument>();
-  auto *parent = ba.getOwner()->getParentOp();
-  // If inside an Op holding a region, the block argument corresponds to an
-  // argument passed to the containing Op.
-  auto popFn = [&](auto rop) {
-    populateSets(reach, visited, rop.blockArgToSourceOp(ba.getArgNumber()));
-  };
-  if (auto rop = mlir::dyn_cast<DoLoopOp>(parent)) {
-    popFn(rop);
-    return;
+private:
+  /// Is \op inside the loop nest region ?
+  bool opIsInsideLoops(mlir::Operation *op) const {
+    auto *region = op->getParentRegion();
+    while (region) {
+      if (region == loopRegion)
+        return true;
+      region = region->getParentRegion();
+    }
+    return false;
   }
-  if (auto rop = mlir::dyn_cast<IterWhileOp>(parent)) {
-    popFn(rop);
-    return;
+
+  /// Recursively trace the use of an operation results, calling
+  /// collectArrayAccessFrom on the direct and indirect user operands.
+  void followUsers(mlir::Operation *op) {
+    for (auto userOperand : op->getOperands())
+      collectArrayAccessFrom(userOperand);
+    // Go through potential converts/coordinate_op.
+    for (auto indirectUser : op->getUsers())
+      followUsers(indirectUser);
   }
-  // Otherwise, a block argument is provided via the pred blocks.
-  for (auto *pred : ba.getOwner()->getPredecessors()) {
-    auto u = pred->getTerminator()->getOperand(ba.getArgNumber());
-    populateSets(reach, visited, u);
-  }
-}
+
+  llvm::SmallVectorImpl<mlir::Operation *> &reach;
+  llvm::SmallPtrSet<mlir::Value, 16> visited;
+  /// Region of the loops nest that produced the array value.
+  mlir::Region *loopRegion;
+};
+} // namespace
 
 /// Return all ops that produce the array value that is stored into the
 /// `array_merge_store`.
 static void reachingValues(llvm::SmallVectorImpl<mlir::Operation *> &reach,
                            mlir::Value seq) {
   reach.clear();
-  llvm::SmallPtrSet<mlir::Value, 16> visited;
-  populateSets(reach, visited, seq);
+  mlir::Region *loopRegion = nullptr;
+  if (auto doLoop = mlir::dyn_cast_or_null<fir::DoLoopOp>(seq.getDefiningOp()))
+    loopRegion = &doLoop->getRegion(0);
+  ReachCollector collector(reach, loopRegion);
+  collector.collectArrayAccessFrom(seq);
 }
 
 /// Find all the array operations that access the array value that is loaded by
@@ -186,7 +240,7 @@ void ArrayCopyAnalysis::arrayAccesses(
   if (lmIter != loadMapSets.end()) {
     for (auto *opnd : lmIter->second) {
       auto *owner = opnd->getOwner();
-      if (mlir::isa<ArrayFetchOp, ArrayUpdateOp>(owner))
+      if (mlir::isa<ArrayFetchOp, ArrayUpdateOp, ArrayModifyOp>(owner))
         accesses.push_back(owner);
     }
     return;
@@ -249,6 +303,13 @@ void ArrayCopyAnalysis::arrayAccesses(
                  << "add update {" << *owner << "} to array value set\n");
       accesses.push_back(owner);
       appendToQueue(update.getResult());
+    } else if (auto update = mlir::dyn_cast<ArrayModifyOp>(owner)) {
+      // Keep track of array value modification and thread the return value
+      // uses.
+      LLVM_DEBUG(llvm::dbgs()
+                 << "add modify {" << *owner << "} to array value set\n");
+      accesses.push_back(owner);
+      appendToQueue(update.getResult(1));
     } else if (auto br = mlir::dyn_cast<mlir::BranchOp>(owner)) {
       branchOp(br.getDest(), br.destOperands());
     } else if (auto br = mlir::dyn_cast<mlir::CondBranchOp>(owner)) {
@@ -303,6 +364,12 @@ static bool conflictOnMerge(llvm::ArrayRef<mlir::Operation *> accesses) {
         continue;
       }
       compareVector = u.indices();
+    } else if (auto f = mlir::dyn_cast<ArrayModifyOp>(op)) {
+      if (indices.empty()) {
+        indices = f.indices();
+        continue;
+      }
+      compareVector = f.indices();
     } else if (auto f = mlir::dyn_cast<ArrayFetchOp>(op)) {
       if (indices.empty()) {
         indices = f.indices();
@@ -362,7 +429,7 @@ void ArrayCopyAnalysis::construct(mlir::MutableArrayRef<mlir::Region> regions) {
                                   << ", accesses: " << accesses.size() << '\n');
           for (auto *acc : accesses) {
             LLVM_DEBUG(llvm::dbgs() << " access: " << *acc << '\n');
-            if (mlir::isa<ArrayFetchOp, ArrayUpdateOp>(acc)) {
+            if (mlir::isa<ArrayFetchOp, ArrayUpdateOp, ArrayModifyOp>(acc)) {
               if (useMap.count(acc)) {
                 mlir::emitError(
                     load.getLoc(),
@@ -496,103 +563,17 @@ genCoorOp(mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Type eleTy,
 }
 
 namespace {
-/// Conversion of fir.array_update Op.
+/// Conversion of fir.array_update and fir.array_modify Ops.
 /// If there is a conflict for the update, then we need to perform a
 /// copy-in/copy-out to preserve the original values of the array. If there is
 /// no conflict, then it is save to eschew making any copies.
-class ArrayUpdateConversion : public mlir::OpRewritePattern<ArrayUpdateOp> {
+template <typename ArrayOp>
+class ArrayUpdateConversionBase : public mlir::OpRewritePattern<ArrayOp> {
 public:
-  explicit ArrayUpdateConversion(mlir::MLIRContext *ctx,
-                                 const ArrayCopyAnalysis &a,
-                                 const OperationUseMapT &m)
-      : OpRewritePattern{ctx}, analysis{a}, useMap{m} {}
-
-  mlir::LogicalResult
-  matchAndRewrite(ArrayUpdateOp update,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto *op = update.getOperation();
-    auto *loadOp = useMap.lookup(op);
-    auto load = mlir::cast<ArrayLoadOp>(loadOp);
-    LLVM_DEBUG(llvm::outs() << "does " << load << " have a conflict?\n");
-    auto loc = update.getLoc();
-    auto copyElement = [&](mlir::Value coor) {
-      auto input = update.merge();
-      if (auto inEleTy = fir::dyn_cast_ptrEleTy(input.getType())) {
-        [[maybe_unused]] auto outEleTy =
-            fir::unwrapSequenceType(update.getType());
-        if (auto inChrTy = inEleTy.dyn_cast<fir::CharacterType>()) {
-          assert(outEleTy.isa<fir::CharacterType>());
-          fir::factory::genCharacterCopy(input, recoverCharLen(input), coor,
-                                         recoverCharLen(coor), rewriter, loc);
-        } else if (inEleTy.isa<fir::RecordType>()) {
-          fir::FirOpBuilder builder(
-              rewriter,
-              fir::getKindMapping(update->getParentOfType<mlir::ModuleOp>()));
-          if (!update.typeparams().empty()) {
-            auto boxTy = fir::BoxType::get(inEleTy);
-            mlir::Value emptyShape, emptySlice;
-            auto lhs = rewriter.create<fir::EmboxOp>(
-                loc, boxTy, coor, emptyShape, emptySlice, update.typeparams());
-            auto rhs = rewriter.create<fir::EmboxOp>(
-                loc, boxTy, input, emptyShape, emptySlice, update.typeparams());
-            fir::factory::genRecordAssignment(builder, loc, fir::BoxValue(lhs),
-                                              fir::BoxValue(rhs));
-          } else {
-            fir::factory::genRecordAssignment(builder, loc, coor, input);
-          }
-        } else {
-          llvm::report_fatal_error("not a legal reference type");
-        }
-      } else {
-        rewriter.create<fir::StoreOp>(loc, input, coor);
-      }
-    };
-
-    if (analysis.hasPotentialConflict(loadOp)) {
-      // If there is a conflict between the arrays, then we copy the lhs array
-      // to a temporary, update the temporary, and copy the temporary back to
-      // the lhs array. This yields Fortran's copy-in copy-out array semantics.
-      LLVM_DEBUG(llvm::outs() << "Yes, conflict was found\n");
-      rewriter.setInsertionPoint(loadOp);
-      // Copy in.
-      llvm::SmallVector<mlir::Value> extents;
-      auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents);
-      auto allocmem = rewriter.create<AllocMemOp>(
-          loc, dyn_cast_ptrOrBoxEleTy(load.memref().getType()),
-          load.typeparams(), extents);
-      genArrayCopy(load.getLoc(), rewriter, allocmem, load.memref(), shapeOp,
-                   load.getType());
-      rewriter.setInsertionPoint(op);
-      auto coor =
-          genCoorOp(rewriter, loc, getEleTy(load.getType()),
-                    toRefType(update.merge().getType()), allocmem, shapeOp,
-                    load.slice(), update.indices(), load.typeparams(),
-                    update->hasAttr(fir::factory::attrFortranArrayOffsets()));
-      copyElement(coor);
-      auto *storeOp = useMap.lookup(loadOp);
-      rewriter.setInsertionPoint(storeOp);
-      // Copy out.
-      auto store = mlir::cast<ArrayMergeStoreOp>(storeOp);
-      genArrayCopy(store.getLoc(), rewriter, store.memref(), allocmem, shapeOp,
-                   load.getType());
-      rewriter.create<FreeMemOp>(loc, allocmem);
-    } else {
-      // Otherwise, when there is no conflict (a possible loop-carried
-      // dependence), the lhs array can be updated in place.
-      LLVM_DEBUG(llvm::outs() << "No, conflict wasn't found\n");
-      rewriter.setInsertionPoint(op);
-      auto coorTy = getEleTy(load.getType());
-      auto coor =
-          genCoorOp(rewriter, loc, coorTy, toRefType(update.merge().getType()),
-                    load.memref(), load.shape(), load.slice(), update.indices(),
-                    load.typeparams(),
-                    update->hasAttr(fir::factory::attrFortranArrayOffsets()));
-      copyElement(coor);
-    }
-    update.replaceAllUsesWith(load.getResult());
-    rewriter.replaceOp(update, load.getResult());
-    return mlir::success();
-  }
+  explicit ArrayUpdateConversionBase(mlir::MLIRContext *ctx,
+                                     const ArrayCopyAnalysis &a,
+                                     const OperationUseMapT &m)
+      : mlir::OpRewritePattern<ArrayOp>{ctx}, analysis{a}, useMap{m} {}
 
   static llvm::SmallVector<mlir::Value> recoverTypeParams(mlir::Value val) {
     auto *op = val.getDefiningOp();
@@ -603,6 +584,8 @@ public:
     if (auto ao = mlir::dyn_cast<fir::ArrayFetchOp>(op))
       return {ao.typeparams().begin(), ao.typeparams().end()};
     if (auto ao = mlir::dyn_cast<fir::ArrayUpdateOp>(op))
+      return {ao.typeparams().begin(), ao.typeparams().end()};
+    if (auto ao = mlir::dyn_cast<fir::ArrayModifyOp>(op))
       return {ao.typeparams().begin(), ao.typeparams().end()};
     if (auto ao = mlir::dyn_cast<fir::ArrayLoadOp>(op))
       return {ao.typeparams().begin(), ao.typeparams().end()};
@@ -656,9 +639,141 @@ public:
     rewriter.restoreInsertionPoint(insPt);
   }
 
+  /// Copy the RHS element into the LHS and insert copy-in/copy-out between a
+  /// temp and the LHS if the analysis found potential overlaps between the RHS
+  /// and LHS arrays. The element copy generator must be provided through \p
+  /// assignElement. \p update must be the ArrayUpdateOp or the ArrayModifyOp.
+  /// Returns the address of the LHS element inside the loop and the LHS
+  /// ArrayLoad result.
+  std::pair<mlir::Value, mlir::Value>
+  materializeAssignment(mlir::Location loc, mlir::PatternRewriter &rewriter,
+                        ArrayOp update,
+                        const std::function<void(mlir::Value)> &assignElement,
+                        mlir::Type lhsEltRefType) const {
+    auto *op = update.getOperation();
+    auto *loadOp = useMap.lookup(op);
+    auto load = mlir::cast<ArrayLoadOp>(loadOp);
+    LLVM_DEBUG(llvm::outs() << "does " << load << " have a conflict?\n");
+    if (analysis.hasPotentialConflict(loadOp)) {
+      // If there is a conflict between the arrays, then we copy the lhs array
+      // to a temporary, update the temporary, and copy the temporary back to
+      // the lhs array. This yields Fortran's copy-in copy-out array semantics.
+      LLVM_DEBUG(llvm::outs() << "Yes, conflict was found\n");
+      rewriter.setInsertionPoint(loadOp);
+      // Copy in.
+      llvm::SmallVector<mlir::Value> extents;
+      auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents);
+      auto allocmem = rewriter.create<AllocMemOp>(
+          loc, dyn_cast_ptrOrBoxEleTy(load.memref().getType()),
+          load.typeparams(), extents);
+      genArrayCopy(load.getLoc(), rewriter, allocmem, load.memref(), shapeOp,
+                   load.getType());
+      rewriter.setInsertionPoint(op);
+      auto coor = genCoorOp(
+          rewriter, loc, getEleTy(load.getType()), lhsEltRefType, allocmem,
+          shapeOp, load.slice(), update.indices(), load.typeparams(),
+          update->hasAttr(fir::factory::attrFortranArrayOffsets()));
+      assignElement(coor);
+      auto *storeOp = useMap.lookup(loadOp);
+      auto store = mlir::cast<ArrayMergeStoreOp>(storeOp);
+      rewriter.setInsertionPoint(storeOp);
+      // Copy out.
+      genArrayCopy(store.getLoc(), rewriter, store.memref(), allocmem, shapeOp,
+                   load.getType());
+      rewriter.create<FreeMemOp>(loc, allocmem);
+      return {coor, load.getResult()};
+    }
+    // Otherwise, when there is no conflict (a possible loop-carried
+    // dependence), the lhs array can be updated in place.
+    LLVM_DEBUG(llvm::outs() << "No, conflict wasn't found\n");
+    rewriter.setInsertionPoint(op);
+    auto coorTy = getEleTy(load.getType());
+    auto coor = genCoorOp(
+        rewriter, loc, coorTy, lhsEltRefType, load.memref(), load.shape(),
+        load.slice(), update.indices(), load.typeparams(),
+        update->hasAttr(fir::factory::attrFortranArrayOffsets()));
+    assignElement(coor);
+    return {coor, load.getResult()};
+  }
+
 private:
   const ArrayCopyAnalysis &analysis;
   const OperationUseMapT &useMap;
+};
+
+class ArrayUpdateConversion : public ArrayUpdateConversionBase<ArrayUpdateOp> {
+public:
+  explicit ArrayUpdateConversion(mlir::MLIRContext *ctx,
+                                 const ArrayCopyAnalysis &a,
+                                 const OperationUseMapT &m)
+      : ArrayUpdateConversionBase{ctx, a, m} {}
+
+  mlir::LogicalResult
+  matchAndRewrite(ArrayUpdateOp update,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto loc = update.getLoc();
+    auto assignElement = [&](mlir::Value coor) {
+      auto input = update.merge();
+      if (auto inEleTy = fir::dyn_cast_ptrEleTy(input.getType())) {
+        [[maybe_unused]] auto outEleTy =
+            fir::unwrapSequenceType(update.getType());
+        if (auto inChrTy = inEleTy.dyn_cast<fir::CharacterType>()) {
+          assert(outEleTy.isa<fir::CharacterType>());
+          fir::factory::genCharacterCopy(input, recoverCharLen(input), coor,
+                                         recoverCharLen(coor), rewriter, loc);
+        } else if (inEleTy.isa<fir::RecordType>()) {
+          fir::FirOpBuilder builder(
+              rewriter,
+              fir::getKindMapping(update->getParentOfType<mlir::ModuleOp>()));
+          if (!update.typeparams().empty()) {
+            auto boxTy = fir::BoxType::get(inEleTy);
+            mlir::Value emptyShape, emptySlice;
+            auto lhs = rewriter.create<fir::EmboxOp>(
+                loc, boxTy, coor, emptyShape, emptySlice, update.typeparams());
+            auto rhs = rewriter.create<fir::EmboxOp>(
+                loc, boxTy, input, emptyShape, emptySlice, update.typeparams());
+            fir::factory::genRecordAssignment(builder, loc, fir::BoxValue(lhs),
+                                              fir::BoxValue(rhs));
+          } else {
+            fir::factory::genRecordAssignment(builder, loc, coor, input);
+          }
+        } else {
+          llvm::report_fatal_error("not a legal reference type");
+        }
+      } else {
+        rewriter.create<fir::StoreOp>(loc, input, coor);
+      }
+    };
+    auto lhsEltRefType = toRefType(update.merge().getType());
+    auto [_, lhsLoadResult] = materializeAssignment(
+        loc, rewriter, update, assignElement, lhsEltRefType);
+    update.replaceAllUsesWith(lhsLoadResult);
+    rewriter.replaceOp(update, lhsLoadResult);
+    return mlir::success();
+  }
+};
+
+class ArrayModifyConversion : public ArrayUpdateConversionBase<ArrayModifyOp> {
+public:
+  explicit ArrayModifyConversion(mlir::MLIRContext *ctx,
+                                 const ArrayCopyAnalysis &a,
+                                 const OperationUseMapT &m)
+      : ArrayUpdateConversionBase{ctx, a, m} {}
+
+  mlir::LogicalResult
+  matchAndRewrite(ArrayModifyOp modify,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto loc = modify.getLoc();
+    auto assignElement = [](mlir::Value) {
+      // Assignment already materialized by lowering using lhs element address.
+    };
+    auto lhsEltRefType = modify.getResult(0).getType();
+    auto [lhsEltCoor, lhsLoadResult] = materializeAssignment(
+        loc, rewriter, modify, assignElement, lhsEltRefType);
+    modify.replaceAllUsesWith(mlir::ValueRange{lhsEltCoor, lhsLoadResult});
+    rewriter.replaceOp(modify, mlir::ValueRange{lhsEltCoor, lhsLoadResult});
+    return mlir::success();
+  }
 };
 
 class ArrayFetchConversion : public mlir::OpRewritePattern<ArrayFetchOp> {
@@ -708,10 +823,11 @@ public:
     mlir::OwningRewritePatternList patterns1(context);
     patterns1.insert<ArrayFetchConversion>(context, useMap);
     patterns1.insert<ArrayUpdateConversion>(context, analysis, useMap);
+    patterns1.insert<ArrayModifyConversion>(context, analysis, useMap);
     mlir::ConversionTarget target(*context);
     target.addLegalDialect<FIROpsDialect, mlir::scf::SCFDialect,
                            mlir::StandardOpsDialect>();
-    target.addIllegalOp<ArrayFetchOp, ArrayUpdateOp>();
+    target.addIllegalOp<ArrayFetchOp, ArrayUpdateOp, ArrayModifyOp>();
     // Rewrite the array fetch and array update ops.
     if (mlir::failed(
             mlir::applyPartialConversion(func, target, std::move(patterns1)))) {

--- a/flang/test/Fir/array-modify.fir
+++ b/flang/test/Fir/array-modify.fir
@@ -1,0 +1,130 @@
+// Test array-copy-value pass (copy elision) with fir.array_modify
+// RUN: fir-opt %s --array-value-copy | FileCheck %s
+
+// Test user_defined_assignment(arg0(:), arg1(:))
+func @no_overlap(%arg0: !fir.ref<!fir.array<100xf32>>, %arg1: !fir.ref<!fir.array<100xf32>>) {
+  %c100 = constant 100 : index
+  %c99 = constant 99 : index
+  %c1 = constant 1 : index
+  %c0 = constant 0 : index
+  %0 = fir.alloca f32
+  %1 = fir.shape %c100 : (index) -> !fir.shape<1>
+  %2 = fir.array_load %arg0(%1) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
+  %3 = fir.array_load %arg1(%1) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
+  %4 = fir.do_loop %arg2 = %c0 to %c99 step %c1 unordered iter_args(%arg3 = %2) -> (!fir.array<100xf32>) {
+    %5 = fir.array_fetch %3, %arg2 : (!fir.array<100xf32>, index) -> f32
+    %6:2 = fir.array_modify %arg3, %arg2 : (!fir.array<100xf32>, index) -> (!fir.ref<f32>, !fir.array<100xf32>)
+    fir.store %5 to %0 : !fir.ref<f32>
+    fir.call @user_defined_assignment(%6#0, %0) : (!fir.ref<f32>, !fir.ref<f32>) -> ()
+    fir.result %6#1 : !fir.array<100xf32>
+  }
+  fir.array_merge_store %2, %4 to %arg0 : !fir.array<100xf32>, !fir.array<100xf32>, !fir.ref<!fir.array<100xf32>>
+  return
+}
+// CHECK-LABEL:   func @no_overlap(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>) {
+// CHECK-DAG:           %[[VAL_2:.*]] = constant 100 : index
+// CHECK-DAG:           %[[VAL_3:.*]] = constant 99 : index
+// CHECK-DAG:           %[[VAL_4:.*]] = constant 1 : index
+// CHECK-DAG:           %[[VAL_5:.*]] = constant 0 : index
+// CHECK:           %[[VAL_6:.*]] = fir.alloca f32
+// CHECK:           %[[VAL_7:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+// CHECK:           %[[VAL_8:.*]] = fir.undefined !fir.array<100xf32>
+// CHECK:           %[[VAL_9:.*]] = fir.undefined !fir.array<100xf32>
+// CHECK:           %[[VAL_10:.*]] = fir.do_loop %[[VAL_11:.*]] = %[[VAL_5]] to %[[VAL_3]] step %[[VAL_4]] unordered iter_args(%[[VAL_12:.*]] = %[[VAL_8]]) -> (!fir.array<100xf32>) {
+// CHECK:             %[[VAL_13:.*]] = constant 1 : index
+// CHECK:             %[[VAL_14:.*]] = addi %[[VAL_11]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_15:.*]] = fir.array_coor %[[VAL_1]](%[[VAL_7]]) %[[VAL_14]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             %[[VAL_16:.*]] = fir.load %[[VAL_15]] : !fir.ref<f32>
+// CHECK:             %[[VAL_17:.*]] = constant 1 : index
+// CHECK:             %[[VAL_18:.*]] = addi %[[VAL_11]], %[[VAL_17]] : index
+// CHECK:             %[[VAL_19:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_7]]) %[[VAL_18]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             fir.store %[[VAL_16]] to %[[VAL_6]] : !fir.ref<f32>
+// CHECK:             fir.call @user_defined_assignment(%[[VAL_19]], %[[VAL_6]]) : (!fir.ref<f32>, !fir.ref<f32>) -> ()
+// CHECK:             fir.result %[[VAL_8]] : !fir.array<100xf32>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+
+// Test user_defined_assignment(arg0(:), arg0(100:1:-1))
+func @overlap(%arg0: !fir.ref<!fir.array<100xf32>>) {
+  %c100 = constant 100 : index
+  %c99 = constant 99 : index
+  %c1 = constant 1 : index
+  %c-1 = constant -1 : index
+  %c0 = constant 0 : index
+  %0 = fir.alloca f32
+  %1 = fir.shape %c100 : (index) -> !fir.shape<1>
+  %2 = fir.array_load %arg0(%1) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
+  %3 = fir.slice %c100, %c1, %c-1 : (index, index, index) -> !fir.slice<1>
+  %4 = fir.array_load %arg0(%1) [%3] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
+  %5 = fir.do_loop %arg1 = %c0 to %c99 step %c1 unordered iter_args(%arg2 = %2) -> (!fir.array<100xf32>) {
+    %6 = fir.array_fetch %4, %arg1 : (!fir.array<100xf32>, index) -> f32
+    %7:2 = fir.array_modify %arg2, %arg1 : (!fir.array<100xf32>, index) -> (!fir.ref<f32>, !fir.array<100xf32>)
+    fir.store %6 to %0 : !fir.ref<f32>
+    fir.call @user_defined_assignment(%7#0, %0) : (!fir.ref<f32>, !fir.ref<f32>) -> ()
+    fir.result %7#1 : !fir.array<100xf32>
+  }
+  fir.array_merge_store %2, %5 to %arg0 : !fir.array<100xf32>, !fir.array<100xf32>, !fir.ref<!fir.array<100xf32>>
+  return
+}
+// CHECK-LABEL:   func @overlap(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>) {
+// CHECK-DAG:           %[[VAL_1:.*]] = constant 100 : index
+// CHECK-DAG:           %[[VAL_2:.*]] = constant 99 : index
+// CHECK-DAG:           %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:           %[[VAL_4:.*]] = constant -1 : index
+// CHECK-DAG:           %[[VAL_5:.*]] = constant 0 : index
+// CHECK:           %[[VAL_6:.*]] = fir.alloca f32
+// CHECK:           %[[VAL_7:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
+// CHECK:           %[[VAL_8:.*]] = fir.allocmem !fir.array<100xf32>, %[[VAL_1]]
+// CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_1]] : (index) -> index
+// CHECK:           %[[VAL_10:.*]] = constant 0 : index
+// CHECK:           %[[VAL_11:.*]] = constant 1 : index
+// CHECK:           %[[VAL_12:.*]] = subi %[[VAL_9]], %[[VAL_11]] : index
+// CHECK:           fir.do_loop %[[VAL_13:.*]] = %[[VAL_10]] to %[[VAL_12]] step %[[VAL_11]] {
+// CHECK:             %[[VAL_14:.*]] = constant 1 : index
+// CHECK:             %[[VAL_15:.*]] = addi %[[VAL_13]], %[[VAL_14]] : index
+// CHECK:             %[[VAL_16:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_7]]) %[[VAL_15]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             %[[VAL_17:.*]] = fir.load %[[VAL_16]] : !fir.ref<f32>
+// CHECK:             %[[VAL_18:.*]] = constant 1 : index
+// CHECK:             %[[VAL_19:.*]] = addi %[[VAL_13]], %[[VAL_18]] : index
+// CHECK:             %[[VAL_20:.*]] = fir.array_coor %[[VAL_8]](%[[VAL_7]]) %[[VAL_19]] : (!fir.heap<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             fir.store %[[VAL_17]] to %[[VAL_20]] : !fir.ref<f32>
+// CHECK:           }
+// CHECK:           %[[VAL_21:.*]] = fir.undefined !fir.array<100xf32>
+// CHECK:           %[[VAL_22:.*]] = fir.slice %[[VAL_1]], %[[VAL_3]], %[[VAL_4]] : (index, index, index) -> !fir.slice<1>
+// CHECK:           %[[VAL_23:.*]] = fir.undefined !fir.array<100xf32>
+// CHECK:           %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_5]] to %[[VAL_2]] step %[[VAL_3]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_21]]) -> (!fir.array<100xf32>) {
+// CHECK:             %[[VAL_27:.*]] = constant 1 : index
+// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_25]], %[[VAL_27]] : index
+// CHECK:             %[[VAL_29:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_7]]) {{\[}}%[[VAL_22]]] %[[VAL_28]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+// CHECK:             %[[VAL_30:.*]] = fir.load %[[VAL_29]] : !fir.ref<f32>
+// CHECK:             %[[VAL_31:.*]] = constant 1 : index
+// CHECK:             %[[VAL_32:.*]] = addi %[[VAL_25]], %[[VAL_31]] : index
+// CHECK:             %[[VAL_33:.*]] = fir.array_coor %[[VAL_8]](%[[VAL_7]]) %[[VAL_32]] : (!fir.heap<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             fir.store %[[VAL_30]] to %[[VAL_6]] : !fir.ref<f32>
+// CHECK:             fir.call @user_defined_assignment(%[[VAL_33]], %[[VAL_6]]) : (!fir.ref<f32>, !fir.ref<f32>) -> ()
+// CHECK:             fir.result %[[VAL_21]] : !fir.array<100xf32>
+// CHECK:           }
+// CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_1]] : (index) -> index
+// CHECK:           %[[VAL_35:.*]] = constant 0 : index
+// CHECK:           %[[VAL_36:.*]] = constant 1 : index
+// CHECK:           %[[VAL_37:.*]] = subi %[[VAL_34]], %[[VAL_36]] : index
+// CHECK:           fir.do_loop %[[VAL_38:.*]] = %[[VAL_35]] to %[[VAL_37]] step %[[VAL_36]] {
+// CHECK:             %[[VAL_39:.*]] = constant 1 : index
+// CHECK:             %[[VAL_40:.*]] = addi %[[VAL_38]], %[[VAL_39]] : index
+// CHECK:             %[[VAL_41:.*]] = fir.array_coor %[[VAL_8]](%[[VAL_7]]) %[[VAL_40]] : (!fir.heap<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_41]] : !fir.ref<f32>
+// CHECK:             %[[VAL_43:.*]] = constant 1 : index
+// CHECK:             %[[VAL_44:.*]] = addi %[[VAL_38]], %[[VAL_43]] : index
+// CHECK:             %[[VAL_45:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_7]]) %[[VAL_44]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+// CHECK:             fir.store %[[VAL_42]] to %[[VAL_45]] : !fir.ref<f32>
+// CHECK:           }
+// CHECK:           fir.freemem %[[VAL_8]] : !fir.heap<!fir.array<100xf32>>
+// CHECK:           return
+// CHECK:         }
+
+func private @user_defined_assignment(!fir.ref<f32>, !fir.ref<f32>)

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -613,6 +613,17 @@ func @test_misc_ops(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m : index, %n : inde
   %av2 = fir.array_update %av1, %f, %i10, %j20 : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
   fir.array_merge_store %av1, %av2 to %arr1 : !fir.array<?x?xf32>, !fir.array<?x?xf32>, !fir.ref<!fir.array<?x?xf32>>
 
+
+  // CHECK: [[AV3:%.*]] = fir.array_load [[ARR1]]([[SHAPE]]) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.array<?x?xf32>
+  // CHECK: [[FVAL2:%.*]] = fir.array_fetch [[AV3]], [[I10]], [[J20]] : (!fir.array<?x?xf32>, index, index) -> f32
+  // CHECK: [[AV4:%.*]]:2 = fir.array_modify [[AV3]], [[I10]], [[J20]] : (!fir.array<?x?xf32>, index, index) -> (!fir.ref<f32>, !fir.array<?x?xf32>)
+  // CHECK: fir.store [[FVAL2]] to [[AV4]]#0 : !fir.ref<f32>
+  // CHECK: fir.array_merge_store [[AV3]], [[AV4]]#1 to [[ARR1]] : !fir.array<?x?xf32>, !fir.array<?x?xf32>, !fir.ref<!fir.array<?x?xf32>>
+  %av3 = fir.array_load %arr1(%s) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.array<?x?xf32>
+  %f2 = fir.array_fetch %av3, %i10, %j20 : (!fir.array<?x?xf32>, index, index) -> f32
+  %addr, %av4 = fir.array_modify %av3, %i10, %j20 : (!fir.array<?x?xf32>, index, index) -> (!fir.ref<f32>, !fir.array<?x?xf32>)
+  fir.store %f2 to %addr : !fir.ref<f32>
+  fir.array_merge_store %av3, %av4 to %arr1 : !fir.array<?x?xf32>, !fir.array<?x?xf32>, !fir.ref<!fir.array<?x?xf32>>
   return
 }
 

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -539,3 +539,16 @@ fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
   fir.has_value %2 : !fir.array<32x32xi32>
 }
 
+// -----
+
+func @bad_array_modify(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m : index, %n : index, %o : index, %p : index, %f : f32) {
+  %i10 = constant 10 : index
+  %j20 = constant 20 : index
+  %s = fir.shape_shift %m, %n, %o, %p : (index, index, index, index) -> !fir.shapeshift<2>
+  %av1 = fir.array_load %arr1(%s) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.array<?x?xf32>
+  // expected-error@+1 {{'fir.array_modify' op number of indices must match array dimension}}
+  %addr, %av2 = fir.array_modify %av1, %i10 : (!fir.array<?x?xf32>, index) -> (!fir.ref<f32>, !fir.array<?x?xf32>)
+  fir.store %f to %addr : !fir.ref<f32>
+  fir.array_merge_store %av1, %av2 to %arr1 : !fir.array<?x?xf32>, !fir.array<?x?xf32>, !fir.ref<!fir.array<?x?xf32>>
+  return
+}

--- a/flang/test/Lower/array-user-def-assignments.f90
+++ b/flang/test/Lower/array-user-def-assignments.f90
@@ -1,0 +1,194 @@
+! Test lower of elemental user defined assignments
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module defined_assignments
+  type t
+    integer :: i
+  end type
+  interface assignment(=)
+    elemental subroutine assign_t(a,b)
+      import t
+      type(t),intent(out) :: a
+      type(t),intent(in) :: b
+    end
+  end interface
+  interface assignment(=)
+    elemental subroutine assign_logical_to_real(a,b)
+      real, intent(out) :: a
+      logical, intent(in) :: b
+    end
+  end interface
+  interface assignment(=)
+    elemental subroutine assign_real_to_logical(a,b)
+      logical, intent(out) :: a
+      real, intent(in) :: b
+    end
+  end interface
+end module
+
+! CHECK-LABEL: func @_QPtest_derived(
+! CHECK-SAME:                        %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>) {
+subroutine test_derived(x)
+  use defined_assignments
+  type(t) :: x(100)
+  x = x(100:1:-1)
+! CHECK:         %[[VAL_1:.*]] = constant 100 : index
+! CHECK:         %[[VAL_2:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_3:.*]] = fir.array_load %[[VAL_0]](%[[VAL_2]]) : (!fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>, !fir.shape<1>) -> !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>
+! CHECK:         %[[VAL_4:.*]] = constant 100 : i64
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:         %[[VAL_6:.*]] = constant 100 : i64
+! CHECK:         %[[VAL_7:.*]] = constant 1 : i64
+! CHECK:         %[[VAL_8:.*]] = constant -1 : i64
+! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_10:.*]] = fir.slice %[[VAL_6]], %[[VAL_7]], %[[VAL_8]] : (i64, i64, i64) -> !fir.slice<1>
+! CHECK:         %[[VAL_11:.*]] = fir.array_load %[[VAL_0]](%[[VAL_9]]) {{\[}}%[[VAL_10]]] : (!fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>
+! CHECK:         %[[VAL_12:.*]] = constant 1 : index
+! CHECK:         %[[VAL_13:.*]] = constant 0 : index
+! CHECK:         %[[VAL_14:.*]] = subi %[[VAL_5]], %[[VAL_12]] : index
+! CHECK:         %[[VAL_15:.*]] = fir.do_loop %[[VAL_16:.*]] = %[[VAL_13]] to %[[VAL_14]] step %[[VAL_12]] unordered iter_args(%[[VAL_17:.*]] = %[[VAL_3]]) -> (!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>) {
+! CHECK:           %[[VAL_18:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_16]] : (!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>, index) -> !fir.ref<!fir.type<_QMdefined_assignmentsTt{i:i32}>>
+! CHECK:           %[[VAL_19:.*]]:2 = fir.array_modify %[[VAL_17]], %[[VAL_16]] : (!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>, index) -> (!fir.ref<!fir.type<_QMdefined_assignmentsTt{i:i32}>>, !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>)
+! CHECK:           fir.call @_QPassign_t(%[[VAL_19]]#0, %[[VAL_18]]) : (!fir.ref<!fir.type<_QMdefined_assignmentsTt{i:i32}>>, !fir.ref<!fir.type<_QMdefined_assignmentsTt{i:i32}>>) -> ()
+! CHECK:           fir.result %[[VAL_19]]#1 : !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_3]], %[[VAL_20:.*]] to %[[VAL_0]] : !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>, !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>, !fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_intrinsic(
+! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>) {
+subroutine test_intrinsic(x)
+  use defined_assignments
+  real :: x(100)
+  x = x(100:1:-1) .lt. 0.
+! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.logical<4>
+! CHECK:         %[[VAL_2:.*]] = constant 100 : index
+! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]](%[[VAL_3]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
+! CHECK:         %[[VAL_5:.*]] = constant 100 : i64
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i64) -> index
+! CHECK:         %[[VAL_7:.*]] = constant 100 : i64
+! CHECK:         %[[VAL_8:.*]] = constant 1 : i64
+! CHECK:         %[[VAL_9:.*]] = constant -1 : i64
+! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_11:.*]] = fir.slice %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : (i64, i64, i64) -> !fir.slice<1>
+! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_10]]) {{\[}}%[[VAL_11]]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
+! CHECK:         %[[VAL_13:.*]] = constant 0.000000e+00 : f32
+! CHECK:         %[[VAL_14:.*]] = constant 1 : index
+! CHECK:         %[[VAL_15:.*]] = constant 0 : index
+! CHECK:         %[[VAL_16:.*]] = subi %[[VAL_6]], %[[VAL_14]] : index
+! CHECK:         %[[VAL_17:.*]] = fir.do_loop %[[VAL_18:.*]] = %[[VAL_15]] to %[[VAL_16]] step %[[VAL_14]] unordered iter_args(%[[VAL_19:.*]] = %[[VAL_4]]) -> (!fir.array<100xf32>) {
+! CHECK:           %[[VAL_20:.*]] = fir.array_fetch %[[VAL_12]], %[[VAL_18]] : (!fir.array<100xf32>, index) -> f32
+! CHECK:           %[[VAL_21:.*]] = cmpf olt, %[[VAL_20]], %[[VAL_13]] : f32
+! CHECK:           %[[VAL_22:.*]]:2 = fir.array_modify %[[VAL_19]], %[[VAL_18]] : (!fir.array<100xf32>, index) -> (!fir.ref<f32>, !fir.array<100xf32>)
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_21]] : (i1) -> !fir.logical<4>
+! CHECK:           fir.store %[[VAL_23]] to %[[VAL_1]] : !fir.ref<!fir.logical<4>>
+! CHECK:           fir.call @_QPassign_logical_to_real(%[[VAL_22]]#0, %[[VAL_1]]) : (!fir.ref<f32>, !fir.ref<!fir.logical<4>>) -> ()
+! CHECK:           fir.result %[[VAL_22]]#1 : !fir.array<100xf32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_4]], %[[VAL_24:.*]] to %[[VAL_0]] : !fir.array<100xf32>, !fir.array<100xf32>, !fir.ref<!fir.array<100xf32>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_intrinsic_2(
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>,
+subroutine test_intrinsic_2(x, y)
+  use defined_assignments
+  logical :: x(100)
+  real :: y(100)
+  x = y
+! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>) {
+! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
+! CHECK:         %[[VAL_3:.*]] = constant 100 : index
+! CHECK:         %[[VAL_4:.*]] = constant 100 : index
+! CHECK:         %[[VAL_5:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_6:.*]] = fir.array_load %[[VAL_0]](%[[VAL_5]]) : (!fir.ref<!fir.array<100x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<100x!fir.logical<4>>
+! CHECK:         %[[VAL_7:.*]] = constant 100 : i64
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
+! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_1]](%[[VAL_9]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
+! CHECK:         %[[VAL_11:.*]] = constant 1 : index
+! CHECK:         %[[VAL_12:.*]] = constant 0 : index
+! CHECK:         %[[VAL_13:.*]] = subi %[[VAL_8]], %[[VAL_11]] : index
+! CHECK:         %[[VAL_14:.*]] = fir.do_loop %[[VAL_15:.*]] = %[[VAL_12]] to %[[VAL_13]] step %[[VAL_11]] unordered iter_args(%[[VAL_16:.*]] = %[[VAL_6]]) -> (!fir.array<100x!fir.logical<4>>) {
+! CHECK:           %[[VAL_17:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_15]] : (!fir.array<100xf32>, index) -> f32
+! CHECK:           %[[VAL_18:.*]]:2 = fir.array_modify %[[VAL_16]], %[[VAL_15]] : (!fir.array<100x!fir.logical<4>>, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<100x!fir.logical<4>>)
+! CHECK:           fir.store %[[VAL_17]] to %[[VAL_2]] : !fir.ref<f32>
+! CHECK:           fir.call @_QPassign_real_to_logical(%[[VAL_18]]#0, %[[VAL_2]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<f32>) -> ()
+! CHECK:           fir.result %[[VAL_18]]#1 : !fir.array<100x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_6]], %[[VAL_19:.*]] to %[[VAL_0]] : !fir.array<100x!fir.logical<4>>, !fir.array<100x!fir.logical<4>>, !fir.ref<!fir.array<100x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPfrom_char(
+! CHECK-SAME:                     %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                     %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+subroutine from_char(i, c)
+  interface assignment(=)
+    elemental subroutine sfrom_char(a,b)
+      integer, intent(out) :: a
+      character(*),intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:)
+  character(*) :: c(:)
+  i = c
+! CHECK:         %[[VAL_2:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_3:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.array<?x!fir.char<1,?>>
+! CHECK:         %[[VAL_4:.*]] = constant 0 : index
+! CHECK:         %[[VAL_5:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_4]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_6:.*]] = constant 1 : index
+! CHECK:         %[[VAL_7:.*]] = constant 0 : index
+! CHECK:         %[[VAL_8:.*]] = subi %[[VAL_5]]#1, %[[VAL_6]] : index
+! CHECK:         %[[VAL_9:.*]] = fir.do_loop %[[VAL_10:.*]] = %[[VAL_7]] to %[[VAL_8]] step %[[VAL_6]] unordered iter_args(%[[VAL_11:.*]] = %[[VAL_2]]) -> (!fir.array<?xi32>) {
+! CHECK:           %[[VAL_12:.*]] = fir.array_fetch %[[VAL_3]], %[[VAL_10]] : (!fir.array<?x!fir.char<1,?>>, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:           %[[VAL_13:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_14:.*]]:2 = fir.array_modify %[[VAL_11]], %[[VAL_10]] : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
+! CHECK:           %[[VAL_15:.*]] = fir.emboxchar %[[VAL_12]], %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPsfrom_char(%[[VAL_14]]#0, %[[VAL_15]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:           fir.result %[[VAL_14]]#1 : !fir.array<?xi32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_2]], %[[VAL_16:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPto_char(
+! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+subroutine to_char(i, c)
+  interface assignment(=)
+    elemental subroutine sto_char(a,b)
+      character(*), intent(out) :: a
+      integer,intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:)
+  character(*) :: c(:)
+  c = i
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
+! CHECK:         %[[VAL_3:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.array<?x!fir.char<1,?>>
+! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_5:.*]] = constant 0 : index
+! CHECK:         %[[VAL_6:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_5]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_7:.*]] = constant 1 : index
+! CHECK:         %[[VAL_8:.*]] = constant 0 : index
+! CHECK:         %[[VAL_9:.*]] = subi %[[VAL_6]]#1, %[[VAL_7]] : index
+! CHECK:         %[[VAL_10:.*]] = fir.do_loop %[[VAL_11:.*]] = %[[VAL_8]] to %[[VAL_9]] step %[[VAL_7]] unordered iter_args(%[[VAL_12:.*]] = %[[VAL_3]]) -> (!fir.array<?x!fir.char<1,?>>) {
+! CHECK:           %[[VAL_13:.*]] = fir.array_fetch %[[VAL_4]], %[[VAL_11]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:           %[[VAL_14:.*]]:2 = fir.array_modify %[[VAL_12]], %[[VAL_11]] : (!fir.array<?x!fir.char<1,?>>, index) -> (!fir.ref<!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>)
+! CHECK:           %[[VAL_15:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_16:.*]] = fir.emboxchar %[[VAL_14]]#0, %[[VAL_15]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           fir.call @_QPsto_char(%[[VAL_16]], %[[VAL_2]]) : (!fir.boxchar<1>, !fir.ref<i32>) -> ()
+! CHECK:           fir.result %[[VAL_14]]#1 : !fir.array<?x!fir.char<1,?>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_3]], %[[VAL_17:.*]] to %[[VAL_1]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine

--- a/flang/test/Lower/array-user-def-assignments.f90
+++ b/flang/test/Lower/array-user-def-assignments.f90
@@ -192,3 +192,628 @@ subroutine to_char(i, c)
 ! CHECK:         return
 ! CHECK:       }
 end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test user defined assignments inside FORALL and WHERE
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPtest_in_forall_1(
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
+! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+subroutine test_in_forall_1(x, y)
+  use defined_assignments
+  logical :: x(10)
+  real :: y(10)
+  forall (i=1:10) x(i) = y(i)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_4:.*]] = constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = constant 10 : index
+! CHECK:         %[[VAL_6:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i32) -> index
+! CHECK:         %[[VAL_10:.*]] = constant 1 : index
+! CHECK:         %[[VAL_11:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_11]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_14:.*]] = fir.array_load %[[VAL_1]](%[[VAL_13]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_15:.*]] = fir.do_loop %[[VAL_16:.*]] = %[[VAL_7]] to %[[VAL_9]] step %[[VAL_10]] unordered iter_args(%[[VAL_17:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_16]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_18]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]] = fir.array_fetch %[[VAL_14]], %[[VAL_21]] {Fortran.offsets} : (!fir.array<10xf32>, index) -> f32
+! CHECK:           %[[VAL_23:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (i32) -> i64
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i64) -> index
+! CHECK:           %[[VAL_26:.*]]:2 = fir.array_modify %[[VAL_17]], %[[VAL_25]] {Fortran.offsets} : (!fir.array<10x!fir.logical<4>>, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<10x!fir.logical<4>>)
+! CHECK:           fir.store %[[VAL_22]] to %[[VAL_2]] : !fir.ref<f32>
+! CHECK:           fir.call @_QPassign_real_to_logical(%[[VAL_26]]#0, %[[VAL_2]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<f32>) -> ()
+! CHECK:           fir.result %[[VAL_26]]#1 : !fir.array<10x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_12]], %[[VAL_27:.*]] to %[[VAL_0]] : !fir.array<10x!fir.logical<4>>, !fir.array<10x!fir.logical<4>>, !fir.ref<!fir.array<10x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_in_forall_2(
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
+! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+subroutine test_in_forall_2(x, y)
+  use defined_assignments
+  logical :: x(10)
+  real :: y(10)
+  forall (i=1:10) y(i) = y(i).lt.0.
+! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.logical<4>
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_4:.*]] = constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:         %[[VAL_7:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> index
+! CHECK:         %[[VAL_9:.*]] = constant 1 : index
+! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_11:.*]] = fir.array_load %[[VAL_1]](%[[VAL_10]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_13:.*]] = fir.array_load %[[VAL_1]](%[[VAL_12]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_14:.*]] = fir.do_loop %[[VAL_15:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_9]] unordered iter_args(%[[VAL_16:.*]] = %[[VAL_11]]) -> (!fir.array<10xf32>) {
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_15]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_17]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
+! CHECK:           %[[VAL_21:.*]] = fir.array_fetch %[[VAL_13]], %[[VAL_20]] {Fortran.offsets} : (!fir.array<10xf32>, index) -> f32
+! CHECK:           %[[VAL_22:.*]] = constant 0.000000e+00 : f32
+! CHECK:           %[[VAL_23:.*]] = cmpf olt, %[[VAL_21]], %[[VAL_22]] : f32
+! CHECK:           %[[VAL_24:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i32) -> i64
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i64) -> index
+! CHECK:           %[[VAL_27:.*]]:2 = fir.array_modify %[[VAL_16]], %[[VAL_26]] {Fortran.offsets} : (!fir.array<10xf32>, index) -> (!fir.ref<f32>, !fir.array<10xf32>)
+! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_23]] : (i1) -> !fir.logical<4>
+! CHECK:           fir.store %[[VAL_28]] to %[[VAL_2]] : !fir.ref<!fir.logical<4>>
+! CHECK:           fir.call @_QPassign_logical_to_real(%[[VAL_27]]#0, %[[VAL_2]]) : (!fir.ref<f32>, !fir.ref<!fir.logical<4>>) -> ()
+! CHECK:           fir.result %[[VAL_27]]#1 : !fir.array<10xf32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_11]], %[[VAL_29:.*]] to %[[VAL_1]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_intrinsic_where_1(
+! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
+! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>,
+! CHECK-SAME:                                  %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>) {
+subroutine test_intrinsic_where_1(x, y, l)
+  use defined_assignments
+  logical :: x(10), l(10)
+  real :: y(10)
+  where(l) x = y
+! CHECK:         %[[VAL_3:.*]] = fir.alloca f32
+! CHECK:         %[[VAL_4:.*]] = constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = constant 10 : index
+! CHECK:         %[[VAL_6:.*]] = constant 10 : index
+! CHECK:         %[[VAL_7:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_8:.*]] = fir.array_load %[[VAL_0]](%[[VAL_7]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_9:.*]] = constant 10 : i64
+! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i64) -> index
+! CHECK:         %[[VAL_11:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_1]](%[[VAL_11]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_13:.*]] = constant 10 : i64
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i64) -> index
+! CHECK:         %[[VAL_15:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_16:.*]] = fir.array_load %[[VAL_2]](%[[VAL_15]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_17:.*]] = fir.allocmem !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_18:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_19:.*]] = fir.array_load %[[VAL_17]](%[[VAL_18]]) : (!fir.heap<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_20:.*]] = constant 1 : index
+! CHECK:         %[[VAL_21:.*]] = constant 0 : index
+! CHECK:         %[[VAL_22:.*]] = subi %[[VAL_14]], %[[VAL_20]] : index
+! CHECK:         %[[VAL_23:.*]] = fir.do_loop %[[VAL_24:.*]] = %[[VAL_21]] to %[[VAL_22]] step %[[VAL_20]] unordered iter_args(%[[VAL_25:.*]] = %[[VAL_19]]) -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:           %[[VAL_26:.*]] = fir.array_fetch %[[VAL_16]], %[[VAL_24]] : (!fir.array<10x!fir.logical<4>>, index) -> !fir.logical<4>
+! CHECK:           %[[VAL_27:.*]] = fir.array_update %[[VAL_25]], %[[VAL_26]], %[[VAL_24]] : (!fir.array<10x!fir.logical<4>>, !fir.logical<4>, index) -> !fir.array<10x!fir.logical<4>>
+! CHECK:           fir.result %[[VAL_27]] : !fir.array<10x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_19]], %[[VAL_28:.*]] to %[[VAL_17]] : !fir.array<10x!fir.logical<4>>, !fir.array<10x!fir.logical<4>>, !fir.heap<!fir.array<10x!fir.logical<4>>>
+! CHECK:         %[[VAL_29:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_30:.*]] = constant 1 : index
+! CHECK:         %[[VAL_31:.*]] = constant 0 : index
+! CHECK:         %[[VAL_32:.*]] = subi %[[VAL_10]], %[[VAL_30]] : index
+! CHECK:         %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_31]] to %[[VAL_32]] step %[[VAL_30]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_8]]) -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:           %[[VAL_36:.*]] = constant 1 : index
+! CHECK:           %[[VAL_37:.*]] = addi %[[VAL_34]], %[[VAL_36]] : index
+! CHECK:           %[[VAL_38:.*]] = fir.array_coor %[[VAL_17]](%[[VAL_29]]) %[[VAL_37]] : (!fir.heap<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>, index) -> !fir.ref<!fir.logical<4>>
+! CHECK:           %[[VAL_39:.*]] = fir.load %[[VAL_38]] : !fir.ref<!fir.logical<4>>
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (!fir.logical<4>) -> i1
+! CHECK:           %[[VAL_41:.*]] = fir.if %[[VAL_40]] -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:             %[[VAL_42:.*]] = fir.array_fetch %[[VAL_12]], %[[VAL_34]] : (!fir.array<10xf32>, index) -> f32
+! CHECK:             %[[VAL_43:.*]]:2 = fir.array_modify %[[VAL_35]], %[[VAL_34]] : (!fir.array<10x!fir.logical<4>>, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<10x!fir.logical<4>>)
+! CHECK:             fir.store %[[VAL_42]] to %[[VAL_3]] : !fir.ref<f32>
+! CHECK:             fir.call @_QPassign_real_to_logical(%[[VAL_43]]#0, %[[VAL_3]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<f32>) -> ()
+! CHECK:             fir.result %[[VAL_43]]#1 : !fir.array<10x!fir.logical<4>>
+! CHECK:           } else {
+! CHECK:             fir.result %[[VAL_35]] : !fir.array<10x!fir.logical<4>>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_44:.*]] : !fir.array<10x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_45:.*]] to %[[VAL_0]] : !fir.array<10x!fir.logical<4>>, !fir.array<10x!fir.logical<4>>, !fir.ref<!fir.array<10x!fir.logical<4>>>
+! CHECK:         fir.freemem %[[VAL_17]] : !fir.heap<!fir.array<10x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_intrinsic_where_2(
+! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
+! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>,
+! CHECK-SAME:                                  %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>) {
+subroutine test_intrinsic_where_2(x, y, l)
+  use defined_assignments
+  logical :: x(10), l(10)
+  real :: y(10)
+  where(l) y = y.lt.0.
+! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.logical<4>
+! CHECK:         %[[VAL_4:.*]] = constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = constant 10 : index
+! CHECK:         %[[VAL_6:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_7:.*]] = fir.array_load %[[VAL_1]](%[[VAL_6]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_8:.*]] = constant 10 : i64
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
+! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_11:.*]] = fir.array_load %[[VAL_1]](%[[VAL_10]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
+! CHECK:         %[[VAL_12:.*]] = constant 0.000000e+00 : f32
+! CHECK:         %[[VAL_13:.*]] = constant 10 : i64
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i64) -> index
+! CHECK:         %[[VAL_15:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_16:.*]] = fir.array_load %[[VAL_2]](%[[VAL_15]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_17:.*]] = fir.allocmem !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_18:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_19:.*]] = fir.array_load %[[VAL_17]](%[[VAL_18]]) : (!fir.heap<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_20:.*]] = constant 1 : index
+! CHECK:         %[[VAL_21:.*]] = constant 0 : index
+! CHECK:         %[[VAL_22:.*]] = subi %[[VAL_14]], %[[VAL_20]] : index
+! CHECK:         %[[VAL_23:.*]] = fir.do_loop %[[VAL_24:.*]] = %[[VAL_21]] to %[[VAL_22]] step %[[VAL_20]] unordered iter_args(%[[VAL_25:.*]] = %[[VAL_19]]) -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:           %[[VAL_26:.*]] = fir.array_fetch %[[VAL_16]], %[[VAL_24]] : (!fir.array<10x!fir.logical<4>>, index) -> !fir.logical<4>
+! CHECK:           %[[VAL_27:.*]] = fir.array_update %[[VAL_25]], %[[VAL_26]], %[[VAL_24]] : (!fir.array<10x!fir.logical<4>>, !fir.logical<4>, index) -> !fir.array<10x!fir.logical<4>>
+! CHECK:           fir.result %[[VAL_27]] : !fir.array<10x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_19]], %[[VAL_28:.*]] to %[[VAL_17]] : !fir.array<10x!fir.logical<4>>, !fir.array<10x!fir.logical<4>>, !fir.heap<!fir.array<10x!fir.logical<4>>>
+! CHECK:         %[[VAL_29:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_30:.*]] = constant 1 : index
+! CHECK:         %[[VAL_31:.*]] = constant 0 : index
+! CHECK:         %[[VAL_32:.*]] = subi %[[VAL_9]], %[[VAL_30]] : index
+! CHECK:         %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_31]] to %[[VAL_32]] step %[[VAL_30]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_7]]) -> (!fir.array<10xf32>) {
+! CHECK:           %[[VAL_36:.*]] = constant 1 : index
+! CHECK:           %[[VAL_37:.*]] = addi %[[VAL_34]], %[[VAL_36]] : index
+! CHECK:           %[[VAL_38:.*]] = fir.array_coor %[[VAL_17]](%[[VAL_29]]) %[[VAL_37]] : (!fir.heap<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>, index) -> !fir.ref<!fir.logical<4>>
+! CHECK:           %[[VAL_39:.*]] = fir.load %[[VAL_38]] : !fir.ref<!fir.logical<4>>
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (!fir.logical<4>) -> i1
+! CHECK:           %[[VAL_41:.*]] = fir.if %[[VAL_40]] -> (!fir.array<10xf32>) {
+! CHECK:             %[[VAL_42:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_34]] : (!fir.array<10xf32>, index) -> f32
+! CHECK:             %[[VAL_43:.*]] = cmpf olt, %[[VAL_42]], %[[VAL_12]] : f32
+! CHECK:             %[[VAL_44:.*]]:2 = fir.array_modify %[[VAL_35]], %[[VAL_34]] : (!fir.array<10xf32>, index) -> (!fir.ref<f32>, !fir.array<10xf32>)
+! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_43]] : (i1) -> !fir.logical<4>
+! CHECK:             fir.store %[[VAL_45]] to %[[VAL_3]] : !fir.ref<!fir.logical<4>>
+! CHECK:             fir.call @_QPassign_logical_to_real(%[[VAL_44]]#0, %[[VAL_3]]) : (!fir.ref<f32>, !fir.ref<!fir.logical<4>>) -> ()
+! CHECK:             fir.result %[[VAL_44]]#1 : !fir.array<10xf32>
+! CHECK:           } else {
+! CHECK:             fir.result %[[VAL_35]] : !fir.array<10xf32>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_46:.*]] : !fir.array<10xf32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_7]], %[[VAL_47:.*]] to %[[VAL_1]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>
+! CHECK:         fir.freemem %[[VAL_17]] : !fir.heap<!fir.array<10x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_scalar_func_but_not_elemental(
+! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>,
+! CHECK-SAME:                                              %[[VAL_1:.*]]: !fir.ref<!fir.array<100xi32>>) {
+subroutine test_scalar_func_but_not_elemental(x, y)
+  interface assignment(=)
+    ! scalar, but not elemental
+    elemental subroutine assign_integer_to_logical(a,b)
+      logical, intent(out) :: a
+      integer, intent(in) :: b
+    end
+  end interface
+  logical :: x(100)
+  integer :: y(100)
+  ! Scalar assignment in forall should be treated just like elemental
+  ! functions.
+  forall(i=1:10) x(i) = y(i)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_4:.*]] = constant 100 : index
+! CHECK:         %[[VAL_5:.*]] = constant 100 : index
+! CHECK:         %[[VAL_6:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i32) -> index
+! CHECK:         %[[VAL_10:.*]] = constant 1 : index
+! CHECK:         %[[VAL_11:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_11]]) : (!fir.ref<!fir.array<100x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<100x!fir.logical<4>>
+! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_14:.*]] = fir.array_load %[[VAL_1]](%[[VAL_13]]) : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.array<100xi32>
+! CHECK:         %[[VAL_15:.*]] = fir.do_loop %[[VAL_16:.*]] = %[[VAL_7]] to %[[VAL_9]] step %[[VAL_10]] unordered iter_args(%[[VAL_17:.*]] = %[[VAL_12]]) -> (!fir.array<100x!fir.logical<4>>) {
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_16]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_18]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]] = fir.array_fetch %[[VAL_14]], %[[VAL_21]] {Fortran.offsets} : (!fir.array<100xi32>, index) -> i32
+! CHECK:           %[[VAL_23:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (i32) -> i64
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i64) -> index
+! CHECK:           %[[VAL_26:.*]]:2 = fir.array_modify %[[VAL_17]], %[[VAL_25]] {Fortran.offsets} : (!fir.array<100x!fir.logical<4>>, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<100x!fir.logical<4>>)
+! CHECK:           fir.store %[[VAL_22]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           fir.call @_QPassign_integer_to_logical(%[[VAL_26]]#0, %[[VAL_2]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<i32>) -> ()
+! CHECK:           fir.result %[[VAL_26]]#1 : !fir.array<100x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_12]], %[[VAL_27:.*]] to %[[VAL_0]] : !fir.array<100x!fir.logical<4>>, !fir.array<100x!fir.logical<4>>, !fir.ref<!fir.array<100x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_in_forall_with_cleanup(
+! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
+! CHECK-SAME:                                       %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+subroutine test_in_forall_with_cleanup(x, y)
+  use defined_assignments
+  interface
+    pure function returns_alloc(i)
+      integer, intent(in) :: i
+      real, allocatable :: returns_alloc
+    end function
+  end interface
+  logical :: x(10)
+  real :: y(10)
+  forall (i=1:10) x(i) = returns_alloc(i)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = ".result"}
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_4:.*]] = constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:         %[[VAL_7:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> index
+! CHECK:         %[[VAL_9:.*]] = constant 1 : index
+! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_11:.*]] = fir.array_load %[[VAL_0]](%[[VAL_10]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
+! CHECK:         %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_9]] unordered iter_args(%[[VAL_14:.*]] = %[[VAL_11]]) -> (!fir.array<10x!fir.logical<4>>) {
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_13]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_15]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_16:.*]] = fir.call @_QPreturns_alloc(%[[VAL_3]]) : (!fir.ref<i32>) -> !fir.box<!fir.heap<f32>>
+! CHECK:           fir.save_result %[[VAL_16]] to %[[VAL_2]] : !fir.box<!fir.heap<f32>>, !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_17:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_18:.*]] = fir.box_addr %[[VAL_17]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]]:2 = fir.array_modify %[[VAL_14]], %[[VAL_21]] {Fortran.offsets} : (!fir.array<10x!fir.logical<4>>, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<10x!fir.logical<4>>)
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_18]] : (!fir.heap<f32>) -> !fir.ref<f32>
+! CHECK:           fir.call @_QPassign_real_to_logical(%[[VAL_22]]#0, %[[VAL_23]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<f32>) -> ()
+! CHECK:           %[[VAL_24:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_25:.*]] = fir.box_addr %[[VAL_24]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (!fir.heap<f32>) -> i64
+! CHECK:           %[[VAL_27:.*]] = constant 0 : i64
+! CHECK:           %[[VAL_28:.*]] = cmpi ne, %[[VAL_26]], %[[VAL_27]] : i64
+! CHECK:           fir.if %[[VAL_28]] {
+! CHECK:             fir.freemem %[[VAL_25]] : !fir.heap<f32>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_22]]#1 : !fir.array<10x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_11]], %[[VAL_29:.*]] to %[[VAL_0]] : !fir.array<10x!fir.logical<4>>, !fir.array<10x!fir.logical<4>>, !fir.ref<!fir.array<10x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_forall_array(
+! CHECK-SAME:                             %[[VAL_0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>,
+! CHECK-SAME:                             %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+subroutine test_forall_array(x, y)
+  use defined_assignments
+  logical :: x(:, :)
+  real :: y(:, :)
+  forall (i=1:10) x(i, :) = y(i, :)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_4:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:         %[[VAL_6:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = constant 1 : index
+! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.array<?x?x!fir.logical<4>>
+! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.array<?x?xf32>
+! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_9]]) -> (!fir.array<?x?x!fir.logical<4>>) {
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_15:.*]] = constant 1 : index
+! CHECK:           %[[VAL_16:.*]] = constant 1 : index
+! CHECK:           %[[VAL_17:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_16]] : (!fir.box<!fir.array<?x?x!fir.logical<4>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_18:.*]] = addi %[[VAL_15]], %[[VAL_17]]#1 : index
+! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_18]], %[[VAL_15]] : index
+! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]] = constant 0 : index
+! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_19]], %[[VAL_15]] : index
+! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_22]] : index
+! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_22]] : index
+! CHECK:           %[[VAL_28:.*]] = constant 1 : index
+! CHECK:           %[[VAL_29:.*]] = constant 0 : index
+! CHECK:           %[[VAL_30:.*]] = subi %[[VAL_27]], %[[VAL_28]] : index
+! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_29]] to %[[VAL_30]] step %[[VAL_28]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_13]]) -> (!fir.array<?x?x!fir.logical<4>>) {
+! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> i64
+! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i64) -> index
+! CHECK:             %[[VAL_37:.*]] = constant 1 : index
+! CHECK:             %[[VAL_38:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i64) -> index
+! CHECK:             %[[VAL_40:.*]] = muli %[[VAL_32]], %[[VAL_39]] : index
+! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_37]], %[[VAL_40]] : index
+! CHECK:             %[[VAL_42:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_36]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<?x?xf32>, index, index) -> f32
+! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
+! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
+! CHECK:             %[[VAL_46:.*]] = constant 1 : index
+! CHECK:             %[[VAL_47:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index
+! CHECK:             %[[VAL_49:.*]] = muli %[[VAL_32]], %[[VAL_48]] : index
+! CHECK:             %[[VAL_50:.*]] = addi %[[VAL_46]], %[[VAL_49]] : index
+! CHECK:             %[[VAL_51:.*]]:2 = fir.array_modify %[[VAL_13]], %[[VAL_45]], %[[VAL_50]] {Fortran.offsets} : (!fir.array<?x?x!fir.logical<4>>, index, index) -> (!fir.ref<!fir.logical<4>>, !fir.array<?x?x!fir.logical<4>>)
+! CHECK:             fir.store %[[VAL_42]] to %[[VAL_2]] : !fir.ref<f32>
+! CHECK:             fir.call @_QPassign_real_to_logical(%[[VAL_51]]#0, %[[VAL_2]]) : (!fir.ref<!fir.logical<4>>, !fir.ref<f32>) -> ()
+! CHECK:             fir.result %[[VAL_51]]#1 : !fir.array<?x?x!fir.logical<4>>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_52:.*]] : !fir.array<?x?x!fir.logical<4>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_9]], %[[VAL_53:.*]] to %[[VAL_0]] : !fir.array<?x?x!fir.logical<4>>, !fir.array<?x?x!fir.logical<4>>, !fir.box<!fir.array<?x?x!fir.logical<4>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPfrom_char_forall(
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+subroutine from_char_forall(i, c)
+  interface assignment(=)
+    elemental subroutine sfrom_char(a,b)
+      integer, intent(out) :: a
+      character(*),intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:)
+  character(*) :: c(:)
+  forall (j=1:10) i(j) = c(j)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
+! CHECK:         %[[VAL_3:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i32) -> index
+! CHECK:         %[[VAL_5:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:         %[[VAL_7:.*]] = constant 1 : index
+! CHECK:         %[[VAL_8:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.array<?x!fir.char<1,?>>
+! CHECK:         %[[VAL_10:.*]] = fir.do_loop %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_6]] step %[[VAL_7]] unordered iter_args(%[[VAL_12:.*]] = %[[VAL_8]]) -> (!fir.array<?xi32>) {
+! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_11]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           %[[VAL_14:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i32) -> i64
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i64) -> index
+! CHECK:           %[[VAL_17:.*]] = fir.array_fetch %[[VAL_9]], %[[VAL_16]] {Fortran.offsets} : (!fir.array<?x!fir.char<1,?>>, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:           %[[VAL_18:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]]:2 = fir.array_modify %[[VAL_12]], %[[VAL_21]] {Fortran.offsets} : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
+! CHECK:           %[[VAL_23:.*]] = fir.emboxchar %[[VAL_17]], %[[VAL_18]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPsfrom_char(%[[VAL_22]]#0, %[[VAL_23]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:           fir.result %[[VAL_22]]#1 : !fir.array<?xi32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_24:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPto_char_forall(
+! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
+! CHECK-SAME:                          %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+subroutine to_char_forall(i, c)
+  interface assignment(=)
+    elemental subroutine sto_char(a,b)
+      character(*), intent(out) :: a
+      integer,intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:)
+  character(*) :: c(:)
+  forall (j=1:10) c(j) = i(j)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
+! CHECK:         %[[VAL_4:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:         %[[VAL_6:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = constant 1 : index
+! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.array<?x!fir.char<1,?>>
+! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_9]]) -> (!fir.array<?x!fir.char<1,?>>) {
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i64) -> index
+! CHECK:           %[[VAL_18:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_17]] {Fortran.offsets} : (!fir.array<?xi32>, index) -> i32
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]]:2 = fir.array_modify %[[VAL_13]], %[[VAL_21]] {Fortran.offsets} : (!fir.array<?x!fir.char<1,?>>, index) -> (!fir.ref<!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>)
+! CHECK:           %[[VAL_23:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_24:.*]] = fir.emboxchar %[[VAL_22]]#0, %[[VAL_23]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.store %[[VAL_18]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           fir.call @_QPsto_char(%[[VAL_24]], %[[VAL_2]]) : (!fir.boxchar<1>, !fir.ref<i32>) -> ()
+! CHECK:           fir.result %[[VAL_22]]#1 : !fir.array<?x!fir.char<1,?>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_9]], %[[VAL_25:.*]] to %[[VAL_1]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPfrom_char_forall_array(
+! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>,
+! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>) {
+subroutine from_char_forall_array(i, c)
+  interface assignment(=)
+    elemental subroutine sfrom_char(a,b)
+      integer, intent(out) :: a
+      character(*),intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:, :)
+  character(*) :: c(:, :)
+  forall (j=1:10) i(j, :) = c(j, :)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
+! CHECK:         %[[VAL_3:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i32) -> index
+! CHECK:         %[[VAL_5:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:         %[[VAL_7:.*]] = constant 1 : index
+! CHECK:         %[[VAL_8:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?xi32>>) -> !fir.array<?x?xi32>
+! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> !fir.array<?x?x!fir.char<1,?>>
+! CHECK:         %[[VAL_10:.*]] = fir.do_loop %[[VAL_11:.*]] = %[[VAL_4]] to %[[VAL_6]] step %[[VAL_7]] unordered iter_args(%[[VAL_12:.*]] = %[[VAL_8]]) -> (!fir.array<?x?xi32>) {
+! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_11]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           %[[VAL_14:.*]] = constant 1 : index
+! CHECK:           %[[VAL_15:.*]] = constant 1 : index
+! CHECK:           %[[VAL_16:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_15]] : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_17:.*]] = addi %[[VAL_14]], %[[VAL_16]]#1 : index
+! CHECK:           %[[VAL_18:.*]] = subi %[[VAL_17]], %[[VAL_14]] : index
+! CHECK:           %[[VAL_19:.*]] = constant 1 : i64
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
+! CHECK:           %[[VAL_21:.*]] = constant 0 : index
+! CHECK:           %[[VAL_22:.*]] = subi %[[VAL_18]], %[[VAL_14]] : index
+! CHECK:           %[[VAL_23:.*]] = addi %[[VAL_22]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_24:.*]] = divi_signed %[[VAL_23]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_25:.*]] = cmpi sgt, %[[VAL_24]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_26:.*]] = select %[[VAL_25]], %[[VAL_24]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_27:.*]] = constant 1 : index
+! CHECK:           %[[VAL_28:.*]] = constant 0 : index
+! CHECK:           %[[VAL_29:.*]] = subi %[[VAL_26]], %[[VAL_27]] : index
+! CHECK:           %[[VAL_30:.*]] = fir.do_loop %[[VAL_31:.*]] = %[[VAL_28]] to %[[VAL_29]] step %[[VAL_27]] unordered iter_args(%[[VAL_32:.*]] = %[[VAL_12]]) -> (!fir.array<?x?xi32>) {
+! CHECK:             %[[VAL_33:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i32) -> i64
+! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i64) -> index
+! CHECK:             %[[VAL_36:.*]] = constant 1 : index
+! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
+! CHECK:             %[[VAL_39:.*]] = muli %[[VAL_31]], %[[VAL_38]] : index
+! CHECK:             %[[VAL_40:.*]] = addi %[[VAL_36]], %[[VAL_39]] : index
+! CHECK:             %[[VAL_41:.*]] = fir.array_fetch %[[VAL_9]], %[[VAL_35]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<?x?x!fir.char<1,?>>, index, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:             %[[VAL_42:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> index
+! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
+! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
+! CHECK:             %[[VAL_46:.*]] = constant 1 : index
+! CHECK:             %[[VAL_47:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index
+! CHECK:             %[[VAL_49:.*]] = muli %[[VAL_31]], %[[VAL_48]] : index
+! CHECK:             %[[VAL_50:.*]] = addi %[[VAL_46]], %[[VAL_49]] : index
+! CHECK:             %[[VAL_51:.*]]:2 = fir.array_modify %[[VAL_12]], %[[VAL_45]], %[[VAL_50]] {Fortran.offsets} : (!fir.array<?x?xi32>, index, index) -> (!fir.ref<i32>, !fir.array<?x?xi32>)
+! CHECK:             %[[VAL_52:.*]] = fir.emboxchar %[[VAL_41]], %[[VAL_42]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:             fir.call @_QPsfrom_char(%[[VAL_51]]#0, %[[VAL_52]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:             fir.result %[[VAL_51]]#1 : !fir.array<?x?xi32>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_53:.*]] : !fir.array<?x?xi32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_54:.*]] to %[[VAL_0]] : !fir.array<?x?xi32>, !fir.array<?x?xi32>, !fir.box<!fir.array<?x?xi32>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! CHECK-LABEL: func @_QPto_char_forall_array(
+! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>,
+! CHECK-SAME:                                %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>) {
+subroutine to_char_forall_array(i, c)
+  interface assignment(=)
+    elemental subroutine sto_char(a,b)
+      character(*), intent(out) :: a
+      integer,intent(in) :: b
+    end subroutine
+  end interface
+  integer :: i(:, :)
+  character(*) :: c(:, :)
+  forall (j=1:10) c(j, :) = i(j, :)
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
+! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
+! CHECK:         %[[VAL_4:.*]] = constant 1 : i32
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:         %[[VAL_6:.*]] = constant 10 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = constant 1 : index
+! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> !fir.array<?x?x!fir.char<1,?>>
+! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?xi32>>) -> !fir.array<?x?xi32>
+! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_9]]) -> (!fir.array<?x?x!fir.char<1,?>>) {
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_3]] : !fir.ref<i32>
+! CHECK:           %[[VAL_15:.*]] = constant 1 : index
+! CHECK:           %[[VAL_16:.*]] = constant 1 : index
+! CHECK:           %[[VAL_17:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_16]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_18:.*]] = addi %[[VAL_15]], %[[VAL_17]]#1 : index
+! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_18]], %[[VAL_15]] : index
+! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+! CHECK:           %[[VAL_22:.*]] = constant 0 : index
+! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_19]], %[[VAL_15]] : index
+! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_21]] : index
+! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_22]] : index
+! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_22]] : index
+! CHECK:           %[[VAL_28:.*]] = constant 1 : index
+! CHECK:           %[[VAL_29:.*]] = constant 0 : index
+! CHECK:           %[[VAL_30:.*]] = subi %[[VAL_27]], %[[VAL_28]] : index
+! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_29]] to %[[VAL_30]] step %[[VAL_28]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_13]]) -> (!fir.array<?x?x!fir.char<1,?>>) {
+! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> i64
+! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i64) -> index
+! CHECK:             %[[VAL_37:.*]] = constant 1 : index
+! CHECK:             %[[VAL_38:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i64) -> index
+! CHECK:             %[[VAL_40:.*]] = muli %[[VAL_32]], %[[VAL_39]] : index
+! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_37]], %[[VAL_40]] : index
+! CHECK:             %[[VAL_42:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_36]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<?x?xi32>, index, index) -> i32
+! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
+! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
+! CHECK:             %[[VAL_46:.*]] = constant 1 : index
+! CHECK:             %[[VAL_47:.*]] = constant 1 : i64
+! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index
+! CHECK:             %[[VAL_49:.*]] = muli %[[VAL_32]], %[[VAL_48]] : index
+! CHECK:             %[[VAL_50:.*]] = addi %[[VAL_46]], %[[VAL_49]] : index
+! CHECK:             %[[VAL_51:.*]]:2 = fir.array_modify %[[VAL_13]], %[[VAL_45]], %[[VAL_50]] {Fortran.offsets} : (!fir.array<?x?x!fir.char<1,?>>, index, index) -> (!fir.ref<!fir.char<1,?>>, !fir.array<?x?x!fir.char<1,?>>)
+! CHECK:             %[[VAL_52:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> index
+! CHECK:             %[[VAL_53:.*]] = fir.emboxchar %[[VAL_51]]#0, %[[VAL_52]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:             fir.store %[[VAL_42]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:             fir.call @_QPsto_char(%[[VAL_53]], %[[VAL_2]]) : (!fir.boxchar<1>, !fir.ref<i32>) -> ()
+! CHECK:             fir.result %[[VAL_51]]#1 : !fir.array<?x?x!fir.char<1,?>>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_54:.*]] : !fir.array<?x?x!fir.char<1,?>>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_9]], %[[VAL_55:.*]] to %[[VAL_1]] : !fir.array<?x?x!fir.char<1,?>>, !fir.array<?x?x!fir.char<1,?>>, !fir.box<!fir.array<?x?x!fir.char<1,?>>>
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! TODO: test array user defined assignment inside FORALL.
+!subroutine test_todo(x, y)
+!  interface assignment(=)
+!    ! User assignment is not elemental, it takes array arguments.
+!    pure subroutine assign_array(a,b)
+!      logical, intent(out) :: a(:)
+!      integer, intent(in) :: b(:)
+!    end
+!  end interface
+!  logical :: x(10, 10)
+!  integer :: y(10, 10)
+!  forall(i=1:10) x(i, :) = y(i, :)
+!end subroutine


### PR DESCRIPTION
**1. Introduce a new fir.array_modify to decorrelate the identification of the assignment from its semantics**

fir.array_update is only handling intrinsic assignments.
They are two big differences with user defined assignments:
- The LHS and RHS types may not match, this does not play well
   with fir.array_update that relies on both the merge and the
   updated element to have the same type.
- User defined assignment has a call semantics, with potential
   side effects. So if a fir.array_update can hide a call, it traits
   would need to be updated.

Instead of hiding more semantic in the fir.array_update, introduce
a new fir.array_modify op that allows de-correlating indicating that
an array value element is modified, and how it is modified.
This allow the ArrayValueCopy pass to still perform copy elision
while not having to implement the call itself, and could in general
be used for all kind of assignments (e.g. character assignment).

Note that fir.array_modify still has a merge argument that is not used to generate anything but is central for the ArrayValueCopy alias analysis (see populateSets in ArrayValueCopy.cpp).

**2. Update Lowering to use it and lower user defined assignment in elemental contexts**

Note: user assignments involving characters need a bit more work because the RHS length is not tracked currently at the place where array_update are generated. Elemental user defined assignment Where and Forall are also not yet handled.