### PR TITLE
[fir] Convert fir.select and fir.select_rank to llvm.switch

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -478,7 +478,7 @@ class fir_SwitchTerminatorOp<string mnemonic, list<OpTrait> traits = []> :
 
     // The number of destination conditions that may be tested
     unsigned getNumConditions() {
-      return (*this)->getAttrOfType<mlir::ArrayAttr>(getCasesAttr()).size();
+      return getCases().size();
     }
 
     // The selector is the value being tested to determine the destination
@@ -506,6 +506,10 @@ class fir_SwitchTerminatorOp<string mnemonic, list<OpTrait> traits = []> :
         p.printSuccessorAndUseList(succ, ops.getValue());
       else
         p.printSuccessor(succ);
+    }
+
+    mlir::ArrayAttr getCases() {
+      return (*this)->getAttrOfType<mlir::ArrayAttr>(getCasesAttr());
     }
 
     unsigned targetOffsetSize();

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2678,34 +2678,6 @@ template <typename OP>
 void selectMatchAndRewrite(fir::LLVMTypeConverter &lowering, OP select,
                            OperandTy operands,
                            mlir::ConversionPatternRewriter &rewriter) {
-  // // We could target the LLVM switch instruction, but it isn't part of the
-  // // LLVM IR dialect.  Create an if-then-else ladder instead.
-  // auto conds = select.getNumConditions();
-  // auto attrName = OP::getCasesAttr();
-  // auto caseAttr = select->template getAttrOfType<mlir::ArrayAttr>(attrName);
-  // auto cases = caseAttr.getValue();
-  // auto ty = select.getSelector().getType();
-  // auto ity = lowering.convertType(ty);
-  // auto selector = select.getSelector(operands);
-  // auto loc = select.getLoc();
-  // assert(conds > 0 && "select must have cases");
-  // for (decltype(conds) t = 0; t != conds; ++t) {
-  //   mlir::Block *dest = select.getSuccessor(t);
-  //   auto destOps = select.getSuccessorOperands(operands, t);
-  //   auto &attr = cases[t];
-  //   if (auto intAttr = attr.template dyn_cast<mlir::IntegerAttr>()) {
-  //     auto ci = rewriter.create<mlir::LLVM::ConstantOp>(
-  //         loc, ity, rewriter.getIntegerAttr(ty, intAttr.getInt()));
-  //     auto cmp = rewriter.create<mlir::LLVM::ICmpOp>(
-  //         loc, mlir::LLVM::ICmpPredicate::eq, selector, ci);
-  //     genCaseLadderStep(loc, cmp, dest, destOps, rewriter);
-  //     continue;
-  //   }
-  //   assert(attr.template dyn_cast_or_null<mlir::UnitAttr>());
-  //   assert((t + 1 == conds) && "unit must be last");
-  //   genBrOp(select, dest, destOps, rewriter);
-  // }
-
   auto conds = select.getNumConditions();
   auto caseAttr =
       select->template getAttrOfType<mlir::ArrayAttr>(OP::getCasesAttr());

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -2678,33 +2678,78 @@ template <typename OP>
 void selectMatchAndRewrite(fir::LLVMTypeConverter &lowering, OP select,
                            OperandTy operands,
                            mlir::ConversionPatternRewriter &rewriter) {
-  // We could target the LLVM switch instruction, but it isn't part of the
-  // LLVM IR dialect.  Create an if-then-else ladder instead.
+  // // We could target the LLVM switch instruction, but it isn't part of the
+  // // LLVM IR dialect.  Create an if-then-else ladder instead.
+  // auto conds = select.getNumConditions();
+  // auto attrName = OP::getCasesAttr();
+  // auto caseAttr = select->template getAttrOfType<mlir::ArrayAttr>(attrName);
+  // auto cases = caseAttr.getValue();
+  // auto ty = select.getSelector().getType();
+  // auto ity = lowering.convertType(ty);
+  // auto selector = select.getSelector(operands);
+  // auto loc = select.getLoc();
+  // assert(conds > 0 && "select must have cases");
+  // for (decltype(conds) t = 0; t != conds; ++t) {
+  //   mlir::Block *dest = select.getSuccessor(t);
+  //   auto destOps = select.getSuccessorOperands(operands, t);
+  //   auto &attr = cases[t];
+  //   if (auto intAttr = attr.template dyn_cast<mlir::IntegerAttr>()) {
+  //     auto ci = rewriter.create<mlir::LLVM::ConstantOp>(
+  //         loc, ity, rewriter.getIntegerAttr(ty, intAttr.getInt()));
+  //     auto cmp = rewriter.create<mlir::LLVM::ICmpOp>(
+  //         loc, mlir::LLVM::ICmpPredicate::eq, selector, ci);
+  //     genCaseLadderStep(loc, cmp, dest, destOps, rewriter);
+  //     continue;
+  //   }
+  //   assert(attr.template dyn_cast_or_null<mlir::UnitAttr>());
+  //   assert((t + 1 == conds) && "unit must be last");
+  //   genBrOp(select, dest, destOps, rewriter);
+  // }
+
   auto conds = select.getNumConditions();
-  auto attrName = OP::getCasesAttr();
-  auto caseAttr = select->template getAttrOfType<mlir::ArrayAttr>(attrName);
+  auto caseAttr =
+      select->template getAttrOfType<mlir::ArrayAttr>(OP::getCasesAttr());
   auto cases = caseAttr.getValue();
-  auto ty = select.getSelector().getType();
-  auto ity = lowering.convertType(ty);
   auto selector = select.getSelector(operands);
   auto loc = select.getLoc();
   assert(conds > 0 && "select must have cases");
+
+  llvm::SmallVector<mlir::Block *> destinations;
+  llvm::SmallVector<mlir::ValueRange> destinationsOperands;
+  mlir::Block *defaultDestination;
+  mlir::ValueRange defaultOperands;
+  llvm::SmallVector<int32_t> caseValues;
+
   for (decltype(conds) t = 0; t != conds; ++t) {
     mlir::Block *dest = select.getSuccessor(t);
     auto destOps = select.getSuccessorOperands(operands, t);
     auto &attr = cases[t];
     if (auto intAttr = attr.template dyn_cast<mlir::IntegerAttr>()) {
-      auto ci = rewriter.create<mlir::LLVM::ConstantOp>(
-          loc, ity, rewriter.getIntegerAttr(ty, intAttr.getInt()));
-      auto cmp = rewriter.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::eq, selector, ci);
-      genCaseLadderStep(loc, cmp, dest, destOps, rewriter);
+      destinations.push_back(dest);
+      destinationsOperands.push_back(destOps.hasValue() ? *destOps
+                                                        : ValueRange());
+      caseValues.push_back(intAttr.getInt());
       continue;
     }
     assert(attr.template dyn_cast_or_null<mlir::UnitAttr>());
     assert((t + 1 == conds) && "unit must be last");
-    genBrOp(select, dest, destOps, rewriter);
+    defaultDestination = dest;
+    defaultOperands = destOps.hasValue() ? *destOps : ValueRange();
   }
+
+  // LLVM::SwitchOp takes a i32 type for the selector.
+  if (select.getSelector().getType() != rewriter.getI32Type())
+    selector =
+        rewriter.create<LLVM::TruncOp>(loc, rewriter.getI32Type(), selector);
+
+  rewriter.replaceOpWithNewOp<mlir::LLVM::SwitchOp>(
+      select, selector,
+      /*defaultDestination=*/defaultDestination,
+      /*defaultOperands=*/defaultOperands,
+      /*caseValues=*/caseValues,
+      /*caseDestinations=*/destinations,
+      /*caseOperands=*/destinationsOperands,
+      /*branchWeights=*/ArrayRef<int32_t>());
 }
 
 /// conversion of fir::SelectOp to an if-then-else ladder

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -1,0 +1,91 @@
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir %s | FileCheck %s
+
+// Test `fir.select` operation conversion pattern.
+// Check that the if-then-else ladder is correctly constructed and that we
+// branch to the correct block.
+
+func @select(%arg : index, %arg2 : i32) -> i32 {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  %2 = arith.constant 3 : i32
+  %3 = arith.constant 4 : i32
+  fir.select %arg:index [ 1, ^bb1(%0:i32),
+                          2, ^bb2(%2,%arg,%arg2:i32,index,i32),
+                          3, ^bb3(%arg2,%2:i32,i32),
+                          4, ^bb4(%1:i32),
+                          unit, ^bb5 ]
+  ^bb1(%a : i32) :
+    return %a : i32
+  ^bb2(%b : i32, %b2 : index, %b3:i32) :
+    %castidx = arith.index_cast %b2 : index to i32
+    %4 = arith.addi %b, %castidx : i32
+    %5 = arith.addi %4, %b3 : i32
+    return %5 : i32
+  ^bb3(%c:i32, %c2:i32) :
+    %6 = arith.addi %c, %c2 : i32
+    return %6 : i32
+  ^bb4(%d : i32) :
+    return %d : i32
+  ^bb5 :
+    %zero = arith.constant 0 : i32
+    return %zero : i32
+}
+
+// CHECK-LABEL: func @select(
+// CHECK-SAME:               %[[SELECTVALUE:.*]]: [[IDX:.*]],
+// CHECK-SAME:               %[[ARG1:.*]]: i32)
+// CHECK:         %[[C0:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:         %[[C1:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:         %[[C2:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK:         %[[SELECTOR:.*]] = llvm.trunc %[[SELECTVALUE]] : i{{.*}} to i32
+// CHECK:         llvm.switch %[[SELECTOR]], ^bb5 [
+// CHECK:           1: ^bb1(%[[C0]] : i32),
+// CHECK:           2: ^bb2(%[[C2]], %[[SELECTVALUE]], %[[ARG1]] : i32, [[IDX]], i32),
+// CHECK:           3: ^bb3(%[[ARG1]], %[[C2]] : i32, i32),
+// CHECK:           4: ^bb4(%[[C1]] : i32)
+// CHECK:         ]
+
+// -----
+
+// Test `fir.select_rank` operation conversion pattern.
+// Check that the if-then-else ladder is correctly constructed and that we
+// branch to the correct block.
+
+func @select_rank(%arg : i32, %arg2 : i32) -> i32 {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  %2 = arith.constant 3 : i32
+  %3 = arith.constant 4 : i32
+  fir.select_rank %arg:i32 [ 1, ^bb1(%0:i32),
+                             2, ^bb2(%2,%arg,%arg2:i32,i32,i32),
+                             3, ^bb3(%arg2,%2:i32,i32),
+                             4, ^bb4(%1:i32),
+                             unit, ^bb5 ]
+  ^bb1(%a : i32) :
+    return %a : i32
+  ^bb2(%b : i32, %b2 : i32, %b3:i32) :
+    %4 = arith.addi %b, %b2 : i32
+    %5 = arith.addi %4, %b3 : i32
+    return %5 : i32
+  ^bb3(%c:i32, %c2:i32) :
+    %6 = arith.addi %c, %c2 : i32
+    return %6 : i32
+  ^bb4(%d : i32) :
+    return %d : i32
+  ^bb5 :
+    %zero = arith.constant 0 : i32
+    return %zero : i32
+}
+
+// CHECK-LABEL: func @select_rank(
+// CHECK-SAME:                    %[[SELECTVALUE:.*]]: i32,
+// CHECK-SAME:                    %[[ARG1:.*]]: i32)
+// CHECK:         %[[C0:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:         %[[C1:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:         %[[C2:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK:         llvm.switch %[[SELECTVALUE]], ^bb5 [
+// CHECK:           1: ^bb1(%[[C0]] : i32),
+// CHECK:           2: ^bb2(%[[C2]], %[[SELECTVALUE]], %[[ARG1]] : i32, i32, i32),
+// CHECK:           3: ^bb3(%[[ARG1]], %[[C2]] : i32, i32),
+// CHECK:           4: ^bb4(%[[C1]] : i32)
+// CHECK:         ]

