### PR TITLE
[flang] Add a TODO for calls to procedures declared in outer scopes

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1898,8 +1898,8 @@ public:
     bool addHostAssociations = false;
     if (const auto *sym = caller.getIfIndirectCallSymbol()) {
       funcPointer = symMap.lookupSymbol(*sym).getAddr();
-      assert(funcPointer &&
-             "dummy procedure or procedure pointer not in symbol map");
+      if (!funcPointer)
+        TODO(loc, "calling a dummy procedure declared in an outer scope");
     } else {
       auto funcOpType = caller.getFuncOp().getType();
       auto symbolAttr = builder.getSymbolRefAttr(caller.getMangledName());


### PR DESCRIPTION
When an internal procedure calls a procedure whose name is declared in
an outer scope, we raise an assertion.  This change simply changes that
assertion to a "TODO" so that users will know that this is not yet
implemented rather than an internal error.

An example program can be seen in issue #1186.