### PR TITLE
Call OutputInteger{8,16,32,64,128} functions

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -18,6 +18,7 @@
 #define FORTRAN_OPTIMIZER_BUILDER_RUNTIME_RTBUILDER_H
 
 #include "flang/Common/Fortran.h"
+#include "flang/Common/uint128.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -138,6 +139,13 @@ template <>
 constexpr TypeBuilderFunc getModel<long long>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
     return mlir::IntegerType::get(context, 8 * sizeof(std::size_t));
+  };
+}
+template <>
+constexpr TypeBuilderFunc getModel<Fortran::common::int128_t>() {
+  return [](mlir::MLIRContext *context) -> mlir::Type {
+    return mlir::IntegerType::get(context,
+                                  8 * sizeof(Fortran::common::int128_t));
   };
 }
 template <>

--- a/flang/test/Lower/OpenMP/omp-master.f90
+++ b/flang/test/Lower/OpenMP/omp-master.f90
@@ -68,7 +68,7 @@ if (alpha .ge. gama) then
 !$OMP PARALLEL
 !FIRDialect:   omp.parallel {
 !FIRDialect:     fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:     fir.call @_FortranAioOutputInteger64
+!FIRDialect:     fir.call @_FortranAioOutputInteger32
 !FIRDialect:     fir.call @_FortranAioEndIoStatement
 !FIRDialect:   omp.terminator
 !FIRDialect:   }

--- a/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
@@ -91,22 +91,17 @@ end subroutine
 !FIRDialect-DAG:    fir.store %[[ARG6_VAL]] to %[[ARG6_PVT]] : !fir.ref<i128>
 !FIRDialect-DAG:    %[[LIST_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput
 !FIRDialect-DAG:    %[[ARG1_PVT_VAL:.*]] = fir.load %[[ARG1_PVT]] : !fir.ref<i32>
-!FIRDialect-DAG:    %[[ARG1_PVT_CVT:.*]] = fir.convert %[[ARG1_PVT_VAL]] : (i32) -> i64
-!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG1_PVT_CVT]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger32(%[[LIST_IO]], %[[ARG1_PVT_VAL]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect-DAG:    %[[ARG2_PVT_VAL:.*]] = fir.load %[[ARG2_PVT]] : !fir.ref<i8>
-!FIRDialect-DAG:    %[[ARG2_PVT_CVT:.*]] = fir.convert %[[ARG2_PVT_VAL]] : (i8) -> i64
-!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG2_PVT_CVT]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger8(%[[LIST_IO]], %[[ARG2_PVT_VAL]]) : (!fir.ref<i8>, i8) -> i1
 !FIRDialect-DAG:    %[[ARG3_PVT_VAL:.*]] = fir.load %[[ARG3_PVT]] : !fir.ref<i16>
-!FIRDialect-DAG:    %[[ARG3_PVT_CVT:.*]] = fir.convert %[[ARG3_PVT_VAL]] : (i16) -> i64
-!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG3_PVT_CVT]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger16(%[[LIST_IO]], %[[ARG3_PVT_VAL]]) : (!fir.ref<i8>, i16) -> i1
 !FIRDialect-DAG:    %[[ARG4_PVT_VAL:.*]] = fir.load %[[ARG4_PVT]] : !fir.ref<i32>
-!FIRDialect-DAG:    %[[ARG4_PVT_CVT:.*]] = fir.convert %[[ARG4_PVT_VAL]] : (i32) -> i64
-!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG4_PVT_CVT]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger32(%[[LIST_IO]], %[[ARG4_PVT_VAL]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect-DAG:    %[[ARG5_PVT_VAL:.*]] = fir.load %[[ARG5_PVT]] : !fir.ref<i64>
 !FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG5_PVT_VAL]]) : (!fir.ref<i8>, i64) -> i1
 !FIRDialect-DAG:    %[[ARG6_PVT_VAL:.*]] = fir.load %[[ARG6_PVT]] : !fir.ref<i128>
