### PR TITLE
Get rid of Optimizer/Transforms headers dep in Dialect

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
@@ -11,6 +11,10 @@ mlir_tablegen(FIROpsTypes.h.inc --gen-typedef-decls)
 mlir_tablegen(FIROpsTypes.cpp.inc --gen-typedef-defs)
 add_public_tablegen_target(FIRTypesIncGen)
 
+set(LLVM_TARGET_DEFINITIONS RewritePatterns.td)
+mlir_tablegen(RewritePatterns.inc -gen-rewriters)
+add_public_tablegen_target(RewritePatternsIncGen)
+
 add_custom_target(flang-doc)
 set(dialect_doc_filename "FIRLangRef")
 

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -15,6 +15,10 @@
 
 #include "mlir/IR/Dialect.h"
 
+namespace mlir {
+  class BlockAndValueMapping;
+} // namespace mlir
+
 namespace fir {
 
 /// FIR dialect
@@ -49,6 +53,11 @@ public:
 
   static llvm::StringRef getDialectNamespace() { return "fircg"; }
 };
+
+/// Support for inlining on FIR.
+bool canLegallyInline(mlir::Operation *op, mlir::Region *reg, bool,
+                      mlir::BlockAndValueMapping &map);
+bool canLegallyInline(mlir::Operation *, mlir::Operation *, bool);
 
 } // namespace fir
 

--- a/flang/include/flang/Optimizer/Dialect/RewritePatterns.td
+++ b/flang/include/flang/Optimizer/Dialect/RewritePatterns.td
@@ -1,4 +1,4 @@
-//===-- RewritePatterns.td - FIR Rewrite Patterns -----------*- tablegen -*-===//
+//===-- RewritePatterns.td - FIR Rewrite Patterns ----------*- tablegen -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Transforms/CMakeLists.txt
@@ -1,8 +1,4 @@
 
-set(LLVM_TARGET_DEFINITIONS RewritePatterns.td)
-mlir_tablegen(RewritePatterns.inc -gen-rewriters)
-add_public_tablegen_target(RewritePatternsIncGen)
-
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name OptTransform)
 add_public_tablegen_target(FIROptTransformsPassIncGen)

--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -44,11 +44,6 @@ std::unique_ptr<mlir::Pass> createExternalNameConversionPass();
 /// TODO: This pass needs some additional work.
 std::unique_ptr<mlir::Pass> createMemToRegPass();
 
-/// Support for inlining on FIR.
-bool canLegallyInline(mlir::Operation *op, mlir::Region *reg, bool,
-                      mlir::BlockAndValueMapping &map);
-bool canLegallyInline(mlir::Operation *, mlir::Operation *, bool);
-
 /// Optionally force the body of a DO to execute at least once.
 bool isAlwaysExecuteLoopBody();
 

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flang_library(FIRDialect
   FIRSupport
   FIROpsIncGen
   FIRTypesIncGen
+  RewritePatternsIncGen
 
   LINK_LIBS
   FIRSupport

--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -14,7 +14,6 @@
 #include "flang/Optimizer/Dialect/FIRAttr.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
-#include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 using namespace fir;

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -25,7 +25,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace {
-#include "flang/Optimizer/Transforms/RewritePatterns.inc"
+#include "flang/Optimizer/Dialect/RewritePatterns.inc"
 } // namespace
 using namespace fir;
 

--- a/flang/lib/Optimizer/Dialect/Inliner.cpp
+++ b/flang/lib/Optimizer/Dialect/Inliner.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "flang/Optimizer/Transforms/Passes.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "llvm/Support/CommandLine.h"
 
 static llvm::cl::opt<bool>

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -19,7 +19,6 @@ add_flang_library(FIRTransforms
   FIRDialect
   FIRSupport
   FIROptTransformsPassIncGen
-  RewritePatternsIncGen
 
   LINK_LIBS
   FIRAnalysis


### PR DESCRIPTION
- Move `RewritePatterns.td` to `flang/Optimizer/Dialect`
- Move `canLegallyInline` delcaration from `Passes.h` to `FIRDialect.h`