### PR TITLE
[flang][driver] Add support for the `-emit-llvm` option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1063,7 +1063,7 @@ def d_Flag : Flag<["-"], "d">, Group<d_Group>;
 def d_Joined : Joined<["-"], "d">, Group<d_Group>;
 def emit_ast : Flag<["-"], "emit-ast">,
   HelpText<"Emit Clang AST files for source inputs">;
-def emit_llvm : Flag<["-"], "emit-llvm">, Flags<[CC1Option]>, Group<Action_Group>,
+def emit_llvm : Flag<["-"], "emit-llvm">, Flags<[CC1Option, FC1Option]>, Group<Action_Group>,
   HelpText<"Use the LLVM representation for assembler and object files">;
 def emit_interface_stubs : Flag<["-"], "emit-interface-stubs">, Flags<[CC1Option]>, Group<Action_Group>,
   HelpText<"Generate Interface Stub Files.">;

--- a/flang/include/flang/Frontend/CompilerInstance.h
+++ b/flang/include/flang/Frontend/CompilerInstance.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_FLANG_FRONTEND_COMPILERINSTANCE_H
 #define LLVM_FLANG_FRONTEND_COMPILERINSTANCE_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "flang/Frontend/CompilerInvocation.h"
 #include "flang/Frontend/FrontendAction.h"
 #include "flang/Frontend/PreprocessorOptions.h"
@@ -72,6 +73,10 @@ class CompilerInstance {
   /// facilitate this. It is optional and will normally be just a nullptr.
   std::unique_ptr<llvm::raw_pwrite_stream> outputStream_;
 
+  std::unique_ptr<mlir::MLIRContext> mlirCtx_;
+
+  std::unique_ptr<mlir::ModuleOp> mlirModule_;
+
 public:
   explicit CompilerInstance();
 
@@ -127,6 +132,22 @@ public:
 
   void setSemantics(std::unique_ptr<Fortran::semantics::Semantics> semantics) {
     semantics_ = std::move(semantics);
+  }
+
+  /// }
+  /// @name MLIR
+  mlir::MLIRContext &mlirCtx() { return *mlirCtx_; }
+  const mlir::MLIRContext &mlirCtx() const { return *mlirCtx_; }
+
+  void setMlirCtx(std::unique_ptr<mlir::MLIRContext> mlirCtx) {
+    mlirCtx_ = std::move(mlirCtx);
+  }
+
+  mlir::ModuleOp &mlirModule() { return *mlirModule_; }
+  const mlir::ModuleOp &mlirModule() const { return *mlirModule_; }
+
+  void setMlirModule(std::unique_ptr<mlir::ModuleOp> module) {
+    mlirModule_ = std::move(module);
   }
 
   /// }

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -159,6 +159,10 @@ class EmitMLIRAction : public CodeGenAction {
   void ExecuteAction() override;
 };
 
+class EmitLLVMAction : public CodeGenAction {
+  void ExecuteAction() override;
+};
+
 } // namespace Fortran::frontend
 
 #endif // LLVM_FLANG_FRONTEND_FRONTENDACTIONS_H

