### PR TITLE
When there is a call to a function which host associations,

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -56,11 +56,6 @@ mlir::FuncOp createFuncOp(mlir::Location loc, mlir::ModuleOp module,
                           llvm::StringRef name, mlir::FunctionType type,
                           llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
-/// Get or create a GlobalOp in a module.
-fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
-                             llvm::StringRef name, mlir::Type type,
-                             llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
-
 /// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
 static constexpr llvm::StringRef getContiguousAttrName() {
   return "fir.contiguous";
@@ -81,6 +76,10 @@ static constexpr llvm::StringRef getSymbolAttrName() { return "fir.sym_name"; }
 static constexpr llvm::StringRef getHostAssocAttrName() {
   return "fir.host_assoc";
 }
+
+/// Does the function, \p func, have a host-associations tuple argument?
+/// Some internal procedures may have access to host procedure variables.
+bool hasHostAssociationArgument(mlir::FuncOp func);
 
 /// Tell if \p value is:
 ///   - a function argument that has attribute \p attributeName

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3221,15 +3221,13 @@ mlir::FuncOp fir::createFuncOp(mlir::Location loc, mlir::ModuleOp module,
   return result;
 }
 
-fir::GlobalOp fir::createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
-                                  StringRef name, mlir::Type type,
-                                  llvm::ArrayRef<mlir::NamedAttribute> attrs) {
-  if (auto g = module.lookupSymbol<fir::GlobalOp>(name))
-    return g;
-  mlir::OpBuilder modBuilder(module.getBodyRegion());
-  auto result = modBuilder.create<fir::GlobalOp>(loc, name, type, attrs);
-  result.setVisibility(mlir::SymbolTable::Visibility::Private);
-  return result;
+bool fir::hasHostAssociationArgument(mlir::FuncOp func) {
+  if (auto allArgAttrs = func.getAllArgAttrs())
+    for (auto attr : allArgAttrs)
+      if (auto dict = attr.template dyn_cast_or_null<mlir::DictionaryAttr>())
+        if (dict.get(fir::getHostAssocAttrName()))
+          return true;
+  return false;
 }
 
 bool fir::valueHasFirAttribute(mlir::Value value,


### PR DESCRIPTION
pessimistically assume that the procedure will access all the arrays and
copies need to be made. [i0c]