### PR TITLE
[NFC] Apply clang-format to DoLoopHelper

### DIFF
--- a/flang/lib/Optimizer/Builder/DoLoopHelper.cpp
+++ b/flang/lib/Optimizer/Builder/DoLoopHelper.cpp
@@ -12,9 +12,10 @@
 // DoLoopHelper implementation
 //===----------------------------------------------------------------------===//
 
-fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
-    mlir::Value lb, mlir::Value ub, mlir::Value step,
-    const BodyGenerator &bodyGenerator) {
+fir::DoLoopOp
+fir::factory::DoLoopHelper::createLoop(mlir::Value lb, mlir::Value ub,
+                                       mlir::Value step,
+                                       const BodyGenerator &bodyGenerator) {
   auto lbi = builder.convertToIndexType(loc, lb);
   auto ubi = builder.convertToIndexType(loc, ub);
   assert(step && "step must be an actual Value");
@@ -28,15 +29,17 @@ fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
   return loop;
 }
 
-fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
-    mlir::Value lb, mlir::Value ub, const BodyGenerator &bodyGenerator) {
-  return createLoop(lb, ub,
-             builder.createIntegerConstant(loc, builder.getIndexType(), 1),
-             bodyGenerator);
+fir::DoLoopOp
+fir::factory::DoLoopHelper::createLoop(mlir::Value lb, mlir::Value ub,
+                                       const BodyGenerator &bodyGenerator) {
+  return createLoop(
+      lb, ub, builder.createIntegerConstant(loc, builder.getIndexType(), 1),
+      bodyGenerator);
 }
 
-fir::DoLoopOp fir::factory::DoLoopHelper::createLoop(
-    mlir::Value count, const BodyGenerator &bodyGenerator) {
+fir::DoLoopOp
+fir::factory::DoLoopHelper::createLoop(mlir::Value count,
+                                       const BodyGenerator &bodyGenerator) {
   auto indexType = builder.getIndexType();
   auto zero = builder.createIntegerConstant(loc, indexType, 0);
   auto one = builder.createIntegerConstant(loc, count.getType(), 1);


### PR DESCRIPTION
Sync back after upstreaming in order to have a clearer view of what has to be done. 