### PR TITLE
[flang] Fix lowering of function calls that return arrays of derived …

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -5606,11 +5606,12 @@ public:
     return std::visit([&](const auto &v) { return genarr(v, &x); }, x.parent());
   }
 
-  template <Fortran::common::TypeCategory TC, int KIND>
-  CC genarr(
-      const Fortran::evaluate::FunctionRef<Fortran::evaluate::Type<TC, KIND>>
-          &x) {
-    return genProcRef(x, {converter.genType(TC, KIND)});
+  template <typename T>
+  CC genarr(const Fortran::evaluate::FunctionRef<T> &funRef) {
+    // Note that it's possible that the function being called returns either an
+    // array or a scalar.  In the first case, use the element type of the array.
+    return genProcRef(
+        funRef, fir::unwrapSequenceType(converter.genType(toEvExpr(funRef))));
   }
 
   //===--------------------------------------------------------------------===//

--- a/flang/test/Lower/intrinsic-procedures/eoshift.f90
+++ b/flang/test/Lower/intrinsic-procedures/eoshift.f90
@@ -52,7 +52,7 @@ subroutine eoshift_test3(arr, shift, dim)
   character(4), dimension(3,3) :: arr, res
   integer :: shift, dim
 
-! CHECK: %[[resBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>
+! CHECK: %[[resBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,4>>>>
 ! CHECK: %[[arr:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK: %[[array:.*]] = fir.convert %[[arr]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<3x3x!fir.char<1,4>>>
 ! CHECK: %[[res:.*]] = fir.alloca !fir.array<3x3x!fir.char<1,4>> {bindc_name = "res", uniq_name = "_QFeoshift_test3Eres"}
@@ -64,7 +64,7 @@ subroutine eoshift_test3(arr, shift, dim)
 
 ! CHECK: %[[boundBox:.*]] = fir.absent !fir.box<none>
 ! CHECK: %[[shiftBox:.*]] = fir.embox %arg1 : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK: %[[resIRBox:.*]] = fir.convert %[[resBox]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[resIRBox:.*]] = fir.convert %[[resBox]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x!fir.char<1,4>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: %[[arrayBoxNone:.*]] = fir.convert %[[arrayBox]] : (!fir.box<!fir.array<3x3x!fir.char<1,4>>>) -> !fir.box<none>
 ! CHECK: %[[shiftBoxNone:.*]] = fir.convert %[[shiftBox]] : (!fir.box<i32>) -> !fir.box<none>
 ! CHECK: %[[tmp:.*]] = fir.call @_FortranAEoshift(%[[resIRBox]], %[[arrayBoxNone]], %[[shiftBoxNone]], %[[boundBox]], %[[dim]], {{.*}}, {{.*}}) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.box<none>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> none


### PR DESCRIPTION
…types

When processing the return value of a function call, the lowering code was
incorrectly calling the template function "genarr()" for "ProcedureRef"
arguments rather than "FunctionRef" arguments.  This caused the return type of
the function to be specified as "llvm::None" which caused downstream problems.

The problem was that the version of "genarr" for "FunctionRef" arguments was
declared in such a way that it only was used for arrays whose elements were
intrinsic types.  I fixed this by implementing a more general version of
"genarr" for "FunctionRef" arguments that works for both intrinsic types and
derived types.