### PR TITLE
Apply clang-tidy fixes in Optimizer directories

### DIFF
--- a/flang/include/flang/Optimizer/Analysis/IteratedDominanceFrontier.h
+++ b/flang/include/flang/Optimizer/Analysis/IteratedDominanceFrontier.h
@@ -45,15 +45,15 @@ namespace fir {
 template <class NodeTy, bool IsPostDom>
 class IDFCalculator {
 public:
-  IDFCalculator(mlir::DominanceInfo &DT) : DT(DT), useLiveIn(false) {}
+  IDFCalculator(mlir::DominanceInfo &dt) : dt(dt), useLiveIn(false) {}
 
   /// Give the IDF calculator the set of blocks in which the value is
   /// defined.  This is equivalent to the set of starting blocks it should be
   /// calculating the IDF for (though later gets pruned based on liveness).
   ///
   /// Note: This set *must* live for the entire lifetime of the IDF calculator.
-  void setDefiningBlocks(const llvm::SmallPtrSetImpl<NodeTy *> &Blocks) {
-    DefBlocks = &Blocks;
+  void setDefiningBlocks(const llvm::SmallPtrSetImpl<NodeTy *> &blocks) {
+    defBlocks = &blocks;
   }
 
   /// Give the IDF calculator the set of blocks in which the value is
@@ -61,15 +61,15 @@ public:
   /// not include blocks where any phi insertion would be dead.
   ///
   /// Note: This set *must* live for the entire lifetime of the IDF calculator.
-  void setLiveInBlocks(const llvm::SmallPtrSetImpl<NodeTy *> &Blocks) {
-    LiveInBlocks = &Blocks;
+  void setLiveInBlocks(const llvm::SmallPtrSetImpl<NodeTy *> &blocks) {
+    liveInBlocks = &blocks;
     useLiveIn = true;
   }
 
   /// Reset the live-in block set to be empty, and tell the IDF
   /// calculator to not use liveness anymore.
   void resetLiveInBlocks() {
-    LiveInBlocks = nullptr;
+    liveInBlocks = nullptr;
     useLiveIn = false;
   }
 
@@ -79,13 +79,13 @@ public:
   /// the file-level comment.  It performs DF->IDF pruning using the live-in
   /// set, to avoid computing the IDF for blocks where an inserted PHI node
   /// would be dead.
-  void calculate(llvm::SmallVectorImpl<NodeTy *> &IDFBlocks);
+  void calculate(llvm::SmallVectorImpl<NodeTy *> &idfBlocks);
 
 private:
-  mlir::DominanceInfo &DT;
+  mlir::DominanceInfo &dt;
   bool useLiveIn;
-  const llvm::SmallPtrSetImpl<NodeTy *> *LiveInBlocks;
-  const llvm::SmallPtrSetImpl<NodeTy *> *DefBlocks;
+  const llvm::SmallPtrSetImpl<NodeTy *> *liveInBlocks;
+  const llvm::SmallPtrSetImpl<NodeTy *> *defBlocks;
 };
 
 typedef IDFCalculator<mlir::Block, false> ForwardIDFCalculator;

--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -413,7 +413,7 @@ public:
   template <typename A, typename = std::enable_if_t<
                             !std::is_same_v<std::decay_t<A>, ExtendedValue>>>
   constexpr ExtendedValue(A &&a) : box{std::forward<A>(a)} {
-    if (auto b = getUnboxed()) {
+    if (const auto *b = getUnboxed()) {
       if (*b) {
         auto type = b->getType();
         if (type.template isa<fir::BoxCharType>())

--- a/flang/include/flang/Optimizer/Builder/Runtime/Assign.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Assign.h
@@ -16,7 +16,7 @@ class Location;
 
 namespace fir {
 class FirOpBuilder;
-}
+} // namespace fir
 
 namespace fir::runtime {
 

--- a/flang/include/flang/Optimizer/Builder/Runtime/Derived.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Derived.h
@@ -16,7 +16,7 @@ class Location;
 
 namespace fir {
 class FirOpBuilder;
-}
+} // namespace fir
 
 namespace fir::runtime {
 

--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -34,7 +34,7 @@ struct c_double_complex_t;
 
 namespace Fortran::runtime {
 class Descriptor;
-}
+} // namespace Fortran::runtime
 
 namespace fir::runtime {
 

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -44,7 +44,7 @@ using LLVMIRLoweringPrinter =
 std::unique_ptr<mlir::Pass> createLLVMDialectToLLVMPass(
     llvm::raw_ostream &output,
     LLVMIRLoweringPrinter printer =
-        [](llvm::Module &M, llvm::raw_ostream &out) { M.print(out, nullptr); });
+        [](llvm::Module &m, llvm::raw_ostream &out) { m.print(out, nullptr); });
 
 // declarative passes
 #define GEN_PASS_REGISTRATION

--- a/flang/include/flang/Optimizer/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Support/FIRContext.h
@@ -22,7 +22,7 @@
 
 namespace mlir {
 class ModuleOp;
-}
+}  // namespace mlir
 
 namespace fir {
 class KindMapping;

--- a/flang/lib/Optimizer/Analysis/IteratedDominanceFrontier.cpp
+++ b/flang/lib/Optimizer/Analysis/IteratedDominanceFrontier.cpp
@@ -23,7 +23,7 @@ namespace fir {
 
 template <class NodeTy, bool IsPostDom>
 void IDFCalculator<NodeTy, IsPostDom>::calculate(
-    llvm::SmallVectorImpl<NodeTy *> &PHIBlocks) {
+    llvm::SmallVectorImpl<NodeTy *> &phiBlocks) {
   // Use a priority queue keyed on dominator tree level so that inserted nodes
   // are handled from the bottom of the dominator tree upwards. We also augment
   // the level with a DFS number to ensure that the blocks are ordered in a
@@ -35,68 +35,68 @@ void IDFCalculator<NodeTy, IsPostDom>::calculate(
       std::priority_queue<DomTreeNodePair,
                           llvm::SmallVector<DomTreeNodePair, 32>,
                           llvm::less_second>;
-  IDFPriorityQueue PQ;
+  IDFPriorityQueue pq;
 
-  if (DefBlocks->empty())
+  if (defBlocks->empty())
     return;
 
-  DT.updateDFSNumbers();
+  dt.updateDFSNumbers();
 
-  for (NodeTy *BB : *DefBlocks) {
-    if (DomTreeNode *Node = DT.getNode(BB))
-      PQ.push({Node, std::make_pair(Node->getLevel(), Node->getDFSNumIn())});
+  for (NodeTy *bb : *defBlocks) {
+    if (DomTreeNode *node = dt.getNode(bb))
+      pq.push({node, std::make_pair(node->getLevel(), node->getDFSNumIn())});
   }
 
-  llvm::SmallVector<DomTreeNode *, 32> Worklist;
-  llvm::SmallPtrSet<DomTreeNode *, 32> VisitedPQ;
-  llvm::SmallPtrSet<DomTreeNode *, 32> VisitedWorklist;
+  llvm::SmallVector<DomTreeNode *, 32> worklist;
+  llvm::SmallPtrSet<DomTreeNode *, 32> visitedpq;
+  llvm::SmallPtrSet<DomTreeNode *, 32> visitedWorklist;
 
-  while (!PQ.empty()) {
-    DomTreeNodePair RootPair = PQ.top();
-    PQ.pop();
-    DomTreeNode *Root = RootPair.first;
-    unsigned RootLevel = RootPair.second.first;
+  while (!pq.empty()) {
+    DomTreeNodePair rootPair = pq.top();
+    pq.pop();
+    DomTreeNode *root = rootPair.first;
+    unsigned rootLevel = rootPair.second.first;
 
     // Walk all dominator tree children of Root, inspecting their CFG edges with
     // targets elsewhere on the dominator tree. Only targets whose level is at
     // most Root's level are added to the iterated dominance frontier of the
     // definition set.
 
-    Worklist.clear();
-    Worklist.push_back(Root);
-    VisitedWorklist.insert(Root);
+    worklist.clear();
+    worklist.push_back(root);
+    visitedWorklist.insert(root);
 
-    while (!Worklist.empty()) {
-      DomTreeNode *Node = Worklist.pop_back_val();
-      NodeTy *BB = Node->getBlock();
+    while (!worklist.empty()) {
+      DomTreeNode *node = worklist.pop_back_val();
+      NodeTy *bb = node->getBlock();
       // Succ is the successor in the direction we are calculating IDF, so it is
       // successor for IDF, and predecessor for Reverse IDF.
-      auto DoWork = [&](NodeTy *Succ) {
-        DomTreeNode *SuccNode = DT.getNode(Succ);
+      auto doWork = [&](NodeTy *succ) {
+        DomTreeNode *succNode = dt.getNode(succ);
 
-        const unsigned SuccLevel = SuccNode->getLevel();
-        if (SuccLevel > RootLevel)
+        const unsigned succLevel = succNode->getLevel();
+        if (succLevel > rootLevel)
           return;
 
-        if (!VisitedPQ.insert(SuccNode).second)
+        if (!visitedpq.insert(succNode).second)
           return;
 
-        NodeTy *SuccBB = SuccNode->getBlock();
-        if (useLiveIn && !LiveInBlocks->count(SuccBB))
+        NodeTy *succBB = succNode->getBlock();
+        if (useLiveIn && !liveInBlocks->count(succBB))
           return;
 
-        PHIBlocks.emplace_back(SuccBB);
-        if (!DefBlocks->count(SuccBB))
-          PQ.push(std::make_pair(
-              SuccNode, std::make_pair(SuccLevel, SuccNode->getDFSNumIn())));
+        phiBlocks.emplace_back(succBB);
+        if (!defBlocks->count(succBB))
+          pq.push(std::make_pair(
+              succNode, std::make_pair(succLevel, succNode->getDFSNumIn())));
       };
 
-      for (auto *Succ : BB->getSuccessors())
-        DoWork(Succ);
+      for (auto *succ : bb->getSuccessors())
+        doWork(succ);
 
-      for (auto DomChild : *Node) {
-        if (VisitedWorklist.insert(DomChild).second)
-          Worklist.push_back(DomChild);
+      for (auto domChild : *node) {
+        if (visitedWorklist.insert(domChild).second)
+          worklist.push_back(domChild);
       }
     }
   }

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -70,7 +70,7 @@ LLVM_ATTRIBUTE_UNUSED static bool needToMaterialize(mlir::Value str) {
 
 /// Unwrap integer constant from mlir::Value.
 static llvm::Optional<std::int64_t> getIntIfConstant(mlir::Value value) {
-  if (auto definingOp = value.getDefiningOp())
+  if (auto *definingOp = value.getDefiningOp())
     if (auto cst = mlir::dyn_cast<mlir::ConstantOp>(definingOp))
       if (auto intAttr = cst.getValue().dyn_cast<mlir::IntegerAttr>())
         return intAttr.getInt();
@@ -135,7 +135,7 @@ fir::factory::CharacterExprHelper::toExtendedValue(mlir::Value character,
     // If the embox is accessible, use its operand to avoid filling
     // the generated fir with embox/unbox.
     mlir::Value boxCharLen;
-    if (auto definingOp = character.getDefiningOp()) {
+    if (auto *definingOp = character.getDefiningOp()) {
       if (auto box = dyn_cast<fir::EmboxCharOp>(definingOp)) {
         base = box.memref();
         boxCharLen = box.len();

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -92,23 +92,21 @@ mlir::Value
 fir::FirOpBuilder::createRealConstant(mlir::Location loc, mlir::Type fltTy,
                                       llvm::APFloat::integerPart val) {
   auto apf = [&]() -> llvm::APFloat {
-    if (auto ty = fltTy.dyn_cast<fir::RealType>()) {
+    if (auto ty = fltTy.dyn_cast<fir::RealType>())
       return llvm::APFloat(kindMap.getFloatSemantics(ty.getFKind()), val);
-    } else {
-      if (fltTy.isF16())
-        return llvm::APFloat(llvm::APFloat::IEEEhalf(), val);
-      if (fltTy.isBF16())
-        return llvm::APFloat(llvm::APFloat::BFloat(), val);
-      if (fltTy.isF32())
-        return llvm::APFloat(llvm::APFloat::IEEEsingle(), val);
-      if (fltTy.isF64())
-        return llvm::APFloat(llvm::APFloat::IEEEdouble(), val);
-      if (fltTy.isF80())
-        return llvm::APFloat(llvm::APFloat::x87DoubleExtended(), val);
-      if (fltTy.isF128())
-        return llvm::APFloat(llvm::APFloat::IEEEquad(), val);
-      llvm_unreachable("unhandled MLIR floating-point type");
-    }
+    if (fltTy.isF16())
+      return llvm::APFloat(llvm::APFloat::IEEEhalf(), val);
+    if (fltTy.isBF16())
+      return llvm::APFloat(llvm::APFloat::BFloat(), val);
+    if (fltTy.isF32())
+      return llvm::APFloat(llvm::APFloat::IEEEsingle(), val);
+    if (fltTy.isF64())
+      return llvm::APFloat(llvm::APFloat::IEEEdouble(), val);
+    if (fltTy.isF80())
+      return llvm::APFloat(llvm::APFloat::x87DoubleExtended(), val);
+    if (fltTy.isF128())
+      return llvm::APFloat(llvm::APFloat::IEEEquad(), val);
+    llvm_unreachable("unhandled MLIR floating-point type");
   };
   return createRealConstant(loc, fltTy, apf());
 }

--- a/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
@@ -293,10 +293,11 @@ mlir::Value fir::runtime::genNearest(fir::FirOpBuilder &builder,
       builder.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OGT, s, zero);
 
   mlir::Type boolTy = mlir::IntegerType::get(builder.getContext(), 1);
-  mlir::Value False = builder.createIntegerConstant(loc, boolTy, 0);
-  mlir::Value True = builder.createIntegerConstant(loc, boolTy, 1);
+  mlir::Value falseCst = builder.createIntegerConstant(loc, boolTy, 0);
+  mlir::Value trueCst = builder.createIntegerConstant(loc, boolTy, 1);
 
-  mlir::Value positive = builder.create<mlir::SelectOp>(loc, cmp, True, False);
+  mlir::Value positive = 
+      builder.create<mlir::SelectOp>(loc, cmp, trueCst, falseCst);
   auto args = fir::runtime::createArguments(builder, loc, funcTy, x, positive);
 
   return builder.create<fir::CallOp>(loc, func, args).getResult(0);

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3021,12 +3021,12 @@ struct DivcOpConversion : public FIROpConversion<fir::DivcOp> {
     auto x1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
     auto y1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
     auto xx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, x1);
-    auto xX = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x1, x1);
+    auto x1x1 = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x1, x1);
     auto yx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, x1);
     auto xy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, y1);
     auto yy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, y1);
-    auto yY = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y1, y1);
-    auto d = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xX, yY);
+    auto y1y1 = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y1, y1);
+    auto d = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, x1x1, y1y1);
     auto rrn = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xx, yy);
     auto rin = rewriter.create<mlir::LLVM::FSubOp>(loc, eleTy, yx, xy);
     auto rr = rewriter.create<mlir::LLVM::FDivOp>(loc, eleTy, rrn, d);

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -65,7 +65,7 @@ namespace fir {
 /// return true if all `Value`s in `operands` are `ConstantOp`s
 bool allConstants(OperandTy operands) {
   for (auto opnd : operands) {
-    if (auto defop = opnd.getDefiningOp())
+    if (auto *defop = opnd.getDefiningOp())
       if (isa<mlir::LLVM::ConstantOp>(defop) || isa<mlir::ConstantOp>(defop))
         continue;
     return false;
@@ -520,7 +520,7 @@ struct BoxCharLenOpConversion : public FIROpConversion<fir::BoxCharLenOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto a = operands[0];
     auto ty = convertType(boxchar.getType());
-    auto ctx = boxchar.getContext();
+    auto *ctx = boxchar.getContext();
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
     rewriter.replaceOpWithNewOp<mlir::LLVM::ExtractValueOp>(boxchar, ty, a, c1);
     return success();
@@ -632,8 +632,8 @@ struct BoxProcHostOpConversion : public FIROpConversion<fir::BoxProcHostOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto a = operands[0];
     auto ty = convertType(boxprochost.getType());
-    auto ctx = boxprochost.getContext();
-    auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
+    auto c1 = mlir::ArrayAttr::get(boxprochost.getContext(), 
+        rewriter.getI32IntegerAttr(1));
     rewriter.replaceOpWithNewOp<mlir::LLVM::ExtractValueOp>(boxprochost, ty, a,
                                                             c1);
     return success();
@@ -735,7 +735,7 @@ struct CmpcOpConversion : public FIROpConversion<fir::CmpcOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::CmpcOp cmp, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto ctxt = cmp.getContext();
+    auto *ctxt = cmp.getContext();
     auto kind = cmp.lhs().getType().cast<fir::ComplexType>().getFKind();
     auto ty = convertType(fir::RealType::get(ctxt, kind));
     auto resTy = convertType(cmp.getType());
@@ -777,7 +777,7 @@ struct ConstcOpConversion : public FIROpConversion<fir::ConstcOp> {
   matchAndRewrite(fir::ConstcOp conc, OperandTy,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto loc = conc.getLoc();
-    auto ctx = conc.getContext();
+    auto *ctx = conc.getContext();
     auto ty = convertType(conc.getType());
     auto ct = conc.getType().cast<fir::ComplexType>();
     auto ety = lowerTy().convertComplexPartType(ct.getFKind());
@@ -958,7 +958,7 @@ struct EmboxCharOpConversion : public FIROpConversion<fir::EmboxCharOp> {
     auto a = operands[0];
     auto b1 = operands[1];
     auto loc = emboxChar.getLoc();
-    auto ctx = emboxChar.getContext();
+    auto *ctx = emboxChar.getContext();
     auto ty = convertType(emboxChar.getType());
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
@@ -1165,8 +1165,9 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
           this->lowerTy().convertType(global.getType()));
       return rewriter.create<mlir::LLVM::AddressOfOp>(loc, ty,
                                                       global.sym_name());
-    } else if (auto global =
-                   module.template lookupSymbol<mlir::LLVM::GlobalOp>(name)) {
+    }
+    if (auto global =
+            module.template lookupSymbol<mlir::LLVM::GlobalOp>(name)) {
       // The global may have already been translated to LLVM.
       auto ty = mlir::LLVM::LLVMPointerType::get(global.getType());
       return rewriter.create<mlir::LLVM::AddressOfOp>(loc, ty,
@@ -1429,8 +1430,8 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::cg::XEmboxOp> {
         if (fir::hasDynamicSize(fir::unwrapSequenceType(
                 fir::unwrapPassByRefType(xbox.memref().getType()))))
           TODO(loc, "fir.embox codegen dynamic size component in derived type");
-        auto beginOffset = xbox.subcomponentOffset() + operands.begin();
-        auto lastOffset = beginOffset + xbox.subcomponent().size();
+        const auto *beginOffset = xbox.subcomponentOffset() + operands.begin();
+        const auto *lastOffset = beginOffset + xbox.subcomponent().size();
         args.append(beginOffset, lastOffset);
       }
       base = rewriter.create<mlir::LLVM::GEPOp>(loc, base.getType(), args);
@@ -1640,7 +1641,7 @@ struct EmboxProcOpConversion : public FIROpConversion<fir::EmboxProcOp> {
   matchAndRewrite(fir::EmboxProcOp emboxproc, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto loc = emboxproc.getLoc();
-    auto ctx = emboxproc.getContext();
+    auto *ctx = emboxproc.getContext();
     auto ty = convertType(emboxproc.getType());
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
@@ -1656,7 +1657,7 @@ struct EmboxProcOpConversion : public FIROpConversion<fir::EmboxProcOp> {
 // Code shared between insert_value and extract_value Ops.
 struct ValueOpCommon {
   static mlir::Attribute getValue(mlir::Value value) {
-    auto defOp = value.getDefiningOp();
+    auto *defOp = value.getDefiningOp();
     if (auto v = dyn_cast<mlir::LLVM::ConstantOp>(defOp))
       return v.value();
     if (auto v = dyn_cast<mlir::ConstantOp>(defOp))
@@ -2030,8 +2031,8 @@ struct CoordinateOpConversion
       //   %addr = coordinate_of %box, %lenp
       if (coor.getNumOperands() == 2) {
         auto coorPtr = *coor.coor().begin();
-        auto s = coorPtr.getDefiningOp();
-        if (s && isa<fir::LenParamIndexOp>(s)) {
+        auto *s = coorPtr.getDefiningOp();
+        if (isa_and_nonnull<fir::LenParamIndexOp>(s)) {
           mlir::Value lenParam = operands[1]; // byte offset
           auto bc =
               rewriter.create<mlir::LLVM::BitcastOp>(loc, voidPtrTy(), base);
@@ -2150,7 +2151,8 @@ struct CoordinateOpConversion
           arrIdx.clear();
           dims.reset();
           continue;
-        } else if (auto arrTy = cpnTy.dyn_cast<fir::SequenceType>()) {
+        }
+        if (auto arrTy = cpnTy.dyn_cast<fir::SequenceType>()) {
           int d = arrTy.getDimension() - 1;
           if (d > 0) {
             dims = d;
@@ -2247,7 +2249,7 @@ struct CoordinateOpConversion
   /// return true if all `Value`s in `operands` are not `FieldIndexOp`s
   static bool noFieldIndexOps(mlir::Operation::operand_range operands) {
     for (auto opnd : operands) {
-      if (auto defop = opnd.getDefiningOp())
+      if (auto *defop = opnd.getDefiningOp())
         if (dyn_cast<fir::FieldIndexOp>(defop))
           return false;
     }
@@ -2261,10 +2263,10 @@ struct CoordinateOpConversion
 
   int64_t getIntValue(mlir::Value val) const {
     if (val) {
-      if (auto defop = val.getDefiningOp()) {
+      if (auto *defop = val.getDefiningOp()) {
         if (auto constOp = dyn_cast<mlir::ConstantIntOp>(defop))
           return constOp.getValue();
-        else if (auto llConstOp = dyn_cast<mlir::LLVM::ConstantOp>(defop))
+        if (auto llConstOp = dyn_cast<mlir::LLVM::ConstantOp>(defop))
           if (auto attr = llConstOp.value().dyn_cast<mlir::IntegerAttr>())
             return attr.getValue().getSExtValue();
       }
@@ -2432,7 +2434,7 @@ struct GlobalOpConversion : public FIROpConversion<fir::GlobalOp> {
       for (auto insertOp : insertOnRangeOps) {
         if (isFullRange(insertOp.coor(), insertOp.getType())) {
           auto seqTyAttr = convertType(insertOp.getType());
-          auto op = insertOp.val().getDefiningOp();
+          auto *op = insertOp.val().getDefiningOp();
           auto constant = mlir::dyn_cast<mlir::ConstantOp>(op);
           if (!constant) {
               auto convertOp = mlir::dyn_cast<fir::ConvertOp>(op);
@@ -2600,10 +2602,10 @@ struct SelectCaseOpConversion : public FIROpConversion<fir::SelectCaseOp> {
         rewriter.setInsertionPointToEnd(thisBlock);
         rewriter.create<mlir::LLVM::CondBrOp>(loc, cmp, newBlock1, newBlock2);
         rewriter.setInsertionPointToEnd(newBlock1);
-        auto caseArg_ = *(cmpOps.begin() + 1);
-        auto cmp_ = rewriter.create<mlir::LLVM::ICmpOp>(
-            loc, mlir::LLVM::ICmpPredicate::sle, selector, caseArg_);
-        genCondBrOp(loc, cmp_, dest, destOps, rewriter, newBlock2);
+        auto caseArg0 = *(cmpOps.begin() + 1);
+        auto cmp0 = rewriter.create<mlir::LLVM::ICmpOp>(
+            loc, mlir::LLVM::ICmpPredicate::sle, selector, caseArg0);
+        genCondBrOp(loc, cmp0, dest, destOps, rewriter, newBlock2);
         rewriter.setInsertionPointToEnd(newBlock2);
         continue;
       }
@@ -2864,7 +2866,7 @@ struct IsPresentOpConversion : public FIROpConversion<fir::IsPresentOp> {
       auto structTy = ptr.getType().cast<mlir::LLVM::LLVMStructType>();
       assert(!structTy.isOpaque() && !structTy.getBody().empty());
       auto ty = structTy.getBody()[0];
-      auto ctx = isPresent.getContext();
+      auto *ctx = isPresent.getContext();
       auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
       ptr = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, ty, ptr, c0);
     }
@@ -2891,7 +2893,7 @@ struct AbsentOpConversion : public FIROpConversion<fir::AbsentOp> {
       auto undefStruct = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
       auto nullField =
           rewriter.create<mlir::LLVM::NullOp>(loc, structTy.getBody()[0]);
-      auto ctx = absent.getContext();
+      auto *ctx = absent.getContext();
       auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
       rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(
           absent, ty, undefStruct, nullField, c0);
@@ -2919,15 +2921,15 @@ mlir::LLVM::InsertValueOp complexSum(OPTY sumop, OperandTy opnds,
   auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
   auto eleTy = lowering.convertType(getComplexEleTy(sumop.getType()));
   auto ty = lowering.convertType(sumop.getType());
-  auto x = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
-  auto y = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
-  auto x_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
-  auto y_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
-  auto rx = rewriter.create<LLVMOP>(loc, eleTy, x, x_);
-  auto ry = rewriter.create<LLVMOP>(loc, eleTy, y, y_);
-  auto r = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-  auto r_ = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r, rx, c0);
-  return rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r_, ry, c1);
+  auto x0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
+  auto y0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
+  auto x1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
+  auto y1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
+  auto rx = rewriter.create<LLVMOP>(loc, eleTy, x0, x1);
+  auto ry = rewriter.create<LLVMOP>(loc, eleTy, y0, y1);
+  auto r0 = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
+  auto r1 = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r0, rx, c0);
+  return rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r1, ry, c1);
 }
 
 struct AddcOpConversion : public FIROpConversion<fir::AddcOp> {
@@ -2973,25 +2975,25 @@ struct MulcOpConversion : public FIROpConversion<fir::MulcOp> {
     auto a = operands[0];
     auto b = operands[1];
     auto loc = mulc.getLoc();
-    auto ctx = mulc.getContext();
+    auto *ctx = mulc.getContext();
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
     auto eleTy = convertType(getComplexEleTy(mulc.getType()));
     auto ty = convertType(mulc.getType());
-    auto x = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
-    auto y = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
-    auto x_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
-    auto y_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
-    auto xx_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x, x_);
-    auto yx_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y, x_);
-    auto xy_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x, y_);
-    auto ri = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xy_, yx_);
-    auto yy_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y, y_);
-    auto rr = rewriter.create<mlir::LLVM::FSubOp>(loc, eleTy, xx_, yy_);
+    auto x0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
+    auto y0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
+    auto x1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
+    auto y1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
+    auto xx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, x1);
+    auto yx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, x1);
+    auto xy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, y1);
+    auto ri = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xy, yx);
+    auto yy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, y1);
+    auto rr = rewriter.create<mlir::LLVM::FSubOp>(loc, eleTy, xx, yy);
     auto ra = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-    auto r_ = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, ra, rr, c0);
-    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r_, ri, c1);
-    rewriter.replaceOp(mulc, r.getResult());
+    auto r1 = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, ra, rr, c0);
+    auto r0 = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r1, ri, c1);
+    rewriter.replaceOp(mulc, r0.getResult());
     return success();
   }
 };
@@ -3009,30 +3011,30 @@ struct DivcOpConversion : public FIROpConversion<fir::DivcOp> {
     auto a = operands[0];
     auto b = operands[1];
     auto loc = divc.getLoc();
-    auto ctx = divc.getContext();
+    auto *ctx = divc.getContext();
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
     auto eleTy = convertType(getComplexEleTy(divc.getType()));
     auto ty = convertType(divc.getType());
-    auto x = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
-    auto y = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
-    auto x_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
-    auto y_ = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
-    auto xx_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x, x_);
-    auto x_x_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x_, x_);
-    auto yx_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y, x_);
-    auto xy_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x, y_);
-    auto yy_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y, y_);
-    auto y_y_ = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y_, y_);
-    auto d = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, x_x_, y_y_);
-    auto rrn = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xx_, yy_);
-    auto rin = rewriter.create<mlir::LLVM::FSubOp>(loc, eleTy, yx_, xy_);
+    auto x0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c0);
+    auto y0 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, a, c1);
+    auto x1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c0);
+    auto y1 = rewriter.create<mlir::LLVM::ExtractValueOp>(loc, eleTy, b, c1);
+    auto xx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, x1);
+    auto xX = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x1, x1);
+    auto yx = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, x1);
+    auto xy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, x0, y1);
+    auto yy = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y0, y1);
+    auto yY = rewriter.create<mlir::LLVM::FMulOp>(loc, eleTy, y1, y1);
+    auto d = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xX, yY);
+    auto rrn = rewriter.create<mlir::LLVM::FAddOp>(loc, eleTy, xx, yy);
+    auto rin = rewriter.create<mlir::LLVM::FSubOp>(loc, eleTy, yx, xy);
     auto rr = rewriter.create<mlir::LLVM::FDivOp>(loc, eleTy, rrn, d);
     auto ri = rewriter.create<mlir::LLVM::FDivOp>(loc, eleTy, rin, d);
     auto ra = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-    auto r_ = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, ra, rr, c0);
