### PR TITLE
[flang] Fix references to equivalenced variables in inner procedures

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -214,6 +214,8 @@ public:
       Fortran::lower::pft::FunctionLikeUnit &funit,
       llvm::SetVector<const Fortran::semantics::Symbol *> &escapees) {
     for (const auto &var : funit.getOrderedSymbolTable()) {
+      if (var.isAggregateStore())
+        continue;
       const auto &sym = var.getSymbol();
       if (const auto *escapingSym = getIfHostProcedureSymbol(sym)) {
         LLVM_DEBUG(llvm::dbgs() << "host associated symbol " << sym << '\n');

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1231,6 +1231,11 @@ struct SymbolDependenceDepth {
       : vars{vars}, reentrant{reentrant} {}
 
   void analyzeAliasesInCurrentScope(const semantics::Scope &scope) {
+    // FIXME: When this function is called on the scope of an internal
+    // procedure whose parent contains an EQUIVALENCE set and the internal
+    // procedure uses variables from that EQUIVALENCE set, we end up creating
+    // an AggregateStore for those variables unnecessarily.
+    //
     /// If this is a function nested in a module no host associated
     /// symbol are added to the function scope for module symbols used in this
     /// scope. As a result, alias analysis in parent module scopes must be


### PR DESCRIPTION
The code that collects that host associated variables variables in inner
procedures was seeing entities of type Fortran::lower::pft::Variable which
were created for handling Fortran variables that appear in EQUIVANCE
statements.  Such entities throw an assertion when `getSymbol() is called on
them because they're not of the `Nominal` variant.

I wrote several tests (with help from Jean and Eric) for various situations
where EQUIVALENCE and host association were combined.  In every case where
there was a host-associated Fortran variable appeared in an EQUIVALENCE
statement, there were two entities created -- an entity of the `AggregateStore`
variant and an entity of the `Nominal` variant.

So it seems safe and correct to just ignore `Variable`s of the `AggregateStore`
variant when gathering host associated entities.  So that's what I did.

Note that my first attempt to fix this was in PR#1165.