### PR TITLE
[flang] Add lowering stubs for OpenMP/OpenACC declarative construct in module

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -138,6 +138,9 @@ using Directives =
                parser::OpenACCDeclarativeConstruct, parser::OpenMPConstruct,
                parser::OpenMPDeclarativeConstruct, parser::OmpEndLoopDirective>;
 
+using DeclConstructs = std::tuple<parser::OpenMPDeclarativeConstruct,
+                                  parser::OpenACCDeclarativeConstruct>;
+
 template <typename A>
 static constexpr bool isActionStmt{common::HasMember<A, ActionStmts>};
 
@@ -155,6 +158,9 @@ static constexpr bool isConstruct{common::HasMember<A, Constructs>};
 
 template <typename A>
 static constexpr bool isDirective{common::HasMember<A, Directives>};
+
+template <typename A>
+static constexpr bool isDeclConstruct{common::HasMember<A, DeclConstructs>};
 
 template <typename A>
 static constexpr bool isIntermediateConstructStmt{common::HasMember<
@@ -701,6 +707,7 @@ struct ModuleLikeUnit : public ProgramUnit {
   ModuleStatement beginStmt;
   ModuleStatement endStmt;
   std::list<FunctionLikeUnit> nestedFunctions;
+  EvaluationList evaluationList;
   std::vector<std::vector<Variable>> varList;
 };
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -128,8 +128,9 @@ public:
     // Preliminary translation pass.
     //  - Declare all functions that have definitions so that definition
     //    signatures prevail over call site signatures.
-    //  - Define module variables so they are available before lowering any
-    //    function that may use them.
+    //  - Define module variables and OpenMP/OpenACC declarative construct so
+    //    that they are available before lowering any function that may use
+    //    them.
     //  - Translate block data programs so that common block definitions with
     //    data initializations take precedence over other definitions.
     for (Fortran::lower::pft::Program::Units &u : pft.getUnits()) {
@@ -139,7 +140,7 @@ public:
                 declareFunction(f);
               },
               [&](Fortran::lower::pft::ModuleLikeUnit &m) {
-                lowerModuleVariables(m);
+                lowerModuleDeclScope(m);
                 for (Fortran::lower::pft::FunctionLikeUnit &f :
                      m.nestedFunctions)
                   declareFunction(f);
@@ -2690,8 +2691,9 @@ private:
       lowerFunc(f); // internal procedure
   }
 
-  /// Lower module variable definitions to fir::globalOp
-  void lowerModuleVariables(Fortran::lower::pft::ModuleLikeUnit &mod) {
+  /// Lower module variable definitions to fir::globalOp and OpenMP/OpenACC
+  /// declarative construct.
+  void lowerModuleDeclScope(Fortran::lower::pft::ModuleLikeUnit &mod) {
     // FIXME: get rid of the bogus function context and instantiate the
     // globals directly into the module.
     MLIRContext *context = &getMLIRContext();
@@ -2708,6 +2710,8 @@ private:
       if (!owningScope || mod.getScope() == *owningScope)
         Fortran::lower::defineModuleVariable(*this, var);
     }
+    for (auto &eval : mod.evaluationList)
+      genFIR(eval);
     if (mlir::Region *region = func.getCallableRegion())
       region->dropAllReferences();
     func.erase();

--- a/flang/test/Lower/OpenMP/omp-threadprivate.f90
+++ b/flang/test/Lower/OpenMP/omp-threadprivate.f90
@@ -3,6 +3,11 @@
 ! RUN: %bbc -fopenmp -emit-fir %s -o  - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 
+module mod1
+  integer :: z
+  !$omp threadprivate(z)
+end
+
 program main
   integer, save :: x, y
 


### PR DESCRIPTION
The OpenMP/OpenACC declarative construct can be declared in module declaration scope. This patch adds interface for lowering it.