-    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r_, ri, c1);
-    rewriter.replaceOp(divc, r.getResult());
+    auto r1 = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, ra, rr, c0);
+    auto r0 = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r1, ri, c1);
+    rewriter.replaceOp(divc, r0.getResult());
     return success();
   }
 };
@@ -3046,7 +3048,7 @@ struct NegcOpConversion : public FIROpConversion<fir::NegcOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // given: -(x + iy)
     // result: -x - iy
-    auto ctxt = neg.getContext();
+    auto *ctxt = neg.getContext();
     auto eleTy = convertType(getComplexEleTy(neg.getType()));
     auto ty = convertType(neg.getType());
     auto loc = neg.getLoc();

--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -115,7 +115,7 @@ struct TargetI386 : public GenericTarget<TargetI386> {
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct TargetX8664 : public GenericTarget<TargetX8664> {
+struct TargetX86_64 : public GenericTarget<TargetX86_64> {
   using GenericTarget::GenericTarget;
 
   static constexpr int defaultWidth = 64;
@@ -255,8 +255,8 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &&trp,
       break;
     case llvm::Triple::OSType::Linux:
     case llvm::Triple::OSType::Darwin:
-      return std::make_unique<TargetX8664>(ctx, std::move(trp),
-                                           std::move(kindMap));
+      return std::make_unique<TargetX86_64>(ctx, std::move(trp),
+                                            std::move(kindMap));
     }
     break;
   case llvm::Triple::ArchType::aarch64:

--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -115,7 +115,7 @@ struct TargetI386 : public GenericTarget<TargetI386> {
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct TargetX86_64 : public GenericTarget<TargetX86_64> {
+struct TargetX8664 : public GenericTarget<TargetX8664> {
   using GenericTarget::GenericTarget;
 
   static constexpr int defaultWidth = 64;
@@ -255,8 +255,8 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &&trp,
       break;
     case llvm::Triple::OSType::Linux:
     case llvm::Triple::OSType::Darwin:
-      return std::make_unique<TargetX86_64>(ctx, std::move(trp),
-                                            std::move(kindMap));
+      return std::make_unique<TargetX8664>(ctx, std::move(trp),
+                                           std::move(kindMap));
     }
     break;
   case llvm::Triple::ArchType::aarch64:

--- a/flang/lib/Optimizer/Dialect/FIRAttr.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRAttr.cpp
@@ -14,8 +14,8 @@
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Support/KindMapping.h"
 #include "mlir/IR/AttributeSupport.h"
-#include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/SmallString.h"
 
 using namespace fir;

--- a/flang/lib/Optimizer/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Support/FIRContext.cpp
@@ -33,14 +33,14 @@ static constexpr const char *kindMapName = "fir.kindmap";
 static constexpr const char *defKindName = "fir.defaultkind";
 
 void fir::setKindMapping(mlir::ModuleOp mod, fir::KindMapping &kindMap) {
-  auto ctx = mod.getContext();
+  auto *ctx = mod.getContext();
   mod->setAttr(kindMapName, mlir::StringAttr::get(ctx, kindMap.mapToString()));
   auto defs = kindMap.defaultsToString();
   mod->setAttr(defKindName, mlir::StringAttr::get(ctx, defs));
 }
 
 fir::KindMapping fir::getKindMapping(mlir::ModuleOp mod) {
-  auto ctx = mod.getContext();
+  auto *ctx = mod.getContext();
   if (auto defs = mod->getAttrOfType<mlir::StringAttr>(defKindName)) {
     auto defVals = fir::KindMapping::toDefaultKinds(defs.getValue());
     if (auto maps = mod->getAttrOfType<mlir::StringAttr>(kindMapName))

--- a/flang/lib/Optimizer/Support/InternalNames.cpp
+++ b/flang/lib/Optimizer/Support/InternalNames.cpp
@@ -21,7 +21,7 @@ static llvm::cl::opt<std::string> mainEntryName(
     llvm::cl::desc("override the name of the default PROGRAM entry (may be "
                    "helpful for using other runtimes)"));
 
-constexpr std::int64_t BAD_VALUE = -1;
+constexpr std::int64_t badValue = -1;
 
 inline std::string prefix() { return "_Q"; }
 
@@ -69,9 +69,9 @@ static std::int64_t readInt(llvm::StringRef uniq, std::size_t &i,
   for (i = init; i < end && uniq[i] >= '0' && uniq[i] <= '9'; ++i) {
     // do nothing
   }
-  std::int64_t result = BAD_VALUE;
+  std::int64_t result = badValue;
   if (uniq.substr(init, i - init).getAsInteger(10, result))
-    return BAD_VALUE;
+    return badValue;
   return result;
 }
 

--- a/flang/lib/Optimizer/Support/KindMapping.cpp
+++ b/flang/lib/Optimizer/Support/KindMapping.cpp
@@ -49,8 +49,8 @@ static constexpr const char *kwPPCFP128 = "PPC_FP128";
 /// Integral types default to the kind value being the size of the value in
 /// bytes. The default is to scale from bytes to bits.
 static Bitsize defaultScalingKind(KindTy kind) {
-  const unsigned BITS_IN_BYTE = 8;
-  return kind * BITS_IN_BYTE;
+  const unsigned bitsInByte = 8;
+  return kind * bitsInByte;
 }
 
 /// Floating-point types default to the kind value being the size of the value

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -45,8 +45,7 @@ static mlir::Type getResultArgumentType(mlir::Type resultType,
           [&](mlir::Type type) -> mlir::Type {
             if (options.boxResult)
               return fir::BoxType::get(type);
-            else
-              return fir::ReferenceType::get(type);
+            return fir::ReferenceType::get(type);
           })
       .Case<fir::BoxType>([](mlir::Type type) -> mlir::Type {
         return fir::ReferenceType::get(type);
@@ -162,12 +161,12 @@ public:
     rewriter.setInsertionPoint(ret);
     auto returnedValue = ret.getOperand(0);
     bool replacedStorage = false;
-    if (auto op = returnedValue.getDefiningOp())
+    if (auto *op = returnedValue.getDefiningOp())
       if (auto load = mlir::dyn_cast<fir::LoadOp>(op)) {
         auto resultStorage = load.memref();
         load.memref().replaceAllUsesWith(options.newArg);
         replacedStorage = true;
-        if (auto alloc = resultStorage.getDefiningOp())
+        if (auto *alloc = resultStorage.getDefiningOp())
           if (alloc->use_empty())
             rewriter.eraseOp(alloc);
       }

--- a/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
+++ b/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
@@ -162,7 +162,7 @@ static void populateSets(llvm::SmallVectorImpl<mlir::Operation *> &reach,
     return;
   }
   // Otherwise, a block argument is provided via the pred blocks.
-  for (auto pred : ba.getOwner()->getPredecessors()) {
+  for (auto *pred : ba.getOwner()->getPredecessors()) {
     auto u = pred->getTerminator()->getOperand(ba.getArgNumber());
     populateSets(reach, visited, u);
   }

--- a/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
@@ -99,7 +99,7 @@ public:
     CharacterConversionOptions clOpts{useRuntimeCalls.getValue()};
     if (clOpts.runtimeName.empty()) {
       auto *context = &getContext();
-      auto func = getOperation();
+      auto *func = getOperation();
       mlir::OwningRewritePatternList patterns(context);
       patterns.insert<CharacterConvertConversion>(context);
       mlir::ConversionTarget target(*context);


### PR DESCRIPTION
To help the upstreaming effort this PR just fixes most of the `clang-tidy` warnings in `flang/lib/Optimizer` `flang/include/flang/Optimizer`. 

Most changes are related to variable name that doesn't fit the style. 

