### PR TITLE
[flang] Move `FromDefaultKinds` from bbc.cpp to `flangFrontendTool`

### DIFF
--- a/flang/include/flang/Optimizer/Support/Utils.h
+++ b/flang/include/flang/Optimizer/Support/Utils.h
@@ -13,6 +13,8 @@
 #ifndef FORTRAN_OPTIMIZER_SUPPORT_UTILS_H
 #define FORTRAN_OPTIMIZER_SUPPORT_UTILS_H
 
+#include "flang/Common/default-kinds.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
@@ -20,6 +22,22 @@ namespace fir {
 /// Return the integer value of a ConstantOp.
 inline std::int64_t toInt(mlir::ConstantOp cop) {
   return cop.getValue().cast<mlir::IntegerAttr>().getValue().getSExtValue();
+}
+
+// Translate front-end KINDs for use in the IR and code gen.
+inline std::vector<fir::KindTy>
+fromDefaultKinds(const Fortran::common::IntrinsicTypeDefaultKinds &defKinds) {
+  return {static_cast<fir::KindTy>(defKinds.GetDefaultKind(
+              Fortran::common::TypeCategory::Character)),
+          static_cast<fir::KindTy>(
+              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Complex)),
+          static_cast<fir::KindTy>(defKinds.doublePrecisionKind()),
+          static_cast<fir::KindTy>(
+              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Integer)),
+          static_cast<fir::KindTy>(
+              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Logical)),
+          static_cast<fir::KindTy>(
+              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Real))};
 }
 } // namespace fir
 

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -24,6 +24,7 @@
 #include "flang/Optimizer/Support/InitFIR.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/KindMapping.h"
+#include "flang/Optimizer/Support/Utils.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "flang/Parser/characters.h"
 #include "flang/Parser/dump-parse-tree.h"
@@ -141,22 +142,6 @@ static void printModule(mlir::ModuleOp mlirModule, llvm::raw_ostream &out) {
   out << '\n';
 }
 
-// Translate front-end KINDs for use in the IR and code gen.
-static std::vector<fir::KindTy>
-fromDefaultKinds(const Fortran::common::IntrinsicTypeDefaultKinds &defKinds) {
-  return {static_cast<fir::KindTy>(defKinds.GetDefaultKind(
-              Fortran::common::TypeCategory::Character)),
-          static_cast<fir::KindTy>(
-              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Complex)),
-          static_cast<fir::KindTy>(defKinds.doublePrecisionKind()),
-          static_cast<fir::KindTy>(
-              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Integer)),
-          static_cast<fir::KindTy>(
-              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Logical)),
-          static_cast<fir::KindTy>(
-              defKinds.GetDefaultKind(Fortran::common::TypeCategory::Real))};
-}
-
 static void registerAllPasses() {
   fir::support::registerMLIRPassesForFortranTools();
   fir::registerOptTransformPasses();
@@ -241,7 +226,7 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
   fir::support::loadNonCodegenDialects(ctx);
   auto &defKinds = semanticsContext.defaultKinds();
   fir::KindMapping kindMap(
-      &ctx, llvm::ArrayRef<fir::KindTy>{fromDefaultKinds(defKinds)});
+      &ctx, llvm::ArrayRef<fir::KindTy>{fir::fromDefaultKinds(defKinds)});
   auto burnside = Fortran::lower::LoweringBridge::create(
       ctx, defKinds, semanticsContext.intrinsics(), parsing.allCooked(),
       targetTriple, kindMap);


### PR DESCRIPTION
As pointed out in PR [1], `fromDefaultKinds` should be shared between
`bbc` and `flang-new`. This patch moves it from bbc.cpp to the
`flangFrontendTool` library and makes `bbc` depend on
`flangFrontendTool`.

For consistency with the rest of `flangFrontendTool`, `fromDefaultKinds`
is renamed as `FromDefaultKinds`.

[1] https://github.com/flang-compiler/f18-llvm-project/pull/1113