### PR TITLE
Fix fir.rebox and fir.embox codegen with subcomponents and substrings

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -2198,7 +2198,10 @@ static mlir::LogicalResult verify(fir::ReboxOp op) {
   if (inputEleTy != outEleTy)
     // TODO: check that outBoxTy is a parent type of inputBoxTy for derived
     // types.
-    if (!inputEleTy.isa<fir::RecordType>())
+    // Character input and output types may be different if there is a
+    // substring in the slice, otherwise, they must match.
+    if (!inputEleTy.isa<fir::RecordType>() &&
+        !(op.slice() && inputEleTy.isa<fir::CharacterType>()))
       return op.emitOpError(
           "op input and output element types must match for intrinsic types");
   return mlir::success();

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -681,6 +681,22 @@ func @test_rebox(%arg0: !fir.box<!fir.array<?xf32>>) {
   return
 }
 
+func private @bar_rebox_test_char(!fir.box<!fir.array<?x!fir.char<1,?>>>)
+// CHECK-LABEL: @test_rebox_char(
+func @test_rebox_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,20>>>) {
+  %c7_i64 = arith.constant 7 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,20>>>, index) -> (index, index, index)
+  %1 = fir.slice %c1, %0#1, %c1_i64 substr %c1_i64, %c7_i64 : (index, index, i64, i64, i64) -> !fir.slice<1>
+  // CHECK: fir.rebox %{{.*}} [%{{.*}}] : (!fir.box<!fir.array<?x!fir.char<1,20>>>, !fir.slice<1>) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  %2 = fir.rebox %arg0 [%1] : (!fir.box<!fir.array<?x!fir.char<1,20>>>, !fir.slice<1>) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  fir.call @bar_rebox_test_char(%2) : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> ()
+  return
+}
+
+
 func private @array_func() -> !fir.array<?x!fir.char<1,?>>
 // CHECK-LABEL: @test_save_result(
 func @test_save_result(%buffer: !fir.ref<!fir.array<?x!fir.char<1,?>>>) {

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -132,6 +132,16 @@ func @bad_rebox_11(%arg0: !fir.box<!fir.array<?x?xf32>>) {
 
 // -----
 
+func @test_rebox_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,20>>>) {
+  %c10 = arith.constant 10 : index
+  %1 = fir.shape %c10, %c10 : (index, index) -> !fir.shape<2>
+  // expected-error@+1{{op input and output element types must match for intrinsic types}}
+  %2 = fir.rebox %arg0(%1) : (!fir.box<!fir.array<?x!fir.char<1,20>>>, !fir.shape<2>) -> !fir.box<!fir.array<10x10x!fir.char<1,10>>>
+  return
+}
+
+// -----
+
 func @array_access(%arr : !fir.ref<!fir.array<?x?xf32>>) {
   %c1 = arith.constant 1 : index
   %c100 = arith.constant 100 : index

--- a/flang/test/Fir/rebox-susbtring.fir
+++ b/flang/test/Fir/rebox-susbtring.fir
@@ -1,0 +1,70 @@
+// Test translation to llvm IR of fir.rebox with substring array sections.
+
+// RUN: tco -o - -cg-rewrite --fir-to-llvm-ir -cse %s | FileCheck %s
+
+// Test a fir.rebox with a substring on a character array with constant
+// length (like c(:)(2:*) where c is a fir.box array with constant length).
+
+// CHECK-LABEL: llvm.func @char_section(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<[[char20_descriptor_t:.*]]>)>>) {
+func @char_section(%arg0: !fir.box<!fir.array<?x!fir.char<1,20>>>) {
+  %c7_i64 = arith.constant 7 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0:3 = fir.box_dims %arg0, %c0 : (!fir.box<!fir.array<?x!fir.char<1,20>>>, index) -> (index, index, index)
+  %1 = fir.slice %c1, %0#1, %c1_i64 substr %c1_i64, %c7_i64 : (index, index, i64, i64, i64) -> !fir.slice<1>
+
+// Only test the computation of the base address offset computation accounting for the substring
+
+// CHECK:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:         %[[VAL_7:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:         %[[VAL_30:.*]] = llvm.mlir.constant(0 : i64) : i64
+
+// CHECK:         %[[VAL_37:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_7]]] : (!llvm.ptr<[[char20_descriptor_t]]>)>>, i32, i32) -> !llvm.ptr<ptr<array<20 x i8>>>
+// CHECK:         %[[VAL_38:.*]] = llvm.load %[[VAL_37]] : !llvm.ptr<ptr<array<20 x i8>>>
+// CHECK:         %[[VAL_39:.*]] = llvm.bitcast %[[VAL_38]] : !llvm.ptr<array<20 x i8>> to !llvm.ptr<array<20 x i8>>
+// CHECK:         %[[VAL_40:.*]] = llvm.getelementptr %[[VAL_39]]{{\[}}%[[VAL_30]], %[[VAL_4]]] : (!llvm.ptr<array<20 x i8>>, i64, i64) -> !llvm.ptr<array<20 x i8>>
+// CHECK:         llvm.bitcast %[[VAL_40]] : !llvm.ptr<array<20 x i8>> to !llvm.ptr<i8>
+
+// More offset computation with descriptor strides and triplets that is not character specific ...
+
+  %2 = fir.rebox %arg0 [%1] : (!fir.box<!fir.array<?x!fir.char<1,20>>>, !fir.slice<1>) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  fir.call @bar(%2) : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> ()
+  return
+}
+
+// Test a rebox of an array section like x(3:60:9)%c(2:8) with both a triplet, a component and a substring where x is a fir.box.
+
+// CHECK-LABEL: llvm.func @foo(
+// CHECK-SAME:                 %[[VAL_0:.*]]: !llvm.ptr<struct<(ptr<[[struct_t:.*]]>, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>, ptr<i8>, array<1 x i64>)>>) {
+func private @bar(!fir.box<!fir.array<?x!fir.char<1,?>>>)
+func @foo(%arg0: !fir.box<!fir.array<?x!fir.type<t{i:i32,c:!fir.char<1,10>}>>>) {
+  %c7_i64 = arith.constant 7 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c9_i64 = arith.constant 9 : i64
+  %c60_i64 = arith.constant 60 : i64
+  %c3_i64 = arith.constant 3 : i64
+  %0 = fir.field_index c, !fir.type<t{i:i32,c:!fir.char<1,10>}>
+  %1 = fir.slice %c3_i64, %c60_i64, %c9_i64 path %0 substr %c1_i64, %c7_i64 : (i64, i64, i64, !fir.field, i64, i64) -> !fir.slice<1>
+
+// Only test the computation of the base address offset computation accounting for the substring of the component
+
+// CHECK:         %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:         %[[VAL_17:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:         %[[VAL_21:.*]] = llvm.mlir.constant(0 : i64) : i64
+
+// CHECK:         %[[VAL_30:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_17]], %[[VAL_17]]] : (!llvm.ptr<[[struct_t_descriptor:.*]]>, i32, i32) -> !llvm.ptr<ptr<[[struct_t]]>>
+// CHECK:         %[[VAL_31:.*]] = llvm.load %[[VAL_30]] : !llvm.ptr<ptr<[[struct_t]]>>
+// CHECK:         %[[VAL_32:.*]] = llvm.bitcast %[[VAL_31]] : !llvm.ptr<[[struct_t]]> to !llvm.ptr<[[struct_t]]>
+// CHECK:         %[[VAL_33:.*]] = llvm.getelementptr %[[VAL_32]]{{\[}}%[[VAL_21]], %[[VAL_1]]] : (!llvm.ptr<[[struct_t]]>, i64, i32) -> !llvm.ptr<[[struct_t]]>
+// CHECK:         %[[VAL_34:.*]] = llvm.getelementptr %[[VAL_33]]{{\[}}%[[VAL_4]]] : (!llvm.ptr<[[struct_t]]>, i64) -> !llvm.ptr<[[struct_t]]>
+// CHECK:         llvm.bitcast %[[VAL_34]] : !llvm.ptr<[[struct_t]]> to !llvm.ptr<i8>
+
+// More offset computation with descriptor strides and triplets that is not character specific ...
+
+  %2 = fir.rebox %arg0 [%1] : (!fir.box<!fir.array<?x!fir.type<t{i:i32,c:!fir.char<1,10>}>>>, !fir.slice<1>) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+  fir.call @bar(%2) : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> ()
+  return
+}


### PR DESCRIPTION
Fixes 3 issues around fir.rebox:
  - first "zero" argument was missing in the GEP for subcomponent causing wrong
   addressing in print *, array%field with array an assumed shape or pointer.
  - substring were not applied in the base address computation
  - the verifier refused constant_length_array(:)(2:8) due to type mismatch.

Fix one issue regarding fir.embox found while doing the substring part of rebox:
  - When the base is a character array with dynamic length, the lower bound cannot
    be directly added after the index for the subcomponent or the triplet offset,
    it must be computed in a new GEP.
    Share the code to compute substrings with fir.rebox to fix the issue.

This fixes c0h, c0j nag tests.