### PR TITLE
Implement the correct splitting of FORALL and array expression loops

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -17,7 +17,7 @@
 #ifndef FORTRAN_LOWER_CONVERTEXPR_H
 #define FORTRAN_LOWER_CONVERTEXPR_H
 
-#include "flang/Evaluate/shape.h"
+#include "flang/Evaluate/expression.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 
@@ -172,7 +172,9 @@ createSomeArrayTempValue(AbstractConverter &converter,
 /// Like createSomeArrayTempValue, but the temporary buffer is allocated lazily
 /// (inside the loops instead of before the loops). This can be useful if a
 /// loop's bounds are functions of other loop indices, for example.
-fir::ExtendedValue
+std::pair<fir::ExtendedValue,
+          std::function<
+              std::pair<fir::ExtendedValue, mlir::Value>(fir::FirOpBuilder &)>>
 createLazyArrayTempValue(AbstractConverter &converter,
                          const evaluate::Expr<evaluate::SomeType> &expr,
                          mlir::Value var, mlir::Value shapeBuffer,

--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -169,12 +169,24 @@ createSomeArrayTempValue(AbstractConverter &converter,
                          const evaluate::Expr<evaluate::SomeType> &expr,
                          SymMap &symMap, StatementContext &stmtCtx);
 
+// Lambda to reload the dynamically allocated pointers to a lazy buffer and its
+// extents. This is used to introduce these ssa-values in a place that will
+// dominate any/all subsequent uses after the loop that created the lazy buffer.
+using LoadLazyBufferLambda =
+    std::function<std::pair<fir::ExtendedValue, mlir::Value>(
+        fir::FirOpBuilder &)>;
+
+// Creating a lazy array temporary returns a pair of values. The first is an
+// extended value which is a pointer to the buffer, of array type, with the
+// appropriate dynamic extents. The second argument is a continuation to reload
+// the buffer at some future point in the code gen.
+using CreateLazyArrayResult =
+    std::pair<fir::ExtendedValue, LoadLazyBufferLambda>;
+
 /// Like createSomeArrayTempValue, but the temporary buffer is allocated lazily
 /// (inside the loops instead of before the loops). This can be useful if a
 /// loop's bounds are functions of other loop indices, for example.
-std::pair<fir::ExtendedValue,
-          std::function<
-              std::pair<fir::ExtendedValue, mlir::Value>(fir::FirOpBuilder &)>>
+CreateLazyArrayResult
 createLazyArrayTempValue(AbstractConverter &converter,
                          const evaluate::Expr<evaluate::SomeType> &expr,
                          mlir::Value var, mlir::Value shapeBuffer,

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1235,6 +1235,8 @@ private:
         mlir::Value by;
         if (outermost) {
           assert(headerIndex < lows.size());
+          if (headerIndex == 0)
+            explicitIterSpace.resetInnerArgs();
           lb = lows[headerIndex];
           ub = highs[headerIndex];
           by = steps[headerIndex++];
@@ -1261,7 +1263,8 @@ private:
         forceControlVariableBinding(ctrlVar, lp.getInductionVar());
         loops.push_back(lp);
       }
-      explicitIterSpace.setOuterLoop(loops[0]);
+      if (outermost)
+         explicitIterSpace.setOuterLoop(loops[0]);
       if (const auto &mask =
               std::get<std::optional<Fortran::parser::ScalarLogicalExpr>>(
                   header.t);
@@ -2730,13 +2733,14 @@ private:
     auto nilSh = builder->createNullConstant(loc, shTy);
     builder->create<fir::StoreOp>(loc, nilSh, shape);
     implicitIterSpace.addMaskVariable(exp, var, shape);
-    explicitIterSpace.outermostContext().attachCleanup([=]() {
-      auto load = builder->create<fir::LoadOp>(loc, var);
-      auto cmp = builder->genIsNotNull(loc, load);
-      builder->genIfThen(loc, cmp)
-          .genThen([&]() { builder->create<fir::FreeMemOp>(loc, load); })
-          .end();
-    });
+    explicitIterSpace.outermostContext().attachCleanup(
+        [builder = this->builder, loc, var]() {
+          auto load = builder->create<fir::LoadOp>(loc, var);
+          auto cmp = builder->genIsNotNull(loc, load);
+          builder->genIfThen(loc, cmp)
+              .genThen([&]() { builder->create<fir::FreeMemOp>(loc, load); })
+              .end();
+        });
   }
 
   //===--------------------------------------------------------------------===//

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2819,11 +2819,7 @@ private:
   }
   template <typename A>
   ExtValue gen(const Fortran::evaluate::Constant<A> &x) {
-    auto insPt = builder.saveInsertionPoint();
-    builder.setInsertionPoint(expSpace.getOuterLoop());
-    auto result = asScalar(x);
-    builder.restoreInsertionPoint(insPt);
-    return result;
+    return asScalar(x);
   }
   ExtValue gen(const Fortran::evaluate::ProcedureDesignator &x) {
     return asScalar(x);
@@ -3307,9 +3303,7 @@ public:
     return fir::ArrayBoxValue(tempRes, dest.getExtents());
   }
 
-  static std::pair<ExtValue, std::function<std::pair<ExtValue, mlir::Value>(
-                                 fir::FirOpBuilder &)>>
-  lowerLazyArrayExpression(
+  static Fortran::lower::CreateLazyArrayResult lowerLazyArrayExpression(
       Fortran::lower::AbstractConverter &converter,
       Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
@@ -3321,9 +3315,7 @@ public:
   /// Lower the expression \p expr into a buffer that is created on demand. The
   /// variable containing the pointer to the buffer is \p var and the variable
   /// containing the shape of the buffer is \p shapeBuffer.
-  std::pair<ExtValue, std::function<std::pair<ExtValue, mlir::Value>(
-                          fir::FirOpBuilder &)>>
-  lowerLazyArrayExpression(
+  Fortran::lower::CreateLazyArrayResult lowerLazyArrayExpression(
       const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
       mlir::Value var, mlir::Value shapeBuffer) {
     auto loc = getLoc();
@@ -6070,10 +6062,7 @@ fir::ExtendedValue Fortran::lower::createSomeArrayTempValue(
                                                     expr);
 }
 
-std::pair<fir::ExtendedValue,
-          std::function<
-              std::pair<fir::ExtendedValue, mlir::Value>(fir::FirOpBuilder &)>>
-Fortran::lower::createLazyArrayTempValue(
+Fortran::lower::CreateLazyArrayResult Fortran::lower::createLazyArrayTempValue(
     Fortran::lower::AbstractConverter &converter,
     const Fortran::evaluate::Expr<Fortran::evaluate::SomeType> &expr,
     mlir::Value var, mlir::Value shapeBuffer, Fortran::lower::SymMap &symMap,

--- a/flang/lib/Lower/IterationSpace.h
+++ b/flang/lib/Lower/IterationSpace.h
@@ -255,11 +255,13 @@ public:
       innerArgs.push_back(arg);
   }
 
-  void setOuterLoop(fir::DoLoopOp loop) {
-    if (!outerLoop.hasValue())
-      outerLoop = loop;
-  }
+  /// Reset the outermost `array_load` arguments to the loop nest.
+  void resetInnerArgs() { innerArgs = initialArgs; }
 
+  /// Capture the current outermost loop.
+  void setOuterLoop(fir::DoLoopOp loop) { outerLoop = loop; }
+
+  /// Sets the inner loop argument at position \p offset to \p val.
   void setInnerArg(size_t offset, mlir::Value val) {
     assert(offset < innerArgs.size());
     innerArgs[offset] = val;
@@ -385,6 +387,7 @@ private:
   // Assignment statement context (inside the loop nest).
   StatementContext stmtCtx;
   llvm::SmallVector<mlir::Value> innerArgs;
+  llvm::SmallVector<mlir::Value> initialArgs;
   llvm::Optional<fir::DoLoopOp> outerLoop;
   llvm::Optional<std::function<void(fir::FirOpBuilder &)>> loopCleanup;
   std::size_t forallContextOpen = 0;

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -71,7 +71,8 @@ Fortran::lower::operator<<(llvm::raw_ostream &os,
   for (auto i : llvm::enumerate(symMap.symbolMapStack)) {
     os << " level " << i.index() << "<{\n";
     for (auto iter : i.value())
-      os << "  symbol [" << *iter.first << "] ->\n    " << iter.second;
+      os << "  symbol @" << (void *)iter.first << " [" << *iter.first
+         << "] ->\n    " << iter.second;
     os << " }>\n";
   }
   return os;

--- a/flang/test/Lower/forall-2.f90
+++ b/flang/test/Lower/forall-2.f90
@@ -80,39 +80,39 @@ subroutine slice_with_explicit_iters
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_3]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x10xi32>>, !fir.shape<2>) -> !fir.array<10x10xi32>
-  ! CHECK:         %[[VAL_11:.*]] = constant 1 : i64
-  ! CHECK:         %[[VAL_12:.*]] = constant 1 : i64
-  ! CHECK:         %[[VAL_13:.*]] = fir.do_loop %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_15:.*]] = %[[VAL_10]]) -> (!fir.array<10x10xi32>) {
-  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_14]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_16]] to %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_17:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
-  ! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
-  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
-  ! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
-  ! CHECK:           %[[VAL_25:.*]] = subi %[[VAL_24]], %[[VAL_23]] : index
-  ! CHECK:           %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_27:.*]] = divi_signed %[[VAL_26]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_28:.*]] = cmpi sgt, %[[VAL_27]], %[[VAL_22]] : index
-  ! CHECK:           %[[VAL_29:.*]] = select %[[VAL_28]], %[[VAL_27]], %[[VAL_22]] : index
-  ! CHECK:           %[[VAL_30:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_31:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_32:.*]] = subi %[[VAL_29]], %[[VAL_30]] : index
-  ! CHECK:           %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_31]] to %[[VAL_32]] step %[[VAL_30]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_15]]) -> (!fir.array<10x10xi32>) {
-  ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_37:.*]] = constant 0 : i32
-  ! CHECK:             %[[VAL_38:.*]] = subi %[[VAL_37]], %[[VAL_36]] : i32
-  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
-  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
-  ! CHECK:             %[[VAL_41:.*]] = muli %[[VAL_34]], %[[VAL_40]] : index
-  ! CHECK:             %[[VAL_42:.*]] = addi %[[VAL_39]], %[[VAL_41]] : index
+  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<10x10xi32>) {
+  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_15:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i32) -> i64
+  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i64) -> index
+  ! CHECK:           %[[VAL_20:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_15]] : (i64) -> index
+  ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
+  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_22]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_19]] : index
+  ! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_19]] : index
+  ! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_20]] : index
+  ! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_20]] : index
+  ! CHECK:           %[[VAL_28:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_29:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_30:.*]] = subi %[[VAL_27]], %[[VAL_28]] : index
+  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_29]] to %[[VAL_30]] step %[[VAL_28]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_13]]) -> (!fir.array<10x10xi32>) {
+  ! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_35:.*]] = constant 0 : i32
+  ! CHECK:             %[[VAL_36:.*]] = subi %[[VAL_35]], %[[VAL_34]] : i32
+  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
+  ! CHECK:             %[[VAL_39:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
+  ! CHECK:             %[[VAL_41:.*]] = muli %[[VAL_32]], %[[VAL_40]] : index
+  ! CHECK:             %[[VAL_42:.*]] = addi %[[VAL_38]], %[[VAL_41]] : index
   ! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
-  ! CHECK:             %[[VAL_46:.*]] = fir.array_update %[[VAL_35]], %[[VAL_38]], %[[VAL_42]], %[[VAL_45]] {Fortran.offsets} : (!fir.array<10x10xi32>, i32, index, index) -> !fir.array<10x10xi32>
+  ! CHECK:             %[[VAL_46:.*]] = fir.array_update %[[VAL_33]], %[[VAL_36]], %[[VAL_42]], %[[VAL_45]] {Fortran.offsets} : (!fir.array<10x10xi32>, i32, index, index) -> !fir.array<10x10xi32>
   ! CHECK:             fir.result %[[VAL_46]] : !fir.array<10x10xi32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_47:.*]] : !fir.array<10x10xi32>

--- a/flang/test/Lower/forall-2.f90
+++ b/flang/test/Lower/forall-2.f90
@@ -80,39 +80,39 @@ subroutine slice_with_explicit_iters
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_3]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x10xi32>>, !fir.shape<2>) -> !fir.array<10x10xi32>
-  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<10x10xi32>) {
-  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_15:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i32) -> i64
-  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i64) -> index
-  ! CHECK:           %[[VAL_20:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_15]] : (i64) -> index
-  ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
-  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_22]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_19]] : index
-  ! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_19]] : index
-  ! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_20]] : index
-  ! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_20]] : index
-  ! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_29:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_30:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_31:.*]] = subi %[[VAL_27]], %[[VAL_29]] : index
-  ! CHECK:           %[[VAL_32:.*]] = fir.do_loop %[[VAL_33:.*]] = %[[VAL_30]] to %[[VAL_31]] step %[[VAL_29]] unordered iter_args(%[[VAL_34:.*]] = %[[VAL_10]]) -> (!fir.array<10x10xi32>) {
-  ! CHECK:             %[[VAL_35:.*]] = constant 0 : i32
-  ! CHECK:             %[[VAL_36:.*]] = subi %[[VAL_35]], %[[VAL_28]] : i32
-  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
-  ! CHECK:             %[[VAL_39:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
-  ! CHECK:             %[[VAL_41:.*]] = muli %[[VAL_33]], %[[VAL_40]] : index
-  ! CHECK:             %[[VAL_42:.*]] = addi %[[VAL_38]], %[[VAL_41]] : index
+  ! CHECK:         %[[VAL_11:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_12:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_13:.*]] = fir.do_loop %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_15:.*]] = %[[VAL_10]]) -> (!fir.array<10x10xi32>) {
+  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_14]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_16]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_17:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
+  ! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
+  ! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
+  ! CHECK:           %[[VAL_25:.*]] = subi %[[VAL_24]], %[[VAL_23]] : index
+  ! CHECK:           %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_27:.*]] = divi_signed %[[VAL_26]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_28:.*]] = cmpi sgt, %[[VAL_27]], %[[VAL_22]] : index
+  ! CHECK:           %[[VAL_29:.*]] = select %[[VAL_28]], %[[VAL_27]], %[[VAL_22]] : index
+  ! CHECK:           %[[VAL_30:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_31:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_32:.*]] = subi %[[VAL_29]], %[[VAL_30]] : index
+  ! CHECK:           %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_31]] to %[[VAL_32]] step %[[VAL_30]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_15]]) -> (!fir.array<10x10xi32>) {
+  ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_37:.*]] = constant 0 : i32
+  ! CHECK:             %[[VAL_38:.*]] = subi %[[VAL_37]], %[[VAL_36]] : i32
+  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
+  ! CHECK:             %[[VAL_41:.*]] = muli %[[VAL_34]], %[[VAL_40]] : index
+  ! CHECK:             %[[VAL_42:.*]] = addi %[[VAL_39]], %[[VAL_41]] : index
   ! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
-  ! CHECK:             %[[VAL_46:.*]] = fir.array_update %[[VAL_13]], %[[VAL_36]], %[[VAL_42]], %[[VAL_45]] {Fortran.offsets} : (!fir.array<10x10xi32>, i32, index, index) -> !fir.array<10x10xi32>
+  ! CHECK:             %[[VAL_46:.*]] = fir.array_update %[[VAL_35]], %[[VAL_38]], %[[VAL_42]], %[[VAL_45]] {Fortran.offsets} : (!fir.array<10x10xi32>, i32, index, index) -> !fir.array<10x10xi32>
   ! CHECK:             fir.result %[[VAL_46]] : !fir.array<10x10xi32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_47:.*]] : !fir.array<10x10xi32>

--- a/flang/test/Lower/forall.f90
+++ b/flang/test/Lower/forall.f90
@@ -29,27 +29,28 @@ subroutine test9(a,b,n)
   ! CHECK:         %[[VAL_20:.*]] = fir.array_load %[[VAL_0]](%[[VAL_19]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
   ! CHECK:         %[[VAL_21:.*]] = fir.shape %[[VAL_9]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_22:.*]] = fir.array_load %[[VAL_1]](%[[VAL_21]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
-  ! CHECK:         %[[VAL_23:.*]] = fir.do_loop %[[VAL_24:.*]] = %[[VAL_11]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_25:.*]] = %[[VAL_18]]) -> (!fir.array<?xf32>) {
-  ! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_24]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_26]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_27:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i32) -> i64
-  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (i64) -> index
-  ! CHECK:           %[[VAL_30:.*]] = fir.array_fetch %[[VAL_20]], %[[VAL_29]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
-  ! CHECK:           %[[VAL_31:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_31]] : (i32) -> i64
-  ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i64) -> index
-  ! CHECK:           %[[VAL_34:.*]] = fir.array_fetch %[[VAL_22]], %[[VAL_33]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
-  ! CHECK:           %[[VAL_35:.*]] = addf %[[VAL_30]], %[[VAL_34]] : f32
-  ! CHECK:           %[[VAL_36:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_37:.*]] = constant 1 : i32
-  ! CHECK:           %[[VAL_38:.*]] = addi %[[VAL_36]], %[[VAL_37]] : i32
+  ! CHECK:         %[[VAL_23:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_11]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_18]]) -> (!fir.array<?xf32>) {
+  ! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_25]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_27]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (i32) -> i64
+  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i64) -> index
+  ! CHECK:           %[[VAL_31:.*]] = fir.array_fetch %[[VAL_20]], %[[VAL_30]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
+  ! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i32) -> i64
+  ! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i64) -> index
+  ! CHECK:           %[[VAL_35:.*]] = fir.array_fetch %[[VAL_22]], %[[VAL_34]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
+  ! CHECK:           %[[VAL_36:.*]] = addf %[[VAL_31]], %[[VAL_35]] : f32
+  ! CHECK:           %[[VAL_37:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_38:.*]] = addi %[[VAL_37]], %[[VAL_23]] : i32
   ! CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i32) -> i64
   ! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
-  ! CHECK:           %[[VAL_41:.*]] = fir.array_update %[[VAL_25]], %[[VAL_35]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+  ! CHECK:           %[[VAL_41:.*]] = fir.array_update %[[VAL_26]], %[[VAL_36]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
   ! CHECK:           fir.result %[[VAL_41]] : !fir.array<?xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_18]], %[[VAL_42:.*]] to %[[VAL_0]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>
+
   integer :: n
   real, intent(inout) :: a(n)
   real, intent(in) :: b(n)
@@ -74,29 +75,30 @@ subroutine test_forall_stmt(x, mask)
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_0]](%[[VAL_9]]) : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> !fir.array<200xf32>
-  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<200xf32>) {
-  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
-  ! CHECK:           %[[VAL_17:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_18:.*]] = subi %[[VAL_16]], %[[VAL_17]] : i64
-  ! CHECK:           %[[VAL_19:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_18]] : (!fir.ref<!fir.array<200x!fir.logical<4>>>, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:           %[[VAL_20:.*]] = fir.load %[[VAL_19]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (!fir.logical<4>) -> i1
-  ! CHECK:           %[[VAL_22:.*]] = fir.if %[[VAL_21]] -> (!fir.array<200xf32>) {
-  ! CHECK:             %[[VAL_23:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:         %[[VAL_11:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:         %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_14:.*]] = %[[VAL_10]]) -> (!fir.array<200xf32>) {
+  ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_13]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_15]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i32) -> i64
+  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_17]], %[[VAL_18]] : i64
+  ! CHECK:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_19]] : (!fir.ref<!fir.array<200x!fir.logical<4>>>, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (!fir.logical<4>) -> i1
+  ! CHECK:           %[[VAL_23:.*]] = fir.if %[[VAL_22]] -> (!fir.array<200xf32>) {
   ! CHECK:             %[[VAL_24:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i32) -> i64
   ! CHECK:             %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i64) -> index
-  ! CHECK:             %[[VAL_27:.*]] = fir.array_update %[[VAL_13]], %[[VAL_23]], %[[VAL_26]] {Fortran.offsets} : (!fir.array<200xf32>, f32, index) -> !fir.array<200xf32>
+  ! CHECK:             %[[VAL_27:.*]] = fir.array_update %[[VAL_14]], %[[VAL_11]], %[[VAL_26]] {Fortran.offsets} : (!fir.array<200xf32>, f32, index) -> !fir.array<200xf32>
   ! CHECK:             fir.result %[[VAL_27]] : !fir.array<200xf32>
   ! CHECK:           } else {
-  ! CHECK:             fir.result %[[VAL_13]] : !fir.array<200xf32>
+  ! CHECK:             fir.result %[[VAL_14]] : !fir.array<200xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_28:.*]] : !fir.array<200xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_10]], %[[VAL_29:.*]] to %[[VAL_0]] : !fir.array<200xf32>, !fir.array<200xf32>, !fir.ref<!fir.array<200xf32>>
+
   logical :: mask(200)
   real :: x(200)
   forall (i=1:100,mask(i)) x(i) = 1.
