### PR TITLE
[fir] Fix RTBuilder.cpp unittest

### DIFF
--- a/flang/unittests/CMakeLists.txt
+++ b/flang/unittests/CMakeLists.txt
@@ -39,6 +39,7 @@ endfunction()
 add_subdirectory(Optimizer)
 add_subdirectory(Decimal)
 add_subdirectory(Evaluate)
+add_subdirectory(Lower)
 add_subdirectory(Runtime)
 add_subdirectory(RuntimeGTest)
 

--- a/flang/unittests/Lower/CMakeLists.txt
+++ b/flang/unittests/Lower/CMakeLists.txt
@@ -9,8 +9,6 @@ set(LIBS
 
 add_flang_unittest(FlangLoweringOpenMPTests
   IntervalSet.cpp
-  OpenMPLoweringTest.cpp
-  RTBuilder.cpp  
 )
 target_link_libraries(FlangLoweringOpenMPTests
   PRIVATE

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 set(LIBS
+  FIRCodeGen
   FIRDialect
   FIRSupport
   ${dialect_libs}
@@ -10,6 +11,7 @@ add_flang_unittest(FlangOptimizerTests
   FIRContextTest.cpp
   InternalNamesTest.cpp
   KindMappingTest.cpp
+  RTBuilder.cpp
 )
 target_link_libraries(FlangOptimizerTests
   PRIVATE

--- a/flang/unittests/Optimizer/RTBuilder.cpp
+++ b/flang/unittests/Optimizer/RTBuilder.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../lib/Lower/RTBuilder.h"
+#include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Optimizer/Support/InitFIR.h"
 #include "gtest/gtest.h"
-#include "flang/Optimizer/Dialect/FIRDialect.h"
 #include <complex>
 
 // Check that it is possible to make a difference between complex runtime
@@ -22,9 +22,9 @@ c_float_complex_t c99_cacosf(c_float_complex_t);
 
 TEST(RTBuilderTest, ComplexRuntimeInterface) {
   mlir::MLIRContext ctx;
-  fir::registerAndLoadDialects(ctx);
+  fir::support::loadDialects(ctx);
   mlir::Type c99_cacosf_signature{
-      Fortran::lower::RuntimeTableKey<decltype(c99_cacosf)>::getTypeModel()(
+      fir::runtime::RuntimeTableKey<decltype(c99_cacosf)>::getTypeModel()(
           &ctx)};
   auto c99_cacosf_funcTy = c99_cacosf_signature.cast<mlir::FunctionType>();
   EXPECT_EQ(c99_cacosf_funcTy.getNumInputs(), 1u);


### PR DESCRIPTION
During the upstreaming work I noticed the unittests in `flang/unittests/Lower` were not run anymore. This PR add again the `flang/unittests/Lower` directory and at the same time move the `RTBuilder.cpp` unittest to `flang/unittests/Optmizer` since `RTBuilder.h` was moved there as well. 