-!FIRDialect-DAG:    %[[ARG6_PVT_CVT:.*]] = fir.convert %[[ARG6_PVT_VAL]] : (i128) -> i64
-!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger64(%[[LIST_IO]], %[[ARG6_PVT_CVT]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect-DAG:    %{{.*}} = fir.call @_FortranAioOutputInteger128(%[[LIST_IO]], %[[ARG6_PVT_VAL]]) : (!fir.ref<i8>, i128) -> i1
 !FIRDialect-DAG:    omp.terminator
 !FIRDialect-DAG:  }
 

--- a/flang/test/Lower/OpenMP/omp-parallel-region.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-region.f90
@@ -46,7 +46,7 @@ program parallel
 !FIRDialect-NEXT:     }
 !FIRDialect:     fir.call @_FortranAioBeginExternalListOutput
 !FIRDialect:     fir.load %[[VAR_C]]
-!FIRDialect:     fir.call @_FortranAioOutputInteger64
+!FIRDialect:     fir.call @_FortranAioOutputInteger32
 !FIRDialect:     fir.call @_FortranAioEndIoStatement
 !FIRDialect:     omp.terminator
 !FIRDialect-NEXT: }
@@ -67,7 +67,7 @@ program parallel
 !LLVMIRDialect: ^bb2:  // 2 preds: ^bb0, ^bb1
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput
 !LLVMIRDialect:     llvm.load %[[VAR_C]] : !llvm.ptr<i32>
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement
 !LLVMIRDialect:     omp.terminator
 !LLVMIRDialect-NEXT:   }
@@ -82,7 +82,7 @@ program parallel
 !LLVMIR: %[[COND_RES:.*]] = icmp sgt i32 %{{.*}}, 4
 !LLVMIR: br i1 %[[COND_RES]], label %{{.*}}, label %{{.*}}
 !LLVMIR:   call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   call i1 @_FortranAioOutputInteger64
+!LLVMIR:   call i1 @_FortranAioOutputInteger32
 !LLVMIR:   call i32 @_FortranAioEndIoStatement
         c = a + b
 

--- a/flang/test/Lower/OpenMP/omp-wsloop-dynamic.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-dynamic.f90
@@ -58,14 +58,12 @@ program wsloop_dynamic
 do i=1, 9
 print*, i
 !FIRDialect:    %[[RTBEGIN:.*]] = fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:    %[[CONVERTED:.*]] = fir.convert %[[I]] : (i32) -> i64
