### PR TITLE
[CMake] Fix Clang builds

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -329,7 +329,7 @@ if (FLANG_ENABLE_WERROR)
     append("-Werror" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     append("-Wno-error" CMAKE_REQUIRED_FLAGS)
 
-    # This is GCC-specific workaround for an issue described in
+    # This is workaround for GCC 9.3.0 for an issue described in
     # https://github.com/flang-compiler/f18-llvm-project/pull/1130
     check_cxx_compiler_flag("-Wno-maybe-uninitialized" CXX_SUPPORTS_MAYBE_UNITIALIZED_FLAG)
     if (CXX_SUPPORTS_MAYBE_UNITIALIZED_FLAG)


### PR DESCRIPTION
In https://github.com/flang-compiler/f18-llvm-project/pull/1130, a new
C++ flag was added: `-Wno-maybe-uninitialized`. This flag is
GCC-specific, i.e. it is not supported by e.g. Clang. The following
warning is issued by Clang when trying to use it:
```
warning: unknown warning option '-Wno-maybe-uninitialized'; did you mean
'-Wno-uninitialized'? [-Wunknown-warning-option]
```
This flag was added for all compilers for which
`LLVM_COMPILER_IS_GCC_COMPATIBLE` is `true`. With Clang being considered as
GCC-compatible [1] and `-Werror` being set by default in LLVM Flang, the
aforementioned change causes build failures when using Clang.

This patch works around it by making sure that this flag is only added
when the compiler used to build Flang does support it.

[1] See the current implementation of DetermineGCCCompatible.cmake