--- a/flang/include/flang/Frontend/FrontendOptions.h
+++ b/flang/include/flang/Frontend/FrontendOptions.h
@@ -34,6 +34,9 @@ enum ActionKind {
   /// Emit a .mlir file
   EmitMLIR,
 
+  /// Emit a .llvm file
+  EmitLLVM,
+
   /// Emit a .o file.
   EmitObj,
 

--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -9,6 +9,13 @@
 // This file defines some shared command-line options that can be used when
 // debugging the test tools. This file must be included into the tool.
 
+#include "flang/Optimizer/CodeGen/CodeGen.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/Support/CommandLine.h"
+
 #define DisableOption(DOName, DOOption, DODescription) \
   static llvm::cl::opt<bool> disable##DOName("disable-" DOOption, \
       llvm::cl::desc("disable " DODescription " pass"), llvm::cl::init(false), \
@@ -77,6 +84,35 @@ inline void addLLVMDialectToLLVMPass(
   addPassConditionally(pm, disableLlvmIrToLlvm,
       [&]() { return fir::createLLVMDialectToLLVMPass(output); });
 }
+
+/// Create a pass pipeline for lowering from MLIR to LLVM IR
+///
+/// \param pm - MLIR pass manager that will hold the pipeline definition
+inline void createMLIRToLLVMPassPipeline(mlir::PassManager &pm)
+{
+  // simplify the IR
+  fir::addCSE(pm);
+  pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
+  pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  fir::addCSE(pm);
+  pm.addPass(mlir::createInlinerPass());
+  pm.addPass(mlir::createCSEPass());
+
+  // convert control flow to CFG form
+  fir::addCfgConversionPass(pm);
+  pm.addNestedPass<mlir::FuncOp>(fir::createControlFlowLoweringPass());
+  pm.addPass(mlir::createLowerToCFGPass());
+
+  pm.addPass(mlir::createCanonicalizerPass());
+  fir::addCSE(pm);
+
+  pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
+  fir::addCodeGenRewritePass(pm);
+  fir::addTargetRewritePass(pm);
+  fir::addFIRToLLVMPass(pm);
+}
+
 #undef FLANG_EXCLUDE_CODEGEN
 #endif
 

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -29,6 +29,11 @@ add_flang_library(flangFrontend
   FIRAnalysis
   FIRSupport
   FIRBuilder
+  FIRCodeGen
+  FIRTransforms
+  MLIRTransforms
+  MLIRLLVMToLLVMIRTranslation
+  MLIRSCFToStandard
   ${dialect_libs}
 
   LINK_COMPONENTS

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -126,6 +126,9 @@ static bool ParseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
     case clang::driver::options::OPT_emit_mlir:
       opts.programAction = EmitMLIR;
       break;
+    case clang::driver::options::OPT_emit_llvm:
+      opts.programAction = EmitLLVM;
+      break;
     case clang::driver::options::OPT_emit_obj:
       opts.programAction = EmitObj;
       break;

--- a/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -35,6 +35,8 @@ static std::unique_ptr<FrontendAction> CreateFrontendBaseAction(
     return std::make_unique<ParseSyntaxOnlyAction>();
   case EmitMLIR:
     return std::make_unique<EmitMLIRAction>();
+  case EmitLLVM:
+    return std::make_unique<EmitLLVMAction>();
   case EmitObj:
     return std::make_unique<EmitObjAction>();
   case DebugUnparse:

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -65,6 +65,7 @@
 ! HELP-FC1-NEXT:OPTIONS:
 ! HELP-FC1-NEXT: -cpp                   Enable predefined and command line preprocessor macros
 ! HELP-FC1-NEXT: -D <macro>=<value>     Define <macro> to <value> (or 1 if <value> omitted)
+! HELP-FC1-NEXT: -emit-llvm             Use the LLVM representation for assembler and object files
 ! HELP-FC1-NEXT: -emit-mlir             Build the parse tree, then lower it to MLIR and dump
 ! HELP-FC1-NEXT: -emit-obj Emit native object files
 ! HELP-FC1-NEXT: -E                     Only run the preprocessor

--- a/flang/test/Driver/emit-llvm.f90
+++ b/flang/test/Driver/emit-llvm.f90
@@ -1,0 +1,8 @@
+! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: ; ModuleID = 'FIRModule'
+! CHECK: define void @_QQmain()
+! CHECK-NEXT:  ret void
+! CHECK-NEXT: }
+
+end program

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -112,28 +112,7 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
       return mlir::failure();
     });
   } else {
-    // simplify the IR
-    fir::addCSE(pm);
-    pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
-    pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
-    pm.addPass(mlir::createCanonicalizerPass());
-    fir::addCSE(pm);
-    pm.addPass(mlir::createInlinerPass());
-    pm.addPass(mlir::createCSEPass());
-
-    // convert control flow to CFG form
-    fir::addCfgConversionPass(pm);
-    pm.addNestedPass<mlir::FuncOp>(fir::createControlFlowLoweringPass());
-    pm.addPass(mlir::createLowerToCFGPass());
-
-    pm.addPass(mlir::createCanonicalizerPass());
-    fir::addCSE(pm);
-
-    pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
-    // pm.addPass(fir::createMemToRegPass());
-    fir::addCodeGenRewritePass(pm);
-    fir::addTargetRewritePass(pm);
-    fir::addFIRToLLVMPass(pm);
+    fir::createMLIRToLLVMPassPipeline(pm);
     fir::addLLVMDialectToLLVMPass(pm, out.os());
   }
 


### PR DESCRIPTION
This patch adds support for the `-emit-llvm` option in the frontend
driver. Similarly to Clang, `flang-new -fc1 -emit-llvm file.f` will
generate an LLVM IR file.

In order to better facilitate code re-use, common functionality for
`-emit-llvm` and `-emit-mlir` is extracted into
`CodeGenAction::BeginSourceFileAction`. The pass pipeline was extracted
from tco.cpp.