-!FIRDialect:    fir.call @_FortranAioOutputInteger64(%[[RTBEGIN]], %[[CONVERTED]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect:    fir.call @_FortranAioOutputInteger32(%[[RTBEGIN]], %[[I]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect:    fir.call @_FortranAioEndIoStatement(%[[RTBEGIN]]) : (!fir.ref<i8>) -> i32
 
 
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-!LLVMIRDialect:     %{{.*}} = llvm.sext %arg0 : i32 to i64
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i64) -> i1
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i32) -> i1
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement(%{{.*}}) : (!llvm.ptr<i8>) -> i32
 
 !LLVMIR:   br label %omp_loop.cond
@@ -79,8 +77,7 @@ print*, i
 !LLVMIR:   br label %omp.wsloop.region
 !LLVMIR: omp.wsloop.region:                                ; preds = %omp_loop.body
 !LLVMIR:   %{{.*}} = call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   %{{.*}} = sext i32 %{{.*}} to i64
-!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger64
+!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger32
 !LLVMIR:   %{{.*}} = call i32 @_FortranAioEndIoStatement
 
 end do

--- a/flang/test/Lower/OpenMP/omp-wsloop-monotonic.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-monotonic.f90
@@ -58,14 +58,12 @@ program wsloop_dynamic
 do i=1, 9
 print*, i
 !FIRDialect:    %[[RTBEGIN:.*]] = fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:    %[[CONVERTED:.*]] = fir.convert %[[I]] : (i32) -> i64
-!FIRDialect:    fir.call @_FortranAioOutputInteger64(%[[RTBEGIN]], %[[CONVERTED]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect:    fir.call @_FortranAioOutputInteger32(%[[RTBEGIN]], %[[I]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect:    fir.call @_FortranAioEndIoStatement(%[[RTBEGIN]]) : (!fir.ref<i8>) -> i32
 
 
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-!LLVMIRDialect:     %{{.*}} = llvm.sext %[[I]] : i32 to i64
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i64) -> i1
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i32) -> i1
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement(%{{.*}}) : (!llvm.ptr<i8>) -> i32
 
 !LLVMIR:   br label %omp_loop.cond
@@ -79,8 +77,7 @@ print*, i
 !LLVMIR:   br label %omp.wsloop.region
 !LLVMIR: omp.wsloop.region:                                ; preds = %omp_loop.body
 !LLVMIR:   %{{.*}} = call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   %{{.*}} = sext i32 %{{.*}} to i64
-!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger64
+!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger32
 !LLVMIR:   %{{.*}} = call i32 @_FortranAioEndIoStatement
 
 end do

--- a/flang/test/Lower/OpenMP/omp-wsloop-nonmonotonic.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-nonmonotonic.f90
@@ -58,14 +58,12 @@ program wsloop_dynamic
 do i=1, 9
 print*, i
 !FIRDialect:    %[[RTBEGIN:.*]] = fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:    %[[CONVERTED:.*]] = fir.convert %[[I]] : (i32) -> i64
-!FIRDialect:    fir.call @_FortranAioOutputInteger64(%[[RTBEGIN]], %[[CONVERTED]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect:    fir.call @_FortranAioOutputInteger32(%[[RTBEGIN]], %[[I]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect:    fir.call @_FortranAioEndIoStatement(%[[RTBEGIN]]) : (!fir.ref<i8>) -> i32
 
 
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-!LLVMIRDialect:     %{{.*}} = llvm.sext %arg0 : i32 to i64
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i64) -> i1
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i32) -> i1
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement(%{{.*}}) : (!llvm.ptr<i8>) -> i32
 
 !LLVMIR:   br label %omp_loop.cond
@@ -79,8 +77,7 @@ print*, i
 !LLVMIR:   br label %omp.wsloop.region
 !LLVMIR: omp.wsloop.region:                                ; preds = %omp_loop.body
 !LLVMIR:   %{{.*}} = call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   %{{.*}} = sext i32 %{{.*}} to i64
-!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger64
+!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger32
 !LLVMIR:   %{{.*}} = call i32 @_FortranAioEndIoStatement
 
 end do

--- a/flang/test/Lower/OpenMP/omp-wsloop-simd.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-simd.f90
@@ -58,14 +58,12 @@ program wsloop_dynamic
 do i=1, 9
 print*, i
 !FIRDialect:    %[[RTBEGIN:.*]] = fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:    %[[CONVERTED:.*]] = fir.convert %[[I]] : (i32) -> i64
-!FIRDialect:    fir.call @_FortranAioOutputInteger64(%[[RTBEGIN]], %[[CONVERTED]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect:    fir.call @_FortranAioOutputInteger32(%[[RTBEGIN]], %[[I]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect:    fir.call @_FortranAioEndIoStatement(%[[RTBEGIN]]) : (!fir.ref<i8>) -> i32
 
 
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-!LLVMIRDialect:     %{{.*}} = llvm.sext %arg0 : i32 to i64
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i64) -> i1
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i32) -> i1
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement(%{{.*}}) : (!llvm.ptr<i8>) -> i32
 
 !LLVMIR:   br label %omp_loop.cond
@@ -79,8 +77,7 @@ print*, i
 !LLVMIR:   br label %omp.wsloop.region
 !LLVMIR: omp.wsloop.region:                                ; preds = %omp_loop.body
 !LLVMIR:   %{{.*}} = call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   %{{.*}} = sext i32 %{{.*}} to i64
-!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger64
+!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger32
 !LLVMIR:   %{{.*}} = call i32 @_FortranAioEndIoStatement
 
 end do

--- a/flang/test/Lower/OpenMP/omp-wsloop.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop.f90
@@ -50,14 +50,12 @@ program wsloop
 do i=1, 9
 print*, i
 !FIRDialect:    %[[RTBEGIN:.*]] = fir.call @_FortranAioBeginExternalListOutput
-!FIRDialect:    %[[CONVERTED:.*]] = fir.convert %[[I]] : (i32) -> i64
-!FIRDialect:    fir.call @_FortranAioOutputInteger64(%[[RTBEGIN]], %[[CONVERTED]]) : (!fir.ref<i8>, i64) -> i1
+!FIRDialect:    fir.call @_FortranAioOutputInteger32(%[[RTBEGIN]], %[[I]]) : (!fir.ref<i8>, i32) -> i1
 !FIRDialect:    fir.call @_FortranAioEndIoStatement(%[[RTBEGIN]]) : (!fir.ref<i8>) -> i32
 
 
 !LLVMIRDialect:     llvm.call @_FortranAioBeginExternalListOutput(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, !llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-!LLVMIRDialect:     %{{.*}} = llvm.sext %[[I]] : i32 to i64
-!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i64) -> i1
+!LLVMIRDialect:     llvm.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!llvm.ptr<i8>, i32) -> i1
 !LLVMIRDialect:     llvm.call @_FortranAioEndIoStatement(%{{.*}}) : (!llvm.ptr<i8>) -> i32
 
 !LLVMIR:   br label %omp_loop.cond
@@ -73,8 +71,7 @@ print*, i
 !LLVMIR:   br label %omp.wsloop.region
 !LLVMIR: omp.wsloop.region:                                ; preds = %omp_loop.body
 !LLVMIR:   %{{.*}} = call i8* @_FortranAioBeginExternalListOutput
-!LLVMIR:   %{{.*}} = sext i32 %{{.*}} to i64
-!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger64
+!LLVMIR:   %{{.*}} = call i1 @_FortranAioOutputInteger32
 !LLVMIR:   %{{.*}} = call i32 @_FortranAioEndIoStatement
 
 end do

--- a/flang/test/Lower/io-statement-1.f90
+++ b/flang/test/Lower/io-statement-1.f90
@@ -39,7 +39,7 @@
 
   ! CHECK: call {{.*}}BeginExternalListOutput
   ! Note that 32 bit integers are output as 64 bits in the runtime API
-  ! CHECK: call {{.*}}OutputInteger64
+  ! CHECK: call {{.*}}OutputInteger32
   ! CHECK: call {{.*}}OutputReal32
   ! CHECK: call {{.*}}EndIoStatement
   write (8,*) i, f
@@ -113,3 +113,33 @@ subroutine inquire_test(ch, i, b)
   ! CHECK: call {{.*}}EndIoStatement
   inquire(91, id=id_func(), pending=b)
 end subroutine inquire_test
+
+! CHECK-LABEL: @_QPboz
+subroutine boz
+  ! CHECK: fir.call @_FortranAioOutputInteger8(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i8) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger16(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i16) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger128(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i128) -> i1
+  print '(*(Z3))', 96_1, 96_2, 96_4, 96_8, 96_16
+
+  ! CHECK: fir.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  print '(I3,2Z44)', 40, 2**40_8, 2**40_8+1
+
+  ! CHECK: fir.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  print '(I3,2I44)', 40, 1099511627776,  1099511627777
+
+  ! CHECK: fir.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  print '(I3,2O44)', 40, 2**40_8, 2**40_8+1
+
+  ! CHECK: fir.call @_FortranAioOutputInteger32(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK: fir.call @_FortranAioOutputInteger64(%{{.*}}, %{{.*}}) : (!fir.ref<i8>, i64) -> i1
+  print '(I3,2B44)', 40, 2**40_8, 2**40_8+1
+end

--- a/flang/test/Lower/io-statement-2.f90
+++ b/flang/test/Lower/io-statement-2.f90
@@ -116,7 +116,7 @@ subroutine loopnest
    ! CHECK:   fir.if {{.*}} -> (i1) {
    ! CHECK:     {{.*}}:2 = fir.iterate_while ({{.*}} = {{.*}} to {{.*}} step {{.*}}) and ({{.*}} = {{.*}}) -> (index, i1) {
    ! CHECK:       fir.if {{.*}} -> (i1) {
-   ! CHECK:         OutputInteger64
+   ! CHECK:         OutputInteger32
    ! CHECK:         fir.result {{.*}} : i1
    ! CHECK:       } else {
    ! CHECK:         fir.result {{.*}} : i1


### PR DESCRIPTION
Size specific OutputInteger calls are needed for BOZ edit descriptors.