### PR TITLE
Fix clang warning

### DIFF
--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -163,9 +163,9 @@ TEST(InternalNamesTest, doProgramEntry) {
 }
 
 TEST(InternalNamesTest, doNamelistGroup) {
-  llvm::StringRef actual = NameUniquer::doNamelistGroup({"mod1"}, {}, {"nlg"});
+  std::string actual = NameUniquer::doNamelistGroup({"mod1"}, {}, "nlg");
   std::string expectedMangledName = "_QMmod1Gnlg";
-  ASSERT_EQ(actual.str(), expectedMangledName);
+  ASSERT_EQ(actual, expectedMangledName);
 }
 
 TEST(InternalNamesTest, deconstructTest) {


### PR DESCRIPTION
Fix the following waring: 

```
llvm-project/flang/unittests/Optimizer/InternalNamesTest.cpp:166:28: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
  llvm::StringRef actual = NameUniquer::doNamelistGroup({"mod1"}, {}, "nlg");
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```