@@ -138,50 +140,51 @@ subroutine test_forall_construct(a,b)
   ! CHECK:         %[[VAL_29:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_30:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.array<?x?xf32>
   ! CHECK:         %[[VAL_31:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.array<?x?xf32>
-  ! CHECK:         %[[VAL_32:.*]] = fir.do_loop %[[VAL_33:.*]] = %[[VAL_5]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_34:.*]] = %[[VAL_30]]) -> (!fir.array<?x?xf32>) {
-  ! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_33]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_35]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_36:.*]] = fir.do_loop %[[VAL_37:.*]] = %[[VAL_18]] to %[[VAL_28]] step %[[VAL_29]] unordered iter_args(%[[VAL_38:.*]] = %[[VAL_34]]) -> (!fir.array<?x?xf32>) {
-  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_37]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_39]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_40:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (i32) -> i64
-  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_43:.*]] = subi %[[VAL_41]], %[[VAL_42]] : i64
-  ! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i32) -> i64
-  ! CHECK:             %[[VAL_46:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_47:.*]] = subi %[[VAL_45]], %[[VAL_46]] : i64
-  ! CHECK:             %[[VAL_48:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_43]], %[[VAL_47]] : (!fir.box<!fir.array<?x?xf32>>, i64, i64) -> !fir.ref<f32>
-  ! CHECK:             %[[VAL_49:.*]] = fir.load %[[VAL_48]] : !fir.ref<f32>
-  ! CHECK:             %[[VAL_50:.*]] = constant 0.000000e+00 : f32
-  ! CHECK:             %[[VAL_51:.*]] = cmpf ogt, %[[VAL_49]], %[[VAL_50]] : f32
-  ! CHECK:             %[[VAL_52:.*]] = fir.if %[[VAL_51]] -> (!fir.array<?x?xf32>) {
-  ! CHECK:               %[[VAL_53:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (i32) -> i64
-  ! CHECK:               %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i64) -> index
-  ! CHECK:               %[[VAL_56:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_57:.*]] = fir.convert %[[VAL_56]] : (i32) -> i64
-  ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i64) -> index
-  ! CHECK:               %[[VAL_59:.*]] = fir.array_fetch %[[VAL_31]], %[[VAL_55]], %[[VAL_58]] {Fortran.offsets} : (!fir.array<?x?xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_60:.*]] = constant 3.140000e+00 : f32
-  ! CHECK:               %[[VAL_61:.*]] = divf %[[VAL_59]], %[[VAL_60]] : f32
+  ! CHECK:         %[[VAL_32:.*]] = constant 3.140000e+00 : f32
+  ! CHECK:         %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_5]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_30]]) -> (!fir.array<?x?xf32>) {
+  ! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_34]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_36]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_37:.*]] = fir.do_loop %[[VAL_38:.*]] = %[[VAL_18]] to %[[VAL_28]] step %[[VAL_29]] unordered iter_args(%[[VAL_39:.*]] = %[[VAL_35]]) -> (!fir.array<?x?xf32>) {
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_38]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_40]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_41:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_42:.*]] = fir.convert %[[VAL_41]] : (i32) -> i64
+  ! CHECK:             %[[VAL_43:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_44:.*]] = subi %[[VAL_42]], %[[VAL_43]] : i64
+  ! CHECK:             %[[VAL_45:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i32) -> i64
+  ! CHECK:             %[[VAL_47:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_48:.*]] = subi %[[VAL_46]], %[[VAL_47]] : i64
+  ! CHECK:             %[[VAL_49:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_44]], %[[VAL_48]] : (!fir.box<!fir.array<?x?xf32>>, i64, i64) -> !fir.ref<f32>
+  ! CHECK:             %[[VAL_50:.*]] = fir.load %[[VAL_49]] : !fir.ref<f32>
+  ! CHECK:             %[[VAL_51:.*]] = constant 0.000000e+00 : f32
+  ! CHECK:             %[[VAL_52:.*]] = cmpf ogt, %[[VAL_50]], %[[VAL_51]] : f32
+  ! CHECK:             %[[VAL_53:.*]] = fir.if %[[VAL_52]] -> (!fir.array<?x?xf32>) {
+  ! CHECK:               %[[VAL_54:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i32) -> i64
+  ! CHECK:               %[[VAL_56:.*]] = fir.convert %[[VAL_55]] : (i64) -> index
+  ! CHECK:               %[[VAL_57:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i32) -> i64
+  ! CHECK:               %[[VAL_59:.*]] = fir.convert %[[VAL_58]] : (i64) -> index
+  ! CHECK:               %[[VAL_60:.*]] = fir.array_fetch %[[VAL_31]], %[[VAL_56]], %[[VAL_59]] {Fortran.offsets} : (!fir.array<?x?xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_61:.*]] = divf %[[VAL_60]], %[[VAL_32]] : f32
   ! CHECK:               %[[VAL_62:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (i32) -> i64
   ! CHECK:               %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (i64) -> index
   ! CHECK:               %[[VAL_65:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_66:.*]] = fir.convert %[[VAL_65]] : (i32) -> i64
   ! CHECK:               %[[VAL_67:.*]] = fir.convert %[[VAL_66]] : (i64) -> index
-  ! CHECK:               %[[VAL_68:.*]] = fir.array_update %[[VAL_38]], %[[VAL_61]], %[[VAL_64]], %[[VAL_67]] {Fortran.offsets} : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
+  ! CHECK:               %[[VAL_68:.*]] = fir.array_update %[[VAL_39]], %[[VAL_61]], %[[VAL_64]], %[[VAL_67]] {Fortran.offsets} : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
   ! CHECK:               fir.result %[[VAL_68]] : !fir.array<?x?xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_38]] : !fir.array<?x?xf32>
+  ! CHECK:               fir.result %[[VAL_39]] : !fir.array<?x?xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_69:.*]] : !fir.array<?x?xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_70:.*]] : !fir.array<?x?xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_30]], %[[VAL_71:.*]] to %[[VAL_0]] : !fir.array<?x?xf32>, !fir.array<?x?xf32>, !fir.box<!fir.array<?x?xf32>>
+
   real :: a(:,:), b(:,:)
   forall (i=1:ubound(a,1), j=1:ubound(a,2), b(j,i) > 0.0)
      a(i,j) = b(j,i) / 3.14
@@ -218,36 +221,36 @@ subroutine test2_forall_construct(a,b)
   ! CHECK:         %[[VAL_23:.*]] = fir.array_load %[[VAL_1]](%[[VAL_22]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
   ! CHECK:         %[[VAL_24:.*]] = fir.shape %[[VAL_8]], %[[VAL_9]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_25:.*]] = fir.array_load %[[VAL_1]](%[[VAL_24]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_26:.*]] = fir.do_loop %[[VAL_27:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_28:.*]] = %[[VAL_21]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_27]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_29]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_30:.*]] = fir.do_loop %[[VAL_31:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_32:.*]] = %[[VAL_28]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_33:.*]] = fir.convert %[[VAL_31]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_33]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> i64
-  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i64) -> index
-  ! CHECK:             %[[VAL_37:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i32) -> i64
-  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i64) -> index
-  ! CHECK:             %[[VAL_40:.*]] = fir.array_fetch %[[VAL_23]], %[[VAL_36]], %[[VAL_39]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_41:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i32
-  ! CHECK:             %[[VAL_43:.*]] = addi %[[VAL_41]], %[[VAL_42]] : i32
+  ! CHECK:         %[[VAL_26:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_27:.*]] = fir.do_loop %[[VAL_28:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_29:.*]] = %[[VAL_21]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_28]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_30]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_29]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_32]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_34]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
+  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
+  ! CHECK:             %[[VAL_38:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i32) -> i64
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
+  ! CHECK:             %[[VAL_41:.*]] = fir.array_fetch %[[VAL_23]], %[[VAL_37]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_43:.*]] = addi %[[VAL_42]], %[[VAL_26]] : i32
   ! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
   ! CHECK:             %[[VAL_46:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i32) -> i64
   ! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index
   ! CHECK:             %[[VAL_49:.*]] = fir.array_fetch %[[VAL_25]], %[[VAL_45]], %[[VAL_48]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_50:.*]] = addf %[[VAL_40]], %[[VAL_49]] : f32
+  ! CHECK:             %[[VAL_50:.*]] = addf %[[VAL_41]], %[[VAL_49]] : f32
   ! CHECK:             %[[VAL_51:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i32) -> i64
   ! CHECK:             %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i64) -> index
   ! CHECK:             %[[VAL_54:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i32) -> i64
   ! CHECK:             %[[VAL_56:.*]] = fir.convert %[[VAL_55]] : (i64) -> index
-  ! CHECK:             %[[VAL_57:.*]] = fir.array_update %[[VAL_32]], %[[VAL_50]], %[[VAL_53]], %[[VAL_56]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:             %[[VAL_57:.*]] = fir.array_update %[[VAL_33]], %[[VAL_50]], %[[VAL_53]], %[[VAL_56]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:             fir.result %[[VAL_57]] : !fir.array<100x400xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_58:.*]] : !fir.array<100x400xf32>
@@ -257,35 +260,36 @@ subroutine test2_forall_construct(a,b)
   ! CHECK:         %[[VAL_61:.*]] = fir.array_load %[[VAL_0]](%[[VAL_60]]) : (!fir.ref<!fir.array<100x400xf32>>, !fir.shape<2>) -> !fir.array<100x400xf32>
   ! CHECK:         %[[VAL_62:.*]] = fir.shape %[[VAL_8]], %[[VAL_9]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_63:.*]] = fir.array_load %[[VAL_1]](%[[VAL_62]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_64:.*]] = fir.do_loop %[[VAL_65:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_66:.*]] = %[[VAL_61]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_67:.*]] = fir.convert %[[VAL_65]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_67]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_68:.*]] = fir.do_loop %[[VAL_69:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_70:.*]] = %[[VAL_66]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_69]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_71]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_72:.*]] = constant 1.000000e+00 : f32
-  ! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_74:.*]] = fir.convert %[[VAL_73]] : (i32) -> i64
-  ! CHECK:             %[[VAL_75:.*]] = fir.convert %[[VAL_74]] : (i64) -> index
-  ! CHECK:             %[[VAL_76:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (i32) -> i64
-  ! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_77]] : (i64) -> index
-  ! CHECK:             %[[VAL_79:.*]] = fir.array_fetch %[[VAL_63]], %[[VAL_75]], %[[VAL_78]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_80:.*]] = divf %[[VAL_72]], %[[VAL_79]] : f32
-  ! CHECK:             %[[VAL_81:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_82:.*]] = fir.convert %[[VAL_81]] : (i32) -> i64
-  ! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (i64) -> index
-  ! CHECK:             %[[VAL_84:.*]] = constant 200 : i32
+  ! CHECK:         %[[VAL_64:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:         %[[VAL_65:.*]] = constant 200 : i32
+  ! CHECK:         %[[VAL_66:.*]] = fir.do_loop %[[VAL_67:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_68:.*]] = %[[VAL_61]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_69:.*]] = fir.convert %[[VAL_67]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_69]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_70:.*]] = fir.do_loop %[[VAL_71:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_72:.*]] = %[[VAL_68]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_73:.*]] = fir.convert %[[VAL_71]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_73]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_74:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_75:.*]] = fir.convert %[[VAL_74]] : (i32) -> i64
+  ! CHECK:             %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (i64) -> index
+  ! CHECK:             %[[VAL_77:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_77]] : (i32) -> i64
+  ! CHECK:             %[[VAL_79:.*]] = fir.convert %[[VAL_78]] : (i64) -> index
+  ! CHECK:             %[[VAL_80:.*]] = fir.array_fetch %[[VAL_63]], %[[VAL_76]], %[[VAL_79]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:             %[[VAL_81:.*]] = divf %[[VAL_64]], %[[VAL_80]] : f32
+  ! CHECK:             %[[VAL_82:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (i32) -> i64
+  ! CHECK:             %[[VAL_84:.*]] = fir.convert %[[VAL_83]] : (i64) -> index
   ! CHECK:             %[[VAL_85:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_86:.*]] = addi %[[VAL_84]], %[[VAL_85]] : i32
+  ! CHECK:             %[[VAL_86:.*]] = addi %[[VAL_65]], %[[VAL_85]] : i32
   ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (i32) -> i64
   ! CHECK:             %[[VAL_88:.*]] = fir.convert %[[VAL_87]] : (i64) -> index
-  ! CHECK:             %[[VAL_89:.*]] = fir.array_update %[[VAL_70]], %[[VAL_80]], %[[VAL_83]], %[[VAL_88]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:             %[[VAL_89:.*]] = fir.array_update %[[VAL_72]], %[[VAL_81]], %[[VAL_84]], %[[VAL_88]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:             fir.result %[[VAL_89]] : !fir.array<100x400xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_90:.*]] : !fir.array<100x400xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_61]], %[[VAL_91:.*]] to %[[VAL_0]] : !fir.array<100x400xf32>, !fir.array<100x400xf32>, !fir.ref<!fir.array<100x400xf32>>
+
   real :: a(100,400), b(200,200)
   forall (i=1:100, j=1:200)
      a(i,j) = b(i,j) + b(i+1,j)
@@ -325,51 +329,51 @@ subroutine test3_forall_construct(a,b, mask)
   ! CHECK:         %[[VAL_24:.*]] = fir.array_load %[[VAL_1]](%[[VAL_23]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
   ! CHECK:         %[[VAL_25:.*]] = fir.shape %[[VAL_9]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_26:.*]] = fir.array_load %[[VAL_1]](%[[VAL_25]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_27:.*]] = fir.do_loop %[[VAL_28:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_29:.*]] = %[[VAL_22]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_28]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_30]] to %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_29]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_32]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_34]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
-  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_38:.*]] = subi %[[VAL_36]], %[[VAL_37]] : i64
-  ! CHECK:             %[[VAL_39:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i32) -> i64
-  ! CHECK:             %[[VAL_41:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_42:.*]] = subi %[[VAL_40]], %[[VAL_41]] : i64
-  ! CHECK:             %[[VAL_43:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_38]], %[[VAL_42]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_43]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (!fir.logical<4>) -> i1
-  ! CHECK:             %[[VAL_46:.*]] = fir.if %[[VAL_45]] -> (!fir.array<100x400xf32>) {
-  ! CHECK:               %[[VAL_47:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i32) -> i64
-  ! CHECK:               %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i64) -> index
-  ! CHECK:               %[[VAL_50:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_51:.*]] = fir.convert %[[VAL_50]] : (i32) -> i64
-  ! CHECK:               %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i64) -> index
-  ! CHECK:               %[[VAL_53:.*]] = fir.array_fetch %[[VAL_24]], %[[VAL_49]], %[[VAL_52]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_54:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_55:.*]] = constant 1 : i32
-  ! CHECK:               %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i32
+  ! CHECK:         %[[VAL_27:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_28:.*]] = fir.do_loop %[[VAL_29:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_30:.*]] = %[[VAL_22]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_29]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_31]] to %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_32:.*]] = fir.do_loop %[[VAL_33:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_34:.*]] = %[[VAL_30]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_33]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_35]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
+  ! CHECK:             %[[VAL_38:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_39:.*]] = subi %[[VAL_37]], %[[VAL_38]] : i64
+  ! CHECK:             %[[VAL_40:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (i32) -> i64
+  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_43:.*]] = subi %[[VAL_41]], %[[VAL_42]] : i64
+  ! CHECK:             %[[VAL_44:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_39]], %[[VAL_43]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_45:.*]] = fir.load %[[VAL_44]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (!fir.logical<4>) -> i1
+  ! CHECK:             %[[VAL_47:.*]] = fir.if %[[VAL_46]] -> (!fir.array<100x400xf32>) {
+  ! CHECK:               %[[VAL_48:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> i64
+  ! CHECK:               %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i64) -> index
+  ! CHECK:               %[[VAL_51:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i32) -> i64
+  ! CHECK:               %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i64) -> index
+  ! CHECK:               %[[VAL_54:.*]] = fir.array_fetch %[[VAL_24]], %[[VAL_50]], %[[VAL_53]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_55:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_56:.*]] = addi %[[VAL_55]], %[[VAL_27]] : i32
   ! CHECK:               %[[VAL_57:.*]] = fir.convert %[[VAL_56]] : (i32) -> i64
   ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i64) -> index
   ! CHECK:               %[[VAL_59:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (i32) -> i64
   ! CHECK:               %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (i64) -> index
   ! CHECK:               %[[VAL_62:.*]] = fir.array_fetch %[[VAL_26]], %[[VAL_58]], %[[VAL_61]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_63:.*]] = addf %[[VAL_53]], %[[VAL_62]] : f32
+  ! CHECK:               %[[VAL_63:.*]] = addf %[[VAL_54]], %[[VAL_62]] : f32
   ! CHECK:               %[[VAL_64:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_65:.*]] = fir.convert %[[VAL_64]] : (i32) -> i64
   ! CHECK:               %[[VAL_66:.*]] = fir.convert %[[VAL_65]] : (i64) -> index
   ! CHECK:               %[[VAL_67:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_68:.*]] = fir.convert %[[VAL_67]] : (i32) -> i64
   ! CHECK:               %[[VAL_69:.*]] = fir.convert %[[VAL_68]] : (i64) -> index
-  ! CHECK:               %[[VAL_70:.*]] = fir.array_update %[[VAL_33]], %[[VAL_63]], %[[VAL_66]], %[[VAL_69]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:               %[[VAL_70:.*]] = fir.array_update %[[VAL_34]], %[[VAL_63]], %[[VAL_66]], %[[VAL_69]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:               fir.result %[[VAL_70]] : !fir.array<100x400xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_33]] : !fir.array<100x400xf32>
+  ! CHECK:               fir.result %[[VAL_34]] : !fir.array<100x400xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_71:.*]] : !fir.array<100x400xf32>
   ! CHECK:           }
@@ -380,51 +384,52 @@ subroutine test3_forall_construct(a,b, mask)
   ! CHECK:         %[[VAL_75:.*]] = fir.array_load %[[VAL_0]](%[[VAL_74]]) : (!fir.ref<!fir.array<100x400xf32>>, !fir.shape<2>) -> !fir.array<100x400xf32>
   ! CHECK:         %[[VAL_76:.*]] = fir.shape %[[VAL_9]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_77:.*]] = fir.array_load %[[VAL_1]](%[[VAL_76]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_78:.*]] = fir.do_loop %[[VAL_79:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_80:.*]] = %[[VAL_75]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_81:.*]] = fir.convert %[[VAL_79]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_81]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_82:.*]] = fir.do_loop %[[VAL_83:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_84:.*]] = %[[VAL_80]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_85:.*]] = fir.convert %[[VAL_83]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_85]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_86:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (i32) -> i64
-  ! CHECK:             %[[VAL_88:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_89:.*]] = subi %[[VAL_87]], %[[VAL_88]] : i64
-  ! CHECK:             %[[VAL_90:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_91:.*]] = fir.convert %[[VAL_90]] : (i32) -> i64
-  ! CHECK:             %[[VAL_92:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_93:.*]] = subi %[[VAL_91]], %[[VAL_92]] : i64
-  ! CHECK:             %[[VAL_94:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_89]], %[[VAL_93]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_95:.*]] = fir.load %[[VAL_94]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_96:.*]] = fir.convert %[[VAL_95]] : (!fir.logical<4>) -> i1
-  ! CHECK:             %[[VAL_97:.*]] = fir.if %[[VAL_96]] -> (!fir.array<100x400xf32>) {
-  ! CHECK:               %[[VAL_98:.*]] = constant 1.000000e+00 : f32
-  ! CHECK:               %[[VAL_99:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (i32) -> i64
-  ! CHECK:               %[[VAL_101:.*]] = fir.convert %[[VAL_100]] : (i64) -> index
-  ! CHECK:               %[[VAL_102:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (i32) -> i64
-  ! CHECK:               %[[VAL_104:.*]] = fir.convert %[[VAL_103]] : (i64) -> index
-  ! CHECK:               %[[VAL_105:.*]] = fir.array_fetch %[[VAL_77]], %[[VAL_101]], %[[VAL_104]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_106:.*]] = divf %[[VAL_98]], %[[VAL_105]] : f32
-  ! CHECK:               %[[VAL_107:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_108:.*]] = fir.convert %[[VAL_107]] : (i32) -> i64
-  ! CHECK:               %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (i64) -> index
-  ! CHECK:               %[[VAL_110:.*]] = constant 200 : i32
+  ! CHECK:         %[[VAL_78:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:         %[[VAL_79:.*]] = constant 200 : i32
+  ! CHECK:         %[[VAL_80:.*]] = fir.do_loop %[[VAL_81:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_82:.*]] = %[[VAL_75]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_81]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_83]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_84:.*]] = fir.do_loop %[[VAL_85:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_86:.*]] = %[[VAL_82]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_85]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_87]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_88:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_89:.*]] = fir.convert %[[VAL_88]] : (i32) -> i64
+  ! CHECK:             %[[VAL_90:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_91:.*]] = subi %[[VAL_89]], %[[VAL_90]] : i64
+  ! CHECK:             %[[VAL_92:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_93:.*]] = fir.convert %[[VAL_92]] : (i32) -> i64
+  ! CHECK:             %[[VAL_94:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_95:.*]] = subi %[[VAL_93]], %[[VAL_94]] : i64
+  ! CHECK:             %[[VAL_96:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_91]], %[[VAL_95]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_97:.*]] = fir.load %[[VAL_96]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_98:.*]] = fir.convert %[[VAL_97]] : (!fir.logical<4>) -> i1
+  ! CHECK:             %[[VAL_99:.*]] = fir.if %[[VAL_98]] -> (!fir.array<100x400xf32>) {
+  ! CHECK:               %[[VAL_100:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_101:.*]] = fir.convert %[[VAL_100]] : (i32) -> i64
+  ! CHECK:               %[[VAL_102:.*]] = fir.convert %[[VAL_101]] : (i64) -> index
+  ! CHECK:               %[[VAL_103:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_104:.*]] = fir.convert %[[VAL_103]] : (i32) -> i64
+  ! CHECK:               %[[VAL_105:.*]] = fir.convert %[[VAL_104]] : (i64) -> index
+  ! CHECK:               %[[VAL_106:.*]] = fir.array_fetch %[[VAL_77]], %[[VAL_102]], %[[VAL_105]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_107:.*]] = divf %[[VAL_78]], %[[VAL_106]] : f32
+  ! CHECK:               %[[VAL_108:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (i32) -> i64
+  ! CHECK:               %[[VAL_110:.*]] = fir.convert %[[VAL_109]] : (i64) -> index
   ! CHECK:               %[[VAL_111:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_112:.*]] = addi %[[VAL_110]], %[[VAL_111]] : i32
+  ! CHECK:               %[[VAL_112:.*]] = addi %[[VAL_79]], %[[VAL_111]] : i32
   ! CHECK:               %[[VAL_113:.*]] = fir.convert %[[VAL_112]] : (i32) -> i64
   ! CHECK:               %[[VAL_114:.*]] = fir.convert %[[VAL_113]] : (i64) -> index
-  ! CHECK:               %[[VAL_115:.*]] = fir.array_update %[[VAL_84]], %[[VAL_106]], %[[VAL_109]], %[[VAL_114]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:               %[[VAL_115:.*]] = fir.array_update %[[VAL_86]], %[[VAL_107]], %[[VAL_110]], %[[VAL_114]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:               fir.result %[[VAL_115]] : !fir.array<100x400xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_84]] : !fir.array<100x400xf32>
+  ! CHECK:               fir.result %[[VAL_86]] : !fir.array<100x400xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_116:.*]] : !fir.array<100x400xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_117:.*]] : !fir.array<100x400xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_75]], %[[VAL_118:.*]] to %[[VAL_0]] : !fir.array<100x400xf32>, !fir.array<100x400xf32>, !fir.ref<!fir.array<100x400xf32>>
+
   real :: a(100,400), b(200,200)
   logical :: mask(100,200)
   forall (i=1:100, j=1:200, mask(i,j))
