### PR TITLE
Fix builds with gcc 10.1 libstdc++ (VectorSubscriptBox error)

### DIFF
--- a/flang/include/flang/Lower/VectorSubscripts.h
+++ b/flang/include/flang/Lower/VectorSubscripts.h
@@ -61,6 +61,8 @@ public:
   using ElementalGeneratorWithBoolReturn =
       std::function<mlir::Value(const fir::ExtendedValue &)>;
   struct LoweredVectorSubscript {
+    LoweredVectorSubscript(fir::ExtendedValue &&vector, mlir::Value size)
+        : vector{std::move(vector)}, size{size} {}
     fir::ExtendedValue vector;
     // Vector size, guaranteed to be of indexType.
     mlir::Value size;


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/f18-llvm-project/issues/1157.

The std::variant implementation of some libstdc++ caused clang to try
constructing a LoweredVectorSubscript from a LoweredTriplet, causing
a f18 build error.
This was possible because the compiler thought it could build and
fir::ExtendedValue to build a LoweredVectorSubscript (because
fir::ExtendedValue has a template constructor where the template can match
anything.).
Prevent the compiler from attempting to build a LoweredVectorSubscript here
by adding a constructor to LowereVectorSubscript.