### PR TITLE
Fix 1180 and 1164 - Ensure there is single point of truth regarding what symbol are in global memory 

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -596,17 +596,6 @@ struct FunctionLikeUnit : public ProgramUnit {
   FunctionLikeUnit(FunctionLikeUnit &&) = default;
   FunctionLikeUnit(const FunctionLikeUnit &) = delete;
 
-  /// Return true iff this function like unit is Fortran recursive (actually
-  /// meaning it's reentrant).
-  bool isRecursive() const {
-    if (isMainProgram())
-      return false;
-    const auto &sym = getSubprogramSymbol();
-    return sym.attrs().test(semantics::Attr::RECURSIVE) ||
-           (!sym.attrs().test(semantics::Attr::NON_RECURSIVE) &&
-            defaultRecursiveFunctionSetting());
-  }
-
   std::vector<Variable> getOrderedSymbolTable() { return varList[0]; }
 
   bool isMainProgram() const {

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1348,7 +1348,7 @@ struct SymbolDependenceDepth {
       llvm_unreachable("not yet implemented - derived type analysis");
 
     // Symbol must be something lowering will have to allocate.
-    bool global = semantics::IsSaved(sym);
+    bool global = lower::symbolIsGlobal(sym);
     int depth = 0;
     const auto *symTy = sym.GetType();
     assert(symTy && "symbol must have a type");
@@ -1390,12 +1390,9 @@ struct SymbolDependenceDepth {
         doExplicit(subs.ubound());
       }
       // handle any symbols in initialization expressions
-      if (auto e = details->init()) {
-        // An object that is initialized is implicitly SAVE, so set the flag.
-        global = true;
+      if (auto e = details->init())
         for (const auto &s : evaluate::CollectSymbols(*e))
           depth = std::max(analyze(s) + 1, depth);
-      }
     }
     adjustSize(depth + 1);
     vars[depth].emplace_back(sym, global, depth);

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -54,6 +54,13 @@ SUBROUTINE s3
   ! CHECK: %{{.*}} = fir.load %[[v2loc]] : !fir.ref<f32>
   PRINT *, r(9)
 END SUBROUTINE s3
+  
+! test that equivalence in main program containing arrays are placed in global memory.
+! CHECK: fir.global internal @_QEa : !fir.array<400000000xi8>
+  integer :: a, b(100000000)
+  equivalence (a, b)
+  b(1) = 42
+  print *, a
 
   CALL s1
   CALL s2

--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -17,7 +17,7 @@ program p
   ! CHECK: fir.insert_value
   ! CHECK: fir.address_of
   ! CHECK: fir.insert_value
-  ! CHECK: fir.embox [[ccc]]
+  ! CHECK: fir.address_of(@_QEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
   ! CHECK: fir.insert_value
   ! CHECK: fir.alloca tuple<!fir.ref<i8>, i64, !fir.ref<!fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>>>>
   ! CHECK: fir.address_of
@@ -37,7 +37,7 @@ program p
   ! CHECK: fir.insert_value
   ! CHECK: fir.address_of
   ! CHECK: fir.insert_value
-  ! CHECK: fir.embox [[ccc]]
+  ! CHECK: fir.address_of(@_QEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
   ! CHECK: fir.insert_value
   ! CHECK: fir.alloca tuple<!fir.ref<i8>, i64, !fir.ref<!fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>>>>
   ! CHECK: fir.address_of
@@ -72,3 +72,4 @@ end
   ! CHECK-DAG: fir.global linkonce @_QQcl.6A6A6A00 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.63636300 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.6E6E6E00 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QEccc.desc constant : !fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>

--- a/flang/test/Lower/pointer-assignments.f90
+++ b/flang/test/Lower/pointer-assignments.f90
@@ -316,3 +316,19 @@ subroutine issue857_char(rhs)
   ! CHECK: fir.store %[[len2]] to %[[lhs2_len]] : !fir.ref<index>
   lhs2(1:2, 1:25) => rhs(1:50:1)
 end subroutine
+
+! CHECK-LABEL: func @_QPissue1180(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.target}) {
+subroutine issue1180(x)
+  integer, target :: x
+  integer, pointer :: p
+  common /some_common/ p
+  ! CHECK: %[[VAL_1:.*]] = fir.address_of(@_QBsome_common) : !fir.ref<!fir.array<24xi8>>
+  ! CHECK: %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<24xi8>>) -> !fir.ref<!fir.array<?xi8>>
+  ! CHECK: %[[VAL_3:.*]] = arith.constant 0 : index
+  ! CHECK: %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_3]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+  ! CHECK: %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<i8>) -> !fir.ref<!fir.box<!fir.ptr<i32>>>
+  ! CHECK: %[[VAL_6:.*]] = fir.embox %[[VAL_0]] : (!fir.ref<i32>) -> !fir.box<!fir.ptr<i32>>
+  ! CHECK: fir.store %[[VAL_6]] to %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
+  p => x
+end subroutine


### PR DESCRIPTION
Previously the PFT analysis was both using symbolIsGlobal and doing custom analysis (based on re-entrant aspects). This custom analysis lack to set the global flag for variable in common blocks causing #1180 issue.
The part of  the custom analysis regarding re-entrancy were not done in `symbolIsGlobal` leading to different results there also (notably, causing #1164 since `symbolIsGlobal` was used there and some promotion was not done). Move the re-entrancy analysis inside  `symbolIsGlobal` using the symbol scope to avoid having to thread a boolean to indicate re-entrancy.