@@ -454,31 +459,31 @@ subroutine test_forall_with_array_assignment(aa,bb)
   ! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_11]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_14:.*]] = fir.array_load %[[VAL_1]](%[[VAL_13]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
-  ! CHECK:         %[[VAL_15:.*]] = fir.do_loop %[[VAL_16:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_10]] unordered iter_args(%[[VAL_17:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
-  ! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_16]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_18]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_19:.*]] = constant 64 : i64
-  ! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
-  ! CHECK:           %[[VAL_21:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_20]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_22]] to %[[VAL_23]] step %[[VAL_21]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
-  ! CHECK:             %[[VAL_27:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_28:.*]] = constant 1 : i32
-  ! CHECK:             %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_28]] : i32
+  ! CHECK:         %[[VAL_15:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_16:.*]] = fir.do_loop %[[VAL_17:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_10]] unordered iter_args(%[[VAL_18:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
+  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_17]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_19]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_20:.*]] = constant 64 : i64
+  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+  ! CHECK:           %[[VAL_22:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_23:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_24:.*]] = subi %[[VAL_21]], %[[VAL_22]] : index
+  ! CHECK:           %[[VAL_25:.*]] = fir.do_loop %[[VAL_26:.*]] = %[[VAL_23]] to %[[VAL_24]] step %[[VAL_22]] unordered iter_args(%[[VAL_27:.*]] = %[[VAL_18]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
+  ! CHECK:             %[[VAL_28:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_29:.*]] = addi %[[VAL_28]], %[[VAL_15]] : i32
   ! CHECK:             %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i32) -> i64
   ! CHECK:             %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (i64) -> index
   ! CHECK:             %[[VAL_32:.*]] = fir.field_index block2, !fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>
   ! CHECK:             %[[VAL_33:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_34:.*]] = addi %[[VAL_25]], %[[VAL_33]] : index
+  ! CHECK:             %[[VAL_34:.*]] = addi %[[VAL_26]], %[[VAL_33]] : index
   ! CHECK:             %[[VAL_35:.*]] = fir.array_fetch %[[VAL_14]], %[[VAL_31]], %[[VAL_32]], %[[VAL_34]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, index, !fir.field, index) -> i64
   ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
   ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
   ! CHECK:             %[[VAL_39:.*]] = fir.field_index block1, !fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>
   ! CHECK:             %[[VAL_40:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_25]], %[[VAL_40]] : index
-  ! CHECK:             %[[VAL_42:.*]] = fir.array_update %[[VAL_17]], %[[VAL_35]], %[[VAL_38]], %[[VAL_39]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, i64, index, !fir.field, index) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
+  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_26]], %[[VAL_40]] : index
+  ! CHECK:             %[[VAL_42:.*]] = fir.array_update %[[VAL_27]], %[[VAL_35]], %[[VAL_38]], %[[VAL_39]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, i64, index, !fir.field, index) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:             fir.result %[[VAL_42]] : !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_43:.*]] : !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
@@ -509,219 +514,236 @@ subroutine test_nested_forall_where(a,b)
   ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
   ! CHECK:         %[[VAL_4:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
   ! CHECK:         %[[VAL_5:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
-  ! CHECK:         %[[VAL_6:.*]] = fir.alloca !fir.heap<index>
-  ! CHECK:         %[[VAL_7:.*]] = fir.alloca !fir.heap<i8>
-  ! CHECK:         %[[VAL_8:.*]] = fir.zero_bits !fir.heap<i8>
-  ! CHECK:         fir.store %[[VAL_8]] to %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:         %[[VAL_9:.*]] = fir.zero_bits !fir.heap<index>
-  ! CHECK:         fir.store %[[VAL_9]] to %[[VAL_6]] : !fir.ref<!fir.heap<index>>
-  ! CHECK:         %[[VAL_10:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
-  ! CHECK:         %[[VAL_12:.*]] = constant 0 : index
-  ! CHECK:         %[[VAL_13:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_12]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, index) -> (index, index, index)
-  ! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]]#1 : (index) -> i64
-  ! CHECK:         %[[VAL_15:.*]] = constant 1 : index
-  ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (index) -> i64
-  ! CHECK:         %[[VAL_17:.*]] = addi %[[VAL_14]], %[[VAL_16]] : i64
-  ! CHECK:         %[[VAL_18:.*]] = constant 1 : i64
-  ! CHECK:         %[[VAL_19:.*]] = subi %[[VAL_17]], %[[VAL_18]] : i64
-  ! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> i32
-  ! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i32) -> index
-  ! CHECK:         %[[VAL_22:.*]] = constant 1 : index
-  ! CHECK:         %[[VAL_23:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (i32) -> index
-  ! CHECK:         %[[VAL_25:.*]] = constant 1 : index
-  ! CHECK:         %[[VAL_26:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_25]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, index) -> (index, index, index)
-  ! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_26]]#1 : (index) -> i64
-  ! CHECK:         %[[VAL_28:.*]] = constant 1 : index
-  ! CHECK:         %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (index) -> i64
-  ! CHECK:         %[[VAL_30:.*]] = addi %[[VAL_27]], %[[VAL_29]] : i64
-  ! CHECK:         %[[VAL_31:.*]] = constant 1 : i64
-  ! CHECK:         %[[VAL_32:.*]] = subi %[[VAL_30]], %[[VAL_31]] : i64
-  ! CHECK:         %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i64) -> i32
-  ! CHECK:         %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i32) -> index
-  ! CHECK:         %[[VAL_35:.*]] = constant 1 : index
-  ! CHECK:         %[[VAL_36:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:         %[[VAL_37:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:         %[[VAL_38:.*]] = fir.do_loop %[[VAL_39:.*]] = %[[VAL_11]] to %[[VAL_21]] step %[[VAL_22]] unordered iter_args(%[[VAL_40:.*]] = %[[VAL_36]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:           %[[VAL_41:.*]] = fir.convert %[[VAL_39]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_41]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_42:.*]] = fir.do_loop %[[VAL_43:.*]] = %[[VAL_24]] to %[[VAL_34]] step %[[VAL_35]] unordered iter_args(%[[VAL_44:.*]] = %[[VAL_40]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_43]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_45]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_46:.*]] = constant 100 : i64
-  ! CHECK:             %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i64) -> index
-  ! CHECK:             %[[VAL_48:.*]] = constant 3.140000e+00 : f32
-  ! CHECK:             %[[VAL_49:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
-  ! CHECK:             %[[VAL_51:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_52:.*]] = subi %[[VAL_50]], %[[VAL_51]] : i64
-  ! CHECK:             %[[VAL_53:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (i32) -> i64
-  ! CHECK:             %[[VAL_55:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_56:.*]] = subi %[[VAL_54]], %[[VAL_55]] : i64
-  ! CHECK:             %[[VAL_57:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_52]], %[[VAL_56]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, i64, i64) -> !fir.ref<!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:             %[[VAL_58:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:             %[[VAL_59:.*]] = fir.coordinate_of %[[VAL_57]], %[[VAL_58]] : (!fir.ref<!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.field) -> !fir.ref<!fir.array<100xf32>>
-  ! CHECK:             %[[VAL_60:.*]] = constant 100 : index
-  ! CHECK:             %[[VAL_61:.*]] = fir.shape %[[VAL_60]] : (index) -> !fir.shape<1>
-  ! CHECK:             %[[VAL_62:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_63:.*]] = fir.slice %[[VAL_62]], %[[VAL_60]], %[[VAL_62]] : (index, index, index) -> !fir.slice<1>
-  ! CHECK:             %[[VAL_64:.*]] = fir.array_load %[[VAL_59]](%[[VAL_61]]) {{\[}}%[[VAL_63]]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
-  ! CHECK:             %[[VAL_65:.*]] = constant 0.000000e+00 : f32
-  ! CHECK:             %[[VAL_66:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_67:.*]] = subi %[[VAL_60]], %[[VAL_62]] : index
-  ! CHECK:             %[[VAL_68:.*]] = addi %[[VAL_67]], %[[VAL_62]] : index
-  ! CHECK:             %[[VAL_69:.*]] = divi_signed %[[VAL_68]], %[[VAL_62]] : index
-  ! CHECK:             %[[VAL_70:.*]] = cmpi sgt, %[[VAL_69]], %[[VAL_66]] : index
-  ! CHECK:             %[[VAL_71:.*]] = select %[[VAL_70]], %[[VAL_69]], %[[VAL_66]] : index
-  ! CHECK:             %[[VAL_72:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:             %[[VAL_73:.*]] = fir.convert %[[VAL_72]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:             %[[VAL_74:.*]] = fir.shape %[[VAL_71]] : (index) -> !fir.shape<1>
-  ! CHECK:             %[[VAL_75:.*]] = fir.array_load %[[VAL_73]](%[[VAL_74]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
-  ! CHECK:             %[[VAL_76:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:             %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_77]] : (!fir.heap<!fir.array<?xi8>>) -> i64
-  ! CHECK:             %[[VAL_79:.*]] = constant 0 : i64
-  ! CHECK:             %[[VAL_80:.*]] = cmpi eq, %[[VAL_78]], %[[VAL_79]] : i64
-  ! CHECK:             fir.if %[[VAL_80]] {
-  ! CHECK:               %[[VAL_81:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_71]] {uniq_name = ".lazy.mask"}
-  ! CHECK:               %[[VAL_82:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
-  ! CHECK:               fir.store %[[VAL_81]] to %[[VAL_82]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
-  ! CHECK:               %[[VAL_83:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
-  ! CHECK:               %[[VAL_84:.*]] = constant 0 : index
-  ! CHECK:               %[[VAL_85:.*]] = fir.coordinate_of %[[VAL_83]], %[[VAL_84]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
-  ! CHECK:               fir.store %[[VAL_71]] to %[[VAL_85]] : !fir.ref<index>
-  ! CHECK:               %[[VAL_86:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
-  ! CHECK:               fir.store %[[VAL_83]] to %[[VAL_86]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:         %[[VAL_6:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
+  ! CHECK:         %[[VAL_7:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+  ! CHECK:         %[[VAL_8:.*]] = fir.alloca !fir.heap<index>
+  ! CHECK:         %[[VAL_9:.*]] = fir.alloca !fir.heap<i8>
+  ! CHECK:         %[[VAL_10:.*]] = fir.zero_bits !fir.heap<i8>
+  ! CHECK:         fir.store %[[VAL_10]] to %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_11:.*]] = fir.zero_bits !fir.heap<index>
+  ! CHECK:         fir.store %[[VAL_11]] to %[[VAL_8]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_12:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i32) -> index
+  ! CHECK:         %[[VAL_14:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_15:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_14]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, index) -> (index, index, index)
+  ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]]#1 : (index) -> i64
+  ! CHECK:         %[[VAL_17:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (index) -> i64
+  ! CHECK:         %[[VAL_19:.*]] = addi %[[VAL_16]], %[[VAL_18]] : i64
+  ! CHECK:         %[[VAL_20:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_21:.*]] = subi %[[VAL_19]], %[[VAL_20]] : i64
+  ! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (i64) -> i32
+  ! CHECK:         %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i32) -> index
+  ! CHECK:         %[[VAL_24:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_25:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i32) -> index
+  ! CHECK:         %[[VAL_27:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_28:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_27]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, index) -> (index, index, index)
+  ! CHECK:         %[[VAL_29:.*]] = fir.convert %[[VAL_28]]#1 : (index) -> i64
+  ! CHECK:         %[[VAL_30:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (index) -> i64
+  ! CHECK:         %[[VAL_32:.*]] = addi %[[VAL_29]], %[[VAL_31]] : i64
+  ! CHECK:         %[[VAL_33:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_34:.*]] = subi %[[VAL_32]], %[[VAL_33]] : i64
+  ! CHECK:         %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i64) -> i32
+  ! CHECK:         %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> index
+  ! CHECK:         %[[VAL_37:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_38:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         %[[VAL_39:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         %[[VAL_40:.*]] = fir.do_loop %[[VAL_41:.*]] = %[[VAL_13]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[VAL_42:.*]] = %[[VAL_38]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:           %[[VAL_43:.*]] = fir.convert %[[VAL_41]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_43]] to %[[VAL_7]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_44:.*]] = fir.do_loop %[[VAL_45:.*]] = %[[VAL_26]] to %[[VAL_36]] step %[[VAL_37]] unordered iter_args(%[[VAL_46:.*]] = %[[VAL_42]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:             %[[VAL_47:.*]] = fir.convert %[[VAL_45]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_47]] to %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_48:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> i64
+  ! CHECK:             %[[VAL_50:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_51:.*]] = subi %[[VAL_49]], %[[VAL_50]] : i64
+  ! CHECK:             %[[VAL_52:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i32) -> i64
+  ! CHECK:             %[[VAL_54:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_55:.*]] = subi %[[VAL_53]], %[[VAL_54]] : i64
+  ! CHECK:             %[[VAL_56:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_51]], %[[VAL_55]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, i64, i64) -> !fir.ref<!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:             %[[VAL_57:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:             %[[VAL_58:.*]] = fir.coordinate_of %[[VAL_56]], %[[VAL_57]] : (!fir.ref<!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.field) -> !fir.ref<!fir.array<100xf32>>
+  ! CHECK:             %[[VAL_59:.*]] = constant 100 : index
+  ! CHECK:             %[[VAL_60:.*]] = fir.shape %[[VAL_59]] : (index) -> !fir.shape<1>
+  ! CHECK:             %[[VAL_61:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_62:.*]] = fir.slice %[[VAL_61]], %[[VAL_59]], %[[VAL_61]] : (index, index, index) -> !fir.slice<1>
+  ! CHECK:             %[[VAL_63:.*]] = fir.array_load %[[VAL_58]](%[[VAL_60]]) {{\[}}%[[VAL_62]]] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
+  ! CHECK:             %[[VAL_64:.*]] = constant 0.000000e+00 : f32
+  ! CHECK:             %[[VAL_65:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_66:.*]] = subi %[[VAL_59]], %[[VAL_61]] : index
+  ! CHECK:             %[[VAL_67:.*]] = addi %[[VAL_66]], %[[VAL_61]] : index
+  ! CHECK:             %[[VAL_68:.*]] = divi_signed %[[VAL_67]], %[[VAL_61]] : index
+  ! CHECK:             %[[VAL_69:.*]] = cmpi sgt, %[[VAL_68]], %[[VAL_65]] : index
+  ! CHECK:             %[[VAL_70:.*]] = select %[[VAL_69]], %[[VAL_68]], %[[VAL_65]] : index
+  ! CHECK:             %[[VAL_71:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_72:.*]] = fir.convert %[[VAL_71]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             %[[VAL_73:.*]] = fir.shape %[[VAL_70]] : (index) -> !fir.shape<1>
+  ! CHECK:             %[[VAL_74:.*]] = fir.array_load %[[VAL_72]](%[[VAL_73]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
+  ! CHECK:             %[[VAL_75:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (!fir.heap<!fir.array<?xi8>>) -> i64
+  ! CHECK:             %[[VAL_78:.*]] = constant 0 : i64
+  ! CHECK:             %[[VAL_79:.*]] = cmpi eq, %[[VAL_77]], %[[VAL_78]] : i64
+  ! CHECK:             fir.if %[[VAL_79]] {
+  ! CHECK:               %[[VAL_80:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_70]] {uniq_name = ".lazy.mask"}
+  ! CHECK:               %[[VAL_81:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:               fir.store %[[VAL_80]] to %[[VAL_81]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:               %[[VAL_82:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
+  ! CHECK:               %[[VAL_83:.*]] = constant 0 : index
+  ! CHECK:               %[[VAL_84:.*]] = fir.coordinate_of %[[VAL_82]], %[[VAL_83]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
+  ! CHECK:               fir.store %[[VAL_70]] to %[[VAL_84]] : !fir.ref<index>
+  ! CHECK:               %[[VAL_85:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:               fir.store %[[VAL_82]] to %[[VAL_85]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
   ! CHECK:             }
-  ! CHECK:             %[[VAL_87:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_88:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_89:.*]] = subi %[[VAL_71]], %[[VAL_87]] : index
-  ! CHECK:             %[[VAL_90:.*]] = fir.do_loop %[[VAL_91:.*]] = %[[VAL_88]] to %[[VAL_89]] step %[[VAL_87]] unordered iter_args(%[[VAL_92:.*]] = %[[VAL_75]]) -> (!fir.array<?xi8>) {
-  ! CHECK:               %[[VAL_93:.*]] = fir.array_fetch %[[VAL_64]], %[[VAL_91]] : (!fir.array<100xf32>, index) -> f32
-  ! CHECK:               %[[VAL_94:.*]] = cmpf ogt, %[[VAL_93]], %[[VAL_65]] : f32
-  ! CHECK:               %[[VAL_95:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:               %[[VAL_96:.*]] = fir.convert %[[VAL_95]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:               %[[VAL_97:.*]] = fir.shape %[[VAL_71]] : (index) -> !fir.shape<1>
-  ! CHECK:               %[[VAL_98:.*]] = constant 1 : index
-  ! CHECK:               %[[VAL_99:.*]] = addi %[[VAL_91]], %[[VAL_98]] : index
-  ! CHECK:               %[[VAL_100:.*]] = fir.array_coor %[[VAL_96]](%[[VAL_97]]) %[[VAL_99]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:               %[[VAL_101:.*]] = fir.convert %[[VAL_94]] : (i1) -> i8
-  ! CHECK:               fir.store %[[VAL_101]] to %[[VAL_100]] : !fir.ref<i8>
-  ! CHECK:               fir.result %[[VAL_92]] : !fir.array<?xi8>
+  ! CHECK:             %[[VAL_86:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_87:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_88:.*]] = subi %[[VAL_70]], %[[VAL_86]] : index
+  ! CHECK:             %[[VAL_89:.*]] = fir.do_loop %[[VAL_90:.*]] = %[[VAL_87]] to %[[VAL_88]] step %[[VAL_86]] unordered iter_args(%[[VAL_91:.*]] = %[[VAL_74]]) -> (!fir.array<?xi8>) {
+  ! CHECK:               %[[VAL_92:.*]] = fir.array_fetch %[[VAL_63]], %[[VAL_90]] : (!fir.array<100xf32>, index) -> f32
+  ! CHECK:               %[[VAL_93:.*]] = cmpf ogt, %[[VAL_92]], %[[VAL_64]] : f32
+  ! CHECK:               %[[VAL_94:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:               %[[VAL_95:.*]] = fir.convert %[[VAL_94]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:               %[[VAL_96:.*]] = fir.shape %[[VAL_70]] : (index) -> !fir.shape<1>
+  ! CHECK:               %[[VAL_97:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_98:.*]] = addi %[[VAL_90]], %[[VAL_97]] : index
+  ! CHECK:               %[[VAL_99:.*]] = fir.array_coor %[[VAL_95]](%[[VAL_96]]) %[[VAL_98]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_100:.*]] = fir.convert %[[VAL_93]] : (i1) -> i8
+  ! CHECK:               fir.store %[[VAL_100]] to %[[VAL_99]] : !fir.ref<i8>
+  ! CHECK:               fir.result %[[VAL_91]] : !fir.array<?xi8>
   ! CHECK:             }
-  ! CHECK:             %[[VAL_102:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:             %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:             fir.array_merge_store %[[VAL_75]], %[[VAL_104:.*]] to %[[VAL_103]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
-  ! CHECK:             %[[VAL_105:.*]] = fir.shape %[[VAL_71]] : (index) -> !fir.shape<1>
-  ! CHECK:             %[[VAL_106:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_107:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_108:.*]] = subi %[[VAL_47]], %[[VAL_106]] : index
-  ! CHECK:             %[[VAL_109:.*]] = fir.do_loop %[[VAL_110:.*]] = %[[VAL_107]] to %[[VAL_108]] step %[[VAL_106]] unordered iter_args(%[[VAL_111:.*]] = %[[VAL_36]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:               %[[VAL_112:.*]] = constant 1 : index
-  ! CHECK:               %[[VAL_113:.*]] = addi %[[VAL_110]], %[[VAL_112]] : index
-  ! CHECK:               %[[VAL_114:.*]] = fir.array_coor %[[VAL_103]](%[[VAL_105]]) %[[VAL_113]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:               %[[VAL_115:.*]] = fir.load %[[VAL_114]] : !fir.ref<i8>
-  ! CHECK:               %[[VAL_116:.*]] = fir.convert %[[VAL_115]] : (i8) -> i1
-  ! CHECK:               %[[VAL_117:.*]] = fir.if %[[VAL_116]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:                 %[[VAL_118:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_119:.*]] = fir.convert %[[VAL_118]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_120:.*]] = fir.convert %[[VAL_119]] : (i64) -> index
-  ! CHECK:                 %[[VAL_121:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_122:.*]] = fir.convert %[[VAL_121]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_123:.*]] = fir.convert %[[VAL_122]] : (i64) -> index
-  ! CHECK:                 %[[VAL_124:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:                 %[[VAL_125:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_126:.*]] = addi %[[VAL_110]], %[[VAL_125]] : index
-  ! CHECK:                 %[[VAL_127:.*]] = fir.array_fetch %[[VAL_37]], %[[VAL_120]], %[[VAL_123]], %[[VAL_124]], %[[VAL_126]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
-  ! CHECK:                 %[[VAL_128:.*]] = divf %[[VAL_127]], %[[VAL_48]] : f32
-  ! CHECK:                 %[[VAL_129:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_130:.*]] = fir.convert %[[VAL_129]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_131:.*]] = fir.convert %[[VAL_130]] : (i64) -> index
-  ! CHECK:                 %[[VAL_132:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_133:.*]] = fir.convert %[[VAL_132]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_134:.*]] = fir.convert %[[VAL_133]] : (i64) -> index
-  ! CHECK:                 %[[VAL_135:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:                 %[[VAL_136:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_137:.*]] = addi %[[VAL_110]], %[[VAL_136]] : index
-  ! CHECK:                 %[[VAL_138:.*]] = fir.array_update %[[VAL_44]], %[[VAL_128]], %[[VAL_131]], %[[VAL_134]], %[[VAL_135]], %[[VAL_137]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:                 fir.result %[[VAL_138]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:               } else {
-  ! CHECK:                 fir.result %[[VAL_111]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:               }
-  ! CHECK:               fir.result %[[VAL_139:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:             }
-  ! CHECK:             fir.result %[[VAL_140:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:             %[[VAL_101:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_102:.*]] = fir.convert %[[VAL_101]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             fir.array_merge_store %[[VAL_74]], %[[VAL_103:.*]] to %[[VAL_102]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             fir.result %[[VAL_46]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:           }
-  ! CHECK:           fir.result %[[VAL_141:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:           fir.result %[[VAL_104:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:         }
-  ! CHECK:         fir.array_merge_store %[[VAL_36]], %[[VAL_142:.*]] to %[[VAL_0]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>
-  ! CHECK:         %[[VAL_143:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:         %[[VAL_144:.*]] = fir.convert %[[VAL_143]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-  ! CHECK:         %[[VAL_145:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.array<1xindex>>
-  ! CHECK:         %[[VAL_146:.*]] = constant 0 : index
-  ! CHECK:         %[[VAL_147:.*]] = fir.coordinate_of %[[VAL_145]], %[[VAL_146]] : (!fir.ref<!fir.array<1xindex>>, index) -> !fir.ref<index>
-  ! CHECK:         %[[VAL_148:.*]] = fir.load %[[VAL_147]] : !fir.ref<index>
-  ! CHECK:         %[[VAL_149:.*]] = fir.shape %[[VAL_148]] : (index) -> !fir.shape<1>
-  ! CHECK:         %[[VAL_150:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:         %[[VAL_151:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:         %[[VAL_152:.*]] = fir.do_loop %[[VAL_153:.*]] = %[[VAL_11]] to %[[VAL_21]] step %[[VAL_22]] unordered iter_args(%[[VAL_154:.*]] = %[[VAL_150]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:           %[[VAL_155:.*]] = fir.convert %[[VAL_153]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_155]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_156:.*]] = fir.do_loop %[[VAL_157:.*]] = %[[VAL_24]] to %[[VAL_34]] step %[[VAL_35]] unordered iter_args(%[[VAL_158:.*]] = %[[VAL_154]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:             %[[VAL_159:.*]] = fir.convert %[[VAL_157]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_159]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_160:.*]] = constant 100 : i64
-  ! CHECK:             %[[VAL_161:.*]] = fir.convert %[[VAL_160]] : (i64) -> index
-  ! CHECK:             %[[VAL_162:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_163:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_164:.*]] = subi %[[VAL_161]], %[[VAL_162]] : index
-  ! CHECK:             %[[VAL_165:.*]] = fir.do_loop %[[VAL_166:.*]] = %[[VAL_163]] to %[[VAL_164]] step %[[VAL_162]] unordered iter_args(%[[VAL_167:.*]] = %[[VAL_150]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:               %[[VAL_168:.*]] = constant 1 : index
-  ! CHECK:               %[[VAL_169:.*]] = addi %[[VAL_166]], %[[VAL_168]] : index
-  ! CHECK:               %[[VAL_170:.*]] = fir.array_coor %[[VAL_144]](%[[VAL_149]]) %[[VAL_169]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:               %[[VAL_171:.*]] = fir.load %[[VAL_170]] : !fir.ref<i8>
-  ! CHECK:               %[[VAL_172:.*]] = fir.convert %[[VAL_171]] : (i8) -> i1
-  ! CHECK:               %[[VAL_173:.*]] = fir.if %[[VAL_172]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:                 fir.result %[[VAL_167]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         %[[VAL_105:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_106:.*]] = fir.convert %[[VAL_105]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:         %[[VAL_107:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_108:.*]] = fir.convert %[[VAL_107]] : (!fir.heap<index>) -> !fir.heap<!fir.array<?xindex>>
+  ! CHECK:         %[[VAL_109:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_110:.*]] = fir.coordinate_of %[[VAL_108]], %[[VAL_109]] : (!fir.heap<!fir.array<?xindex>>, index) -> !fir.ref<index>
+  ! CHECK:         %[[VAL_111:.*]] = fir.load %[[VAL_110]] : !fir.ref<index>
+  ! CHECK:         %[[VAL_112:.*]] = fir.shape %[[VAL_111]] : (index) -> !fir.shape<1>
+  ! CHECK:         %[[VAL_113:.*]] = constant 3.140000e+00 : f32
+  ! CHECK:         %[[VAL_114:.*]] = fir.do_loop %[[VAL_115:.*]] = %[[VAL_13]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[VAL_116:.*]] = %[[VAL_38]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:           %[[VAL_117:.*]] = fir.convert %[[VAL_115]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_117]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_118:.*]] = fir.do_loop %[[VAL_119:.*]] = %[[VAL_26]] to %[[VAL_36]] step %[[VAL_37]] unordered iter_args(%[[VAL_120:.*]] = %[[VAL_116]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:             %[[VAL_121:.*]] = fir.convert %[[VAL_119]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_121]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_122:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_123:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_124:.*]] = subi %[[VAL_111]], %[[VAL_122]] : index
+  ! CHECK:             %[[VAL_125:.*]] = fir.do_loop %[[VAL_126:.*]] = %[[VAL_123]] to %[[VAL_124]] step %[[VAL_122]] unordered iter_args(%[[VAL_127:.*]] = %[[VAL_120]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:               %[[VAL_128:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_129:.*]] = addi %[[VAL_126]], %[[VAL_128]] : index
+  ! CHECK:               %[[VAL_130:.*]] = fir.array_coor %[[VAL_106]](%[[VAL_112]]) %[[VAL_129]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_131:.*]] = fir.load %[[VAL_130]] : !fir.ref<i8>
+  ! CHECK:               %[[VAL_132:.*]] = fir.convert %[[VAL_131]] : (i8) -> i1
+  ! CHECK:               %[[VAL_133:.*]] = fir.if %[[VAL_132]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:                 %[[VAL_134:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_135:.*]] = fir.convert %[[VAL_134]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_136:.*]] = fir.convert %[[VAL_135]] : (i64) -> index
+  ! CHECK:                 %[[VAL_137:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_138:.*]] = fir.convert %[[VAL_137]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_139:.*]] = fir.convert %[[VAL_138]] : (i64) -> index
+  ! CHECK:                 %[[VAL_140:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:                 %[[VAL_141:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_126]], %[[VAL_141]] : index
+  ! CHECK:                 %[[VAL_143:.*]] = fir.array_fetch %[[VAL_39]], %[[VAL_136]], %[[VAL_139]], %[[VAL_140]], %[[VAL_142]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
+  ! CHECK:                 %[[VAL_144:.*]] = divf %[[VAL_143]], %[[VAL_113]] : f32
+  ! CHECK:                 %[[VAL_145:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_146:.*]] = fir.convert %[[VAL_145]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_147:.*]] = fir.convert %[[VAL_146]] : (i64) -> index
+  ! CHECK:                 %[[VAL_148:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_149:.*]] = fir.convert %[[VAL_148]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_150:.*]] = fir.convert %[[VAL_149]] : (i64) -> index
+  ! CHECK:                 %[[VAL_151:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:                 %[[VAL_152:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_153:.*]] = addi %[[VAL_126]], %[[VAL_152]] : index
+  ! CHECK:                 %[[VAL_154:.*]] = fir.array_update %[[VAL_127]], %[[VAL_144]], %[[VAL_147]], %[[VAL_150]], %[[VAL_151]], %[[VAL_153]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:                 fir.result %[[VAL_154]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:               } else {
-  ! CHECK:                 %[[VAL_174:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_175:.*]] = fir.convert %[[VAL_174]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_176:.*]] = fir.convert %[[VAL_175]] : (i64) -> index
-  ! CHECK:                 %[[VAL_177:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_178:.*]] = fir.convert %[[VAL_177]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_179:.*]] = fir.convert %[[VAL_178]] : (i64) -> index
-  ! CHECK:                 %[[VAL_180:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:                 %[[VAL_181:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_182:.*]] = addi %[[VAL_166]], %[[VAL_181]] : index
-  ! CHECK:                 %[[VAL_183:.*]] = fir.array_fetch %[[VAL_151]], %[[VAL_176]], %[[VAL_179]], %[[VAL_180]], %[[VAL_182]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
-  ! CHECK:                 %[[VAL_184:.*]] = negf %[[VAL_183]] : f32
-  ! CHECK:                 %[[VAL_185:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_186:.*]] = fir.convert %[[VAL_185]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_187:.*]] = fir.convert %[[VAL_186]] : (i64) -> index
-  ! CHECK:                 %[[VAL_188:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_189:.*]] = fir.convert %[[VAL_188]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_190:.*]] = fir.convert %[[VAL_189]] : (i64) -> index
-  ! CHECK:                 %[[VAL_191:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:                 %[[VAL_192:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_193:.*]] = addi %[[VAL_166]], %[[VAL_192]] : index
-  ! CHECK:                 %[[VAL_194:.*]] = fir.array_update %[[VAL_158]], %[[VAL_184]], %[[VAL_187]], %[[VAL_190]], %[[VAL_191]], %[[VAL_193]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
-  ! CHECK:                 fir.result %[[VAL_194]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:                 fir.result %[[VAL_127]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:               }
-  ! CHECK:               fir.result %[[VAL_195:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:               fir.result %[[VAL_155:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:             }
-  ! CHECK:             fir.result %[[VAL_196:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:             fir.result %[[VAL_156:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:           }
-  ! CHECK:           fir.result %[[VAL_197:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:           fir.result %[[VAL_157:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:         }
-  ! CHECK:         fir.array_merge_store %[[VAL_150]], %[[VAL_198:.*]] to %[[VAL_0]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>
-  ! CHECK:         %[[VAL_199:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<i8>>
-  ! CHECK:         %[[VAL_200:.*]] = fir.convert %[[VAL_199]] : (!fir.heap<i8>) -> i64
-  ! CHECK:         %[[VAL_201:.*]] = constant 0 : i64
-  ! CHECK:         %[[VAL_202:.*]] = cmpi ne, %[[VAL_200]], %[[VAL_201]] : i64
-  ! CHECK:         fir.if %[[VAL_202]] {
-  ! CHECK:           fir.freemem %[[VAL_199]] : !fir.heap<i8>
+  ! CHECK:         fir.array_merge_store %[[VAL_38]], %[[VAL_158:.*]] to %[[VAL_0]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>
+  ! CHECK:         %[[VAL_159:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_160:.*]] = fir.convert %[[VAL_159]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:         %[[VAL_161:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.array<1xindex>>
+  ! CHECK:         %[[VAL_162:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_163:.*]] = fir.coordinate_of %[[VAL_161]], %[[VAL_162]] : (!fir.ref<!fir.array<1xindex>>, index) -> !fir.ref<index>
+  ! CHECK:         %[[VAL_164:.*]] = fir.load %[[VAL_163]] : !fir.ref<index>
+  ! CHECK:         %[[VAL_165:.*]] = fir.shape %[[VAL_164]] : (index) -> !fir.shape<1>
+  ! CHECK:         %[[VAL_166:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         %[[VAL_167:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         %[[VAL_168:.*]] = fir.do_loop %[[VAL_169:.*]] = %[[VAL_13]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[VAL_170:.*]] = %[[VAL_166]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:           %[[VAL_171:.*]] = fir.convert %[[VAL_169]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_171]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_172:.*]] = fir.do_loop %[[VAL_173:.*]] = %[[VAL_26]] to %[[VAL_36]] step %[[VAL_37]] unordered iter_args(%[[VAL_174:.*]] = %[[VAL_170]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:             %[[VAL_175:.*]] = fir.convert %[[VAL_173]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_175]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_176:.*]] = constant 100 : i64
+  ! CHECK:             %[[VAL_177:.*]] = fir.convert %[[VAL_176]] : (i64) -> index
+  ! CHECK:             %[[VAL_178:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_179:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_180:.*]] = subi %[[VAL_177]], %[[VAL_178]] : index
+  ! CHECK:             %[[VAL_181:.*]] = fir.do_loop %[[VAL_182:.*]] = %[[VAL_179]] to %[[VAL_180]] step %[[VAL_178]] unordered iter_args(%[[VAL_183:.*]] = %[[VAL_174]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:               %[[VAL_184:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_185:.*]] = addi %[[VAL_182]], %[[VAL_184]] : index
+  ! CHECK:               %[[VAL_186:.*]] = fir.array_coor %[[VAL_160]](%[[VAL_165]]) %[[VAL_185]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_187:.*]] = fir.load %[[VAL_186]] : !fir.ref<i8>
+  ! CHECK:               %[[VAL_188:.*]] = fir.convert %[[VAL_187]] : (i8) -> i1
+  ! CHECK:               %[[VAL_189:.*]] = fir.if %[[VAL_188]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:                 fir.result %[[VAL_183]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:               } else {
+  ! CHECK:                 %[[VAL_190:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_191:.*]] = fir.convert %[[VAL_190]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_192:.*]] = fir.convert %[[VAL_191]] : (i64) -> index
+  ! CHECK:                 %[[VAL_193:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_194:.*]] = fir.convert %[[VAL_193]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_195:.*]] = fir.convert %[[VAL_194]] : (i64) -> index
+  ! CHECK:                 %[[VAL_196:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:                 %[[VAL_197:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_198:.*]] = addi %[[VAL_182]], %[[VAL_197]] : index
+  ! CHECK:                 %[[VAL_199:.*]] = fir.array_fetch %[[VAL_167]], %[[VAL_192]], %[[VAL_195]], %[[VAL_196]], %[[VAL_198]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
+  ! CHECK:                 %[[VAL_200:.*]] = negf %[[VAL_199]] : f32
+  ! CHECK:                 %[[VAL_201:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_202:.*]] = fir.convert %[[VAL_201]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_203:.*]] = fir.convert %[[VAL_202]] : (i64) -> index
+  ! CHECK:                 %[[VAL_204:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_205:.*]] = fir.convert %[[VAL_204]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_206:.*]] = fir.convert %[[VAL_205]] : (i64) -> index
+  ! CHECK:                 %[[VAL_207:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:                 %[[VAL_208:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_209:.*]] = addi %[[VAL_182]], %[[VAL_208]] : index
+  ! CHECK:                 %[[VAL_210:.*]] = fir.array_update %[[VAL_183]], %[[VAL_200]], %[[VAL_203]], %[[VAL_206]], %[[VAL_207]], %[[VAL_209]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:                 fir.result %[[VAL_210]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:               }
+  ! CHECK:               fir.result %[[VAL_211:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:             }
+  ! CHECK:             fir.result %[[VAL_212:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:           }
+  ! CHECK:           fir.result %[[VAL_213:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:         }
+  ! CHECK:         fir.array_merge_store %[[VAL_166]], %[[VAL_214:.*]] to %[[VAL_0]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>
+  ! CHECK:         %[[VAL_215:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_216:.*]] = fir.convert %[[VAL_215]] : (!fir.heap<i8>) -> i64
+  ! CHECK:         %[[VAL_217:.*]] = constant 0 : i64
+  ! CHECK:         %[[VAL_218:.*]] = cmpi ne, %[[VAL_216]], %[[VAL_217]] : i64
+  ! CHECK:         fir.if %[[VAL_218]] {
+  ! CHECK:           fir.freemem %[[VAL_215]] : !fir.heap<i8>
   ! CHECK:         }
 
   type t
@@ -780,11 +802,11 @@ subroutine test_forall_with_slice(i1,i2)
   ! CHECK:             %[[VAL_39:.*]] = divi_signed %[[VAL_38]], %[[VAL_33]] : index
   ! CHECK:             %[[VAL_40:.*]] = cmpi sgt, %[[VAL_39]], %[[VAL_34]] : index
   ! CHECK:             %[[VAL_41:.*]] = select %[[VAL_40]], %[[VAL_39]], %[[VAL_34]] : index
-  ! CHECK:             %[[VAL_42:.*]] = fir.call @_QPf(%[[VAL_3]]) : (!fir.ref<i32>) -> i32
-  ! CHECK:             %[[VAL_43:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_44:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_45:.*]] = subi %[[VAL_41]], %[[VAL_43]] : index
-  ! CHECK:             %[[VAL_46:.*]] = fir.do_loop %[[VAL_47:.*]] = %[[VAL_44]] to %[[VAL_45]] step %[[VAL_43]] unordered iter_args(%[[VAL_48:.*]] = %[[VAL_18]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:             %[[VAL_42:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_43:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_44:.*]] = subi %[[VAL_41]], %[[VAL_42]] : index
+  ! CHECK:             %[[VAL_45:.*]] = fir.do_loop %[[VAL_46:.*]] = %[[VAL_43]] to %[[VAL_44]] step %[[VAL_42]] unordered iter_args(%[[VAL_47:.*]] = %[[VAL_25]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:               %[[VAL_48:.*]] = fir.call @_QPf(%[[VAL_3]]) : (!fir.ref<i32>) -> i32
   ! CHECK:               %[[VAL_49:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
   ! CHECK:               %[[VAL_51:.*]] = fir.convert %[[VAL_50]] : (i64) -> index
@@ -798,9 +820,9 @@ subroutine test_forall_with_slice(i1,i2)
   ! CHECK:               %[[VAL_59:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (i32) -> i64
   ! CHECK:               %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (i64) -> index
-  ! CHECK:               %[[VAL_62:.*]] = muli %[[VAL_47]], %[[VAL_61]] : index
+  ! CHECK:               %[[VAL_62:.*]] = muli %[[VAL_46]], %[[VAL_61]] : index
   ! CHECK:               %[[VAL_63:.*]] = addi %[[VAL_58]], %[[VAL_62]] : index
-  ! CHECK:               %[[VAL_64:.*]] = fir.array_update %[[VAL_25]], %[[VAL_42]], %[[VAL_51]], %[[VAL_54]], %[[VAL_55]], %[[VAL_63]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>
+  ! CHECK:               %[[VAL_64:.*]] = fir.array_update %[[VAL_47]], %[[VAL_48]], %[[VAL_51]], %[[VAL_54]], %[[VAL_55]], %[[VAL_63]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>
   ! CHECK:               fir.result %[[VAL_64]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_65:.*]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_sliceTt{arr:!fir.array<11xi32>}>>
@@ -841,40 +863,40 @@ subroutine test_forall_with_ranked_dimension
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_3]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>>, !fir.shape<2>) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
-  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
-  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_15:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
-  ! CHECK:           %[[VAL_17:.*]] = subi %[[VAL_16]], %[[VAL_15]] : index
-  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i64) -> index
-  ! CHECK:           %[[VAL_20:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_21:.*]] = subi %[[VAL_17]], %[[VAL_15]] : index
-  ! CHECK:           %[[VAL_22:.*]] = addi %[[VAL_21]], %[[VAL_19]] : index
-  ! CHECK:           %[[VAL_23:.*]] = divi_signed %[[VAL_22]], %[[VAL_19]] : index
-  ! CHECK:           %[[VAL_24:.*]] = cmpi sgt, %[[VAL_23]], %[[VAL_20]] : index
-  ! CHECK:           %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_23]], %[[VAL_20]] : index
-  ! CHECK:           %[[VAL_26:.*]] = fir.call @_QPf(%[[VAL_0]]) : (!fir.ref<i32>) -> i32
-  ! CHECK:           %[[VAL_27:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_28:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_29:.*]] = subi %[[VAL_25]], %[[VAL_27]] : index
-  ! CHECK:           %[[VAL_30:.*]] = fir.do_loop %[[VAL_31:.*]] = %[[VAL_28]] to %[[VAL_29]] step %[[VAL_27]] unordered iter_args(%[[VAL_32:.*]] = %[[VAL_10]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
-  ! CHECK:             %[[VAL_33:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i32) -> i64
-  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i64) -> index
-  ! CHECK:             %[[VAL_36:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
-  ! CHECK:             %[[VAL_39:.*]] = muli %[[VAL_31]], %[[VAL_38]] : index
-  ! CHECK:             %[[VAL_40:.*]] = addi %[[VAL_36]], %[[VAL_39]] : index
-  ! CHECK:             %[[VAL_41:.*]] = fir.field_index arr, !fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>
-  ! CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_43:.*]] = constant 4 : i32
-  ! CHECK:             %[[VAL_44:.*]] = addi %[[VAL_42]], %[[VAL_43]] : i32
+  ! CHECK:         %[[VAL_11:.*]] = constant 1 : i64
+  ! CHECK:         %[[VAL_12:.*]] = constant 4 : i32
+  ! CHECK:         %[[VAL_13:.*]] = fir.do_loop %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_15:.*]] = %[[VAL_10]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_14]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_16]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_17:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_18:.*]] = addi %[[VAL_17]], %[[VAL_2]] : index
+  ! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_18]], %[[VAL_17]] : index
+  ! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
+  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_19]], %[[VAL_17]] : index
+  ! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_22]] : index
+  ! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_22]] : index
+  ! CHECK:           %[[VAL_28:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_29:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_30:.*]] = subi %[[VAL_27]], %[[VAL_28]] : index
+  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_29]] to %[[VAL_30]] step %[[VAL_28]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_15]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:             %[[VAL_34:.*]] = fir.call @_QPf(%[[VAL_0]]) : (!fir.ref<i32>) -> i32
+  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
+  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
+  ! CHECK:             %[[VAL_38:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
+  ! CHECK:             %[[VAL_40:.*]] = muli %[[VAL_32]], %[[VAL_39]] : index
+  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_38]], %[[VAL_40]] : index
+  ! CHECK:             %[[VAL_42:.*]] = fir.field_index arr, !fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>
+  ! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_44:.*]] = addi %[[VAL_43]], %[[VAL_12]] : i32
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i32) -> i64
   ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i64) -> index
-  ! CHECK:             %[[VAL_47:.*]] = fir.array_update %[[VAL_13]], %[[VAL_26]], %[[VAL_35]], %[[VAL_40]], %[[VAL_41]], %[[VAL_46]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
+  ! CHECK:             %[[VAL_47:.*]] = fir.array_update %[[VAL_33]], %[[VAL_34]], %[[VAL_37]], %[[VAL_41]], %[[VAL_42]], %[[VAL_46]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
   ! CHECK:             fir.result %[[VAL_47]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_48:.*]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>

--- a/flang/test/Lower/forall.f90
+++ b/flang/test/Lower/forall.f90
@@ -29,24 +29,24 @@ subroutine test9(a,b,n)
   ! CHECK:         %[[VAL_20:.*]] = fir.array_load %[[VAL_0]](%[[VAL_19]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
   ! CHECK:         %[[VAL_21:.*]] = fir.shape %[[VAL_9]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_22:.*]] = fir.array_load %[[VAL_1]](%[[VAL_21]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
-  ! CHECK:         %[[VAL_23:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_11]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_18]]) -> (!fir.array<?xf32>) {
-  ! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_25]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_27]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (i32) -> i64
-  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i64) -> index
-  ! CHECK:           %[[VAL_31:.*]] = fir.array_fetch %[[VAL_20]], %[[VAL_30]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
-  ! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i32) -> i64
-  ! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i64) -> index
-  ! CHECK:           %[[VAL_35:.*]] = fir.array_fetch %[[VAL_22]], %[[VAL_34]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
-  ! CHECK:           %[[VAL_36:.*]] = addf %[[VAL_31]], %[[VAL_35]] : f32
-  ! CHECK:           %[[VAL_37:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_38:.*]] = addi %[[VAL_37]], %[[VAL_23]] : i32
+  ! CHECK:         %[[VAL_23:.*]] = fir.do_loop %[[VAL_24:.*]] = %[[VAL_11]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_25:.*]] = %[[VAL_18]]) -> (!fir.array<?xf32>) {
+  ! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_24]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_26]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_27:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i32) -> i64
+  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (i64) -> index
+  ! CHECK:           %[[VAL_30:.*]] = fir.array_fetch %[[VAL_20]], %[[VAL_29]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
+  ! CHECK:           %[[VAL_31:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_31]] : (i32) -> i64
+  ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i64) -> index
+  ! CHECK:           %[[VAL_34:.*]] = fir.array_fetch %[[VAL_22]], %[[VAL_33]] {Fortran.offsets} : (!fir.array<?xf32>, index) -> f32
+  ! CHECK:           %[[VAL_35:.*]] = addf %[[VAL_30]], %[[VAL_34]] : f32
+  ! CHECK:           %[[VAL_36:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_37:.*]] = constant 1 : i32
+  ! CHECK:           %[[VAL_38:.*]] = addi %[[VAL_36]], %[[VAL_37]] : i32
   ! CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i32) -> i64
   ! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
-  ! CHECK:           %[[VAL_41:.*]] = fir.array_update %[[VAL_26]], %[[VAL_36]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
+  ! CHECK:           %[[VAL_41:.*]] = fir.array_update %[[VAL_25]], %[[VAL_35]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
   ! CHECK:           fir.result %[[VAL_41]] : !fir.array<?xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_18]], %[[VAL_42:.*]] to %[[VAL_0]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>
@@ -75,25 +75,25 @@ subroutine test_forall_stmt(x, mask)
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_0]](%[[VAL_9]]) : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> !fir.array<200xf32>
-  ! CHECK:         %[[VAL_11:.*]] = constant 1.000000e+00 : f32
-  ! CHECK:         %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_14:.*]] = %[[VAL_10]]) -> (!fir.array<200xf32>) {
-  ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_13]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_15]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i32) -> i64
-  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_17]], %[[VAL_18]] : i64
-  ! CHECK:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_19]] : (!fir.ref<!fir.array<200x!fir.logical<4>>>, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (!fir.logical<4>) -> i1
-  ! CHECK:           %[[VAL_23:.*]] = fir.if %[[VAL_22]] -> (!fir.array<200xf32>) {
+  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<200xf32>) {
+  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
+  ! CHECK:           %[[VAL_17:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_18:.*]] = subi %[[VAL_16]], %[[VAL_17]] : i64
+  ! CHECK:           %[[VAL_19:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_18]] : (!fir.ref<!fir.array<200x!fir.logical<4>>>, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:           %[[VAL_20:.*]] = fir.load %[[VAL_19]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (!fir.logical<4>) -> i1
+  ! CHECK:           %[[VAL_22:.*]] = fir.if %[[VAL_21]] -> (!fir.array<200xf32>) {
+  ! CHECK:             %[[VAL_23:.*]] = constant 1.000000e+00 : f32
   ! CHECK:             %[[VAL_24:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i32) -> i64
   ! CHECK:             %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i64) -> index
-  ! CHECK:             %[[VAL_27:.*]] = fir.array_update %[[VAL_14]], %[[VAL_11]], %[[VAL_26]] {Fortran.offsets} : (!fir.array<200xf32>, f32, index) -> !fir.array<200xf32>
+  ! CHECK:             %[[VAL_27:.*]] = fir.array_update %[[VAL_13]], %[[VAL_23]], %[[VAL_26]] {Fortran.offsets} : (!fir.array<200xf32>, f32, index) -> !fir.array<200xf32>
   ! CHECK:             fir.result %[[VAL_27]] : !fir.array<200xf32>
   ! CHECK:           } else {
-  ! CHECK:             fir.result %[[VAL_14]] : !fir.array<200xf32>
+  ! CHECK:             fir.result %[[VAL_13]] : !fir.array<200xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_28:.*]] : !fir.array<200xf32>
   ! CHECK:         }
@@ -140,44 +140,44 @@ subroutine test_forall_construct(a,b)
   ! CHECK:         %[[VAL_29:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_30:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.array<?x?xf32>
   ! CHECK:         %[[VAL_31:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.array<?x?xf32>
-  ! CHECK:         %[[VAL_32:.*]] = constant 3.140000e+00 : f32
-  ! CHECK:         %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_5]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_30]]) -> (!fir.array<?x?xf32>) {
-  ! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_34]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_36]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_37:.*]] = fir.do_loop %[[VAL_38:.*]] = %[[VAL_18]] to %[[VAL_28]] step %[[VAL_29]] unordered iter_args(%[[VAL_39:.*]] = %[[VAL_35]]) -> (!fir.array<?x?xf32>) {
-  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_38]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_40]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_41:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_42:.*]] = fir.convert %[[VAL_41]] : (i32) -> i64
-  ! CHECK:             %[[VAL_43:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_44:.*]] = subi %[[VAL_42]], %[[VAL_43]] : i64
-  ! CHECK:             %[[VAL_45:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i32) -> i64
-  ! CHECK:             %[[VAL_47:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_48:.*]] = subi %[[VAL_46]], %[[VAL_47]] : i64
-  ! CHECK:             %[[VAL_49:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_44]], %[[VAL_48]] : (!fir.box<!fir.array<?x?xf32>>, i64, i64) -> !fir.ref<f32>
-  ! CHECK:             %[[VAL_50:.*]] = fir.load %[[VAL_49]] : !fir.ref<f32>
-  ! CHECK:             %[[VAL_51:.*]] = constant 0.000000e+00 : f32
-  ! CHECK:             %[[VAL_52:.*]] = cmpf ogt, %[[VAL_50]], %[[VAL_51]] : f32
-  ! CHECK:             %[[VAL_53:.*]] = fir.if %[[VAL_52]] -> (!fir.array<?x?xf32>) {
-  ! CHECK:               %[[VAL_54:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i32) -> i64
-  ! CHECK:               %[[VAL_56:.*]] = fir.convert %[[VAL_55]] : (i64) -> index
-  ! CHECK:               %[[VAL_57:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i32) -> i64
-  ! CHECK:               %[[VAL_59:.*]] = fir.convert %[[VAL_58]] : (i64) -> index
-  ! CHECK:               %[[VAL_60:.*]] = fir.array_fetch %[[VAL_31]], %[[VAL_56]], %[[VAL_59]] {Fortran.offsets} : (!fir.array<?x?xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_61:.*]] = divf %[[VAL_60]], %[[VAL_32]] : f32
+  ! CHECK:         %[[VAL_32:.*]] = fir.do_loop %[[VAL_33:.*]] = %[[VAL_5]] to %[[VAL_15]] step %[[VAL_16]] unordered iter_args(%[[VAL_34:.*]] = %[[VAL_30]]) -> (!fir.array<?x?xf32>) {
+  ! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_33]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_35]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_36:.*]] = fir.do_loop %[[VAL_37:.*]] = %[[VAL_18]] to %[[VAL_28]] step %[[VAL_29]] unordered iter_args(%[[VAL_38:.*]] = %[[VAL_34]]) -> (!fir.array<?x?xf32>) {
+  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_37]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_39]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_40:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (i32) -> i64
+  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_43:.*]] = subi %[[VAL_41]], %[[VAL_42]] : i64
+  ! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i32) -> i64
+  ! CHECK:             %[[VAL_46:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_47:.*]] = subi %[[VAL_45]], %[[VAL_46]] : i64
+  ! CHECK:             %[[VAL_48:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_43]], %[[VAL_47]] : (!fir.box<!fir.array<?x?xf32>>, i64, i64) -> !fir.ref<f32>
+  ! CHECK:             %[[VAL_49:.*]] = fir.load %[[VAL_48]] : !fir.ref<f32>
+  ! CHECK:             %[[VAL_50:.*]] = constant 0.000000e+00 : f32
+  ! CHECK:             %[[VAL_51:.*]] = cmpf ogt, %[[VAL_49]], %[[VAL_50]] : f32
+  ! CHECK:             %[[VAL_52:.*]] = fir.if %[[VAL_51]] -> (!fir.array<?x?xf32>) {
+  ! CHECK:               %[[VAL_53:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (i32) -> i64
+  ! CHECK:               %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i64) -> index
+  ! CHECK:               %[[VAL_56:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_57:.*]] = fir.convert %[[VAL_56]] : (i32) -> i64
+  ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i64) -> index
+  ! CHECK:               %[[VAL_59:.*]] = fir.array_fetch %[[VAL_31]], %[[VAL_55]], %[[VAL_58]] {Fortran.offsets} : (!fir.array<?x?xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_60:.*]] = constant 3.140000e+00 : f32
+  ! CHECK:               %[[VAL_61:.*]] = divf %[[VAL_59]], %[[VAL_60]] : f32
   ! CHECK:               %[[VAL_62:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (i32) -> i64
   ! CHECK:               %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (i64) -> index
   ! CHECK:               %[[VAL_65:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_66:.*]] = fir.convert %[[VAL_65]] : (i32) -> i64
   ! CHECK:               %[[VAL_67:.*]] = fir.convert %[[VAL_66]] : (i64) -> index
-  ! CHECK:               %[[VAL_68:.*]] = fir.array_update %[[VAL_39]], %[[VAL_61]], %[[VAL_64]], %[[VAL_67]] {Fortran.offsets} : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
+  ! CHECK:               %[[VAL_68:.*]] = fir.array_update %[[VAL_38]], %[[VAL_61]], %[[VAL_64]], %[[VAL_67]] {Fortran.offsets} : (!fir.array<?x?xf32>, f32, index, index) -> !fir.array<?x?xf32>
   ! CHECK:               fir.result %[[VAL_68]] : !fir.array<?x?xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_39]] : !fir.array<?x?xf32>
+  ! CHECK:               fir.result %[[VAL_38]] : !fir.array<?x?xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_69:.*]] : !fir.array<?x?xf32>
   ! CHECK:           }
@@ -221,36 +221,36 @@ subroutine test2_forall_construct(a,b)
   ! CHECK:         %[[VAL_23:.*]] = fir.array_load %[[VAL_1]](%[[VAL_22]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
   ! CHECK:         %[[VAL_24:.*]] = fir.shape %[[VAL_8]], %[[VAL_9]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_25:.*]] = fir.array_load %[[VAL_1]](%[[VAL_24]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_26:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_27:.*]] = fir.do_loop %[[VAL_28:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_29:.*]] = %[[VAL_21]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_28]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_30]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_29]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_32]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_34]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
-  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
-  ! CHECK:             %[[VAL_38:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i32) -> i64
-  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
-  ! CHECK:             %[[VAL_41:.*]] = fir.array_fetch %[[VAL_23]], %[[VAL_37]], %[[VAL_40]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_43:.*]] = addi %[[VAL_42]], %[[VAL_26]] : i32
+  ! CHECK:         %[[VAL_26:.*]] = fir.do_loop %[[VAL_27:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_28:.*]] = %[[VAL_21]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_27]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_29]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_30:.*]] = fir.do_loop %[[VAL_31:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_32:.*]] = %[[VAL_28]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_33:.*]] = fir.convert %[[VAL_31]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_33]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> i64
+  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i64) -> index
+  ! CHECK:             %[[VAL_37:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i32) -> i64
+  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i64) -> index
+  ! CHECK:             %[[VAL_40:.*]] = fir.array_fetch %[[VAL_23]], %[[VAL_36]], %[[VAL_39]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:             %[[VAL_41:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i32
+  ! CHECK:             %[[VAL_43:.*]] = addi %[[VAL_41]], %[[VAL_42]] : i32
   ! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index
   ! CHECK:             %[[VAL_46:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i32) -> i64
   ! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index
   ! CHECK:             %[[VAL_49:.*]] = fir.array_fetch %[[VAL_25]], %[[VAL_45]], %[[VAL_48]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_50:.*]] = addf %[[VAL_41]], %[[VAL_49]] : f32
+  ! CHECK:             %[[VAL_50:.*]] = addf %[[VAL_40]], %[[VAL_49]] : f32
   ! CHECK:             %[[VAL_51:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i32) -> i64
   ! CHECK:             %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i64) -> index
   ! CHECK:             %[[VAL_54:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i32) -> i64
   ! CHECK:             %[[VAL_56:.*]] = fir.convert %[[VAL_55]] : (i64) -> index
-  ! CHECK:             %[[VAL_57:.*]] = fir.array_update %[[VAL_33]], %[[VAL_50]], %[[VAL_53]], %[[VAL_56]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:             %[[VAL_57:.*]] = fir.array_update %[[VAL_32]], %[[VAL_50]], %[[VAL_53]], %[[VAL_56]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:             fir.result %[[VAL_57]] : !fir.array<100x400xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_58:.*]] : !fir.array<100x400xf32>
@@ -260,30 +260,30 @@ subroutine test2_forall_construct(a,b)
   ! CHECK:         %[[VAL_61:.*]] = fir.array_load %[[VAL_0]](%[[VAL_60]]) : (!fir.ref<!fir.array<100x400xf32>>, !fir.shape<2>) -> !fir.array<100x400xf32>
   ! CHECK:         %[[VAL_62:.*]] = fir.shape %[[VAL_8]], %[[VAL_9]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_63:.*]] = fir.array_load %[[VAL_1]](%[[VAL_62]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_64:.*]] = constant 1.000000e+00 : f32
-  ! CHECK:         %[[VAL_65:.*]] = constant 200 : i32
-  ! CHECK:         %[[VAL_66:.*]] = fir.do_loop %[[VAL_67:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_68:.*]] = %[[VAL_61]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_69:.*]] = fir.convert %[[VAL_67]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_69]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_70:.*]] = fir.do_loop %[[VAL_71:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_72:.*]] = %[[VAL_68]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_73:.*]] = fir.convert %[[VAL_71]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_73]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_74:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_75:.*]] = fir.convert %[[VAL_74]] : (i32) -> i64
-  ! CHECK:             %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (i64) -> index
-  ! CHECK:             %[[VAL_77:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_77]] : (i32) -> i64
-  ! CHECK:             %[[VAL_79:.*]] = fir.convert %[[VAL_78]] : (i64) -> index
-  ! CHECK:             %[[VAL_80:.*]] = fir.array_fetch %[[VAL_63]], %[[VAL_76]], %[[VAL_79]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:             %[[VAL_81:.*]] = divf %[[VAL_64]], %[[VAL_80]] : f32
-  ! CHECK:             %[[VAL_82:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (i32) -> i64
-  ! CHECK:             %[[VAL_84:.*]] = fir.convert %[[VAL_83]] : (i64) -> index
+  ! CHECK:         %[[VAL_64:.*]] = fir.do_loop %[[VAL_65:.*]] = %[[VAL_11]] to %[[VAL_13]] step %[[VAL_14]] unordered iter_args(%[[VAL_66:.*]] = %[[VAL_61]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_67:.*]] = fir.convert %[[VAL_65]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_67]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_68:.*]] = fir.do_loop %[[VAL_69:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_70:.*]] = %[[VAL_66]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_69]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_71]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_72:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_74:.*]] = fir.convert %[[VAL_73]] : (i32) -> i64
+  ! CHECK:             %[[VAL_75:.*]] = fir.convert %[[VAL_74]] : (i64) -> index
+  ! CHECK:             %[[VAL_76:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (i32) -> i64
+  ! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_77]] : (i64) -> index
+  ! CHECK:             %[[VAL_79:.*]] = fir.array_fetch %[[VAL_63]], %[[VAL_75]], %[[VAL_78]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:             %[[VAL_80:.*]] = divf %[[VAL_72]], %[[VAL_79]] : f32
+  ! CHECK:             %[[VAL_81:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_82:.*]] = fir.convert %[[VAL_81]] : (i32) -> i64
+  ! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (i64) -> index
+  ! CHECK:             %[[VAL_84:.*]] = constant 200 : i32
   ! CHECK:             %[[VAL_85:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_86:.*]] = addi %[[VAL_65]], %[[VAL_85]] : i32
+  ! CHECK:             %[[VAL_86:.*]] = addi %[[VAL_84]], %[[VAL_85]] : i32
   ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (i32) -> i64
   ! CHECK:             %[[VAL_88:.*]] = fir.convert %[[VAL_87]] : (i64) -> index
-  ! CHECK:             %[[VAL_89:.*]] = fir.array_update %[[VAL_72]], %[[VAL_81]], %[[VAL_84]], %[[VAL_88]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:             %[[VAL_89:.*]] = fir.array_update %[[VAL_70]], %[[VAL_80]], %[[VAL_83]], %[[VAL_88]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:             fir.result %[[VAL_89]] : !fir.array<100x400xf32>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_90:.*]] : !fir.array<100x400xf32>
@@ -329,51 +329,51 @@ subroutine test3_forall_construct(a,b, mask)
   ! CHECK:         %[[VAL_24:.*]] = fir.array_load %[[VAL_1]](%[[VAL_23]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
   ! CHECK:         %[[VAL_25:.*]] = fir.shape %[[VAL_9]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_26:.*]] = fir.array_load %[[VAL_1]](%[[VAL_25]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_27:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_28:.*]] = fir.do_loop %[[VAL_29:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_30:.*]] = %[[VAL_22]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_29]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_31]] to %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_32:.*]] = fir.do_loop %[[VAL_33:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_34:.*]] = %[[VAL_30]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_33]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_35]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
-  ! CHECK:             %[[VAL_38:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_39:.*]] = subi %[[VAL_37]], %[[VAL_38]] : i64
-  ! CHECK:             %[[VAL_40:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (i32) -> i64
-  ! CHECK:             %[[VAL_42:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_43:.*]] = subi %[[VAL_41]], %[[VAL_42]] : i64
-  ! CHECK:             %[[VAL_44:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_39]], %[[VAL_43]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_45:.*]] = fir.load %[[VAL_44]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (!fir.logical<4>) -> i1
-  ! CHECK:             %[[VAL_47:.*]] = fir.if %[[VAL_46]] -> (!fir.array<100x400xf32>) {
-  ! CHECK:               %[[VAL_48:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> i64
-  ! CHECK:               %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i64) -> index
-  ! CHECK:               %[[VAL_51:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i32) -> i64
-  ! CHECK:               %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i64) -> index
-  ! CHECK:               %[[VAL_54:.*]] = fir.array_fetch %[[VAL_24]], %[[VAL_50]], %[[VAL_53]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_55:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_56:.*]] = addi %[[VAL_55]], %[[VAL_27]] : i32
+  ! CHECK:         %[[VAL_27:.*]] = fir.do_loop %[[VAL_28:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_29:.*]] = %[[VAL_22]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_28]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_30]] to %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_29]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_32]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_34]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
+  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_38:.*]] = subi %[[VAL_36]], %[[VAL_37]] : i64
+  ! CHECK:             %[[VAL_39:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i32) -> i64
+  ! CHECK:             %[[VAL_41:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_42:.*]] = subi %[[VAL_40]], %[[VAL_41]] : i64
+  ! CHECK:             %[[VAL_43:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_38]], %[[VAL_42]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_43]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (!fir.logical<4>) -> i1
+  ! CHECK:             %[[VAL_46:.*]] = fir.if %[[VAL_45]] -> (!fir.array<100x400xf32>) {
+  ! CHECK:               %[[VAL_47:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i32) -> i64
+  ! CHECK:               %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i64) -> index
+  ! CHECK:               %[[VAL_50:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_51:.*]] = fir.convert %[[VAL_50]] : (i32) -> i64
+  ! CHECK:               %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i64) -> index
+  ! CHECK:               %[[VAL_53:.*]] = fir.array_fetch %[[VAL_24]], %[[VAL_49]], %[[VAL_52]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_54:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_55:.*]] = constant 1 : i32
+  ! CHECK:               %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i32
   ! CHECK:               %[[VAL_57:.*]] = fir.convert %[[VAL_56]] : (i32) -> i64
   ! CHECK:               %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i64) -> index
   ! CHECK:               %[[VAL_59:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (i32) -> i64
   ! CHECK:               %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (i64) -> index
   ! CHECK:               %[[VAL_62:.*]] = fir.array_fetch %[[VAL_26]], %[[VAL_58]], %[[VAL_61]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_63:.*]] = addf %[[VAL_54]], %[[VAL_62]] : f32
+  ! CHECK:               %[[VAL_63:.*]] = addf %[[VAL_53]], %[[VAL_62]] : f32
   ! CHECK:               %[[VAL_64:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_65:.*]] = fir.convert %[[VAL_64]] : (i32) -> i64
   ! CHECK:               %[[VAL_66:.*]] = fir.convert %[[VAL_65]] : (i64) -> index
   ! CHECK:               %[[VAL_67:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:               %[[VAL_68:.*]] = fir.convert %[[VAL_67]] : (i32) -> i64
   ! CHECK:               %[[VAL_69:.*]] = fir.convert %[[VAL_68]] : (i64) -> index
-  ! CHECK:               %[[VAL_70:.*]] = fir.array_update %[[VAL_34]], %[[VAL_63]], %[[VAL_66]], %[[VAL_69]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:               %[[VAL_70:.*]] = fir.array_update %[[VAL_33]], %[[VAL_63]], %[[VAL_66]], %[[VAL_69]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:               fir.result %[[VAL_70]] : !fir.array<100x400xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_34]] : !fir.array<100x400xf32>
+  ! CHECK:               fir.result %[[VAL_33]] : !fir.array<100x400xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_71:.*]] : !fir.array<100x400xf32>
   ! CHECK:           }
@@ -384,45 +384,45 @@ subroutine test3_forall_construct(a,b, mask)
   ! CHECK:         %[[VAL_75:.*]] = fir.array_load %[[VAL_0]](%[[VAL_74]]) : (!fir.ref<!fir.array<100x400xf32>>, !fir.shape<2>) -> !fir.array<100x400xf32>
   ! CHECK:         %[[VAL_76:.*]] = fir.shape %[[VAL_9]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_77:.*]] = fir.array_load %[[VAL_1]](%[[VAL_76]]) : (!fir.ref<!fir.array<200x200xf32>>, !fir.shape<2>) -> !fir.array<200x200xf32>
-  ! CHECK:         %[[VAL_78:.*]] = constant 1.000000e+00 : f32
-  ! CHECK:         %[[VAL_79:.*]] = constant 200 : i32
-  ! CHECK:         %[[VAL_80:.*]] = fir.do_loop %[[VAL_81:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_82:.*]] = %[[VAL_75]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_81]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_83]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_84:.*]] = fir.do_loop %[[VAL_85:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_86:.*]] = %[[VAL_82]]) -> (!fir.array<100x400xf32>) {
-  ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_85]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_87]] to %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_88:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_89:.*]] = fir.convert %[[VAL_88]] : (i32) -> i64
-  ! CHECK:             %[[VAL_90:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_91:.*]] = subi %[[VAL_89]], %[[VAL_90]] : i64
-  ! CHECK:             %[[VAL_92:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_93:.*]] = fir.convert %[[VAL_92]] : (i32) -> i64
-  ! CHECK:             %[[VAL_94:.*]] = constant 1 : i64
-  ! CHECK:             %[[VAL_95:.*]] = subi %[[VAL_93]], %[[VAL_94]] : i64
-  ! CHECK:             %[[VAL_96:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_91]], %[[VAL_95]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_97:.*]] = fir.load %[[VAL_96]] : !fir.ref<!fir.logical<4>>
-  ! CHECK:             %[[VAL_98:.*]] = fir.convert %[[VAL_97]] : (!fir.logical<4>) -> i1
-  ! CHECK:             %[[VAL_99:.*]] = fir.if %[[VAL_98]] -> (!fir.array<100x400xf32>) {
-  ! CHECK:               %[[VAL_100:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_101:.*]] = fir.convert %[[VAL_100]] : (i32) -> i64
-  ! CHECK:               %[[VAL_102:.*]] = fir.convert %[[VAL_101]] : (i64) -> index
-  ! CHECK:               %[[VAL_103:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_104:.*]] = fir.convert %[[VAL_103]] : (i32) -> i64
-  ! CHECK:               %[[VAL_105:.*]] = fir.convert %[[VAL_104]] : (i64) -> index
-  ! CHECK:               %[[VAL_106:.*]] = fir.array_fetch %[[VAL_77]], %[[VAL_102]], %[[VAL_105]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
-  ! CHECK:               %[[VAL_107:.*]] = divf %[[VAL_78]], %[[VAL_106]] : f32
-  ! CHECK:               %[[VAL_108:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (i32) -> i64
-  ! CHECK:               %[[VAL_110:.*]] = fir.convert %[[VAL_109]] : (i64) -> index
+  ! CHECK:         %[[VAL_78:.*]] = fir.do_loop %[[VAL_79:.*]] = %[[VAL_12]] to %[[VAL_14]] step %[[VAL_15]] unordered iter_args(%[[VAL_80:.*]] = %[[VAL_75]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:           %[[VAL_81:.*]] = fir.convert %[[VAL_79]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_81]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_82:.*]] = fir.do_loop %[[VAL_83:.*]] = %[[VAL_17]] to %[[VAL_19]] step %[[VAL_20]] unordered iter_args(%[[VAL_84:.*]] = %[[VAL_80]]) -> (!fir.array<100x400xf32>) {
+  ! CHECK:             %[[VAL_85:.*]] = fir.convert %[[VAL_83]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_85]] to %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_86:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (i32) -> i64
+  ! CHECK:             %[[VAL_88:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_89:.*]] = subi %[[VAL_87]], %[[VAL_88]] : i64
+  ! CHECK:             %[[VAL_90:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_91:.*]] = fir.convert %[[VAL_90]] : (i32) -> i64
+  ! CHECK:             %[[VAL_92:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_93:.*]] = subi %[[VAL_91]], %[[VAL_92]] : i64
+  ! CHECK:             %[[VAL_94:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_89]], %[[VAL_93]] : (!fir.ref<!fir.array<100x200x!fir.logical<4>>>, i64, i64) -> !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_95:.*]] = fir.load %[[VAL_94]] : !fir.ref<!fir.logical<4>>
+  ! CHECK:             %[[VAL_96:.*]] = fir.convert %[[VAL_95]] : (!fir.logical<4>) -> i1
+  ! CHECK:             %[[VAL_97:.*]] = fir.if %[[VAL_96]] -> (!fir.array<100x400xf32>) {
+  ! CHECK:               %[[VAL_98:.*]] = constant 1.000000e+00 : f32
+  ! CHECK:               %[[VAL_99:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (i32) -> i64
+  ! CHECK:               %[[VAL_101:.*]] = fir.convert %[[VAL_100]] : (i64) -> index
+  ! CHECK:               %[[VAL_102:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (i32) -> i64
+  ! CHECK:               %[[VAL_104:.*]] = fir.convert %[[VAL_103]] : (i64) -> index
+  ! CHECK:               %[[VAL_105:.*]] = fir.array_fetch %[[VAL_77]], %[[VAL_101]], %[[VAL_104]] {Fortran.offsets} : (!fir.array<200x200xf32>, index, index) -> f32
+  ! CHECK:               %[[VAL_106:.*]] = divf %[[VAL_98]], %[[VAL_105]] : f32
+  ! CHECK:               %[[VAL_107:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:               %[[VAL_108:.*]] = fir.convert %[[VAL_107]] : (i32) -> i64
+  ! CHECK:               %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (i64) -> index
+  ! CHECK:               %[[VAL_110:.*]] = constant 200 : i32
   ! CHECK:               %[[VAL_111:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-  ! CHECK:               %[[VAL_112:.*]] = addi %[[VAL_79]], %[[VAL_111]] : i32
+  ! CHECK:               %[[VAL_112:.*]] = addi %[[VAL_110]], %[[VAL_111]] : i32
   ! CHECK:               %[[VAL_113:.*]] = fir.convert %[[VAL_112]] : (i32) -> i64
   ! CHECK:               %[[VAL_114:.*]] = fir.convert %[[VAL_113]] : (i64) -> index
-  ! CHECK:               %[[VAL_115:.*]] = fir.array_update %[[VAL_86]], %[[VAL_107]], %[[VAL_110]], %[[VAL_114]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
+  ! CHECK:               %[[VAL_115:.*]] = fir.array_update %[[VAL_84]], %[[VAL_106]], %[[VAL_109]], %[[VAL_114]] {Fortran.offsets} : (!fir.array<100x400xf32>, f32, index, index) -> !fir.array<100x400xf32>
   ! CHECK:               fir.result %[[VAL_115]] : !fir.array<100x400xf32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_86]] : !fir.array<100x400xf32>
+  ! CHECK:               fir.result %[[VAL_84]] : !fir.array<100x400xf32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_116:.*]] : !fir.array<100x400xf32>
   ! CHECK:           }
@@ -459,31 +459,31 @@ subroutine test_forall_with_array_assignment(aa,bb)
   ! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_11]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_14:.*]] = fir.array_load %[[VAL_1]](%[[VAL_13]]) : (!fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, !fir.shape<1>) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
-  ! CHECK:         %[[VAL_15:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_16:.*]] = fir.do_loop %[[VAL_17:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_10]] unordered iter_args(%[[VAL_18:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
-  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_17]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_19]] to %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_20:.*]] = constant 64 : i64
-  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
-  ! CHECK:           %[[VAL_22:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_23:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_24:.*]] = subi %[[VAL_21]], %[[VAL_22]] : index
-  ! CHECK:           %[[VAL_25:.*]] = fir.do_loop %[[VAL_26:.*]] = %[[VAL_23]] to %[[VAL_24]] step %[[VAL_22]] unordered iter_args(%[[VAL_27:.*]] = %[[VAL_18]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
-  ! CHECK:             %[[VAL_28:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_29:.*]] = addi %[[VAL_28]], %[[VAL_15]] : i32
+  ! CHECK:         %[[VAL_15:.*]] = fir.do_loop %[[VAL_16:.*]] = %[[VAL_6]] to %[[VAL_8]] step %[[VAL_10]] unordered iter_args(%[[VAL_17:.*]] = %[[VAL_12]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
+  ! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_16]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_18]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_19:.*]] = constant 64 : i64
+  ! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
+  ! CHECK:           %[[VAL_21:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_20]], %[[VAL_21]] : index
+  ! CHECK:           %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_22]] to %[[VAL_23]] step %[[VAL_21]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_17]]) -> (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>) {
+  ! CHECK:             %[[VAL_27:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_28:.*]] = constant 1 : i32
+  ! CHECK:             %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_28]] : i32
   ! CHECK:             %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i32) -> i64
   ! CHECK:             %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (i64) -> index
   ! CHECK:             %[[VAL_32:.*]] = fir.field_index block2, !fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>
   ! CHECK:             %[[VAL_33:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_34:.*]] = addi %[[VAL_26]], %[[VAL_33]] : index
+  ! CHECK:             %[[VAL_34:.*]] = addi %[[VAL_25]], %[[VAL_33]] : index
   ! CHECK:             %[[VAL_35:.*]] = fir.array_fetch %[[VAL_14]], %[[VAL_31]], %[[VAL_32]], %[[VAL_34]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, index, !fir.field, index) -> i64
   ! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
   ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
   ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
   ! CHECK:             %[[VAL_39:.*]] = fir.field_index block1, !fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>
   ! CHECK:             %[[VAL_40:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_26]], %[[VAL_40]] : index
-  ! CHECK:             %[[VAL_42:.*]] = fir.array_update %[[VAL_27]], %[[VAL_35]], %[[VAL_38]], %[[VAL_39]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, i64, index, !fir.field, index) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
+  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_25]], %[[VAL_40]] : index
+  ! CHECK:             %[[VAL_42:.*]] = fir.array_update %[[VAL_26]], %[[VAL_35]], %[[VAL_38]], %[[VAL_39]], %[[VAL_41]] {Fortran.offsets} : (!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>, i64, index, !fir.field, index) -> !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:             fir.result %[[VAL_42]] : !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_43:.*]] : !fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>
@@ -630,34 +630,34 @@ subroutine test_nested_forall_where(a,b)
   ! CHECK:         %[[VAL_110:.*]] = fir.coordinate_of %[[VAL_108]], %[[VAL_109]] : (!fir.heap<!fir.array<?xindex>>, index) -> !fir.ref<index>
   ! CHECK:         %[[VAL_111:.*]] = fir.load %[[VAL_110]] : !fir.ref<index>
   ! CHECK:         %[[VAL_112:.*]] = fir.shape %[[VAL_111]] : (index) -> !fir.shape<1>
-  ! CHECK:         %[[VAL_113:.*]] = constant 3.140000e+00 : f32
-  ! CHECK:         %[[VAL_114:.*]] = fir.do_loop %[[VAL_115:.*]] = %[[VAL_13]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[VAL_116:.*]] = %[[VAL_38]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:           %[[VAL_117:.*]] = fir.convert %[[VAL_115]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_117]] to %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_118:.*]] = fir.do_loop %[[VAL_119:.*]] = %[[VAL_26]] to %[[VAL_36]] step %[[VAL_37]] unordered iter_args(%[[VAL_120:.*]] = %[[VAL_116]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:             %[[VAL_121:.*]] = fir.convert %[[VAL_119]] : (index) -> i32
-  ! CHECK:             fir.store %[[VAL_121]] to %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_122:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_123:.*]] = constant 0 : index
-  ! CHECK:             %[[VAL_124:.*]] = subi %[[VAL_111]], %[[VAL_122]] : index
-  ! CHECK:             %[[VAL_125:.*]] = fir.do_loop %[[VAL_126:.*]] = %[[VAL_123]] to %[[VAL_124]] step %[[VAL_122]] unordered iter_args(%[[VAL_127:.*]] = %[[VAL_120]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:               %[[VAL_128:.*]] = constant 1 : index
-  ! CHECK:               %[[VAL_129:.*]] = addi %[[VAL_126]], %[[VAL_128]] : index
-  ! CHECK:               %[[VAL_130:.*]] = fir.array_coor %[[VAL_106]](%[[VAL_112]]) %[[VAL_129]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:               %[[VAL_131:.*]] = fir.load %[[VAL_130]] : !fir.ref<i8>
-  ! CHECK:               %[[VAL_132:.*]] = fir.convert %[[VAL_131]] : (i8) -> i1
-  ! CHECK:               %[[VAL_133:.*]] = fir.if %[[VAL_132]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
-  ! CHECK:                 %[[VAL_134:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_135:.*]] = fir.convert %[[VAL_134]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_136:.*]] = fir.convert %[[VAL_135]] : (i64) -> index
-  ! CHECK:                 %[[VAL_137:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-  ! CHECK:                 %[[VAL_138:.*]] = fir.convert %[[VAL_137]] : (i32) -> i64
-  ! CHECK:                 %[[VAL_139:.*]] = fir.convert %[[VAL_138]] : (i64) -> index
-  ! CHECK:                 %[[VAL_140:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
-  ! CHECK:                 %[[VAL_141:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_126]], %[[VAL_141]] : index
-  ! CHECK:                 %[[VAL_143:.*]] = fir.array_fetch %[[VAL_39]], %[[VAL_136]], %[[VAL_139]], %[[VAL_140]], %[[VAL_142]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
-  ! CHECK:                 %[[VAL_144:.*]] = divf %[[VAL_143]], %[[VAL_113]] : f32
+  ! CHECK:         %[[VAL_113:.*]] = fir.do_loop %[[VAL_114:.*]] = %[[VAL_13]] to %[[VAL_23]] step %[[VAL_24]] unordered iter_args(%[[VAL_115:.*]] = %[[VAL_38]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:           %[[VAL_116:.*]] = fir.convert %[[VAL_114]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_116]] to %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_117:.*]] = fir.do_loop %[[VAL_118:.*]] = %[[VAL_26]] to %[[VAL_36]] step %[[VAL_37]] unordered iter_args(%[[VAL_119:.*]] = %[[VAL_115]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:             %[[VAL_120:.*]] = fir.convert %[[VAL_118]] : (index) -> i32
+  ! CHECK:             fir.store %[[VAL_120]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_121:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_122:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_123:.*]] = subi %[[VAL_111]], %[[VAL_121]] : index
+  ! CHECK:             %[[VAL_124:.*]] = fir.do_loop %[[VAL_125:.*]] = %[[VAL_122]] to %[[VAL_123]] step %[[VAL_121]] unordered iter_args(%[[VAL_126:.*]] = %[[VAL_119]]) -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:               %[[VAL_127:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_128:.*]] = addi %[[VAL_125]], %[[VAL_127]] : index
+  ! CHECK:               %[[VAL_129:.*]] = fir.array_coor %[[VAL_106]](%[[VAL_112]]) %[[VAL_128]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_130:.*]] = fir.load %[[VAL_129]] : !fir.ref<i8>
+  ! CHECK:               %[[VAL_131:.*]] = fir.convert %[[VAL_130]] : (i8) -> i1
+  ! CHECK:               %[[VAL_132:.*]] = fir.if %[[VAL_131]] -> (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>) {
+  ! CHECK:                 %[[VAL_133:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_134:.*]] = fir.convert %[[VAL_133]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_135:.*]] = fir.convert %[[VAL_134]] : (i64) -> index
+  ! CHECK:                 %[[VAL_136:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+  ! CHECK:                 %[[VAL_137:.*]] = fir.convert %[[VAL_136]] : (i32) -> i64
+  ! CHECK:                 %[[VAL_138:.*]] = fir.convert %[[VAL_137]] : (i64) -> index
+  ! CHECK:                 %[[VAL_139:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
+  ! CHECK:                 %[[VAL_140:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_141:.*]] = addi %[[VAL_125]], %[[VAL_140]] : index
+  ! CHECK:                 %[[VAL_142:.*]] = fir.array_fetch %[[VAL_39]], %[[VAL_135]], %[[VAL_138]], %[[VAL_139]], %[[VAL_141]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, index, index, !fir.field, index) -> f32
+  ! CHECK:                 %[[VAL_143:.*]] = constant 3.140000e+00 : f32
+  ! CHECK:                 %[[VAL_144:.*]] = divf %[[VAL_142]], %[[VAL_143]] : f32
   ! CHECK:                 %[[VAL_145:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
   ! CHECK:                 %[[VAL_146:.*]] = fir.convert %[[VAL_145]] : (i32) -> i64
   ! CHECK:                 %[[VAL_147:.*]] = fir.convert %[[VAL_146]] : (i64) -> index
@@ -666,11 +666,11 @@ subroutine test_nested_forall_where(a,b)
   ! CHECK:                 %[[VAL_150:.*]] = fir.convert %[[VAL_149]] : (i64) -> index
   ! CHECK:                 %[[VAL_151:.*]] = fir.field_index data, !fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>
   ! CHECK:                 %[[VAL_152:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_153:.*]] = addi %[[VAL_126]], %[[VAL_152]] : index
-  ! CHECK:                 %[[VAL_154:.*]] = fir.array_update %[[VAL_127]], %[[VAL_144]], %[[VAL_147]], %[[VAL_150]], %[[VAL_151]], %[[VAL_153]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:                 %[[VAL_153:.*]] = addi %[[VAL_125]], %[[VAL_152]] : index
+  ! CHECK:                 %[[VAL_154:.*]] = fir.array_update %[[VAL_126]], %[[VAL_144]], %[[VAL_147]], %[[VAL_150]], %[[VAL_151]], %[[VAL_153]] {Fortran.offsets} : (!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>, f32, index, index, !fir.field, index) -> !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:                 fir.result %[[VAL_154]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:               } else {
-  ! CHECK:                 fir.result %[[VAL_127]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
+  ! CHECK:                 fir.result %[[VAL_126]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:               }
   ! CHECK:               fir.result %[[VAL_155:.*]] : !fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>
   ! CHECK:             }
@@ -863,40 +863,40 @@ subroutine test_forall_with_ranked_dimension
   ! CHECK:         %[[VAL_8:.*]] = constant 1 : index
   ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
   ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_3]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>>, !fir.shape<2>) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
-  ! CHECK:         %[[VAL_11:.*]] = constant 1 : i64
-  ! CHECK:         %[[VAL_12:.*]] = constant 4 : i32
-  ! CHECK:         %[[VAL_13:.*]] = fir.do_loop %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_15:.*]] = %[[VAL_10]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
-  ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_14]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_16]] to %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_17:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_18:.*]] = addi %[[VAL_17]], %[[VAL_2]] : index
-  ! CHECK:           %[[VAL_19:.*]] = subi %[[VAL_18]], %[[VAL_17]] : index
-  ! CHECK:           %[[VAL_20:.*]] = constant 1 : i64
-  ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i64) -> index
-  ! CHECK:           %[[VAL_22:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_23:.*]] = subi %[[VAL_19]], %[[VAL_17]] : index
-  ! CHECK:           %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_25:.*]] = divi_signed %[[VAL_24]], %[[VAL_21]] : index
-  ! CHECK:           %[[VAL_26:.*]] = cmpi sgt, %[[VAL_25]], %[[VAL_22]] : index
-  ! CHECK:           %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_25]], %[[VAL_22]] : index
-  ! CHECK:           %[[VAL_28:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_29:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_30:.*]] = subi %[[VAL_27]], %[[VAL_28]] : index
-  ! CHECK:           %[[VAL_31:.*]] = fir.do_loop %[[VAL_32:.*]] = %[[VAL_29]] to %[[VAL_30]] step %[[VAL_28]] unordered iter_args(%[[VAL_33:.*]] = %[[VAL_15]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
-  ! CHECK:             %[[VAL_34:.*]] = fir.call @_QPf(%[[VAL_0]]) : (!fir.ref<i32>) -> i32
-  ! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
-  ! CHECK:             %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
-  ! CHECK:             %[[VAL_38:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_39:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
-  ! CHECK:             %[[VAL_40:.*]] = muli %[[VAL_32]], %[[VAL_39]] : index
-  ! CHECK:             %[[VAL_41:.*]] = addi %[[VAL_38]], %[[VAL_40]] : index
-  ! CHECK:             %[[VAL_42:.*]] = fir.field_index arr, !fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>
-  ! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:             %[[VAL_44:.*]] = addi %[[VAL_43]], %[[VAL_12]] : i32
+  ! CHECK:         %[[VAL_11:.*]] = fir.do_loop %[[VAL_12:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_13:.*]] = %[[VAL_10]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_12]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_15:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
+  ! CHECK:           %[[VAL_17:.*]] = subi %[[VAL_16]], %[[VAL_15]] : index
+  ! CHECK:           %[[VAL_18:.*]] = constant 1 : i64
+  ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i64) -> index
+  ! CHECK:           %[[VAL_20:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_21:.*]] = subi %[[VAL_17]], %[[VAL_15]] : index
+  ! CHECK:           %[[VAL_22:.*]] = addi %[[VAL_21]], %[[VAL_19]] : index
+  ! CHECK:           %[[VAL_23:.*]] = divi_signed %[[VAL_22]], %[[VAL_19]] : index
+  ! CHECK:           %[[VAL_24:.*]] = cmpi sgt, %[[VAL_23]], %[[VAL_20]] : index
+  ! CHECK:           %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_23]], %[[VAL_20]] : index
+  ! CHECK:           %[[VAL_26:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_27:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_28:.*]] = subi %[[VAL_25]], %[[VAL_26]] : index
+  ! CHECK:           %[[VAL_29:.*]] = fir.do_loop %[[VAL_30:.*]] = %[[VAL_27]] to %[[VAL_28]] step %[[VAL_26]] unordered iter_args(%[[VAL_31:.*]] = %[[VAL_13]]) -> (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>) {
+  ! CHECK:             %[[VAL_32:.*]] = fir.call @_QPf(%[[VAL_0]]) : (!fir.ref<i32>) -> i32
+  ! CHECK:             %[[VAL_33:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i32) -> i64
+  ! CHECK:             %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i64) -> index
+  ! CHECK:             %[[VAL_36:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_37:.*]] = constant 1 : i64
+  ! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (i64) -> index
+  ! CHECK:             %[[VAL_39:.*]] = muli %[[VAL_30]], %[[VAL_38]] : index
+  ! CHECK:             %[[VAL_40:.*]] = addi %[[VAL_36]], %[[VAL_39]] : index
+  ! CHECK:             %[[VAL_41:.*]] = fir.field_index arr, !fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>
+  ! CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:             %[[VAL_43:.*]] = constant 4 : i32
+  ! CHECK:             %[[VAL_44:.*]] = addi %[[VAL_42]], %[[VAL_43]] : i32
   ! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i32) -> i64
   ! CHECK:             %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i64) -> index
-  ! CHECK:             %[[VAL_47:.*]] = fir.array_update %[[VAL_33]], %[[VAL_34]], %[[VAL_37]], %[[VAL_41]], %[[VAL_42]], %[[VAL_46]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
+  ! CHECK:             %[[VAL_47:.*]] = fir.array_update %[[VAL_31]], %[[VAL_32]], %[[VAL_35]], %[[VAL_40]], %[[VAL_41]], %[[VAL_46]] {Fortran.offsets} : (!fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>, i32, index, index, !fir.field, index) -> !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
   ! CHECK:             fir.result %[[VAL_47]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>
   ! CHECK:           }
   ! CHECK:           fir.result %[[VAL_48:.*]] : !fir.array<10x10x!fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>>

--- a/flang/test/Lower/nested-where.f90
+++ b/flang/test/Lower/nested-where.f90
@@ -136,36 +136,36 @@ program nested_where
   ! CHECK:         %[[VAL_113:.*]] = fir.coordinate_of %[[VAL_111]], %[[VAL_112]] : (!fir.heap<!fir.array<?xindex>>, index) -> !fir.ref<index>
   ! CHECK:         %[[VAL_114:.*]] = fir.load %[[VAL_113]] : !fir.ref<index>
   ! CHECK:         %[[VAL_115:.*]] = fir.shape %[[VAL_114]] : (index) -> !fir.shape<1>
-  ! CHECK:         %[[VAL_116:.*]] = constant 1 : i32
-  ! CHECK:         %[[VAL_117:.*]] = fir.do_loop %[[VAL_118:.*]] = %[[VAL_18]] to %[[VAL_20]] step %[[VAL_21]] unordered iter_args(%[[VAL_119:.*]] = %[[VAL_23]]) -> (!fir.array<3xi32>) {
-  ! CHECK:           %[[VAL_120:.*]] = fir.convert %[[VAL_118]] : (index) -> i32
-  ! CHECK:           fir.store %[[VAL_120]] to %[[VAL_0]] : !fir.ref<i32>
-  ! CHECK:           %[[VAL_121:.*]] = constant 1 : index
-  ! CHECK:           %[[VAL_122:.*]] = constant 0 : index
-  ! CHECK:           %[[VAL_123:.*]] = subi %[[VAL_114]], %[[VAL_121]] : index
-  ! CHECK:           %[[VAL_124:.*]] = fir.do_loop %[[VAL_125:.*]] = %[[VAL_122]] to %[[VAL_123]] step %[[VAL_121]] unordered iter_args(%[[VAL_126:.*]] = %[[VAL_119]]) -> (!fir.array<3xi32>) {
-  ! CHECK:             %[[VAL_127:.*]] = constant 1 : index
-  ! CHECK:             %[[VAL_128:.*]] = addi %[[VAL_125]], %[[VAL_127]] : index
-  ! CHECK:             %[[VAL_129:.*]] = fir.array_coor %[[VAL_63]](%[[VAL_69]]) %[[VAL_128]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:             %[[VAL_130:.*]] = fir.load %[[VAL_129]] : !fir.ref<i8>
-  ! CHECK:             %[[VAL_131:.*]] = fir.convert %[[VAL_130]] : (i8) -> i1
-  ! CHECK:             %[[VAL_132:.*]] = fir.if %[[VAL_131]] -> (!fir.array<3xi32>) {
-  ! CHECK:               %[[VAL_133:.*]] = constant 1 : index
-  ! CHECK:               %[[VAL_134:.*]] = addi %[[VAL_125]], %[[VAL_133]] : index
-  ! CHECK:               %[[VAL_135:.*]] = fir.array_coor %[[VAL_109]](%[[VAL_115]]) %[[VAL_134]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-  ! CHECK:               %[[VAL_136:.*]] = fir.load %[[VAL_135]] : !fir.ref<i8>
-  ! CHECK:               %[[VAL_137:.*]] = fir.convert %[[VAL_136]] : (i8) -> i1
-  ! CHECK:               %[[VAL_138:.*]] = fir.if %[[VAL_137]] -> (!fir.array<3xi32>) {
+  ! CHECK:         %[[VAL_116:.*]] = fir.do_loop %[[VAL_117:.*]] = %[[VAL_18]] to %[[VAL_20]] step %[[VAL_21]] unordered iter_args(%[[VAL_118:.*]] = %[[VAL_23]]) -> (!fir.array<3xi32>) {
+  ! CHECK:           %[[VAL_119:.*]] = fir.convert %[[VAL_117]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_119]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_120:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_121:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_122:.*]] = subi %[[VAL_114]], %[[VAL_120]] : index
+  ! CHECK:           %[[VAL_123:.*]] = fir.do_loop %[[VAL_124:.*]] = %[[VAL_121]] to %[[VAL_122]] step %[[VAL_120]] unordered iter_args(%[[VAL_125:.*]] = %[[VAL_118]]) -> (!fir.array<3xi32>) {
+  ! CHECK:             %[[VAL_126:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_127:.*]] = addi %[[VAL_124]], %[[VAL_126]] : index
+  ! CHECK:             %[[VAL_128:.*]] = fir.array_coor %[[VAL_63]](%[[VAL_69]]) %[[VAL_127]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:             %[[VAL_129:.*]] = fir.load %[[VAL_128]] : !fir.ref<i8>
+  ! CHECK:             %[[VAL_130:.*]] = fir.convert %[[VAL_129]] : (i8) -> i1
+  ! CHECK:             %[[VAL_131:.*]] = fir.if %[[VAL_130]] -> (!fir.array<3xi32>) {
+  ! CHECK:               %[[VAL_132:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_133:.*]] = addi %[[VAL_124]], %[[VAL_132]] : index
+  ! CHECK:               %[[VAL_134:.*]] = fir.array_coor %[[VAL_109]](%[[VAL_115]]) %[[VAL_133]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_135:.*]] = fir.load %[[VAL_134]] : !fir.ref<i8>
+  ! CHECK:               %[[VAL_136:.*]] = fir.convert %[[VAL_135]] : (i8) -> i1
+  ! CHECK:               %[[VAL_137:.*]] = fir.if %[[VAL_136]] -> (!fir.array<3xi32>) {
+  ! CHECK:                 %[[VAL_138:.*]] = constant 1 : i32
   ! CHECK:                 %[[VAL_139:.*]] = constant 1 : index
-  ! CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_125]], %[[VAL_139]] : index
-  ! CHECK:                 %[[VAL_141:.*]] = fir.array_update %[[VAL_126]], %[[VAL_116]], %[[VAL_140]] {Fortran.offsets} : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
+  ! CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_124]], %[[VAL_139]] : index
+  ! CHECK:                 %[[VAL_141:.*]] = fir.array_update %[[VAL_125]], %[[VAL_138]], %[[VAL_140]] {Fortran.offsets} : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
   ! CHECK:                 fir.result %[[VAL_141]] : !fir.array<3xi32>
   ! CHECK:               } else {
-  ! CHECK:                 fir.result %[[VAL_126]] : !fir.array<3xi32>
+  ! CHECK:                 fir.result %[[VAL_125]] : !fir.array<3xi32>
   ! CHECK:               }
   ! CHECK:               fir.result %[[VAL_142:.*]] : !fir.array<3xi32>
   ! CHECK:             } else {
-  ! CHECK:               fir.result %[[VAL_126]] : !fir.array<3xi32>
+  ! CHECK:               fir.result %[[VAL_125]] : !fir.array<3xi32>
   ! CHECK:             }
   ! CHECK:             fir.result %[[VAL_143:.*]] : !fir.array<3xi32>
   ! CHECK:           }

--- a/flang/test/Lower/nested-where.f90
+++ b/flang/test/Lower/nested-where.f90
@@ -2,6 +2,191 @@
 
 ! CHECK-LABEL: func @_QQmain() {
 program nested_where
+  ! CHECK:         %[[VAL_0:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+  ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+  ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+  ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.heap<index>
+  ! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.heap<i8>
+  ! CHECK:         %[[VAL_5:.*]] = fir.alloca !fir.heap<index>
+  ! CHECK:         %[[VAL_6:.*]] = fir.alloca !fir.heap<i8>
+  ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QEa) : !fir.ref<!fir.array<3xi32>>
+  ! CHECK:         %[[VAL_8:.*]] = constant 3 : index
+  ! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QEmask1) : !fir.ref<!fir.array<3x!fir.logical<4>>>
+  ! CHECK:         %[[VAL_10:.*]] = constant 3 : index
+  ! CHECK:         %[[VAL_11:.*]] = fir.address_of(@_QEmask2) : !fir.ref<!fir.array<3x!fir.logical<4>>>
+  ! CHECK:         %[[VAL_12:.*]] = constant 3 : index
+  ! CHECK:         %[[VAL_13:.*]] = fir.zero_bits !fir.heap<i8>
+  ! CHECK:         fir.store %[[VAL_13]] to %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_14:.*]] = fir.zero_bits !fir.heap<index>
+  ! CHECK:         fir.store %[[VAL_14]] to %[[VAL_5]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_15:.*]] = fir.zero_bits !fir.heap<i8>
+  ! CHECK:         fir.store %[[VAL_15]] to %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_16:.*]] = fir.zero_bits !fir.heap<index>
+  ! CHECK:         fir.store %[[VAL_16]] to %[[VAL_3]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_17:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (i32) -> index
+  ! CHECK:         %[[VAL_19:.*]] = constant 3 : i32
+  ! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> index
+  ! CHECK:         %[[VAL_21:.*]] = constant 1 : index
+  ! CHECK:         %[[VAL_22:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
+  ! CHECK:         %[[VAL_23:.*]] = fir.array_load %[[VAL_7]](%[[VAL_22]]) : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>) -> !fir.array<3xi32>
+  ! CHECK:         %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_18]] to %[[VAL_20]] step %[[VAL_21]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_23]]) -> (!fir.array<3xi32>) {
+  ! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_25]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_27]] to %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_28:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
+  ! CHECK:           %[[VAL_29:.*]] = fir.array_load %[[VAL_9]](%[[VAL_28]]) : (!fir.ref<!fir.array<3x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<3x!fir.logical<4>>
+  ! CHECK:           %[[VAL_30:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           %[[VAL_32:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
+  ! CHECK:           %[[VAL_33:.*]] = fir.array_load %[[VAL_31]](%[[VAL_32]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
+  ! CHECK:           %[[VAL_34:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (!fir.heap<!fir.array<?xi8>>) -> i64
+  ! CHECK:           %[[VAL_37:.*]] = constant 0 : i64
+  ! CHECK:           %[[VAL_38:.*]] = cmpi eq, %[[VAL_36]], %[[VAL_37]] : i64
+  ! CHECK:           fir.if %[[VAL_38]] {
+  ! CHECK:             %[[VAL_39:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_10]] {uniq_name = ".lazy.mask"}
+  ! CHECK:             %[[VAL_40:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:             fir.store %[[VAL_39]] to %[[VAL_40]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:             %[[VAL_41:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
+  ! CHECK:             %[[VAL_42:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_43:.*]] = fir.coordinate_of %[[VAL_41]], %[[VAL_42]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
+  ! CHECK:             fir.store %[[VAL_10]] to %[[VAL_43]] : !fir.ref<index>
+  ! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:             fir.store %[[VAL_41]] to %[[VAL_44]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:           }
+  ! CHECK:           %[[VAL_45:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_46:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_47:.*]] = subi %[[VAL_10]], %[[VAL_45]] : index
+  ! CHECK:           %[[VAL_48:.*]] = fir.do_loop %[[VAL_49:.*]] = %[[VAL_46]] to %[[VAL_47]] step %[[VAL_45]] unordered iter_args(%[[VAL_50:.*]] = %[[VAL_33]]) -> (!fir.array<?xi8>) {
+  ! CHECK:             %[[VAL_51:.*]] = fir.array_fetch %[[VAL_29]], %[[VAL_49]] : (!fir.array<3x!fir.logical<4>>, index) -> !fir.logical<4>
+  ! CHECK:             %[[VAL_52:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             %[[VAL_54:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
+  ! CHECK:             %[[VAL_55:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_56:.*]] = addi %[[VAL_49]], %[[VAL_55]] : index
+  ! CHECK:             %[[VAL_57:.*]] = fir.array_coor %[[VAL_53]](%[[VAL_54]]) %[[VAL_56]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:             %[[VAL_58:.*]] = fir.convert %[[VAL_51]] : (!fir.logical<4>) -> i8
+  ! CHECK:             fir.store %[[VAL_58]] to %[[VAL_57]] : !fir.ref<i8>
+  ! CHECK:             fir.result %[[VAL_50]] : !fir.array<?xi8>
+  ! CHECK:           }
+  ! CHECK:           %[[VAL_59:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           fir.array_merge_store %[[VAL_33]], %[[VAL_61:.*]] to %[[VAL_60]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           fir.result %[[VAL_26]] : !fir.array<3xi32>
+  ! CHECK:         }
+  ! CHECK:         %[[VAL_62:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:         %[[VAL_64:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_65:.*]] = fir.convert %[[VAL_64]] : (!fir.heap<index>) -> !fir.heap<!fir.array<?xindex>>
+  ! CHECK:         %[[VAL_66:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_67:.*]] = fir.coordinate_of %[[VAL_65]], %[[VAL_66]] : (!fir.heap<!fir.array<?xindex>>, index) -> !fir.ref<index>
+  ! CHECK:         %[[VAL_68:.*]] = fir.load %[[VAL_67]] : !fir.ref<index>
+  ! CHECK:         %[[VAL_69:.*]] = fir.shape %[[VAL_68]] : (index) -> !fir.shape<1>
+  ! CHECK:         %[[VAL_70:.*]] = fir.do_loop %[[VAL_71:.*]] = %[[VAL_18]] to %[[VAL_20]] step %[[VAL_21]] unordered iter_args(%[[VAL_72:.*]] = %[[VAL_23]]) -> (!fir.array<3xi32>) {
+  ! CHECK:           %[[VAL_73:.*]] = fir.convert %[[VAL_71]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_73]] to %[[VAL_1]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_74:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+  ! CHECK:           %[[VAL_75:.*]] = fir.array_load %[[VAL_11]](%[[VAL_74]]) : (!fir.ref<!fir.array<3x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<3x!fir.logical<4>>
+  ! CHECK:           %[[VAL_76:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           %[[VAL_78:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+  ! CHECK:           %[[VAL_79:.*]] = fir.array_load %[[VAL_77]](%[[VAL_78]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
+  ! CHECK:           %[[VAL_80:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_81:.*]] = fir.convert %[[VAL_80]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           %[[VAL_82:.*]] = fir.convert %[[VAL_81]] : (!fir.heap<!fir.array<?xi8>>) -> i64
+  ! CHECK:           %[[VAL_83:.*]] = constant 0 : i64
+  ! CHECK:           %[[VAL_84:.*]] = cmpi eq, %[[VAL_82]], %[[VAL_83]] : i64
+  ! CHECK:           fir.if %[[VAL_84]] {
+  ! CHECK:             %[[VAL_85:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_12]] {uniq_name = ".lazy.mask"}
+  ! CHECK:             %[[VAL_86:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:             fir.store %[[VAL_85]] to %[[VAL_86]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
+  ! CHECK:             %[[VAL_87:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
+  ! CHECK:             %[[VAL_88:.*]] = constant 0 : index
+  ! CHECK:             %[[VAL_89:.*]] = fir.coordinate_of %[[VAL_87]], %[[VAL_88]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
+  ! CHECK:             fir.store %[[VAL_12]] to %[[VAL_89]] : !fir.ref<index>
+  ! CHECK:             %[[VAL_90:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:             fir.store %[[VAL_87]] to %[[VAL_90]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
+  ! CHECK:           }
+  ! CHECK:           %[[VAL_91:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_92:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_93:.*]] = subi %[[VAL_12]], %[[VAL_91]] : index
+  ! CHECK:           %[[VAL_94:.*]] = fir.do_loop %[[VAL_95:.*]] = %[[VAL_92]] to %[[VAL_93]] step %[[VAL_91]] unordered iter_args(%[[VAL_96:.*]] = %[[VAL_79]]) -> (!fir.array<?xi8>) {
+  ! CHECK:             %[[VAL_97:.*]] = fir.array_fetch %[[VAL_75]], %[[VAL_95]] : (!fir.array<3x!fir.logical<4>>, index) -> !fir.logical<4>
+  ! CHECK:             %[[VAL_98:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:             %[[VAL_99:.*]] = fir.convert %[[VAL_98]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:             %[[VAL_100:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+  ! CHECK:             %[[VAL_101:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_102:.*]] = addi %[[VAL_95]], %[[VAL_101]] : index
+  ! CHECK:             %[[VAL_103:.*]] = fir.array_coor %[[VAL_99]](%[[VAL_100]]) %[[VAL_102]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:             %[[VAL_104:.*]] = fir.convert %[[VAL_97]] : (!fir.logical<4>) -> i8
+  ! CHECK:             fir.store %[[VAL_104]] to %[[VAL_103]] : !fir.ref<i8>
+  ! CHECK:             fir.result %[[VAL_96]] : !fir.array<?xi8>
+  ! CHECK:           }
+  ! CHECK:           %[[VAL_105:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:           %[[VAL_106:.*]] = fir.convert %[[VAL_105]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           fir.array_merge_store %[[VAL_79]], %[[VAL_107:.*]] to %[[VAL_106]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
+  ! CHECK:           fir.result %[[VAL_72]] : !fir.array<3xi32>
+  ! CHECK:         }
+  ! CHECK:         %[[VAL_108:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
+  ! CHECK:         %[[VAL_110:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<index>>
+  ! CHECK:         %[[VAL_111:.*]] = fir.convert %[[VAL_110]] : (!fir.heap<index>) -> !fir.heap<!fir.array<?xindex>>
+  ! CHECK:         %[[VAL_112:.*]] = constant 0 : index
+  ! CHECK:         %[[VAL_113:.*]] = fir.coordinate_of %[[VAL_111]], %[[VAL_112]] : (!fir.heap<!fir.array<?xindex>>, index) -> !fir.ref<index>
+  ! CHECK:         %[[VAL_114:.*]] = fir.load %[[VAL_113]] : !fir.ref<index>
+  ! CHECK:         %[[VAL_115:.*]] = fir.shape %[[VAL_114]] : (index) -> !fir.shape<1>
+  ! CHECK:         %[[VAL_116:.*]] = constant 1 : i32
+  ! CHECK:         %[[VAL_117:.*]] = fir.do_loop %[[VAL_118:.*]] = %[[VAL_18]] to %[[VAL_20]] step %[[VAL_21]] unordered iter_args(%[[VAL_119:.*]] = %[[VAL_23]]) -> (!fir.array<3xi32>) {
+  ! CHECK:           %[[VAL_120:.*]] = fir.convert %[[VAL_118]] : (index) -> i32
+  ! CHECK:           fir.store %[[VAL_120]] to %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:           %[[VAL_121:.*]] = constant 1 : index
+  ! CHECK:           %[[VAL_122:.*]] = constant 0 : index
+  ! CHECK:           %[[VAL_123:.*]] = subi %[[VAL_114]], %[[VAL_121]] : index
+  ! CHECK:           %[[VAL_124:.*]] = fir.do_loop %[[VAL_125:.*]] = %[[VAL_122]] to %[[VAL_123]] step %[[VAL_121]] unordered iter_args(%[[VAL_126:.*]] = %[[VAL_119]]) -> (!fir.array<3xi32>) {
+  ! CHECK:             %[[VAL_127:.*]] = constant 1 : index
+  ! CHECK:             %[[VAL_128:.*]] = addi %[[VAL_125]], %[[VAL_127]] : index
+  ! CHECK:             %[[VAL_129:.*]] = fir.array_coor %[[VAL_63]](%[[VAL_69]]) %[[VAL_128]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:             %[[VAL_130:.*]] = fir.load %[[VAL_129]] : !fir.ref<i8>
+  ! CHECK:             %[[VAL_131:.*]] = fir.convert %[[VAL_130]] : (i8) -> i1
+  ! CHECK:             %[[VAL_132:.*]] = fir.if %[[VAL_131]] -> (!fir.array<3xi32>) {
+  ! CHECK:               %[[VAL_133:.*]] = constant 1 : index
+  ! CHECK:               %[[VAL_134:.*]] = addi %[[VAL_125]], %[[VAL_133]] : index
+  ! CHECK:               %[[VAL_135:.*]] = fir.array_coor %[[VAL_109]](%[[VAL_115]]) %[[VAL_134]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
+  ! CHECK:               %[[VAL_136:.*]] = fir.load %[[VAL_135]] : !fir.ref<i8>
+  ! CHECK:               %[[VAL_137:.*]] = fir.convert %[[VAL_136]] : (i8) -> i1
+  ! CHECK:               %[[VAL_138:.*]] = fir.if %[[VAL_137]] -> (!fir.array<3xi32>) {
+  ! CHECK:                 %[[VAL_139:.*]] = constant 1 : index
+  ! CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_125]], %[[VAL_139]] : index
+  ! CHECK:                 %[[VAL_141:.*]] = fir.array_update %[[VAL_126]], %[[VAL_116]], %[[VAL_140]] {Fortran.offsets} : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
+  ! CHECK:                 fir.result %[[VAL_141]] : !fir.array<3xi32>
+  ! CHECK:               } else {
+  ! CHECK:                 fir.result %[[VAL_126]] : !fir.array<3xi32>
+  ! CHECK:               }
+  ! CHECK:               fir.result %[[VAL_142:.*]] : !fir.array<3xi32>
+  ! CHECK:             } else {
+  ! CHECK:               fir.result %[[VAL_126]] : !fir.array<3xi32>
+  ! CHECK:             }
+  ! CHECK:             fir.result %[[VAL_143:.*]] : !fir.array<3xi32>
+  ! CHECK:           }
+  ! CHECK:           fir.result %[[VAL_144:.*]] : !fir.array<3xi32>
+  ! CHECK:         }
+  ! CHECK:         fir.array_merge_store %[[VAL_23]], %[[VAL_145:.*]] to %[[VAL_7]] : !fir.array<3xi32>, !fir.array<3xi32>, !fir.ref<!fir.array<3xi32>>
+  ! CHECK:         %[[VAL_146:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_147:.*]] = fir.convert %[[VAL_146]] : (!fir.heap<i8>) -> i64
+  ! CHECK:         %[[VAL_148:.*]] = constant 0 : i64
+  ! CHECK:         %[[VAL_149:.*]] = cmpi ne, %[[VAL_147]], %[[VAL_148]] : i64
+  ! CHECK:         fir.if %[[VAL_149]] {
+  ! CHECK:           fir.freemem %[[VAL_146]] : !fir.heap<i8>
+  ! CHECK:         }
+  ! CHECK:         %[[VAL_150:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<i8>>
+  ! CHECK:         %[[VAL_151:.*]] = fir.convert %[[VAL_150]] : (!fir.heap<i8>) -> i64
+  ! CHECK:         %[[VAL_152:.*]] = constant 0 : i64
+  ! CHECK:         %[[VAL_153:.*]] = cmpi ne, %[[VAL_151]], %[[VAL_152]] : i64
+  ! CHECK:         fir.if %[[VAL_153]] {
+  ! CHECK:           fir.freemem %[[VAL_150]] : !fir.heap<i8>
+  ! CHECK:         }
+
   integer :: a(3) = 0
   logical :: mask1(3) = (/ .true.,.false.,.true. /)
   logical :: mask2(3) = (/ .true.,.true.,.false. /)
@@ -12,167 +197,7 @@ program nested_where
       end where
     endwhere
   end forall
+  ! CHECK:         return
+  ! CHECK:       }
 end program nested_where
 
-! CHECK:         %[[VAL_0:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.heap<index>
-! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.heap<i8>
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.heap<index>
-! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.heap<i8>
-! CHECK:         %[[VAL_5:.*]] = fir.address_of(@_QEa) : !fir.ref<!fir.array<3xi32>>
-! CHECK:         %[[VAL_6:.*]] = constant 3 : index
-! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QEmask1) : !fir.ref<!fir.array<3x!fir.logical<4>>>
-! CHECK:         %[[VAL_8:.*]] = constant 3 : index
-! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QEmask2) : !fir.ref<!fir.array<3x!fir.logical<4>>>
-! CHECK:         %[[VAL_10:.*]] = constant 3 : index
-! CHECK:         %[[VAL_11:.*]] = fir.zero_bits !fir.heap<i8>
-! CHECK:         fir.store %[[VAL_11]] to %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:         %[[VAL_12:.*]] = fir.zero_bits !fir.heap<index>
-! CHECK:         fir.store %[[VAL_12]] to %[[VAL_3]] : !fir.ref<!fir.heap<index>>
-! CHECK:         %[[VAL_13:.*]] = fir.zero_bits !fir.heap<i8>
-! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:         %[[VAL_14:.*]] = fir.zero_bits !fir.heap<index>
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_1]] : !fir.ref<!fir.heap<index>>
-! CHECK:         %[[VAL_15:.*]] = constant 1 : i32
-! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> index
-! CHECK:         %[[VAL_17:.*]] = constant 3 : i32
-! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (i32) -> index
-! CHECK:         %[[VAL_19:.*]] = constant 1 : index
-! CHECK:         %[[VAL_20:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_21:.*]] = fir.array_load %[[VAL_5]](%[[VAL_20]]) : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>) -> !fir.array<3xi32>
-! CHECK:         %[[VAL_22:.*]] = fir.do_loop %[[VAL_23:.*]] = %[[VAL_16]] to %[[VAL_18]] step %[[VAL_19]] unordered iter_args(%[[VAL_24:.*]] = %[[VAL_21]]) -> (!fir.array<3xi32>) {
-! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_23]] : (index) -> i32
-! CHECK:           fir.store %[[VAL_25]] to %[[VAL_0]] : !fir.ref<i32>
-! CHECK:           %[[VAL_26:.*]] = constant 3 : i64
-! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (i64) -> index
-! CHECK:           %[[VAL_28:.*]] = constant 1 : i32
-! CHECK:           %[[VAL_29:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_30:.*]] = fir.array_load %[[VAL_7]](%[[VAL_29]]) : (!fir.ref<!fir.array<3x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<3x!fir.logical<4>>
-! CHECK:           %[[VAL_31:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_31]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_33:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_34:.*]] = fir.array_load %[[VAL_32]](%[[VAL_33]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
-! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (!fir.heap<!fir.array<?xi8>>) -> i64
-! CHECK:           %[[VAL_38:.*]] = constant 0 : i64
-! CHECK:           %[[VAL_39:.*]] = cmpi eq, %[[VAL_37]], %[[VAL_38]] : i64
-! CHECK:           fir.if %[[VAL_39]] {
-! CHECK:             %[[VAL_40:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_8]] {uniq_name = ".lazy.mask"}
-! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
-! CHECK:             fir.store %[[VAL_40]] to %[[VAL_41]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
-! CHECK:             %[[VAL_42:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
-! CHECK:             %[[VAL_43:.*]] = constant 0 : index
-! CHECK:             %[[VAL_44:.*]] = fir.coordinate_of %[[VAL_42]], %[[VAL_43]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
-! CHECK:             fir.store %[[VAL_8]] to %[[VAL_44]] : !fir.ref<index>
-! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
-! CHECK:             fir.store %[[VAL_42]] to %[[VAL_45]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
-! CHECK:           }
-! CHECK:           %[[VAL_46:.*]] = constant 1 : index
-! CHECK:           %[[VAL_47:.*]] = constant 0 : index
-! CHECK:           %[[VAL_48:.*]] = subi %[[VAL_8]], %[[VAL_46]] : index
-! CHECK:           %[[VAL_49:.*]] = fir.do_loop %[[VAL_50:.*]] = %[[VAL_47]] to %[[VAL_48]] step %[[VAL_46]] unordered iter_args(%[[VAL_51:.*]] = %[[VAL_34]]) -> (!fir.array<?xi8>) {
-! CHECK:             %[[VAL_52:.*]] = fir.array_fetch %[[VAL_30]], %[[VAL_50]] : (!fir.array<3x!fir.logical<4>>, index) -> !fir.logical<4>
-! CHECK:             %[[VAL_53:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:             %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:             %[[VAL_55:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
-! CHECK:             %[[VAL_56:.*]] = constant 1 : index
-! CHECK:             %[[VAL_57:.*]] = addi %[[VAL_50]], %[[VAL_56]] : index
-! CHECK:             %[[VAL_58:.*]] = fir.array_coor %[[VAL_54]](%[[VAL_55]]) %[[VAL_57]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-! CHECK:             %[[VAL_59:.*]] = fir.convert %[[VAL_52]] : (!fir.logical<4>) -> i8
-! CHECK:             fir.store %[[VAL_59]] to %[[VAL_58]] : !fir.ref<i8>
-! CHECK:             fir.result %[[VAL_51]] : !fir.array<?xi8>
-! CHECK:           }
-! CHECK:           %[[VAL_60:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           fir.array_merge_store %[[VAL_34]], %[[VAL_62:.*]] to %[[VAL_61]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_63:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_64:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_65:.*]] = fir.array_load %[[VAL_9]](%[[VAL_64]]) : (!fir.ref<!fir.array<3x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<3x!fir.logical<4>>
-! CHECK:           %[[VAL_66:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_67:.*]] = fir.convert %[[VAL_66]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_68:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_69:.*]] = fir.array_load %[[VAL_67]](%[[VAL_68]]) : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>) -> !fir.array<?xi8>
-! CHECK:           %[[VAL_70:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_71:.*]] = fir.convert %[[VAL_70]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_72:.*]] = fir.convert %[[VAL_71]] : (!fir.heap<!fir.array<?xi8>>) -> i64
-! CHECK:           %[[VAL_73:.*]] = constant 0 : i64
-! CHECK:           %[[VAL_74:.*]] = cmpi eq, %[[VAL_72]], %[[VAL_73]] : i64
-! CHECK:           fir.if %[[VAL_74]] {
-! CHECK:             %[[VAL_75:.*]] = fir.allocmem !fir.array<?xi8>, %[[VAL_10]] {uniq_name = ".lazy.mask"}
-! CHECK:             %[[VAL_76:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.heap<i8>>) -> !fir.ref<!fir.heap<!fir.array<?xi8>>>
-! CHECK:             fir.store %[[VAL_75]] to %[[VAL_76]] : !fir.ref<!fir.heap<!fir.array<?xi8>>>
-! CHECK:             %[[VAL_77:.*]] = fir.allocmem !fir.array<1xindex> {uniq_name = ".lazy.mask.shape"}
-! CHECK:             %[[VAL_78:.*]] = constant 0 : index
-! CHECK:             %[[VAL_79:.*]] = fir.coordinate_of %[[VAL_77]], %[[VAL_78]] : (!fir.heap<!fir.array<1xindex>>, index) -> !fir.ref<index>
-! CHECK:             fir.store %[[VAL_10]] to %[[VAL_79]] : !fir.ref<index>
-! CHECK:             %[[VAL_80:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.heap<index>>) -> !fir.ref<!fir.heap<!fir.array<1xindex>>>
-! CHECK:             fir.store %[[VAL_77]] to %[[VAL_80]] : !fir.ref<!fir.heap<!fir.array<1xindex>>>
-! CHECK:           }
-! CHECK:           %[[VAL_81:.*]] = constant 1 : index
-! CHECK:           %[[VAL_82:.*]] = constant 0 : index
-! CHECK:           %[[VAL_83:.*]] = subi %[[VAL_10]], %[[VAL_81]] : index
-! CHECK:           %[[VAL_84:.*]] = fir.do_loop %[[VAL_85:.*]] = %[[VAL_82]] to %[[VAL_83]] step %[[VAL_81]] unordered iter_args(%[[VAL_86:.*]] = %[[VAL_69]]) -> (!fir.array<?xi8>) {
-! CHECK:             %[[VAL_87:.*]] = fir.array_fetch %[[VAL_65]], %[[VAL_85]] : (!fir.array<3x!fir.logical<4>>, index) -> !fir.logical<4>
-! CHECK:             %[[VAL_88:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:             %[[VAL_89:.*]] = fir.convert %[[VAL_88]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:             %[[VAL_90:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
-! CHECK:             %[[VAL_91:.*]] = constant 1 : index
-! CHECK:             %[[VAL_92:.*]] = addi %[[VAL_85]], %[[VAL_91]] : index
-! CHECK:             %[[VAL_93:.*]] = fir.array_coor %[[VAL_89]](%[[VAL_90]]) %[[VAL_92]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-! CHECK:             %[[VAL_94:.*]] = fir.convert %[[VAL_87]] : (!fir.logical<4>) -> i8
-! CHECK:             fir.store %[[VAL_94]] to %[[VAL_93]] : !fir.ref<i8>
-! CHECK:             fir.result %[[VAL_86]] : !fir.array<?xi8>
-! CHECK:           }
-! CHECK:           %[[VAL_95:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:           %[[VAL_96:.*]] = fir.convert %[[VAL_95]] : (!fir.heap<i8>) -> !fir.heap<!fir.array<?xi8>>
-! CHECK:           fir.array_merge_store %[[VAL_69]], %[[VAL_97:.*]] to %[[VAL_96]] : !fir.array<?xi8>, !fir.array<?xi8>, !fir.heap<!fir.array<?xi8>>
-! CHECK:           %[[VAL_98:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_99:.*]] = constant 1 : index
-! CHECK:           %[[VAL_100:.*]] = constant 0 : index
-! CHECK:           %[[VAL_101:.*]] = subi %[[VAL_27]], %[[VAL_99]] : index
-! CHECK:           %[[VAL_102:.*]] = fir.do_loop %[[VAL_103:.*]] = %[[VAL_100]] to %[[VAL_101]] step %[[VAL_99]] unordered iter_args(%[[VAL_104:.*]] = %[[VAL_21]]) -> (!fir.array<3xi32>) {
-! CHECK:             %[[VAL_105:.*]] = constant 1 : index
-! CHECK:             %[[VAL_106:.*]] = addi %[[VAL_103]], %[[VAL_105]] : index
-! CHECK:             %[[VAL_107:.*]] = fir.array_coor %[[VAL_61]](%[[VAL_63]]) %[[VAL_106]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-! CHECK:             %[[VAL_108:.*]] = fir.load %[[VAL_107]] : !fir.ref<i8>
-! CHECK:             %[[VAL_109:.*]] = fir.convert %[[VAL_108]] : (i8) -> i1
-! CHECK:             %[[VAL_110:.*]] = fir.if %[[VAL_109]] -> (!fir.array<3xi32>) {
-! CHECK:               %[[VAL_111:.*]] = constant 1 : index
-! CHECK:               %[[VAL_112:.*]] = addi %[[VAL_103]], %[[VAL_111]] : index
-! CHECK:               %[[VAL_113:.*]] = fir.array_coor %[[VAL_96]](%[[VAL_98]]) %[[VAL_112]] : (!fir.heap<!fir.array<?xi8>>, !fir.shape<1>, index) -> !fir.ref<i8>
-! CHECK:               %[[VAL_114:.*]] = fir.load %[[VAL_113]] : !fir.ref<i8>
-! CHECK:               %[[VAL_115:.*]] = fir.convert %[[VAL_114]] : (i8) -> i1
-! CHECK:               %[[VAL_116:.*]] = fir.if %[[VAL_115]] -> (!fir.array<3xi32>) {
-! CHECK:                 %[[VAL_117:.*]] = constant 1 : index
-! CHECK:                 %[[VAL_118:.*]] = addi %[[VAL_103]], %[[VAL_117]] : index
-! CHECK:                 %[[VAL_119:.*]] = fir.array_update %[[VAL_24]], %[[VAL_28]], %[[VAL_118]] {Fortran.offsets} : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
-! CHECK:                 fir.result %[[VAL_119]] : !fir.array<3xi32>
-! CHECK:               } else {
-! CHECK:                 fir.result %[[VAL_104]] : !fir.array<3xi32>
-! CHECK:               }
-! CHECK:               fir.result %[[VAL_120:.*]] : !fir.array<3xi32>
-! CHECK:             } else {
-! CHECK:               fir.result %[[VAL_104]] : !fir.array<3xi32>
-! CHECK:             }
-! CHECK:             fir.result %[[VAL_121:.*]] : !fir.array<3xi32>
-! CHECK:           }
-! CHECK:           fir.result %[[VAL_122:.*]] : !fir.array<3xi32>
-! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_21]], %[[VAL_123:.*]] to %[[VAL_5]] : !fir.array<3xi32>, !fir.array<3xi32>, !fir.ref<!fir.array<3xi32>>
-! CHECK:         %[[VAL_124:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i8>>
-! CHECK:         %[[VAL_125:.*]] = fir.convert %[[VAL_124]] : (!fir.heap<i8>) -> i64
-! CHECK:         %[[VAL_126:.*]] = constant 0 : i64
-! CHECK:         %[[VAL_127:.*]] = cmpi ne, %[[VAL_125]], %[[VAL_126]] : i64
-! CHECK:         fir.if %[[VAL_127]] {
-! CHECK:           fir.freemem %[[VAL_124]] : !fir.heap<i8>
-! CHECK:         }
-! CHECK:         %[[VAL_128:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.heap<i8>>
-! CHECK:         %[[VAL_129:.*]] = fir.convert %[[VAL_128]] : (!fir.heap<i8>) -> i64
-! CHECK:         %[[VAL_130:.*]] = constant 0 : i64
-! CHECK:         %[[VAL_131:.*]] = cmpi ne, %[[VAL_129]], %[[VAL_130]] : i64
-! CHECK:         fir.if %[[VAL_131]] {
-! CHECK:           fir.freemem %[[VAL_128]] : !fir.heap<i8>
-! CHECK:         }
-! CHECK:         return
-! CHECK:       }


### PR DESCRIPTION
such that the WHERE conditional value buffer is lowered lazily and
threaded forward into the ensuing loops properly. This implements a
structure that will evaluate the WHERE conditions within the FORALL
context, save the results, and propagate those cached results to the
subsequent loop nests which evaluate the array expression assignments
under the WHERE guards.

These changes do not properly account for dynamic reshaping of the WHERE
mask buffer if it is parametric on the enclosing FORALL concurrent header
variables.