### PR TITLE
[fir] Sync DoLoopHelper after upstreaming

### DIFF
--- a/flang/include/flang/Optimizer/Builder/DoLoopHelper.h
+++ b/flang/include/flang/Optimizer/Builder/DoLoopHelper.h
@@ -29,15 +29,16 @@ public:
 
   /// Build loop [\p lb, \p ub] with step \p step.
   /// If \p step is an empty value, 1 is used for the step.
-  void createLoop(mlir::Value lb, mlir::Value ub, mlir::Value step,
-                  const BodyGenerator &bodyGenerator);
+  fir::DoLoopOp createLoop(mlir::Value lb, mlir::Value ub, mlir::Value step,
+                          const BodyGenerator &bodyGenerator);
 
   /// Build loop [\p lb,  \p ub] with step 1.
-  void createLoop(mlir::Value lb, mlir::Value ub,
-                  const BodyGenerator &bodyGenerator);
+  fir::DoLoopOp createLoop(mlir::Value lb, mlir::Value ub,
+                           const BodyGenerator &bodyGenerator);
 
   /// Build loop [0, \p count) with step 1.
-  void createLoop(mlir::Value count, const BodyGenerator &bodyGenerator);
+  fir::DoLoopOp createLoop(mlir::Value count, 
+                           const BodyGenerator &bodyGenerator);
 
 private:
   fir::FirOpBuilder &builder;

--- a/flang/lib/Optimizer/Builder/DoLoopHelper.cpp
+++ b/flang/lib/Optimizer/Builder/DoLoopHelper.cpp
@@ -12,7 +12,7 @@
 // DoLoopHelper implementation
 //===----------------------------------------------------------------------===//
 
-void fir::factory::DoLoopHelper::createLoop(
+fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
     mlir::Value lb, mlir::Value ub, mlir::Value step,
     const BodyGenerator &bodyGenerator) {
   auto lbi = builder.convertToIndexType(loc, lb);
@@ -25,20 +25,21 @@ void fir::factory::DoLoopHelper::createLoop(
   auto index = loop.getInductionVar();
   bodyGenerator(builder, index);
   builder.restoreInsertionPoint(insertPt);
+  return loop;
 }
 
-void fir::factory::DoLoopHelper::createLoop(
+fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
     mlir::Value lb, mlir::Value ub, const BodyGenerator &bodyGenerator) {
-  createLoop(lb, ub,
+  return createLoop(lb, ub,
              builder.createIntegerConstant(loc, builder.getIndexType(), 1),
              bodyGenerator);
 }
 
-void fir::factory::DoLoopHelper::createLoop(
+fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
     mlir::Value count, const BodyGenerator &bodyGenerator) {
   auto indexType = builder.getIndexType();
   auto zero = builder.createIntegerConstant(loc, indexType, 0);
   auto one = builder.createIntegerConstant(loc, count.getType(), 1);
   auto up = builder.create<mlir::SubIOp>(loc, count, one);
-  createLoop(zero, up, one, bodyGenerator);
+  return createLoop(zero, up, one, bodyGenerator);
 }

--- a/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
+++ b/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
@@ -1,0 +1,84 @@
+//===- DoLoopHelperTest.cpp -- DoLoopHelper unit tests --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/DoLoopHelper.h"
+#include "gtest/gtest.h"
+#include "flang/Optimizer/Support/InitFIR.h"
+#include "flang/Optimizer/Support/KindMapping.h"
+#include <string>
+
+struct DoLoopHelperTest : public testing::Test {
+public:
+  void SetUp() {
+    fir::KindMapping kindMap(&context);
+    mlir::OpBuilder builder(&context);
+    firBuilder = new fir::FirOpBuilder(builder, kindMap);
+    fir::support::loadDialects(context);
+  }
+  void TearDown() { delete firBuilder; }
+
+  fir::FirOpBuilder &getBuilder() { return *firBuilder; }
+
+  mlir::MLIRContext context;
+  fir::FirOpBuilder *firBuilder;
+};
+
+void checkConstantValue(const mlir::Value &value, int64_t v) {
+  EXPECT_TRUE(mlir::isa<ConstantOp>(value.getDefiningOp()));
+  auto cstOp = dyn_cast<ConstantOp>(value.getDefiningOp());
+  auto valueAttr = cstOp.getValue().dyn_cast_or_null<IntegerAttr>();
+  EXPECT_EQ(v, valueAttr.getInt());
+}
+
+TEST_F(DoLoopHelperTest, createLoopWithCountTest) {
+  auto firBuilder = getBuilder();
+  fir::factory::DoLoopHelper helper(firBuilder, firBuilder.getUnknownLoc());
+
+  auto c10 = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 10);
+  auto loop =
+      helper.createLoop(c10, [&](fir::FirOpBuilder &, mlir::Value index) {});
+  checkConstantValue(loop.lowerBound(), 0);
+  EXPECT_TRUE(mlir::isa<mlir::SubIOp>(loop.upperBound().getDefiningOp()));
+  auto subOp = dyn_cast<mlir::SubIOp>(loop.upperBound().getDefiningOp());
+  EXPECT_EQ(c10, subOp.lhs());
+  checkConstantValue(subOp.rhs(), 1);
+  checkConstantValue(loop.step(), 1);
+}
+
+TEST_F(DoLoopHelperTest, createLoopWithLowerAndUpperBound) {
+  auto firBuilder = getBuilder();
+  fir::factory::DoLoopHelper helper(firBuilder, firBuilder.getUnknownLoc());
+
+  auto lb = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 1);
+  auto ub = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 20);
+  auto loop =
+      helper.createLoop(lb, ub, [&](fir::FirOpBuilder &, mlir::Value index) {});
+  checkConstantValue(loop.lowerBound(), 1);
+  checkConstantValue(loop.upperBound(), 20);
+  checkConstantValue(loop.step(), 1);
+}
+
+TEST_F(DoLoopHelperTest, createLoopWithStep) {
+  auto firBuilder = getBuilder();
+  fir::factory::DoLoopHelper helper(firBuilder, firBuilder.getUnknownLoc());
+
+  auto lb = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 1);
+  auto ub = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 20);
+  auto step = firBuilder.createIntegerConstant(
+      firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 2);
+  auto loop = helper.createLoop(
+      lb, ub, step, [&](fir::FirOpBuilder &, mlir::Value index) {});
+  checkConstantValue(loop.lowerBound(), 1);
+  checkConstantValue(loop.upperBound(), 20);
+  checkConstantValue(loop.step(), 2);
+}

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 set(LIBS
+  FIRBuilder
   FIRCodeGen
   FIRDialect
   FIRSupport
@@ -8,6 +9,7 @@ set(LIBS
 )
 
 add_flang_unittest(FlangOptimizerTests
+  Builder/DoLoopHelperTest.cpp
   FIRContextTest.cpp
   InternalNamesTest.cpp
   KindMappingTest.cpp


### PR DESCRIPTION
Sync after upstreaming

In order to break the big patch (>5000loc) I have to extract some of the component and add basic unittests to submit smaller patch. 

This is a sync after patch https://reviews.llvm.org/D111713
It basically add a small unittest for the DoLoopHelper and change the return value in order to make the testing easier. 