### PR TITLE
[fir] Restrict array type on fir.insert_on_range

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2056,7 +2056,8 @@ def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoSideEffect]> {
   let summary = "insert sub-value into a range on an existing sequence";
 
   let description = [{
-    Insert copies of a value into an entity with an array type.
+    Insert copies of a value into an entity with an array type of constant shape
+    and size.
     Returns a new ssa value with the same type as the original entity.
     The values are inserted at a contiguous range of indices in Fortran
     row-to-column element order as specified by lower and upper bound

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1462,9 +1462,7 @@ void fir::InsertOnRangeOp::build(mlir::OpBuilder &builder,
 
 /// Range bounds must be nonnegative, and the range must not be empty.
 static mlir::LogicalResult verify(fir::InsertOnRangeOp op) {
-  if (fir::hasDynamicSize(op.seq().getType()) ||
-      fir::sequenceWithNonConstantShape(
-          op.seq().getType().cast<fir::SequenceType>()))
+  if (fir::hasDynamicSize(op.seq().getType()))
     return op.emitOpError("must have constant shape and size");
   if (op.coor().size() < 2 || op.coor().size() % 2 != 0)
     return op.emitOpError("has uneven number of values in ranges");

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1462,6 +1462,10 @@ void fir::InsertOnRangeOp::build(mlir::OpBuilder &builder,
 
 /// Range bounds must be nonnegative, and the range must not be empty.
 static mlir::LogicalResult verify(fir::InsertOnRangeOp op) {
+  if (fir::hasDynamicSize(op.seq().getType()) ||
+      fir::sequenceWithNonConstantShape(
+          op.seq().getType().cast<fir::SequenceType>()))
+    return op.emitOpError("must have constant shape and size");
   if (op.coor().size() < 2 || op.coor().size() % 2 != 0)
     return op.emitOpError("has uneven number of values in ranges");
   bool rangeIsKnownToBeNonempty = false;

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -541,6 +541,26 @@ fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
 
 // -----
 
+fir.global internal @_QEmultiarray : !fir.array<?xi32> {
+  %c0_i32 = arith.constant 1 : i32
+  %0 = fir.undefined !fir.array<?xi32>
+  // expected-error@+1 {{'fir.insert_on_range' op must have constant shape and size}}
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 10 : index] : (!fir.array<?xi32>, i32) -> !fir.array<?xi32>
+  fir.has_value %2 : !fir.array<?xi32>
+}
+
+// -----
+
+fir.global internal @_QEmultiarray : !fir.array<*:i32> {
+  %c0_i32 = arith.constant 1 : i32
+  %0 = fir.undefined !fir.array<*:i32>
+  // expected-error@+1 {{'fir.insert_on_range' op must have constant shape and size}}
+  %2 = fir.insert_on_range %0, %c0_i32, [0 : index, 10 : index] : (!fir.array<*:i32>, i32) -> !fir.array<*:i32>
+  fir.has_value %2 : !fir.array<*:i32>
+}
+
+// -----
+
 func @bad_array_modify(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m : index, %n : index, %o : index, %p : index, %f : f32) {
   %i10 = arith.constant 10 : index
   %j20 = arith.constant 20 : index


### PR DESCRIPTION
Sequence type had no restriction on the insert_on_range operation.
This patch adds a restriction for the type to have constant shape
and size.

In support to upstream the InsertOnRangeOpConversion. https://reviews.llvm.org/D112896