--- a/flang/test/Fir/select.fir
+++ b/flang/test/Fir/select.fir
@@ -6,7 +6,9 @@
 func @f(%a : i32) -> i32 {
    %1 = arith.constant 1 : i32
    %2 = arith.constant 42 : i32
-   // CHECK: icmp eq i32 %{{.*}}, 1
+// CHECK: switch i32 %{{.*}}, label %{{.*}} [
+// CHECK:   i32 1, label %{{.*}}
+// CHECK: ]
    fir.select %a : i32 [1, ^bb2(%1:i32), unit, ^bb3(%2:i32)]
 ^bb2(%3 : i32) :
    return %3 : i32
@@ -20,8 +22,11 @@ func @f(%a : i32) -> i32 {
 func @g(%a : i32) -> i32 {
    %1 = arith.constant 1 : i32
    %2 = arith.constant 42 : i32
-   // CHECK-DAG: icmp eq i32 %{{.*}}, 1
-   // CHECK-DAG: icmp eq i32 %{{.*}}, -1
+
+// CHECK: switch i32 %{{.*}}, label %{{.*}} [
+// CHECK:  i32 1, label %{{.*}}
+// CHECK:  i32 -1, label %{{.*}}
+// CHECK: ]
    fir.select_rank %a : i32 [1, ^bb2(%1:i32), -1, ^bb4, unit, ^bb3(%2:i32)]
 ^bb2(%3 : i32) :
    return %3 : i32


### PR DESCRIPTION
Now that the LLVM IR dialect has the switch operation, `fir.select` and `fir.select_rank` can be converted to `llvm.switch` instead of the if-then-else ladder. 

- Add the test from upstreaming

https://reviews.llvm.org/D113089