### PR TITLE
[flang] Fix lowering of ArrayRef in FORALL statements

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -5705,8 +5705,10 @@ private:
     auto result = genesp(x.base());
     if (pathIsEmpty())
       return result;
-    if (top)
+    if (top) {
+      reversePath.clear();
       return [=](IterSpace) { return asScalar(x); };
+    }
     auto loc = getLoc();
     return [=](IterSpace) {
       fir::emitFatalError(loc, "QQ reached arrayref with path");


### PR DESCRIPTION
The NAG test nag_correct/nag_f08_i/is1.f90 contains an assignment statement
within a FORALL statement.  The right hand side of the assigment statement
contains an array reference where none of the subscript expressions contain
the index variable of the enclosing FORALL statement.  In this situation, the
code that lowers the array reference is in .../flang/lib/Lower/ConvertExpr.cpp
in the function:
  CC genesp(const Fortran::evaluate::ArrayRef &x,
            const Fortran::evaluate::Substring *ss = {}) {

Within this function, if the array reference does not contain any subscript
expressions that refer to the index of an enclosing FORALL statement, the call
explicitSpace->findBinding(&x) returns nothing.  At this point, if the path
that represesents the array reference is not empty, we lower the code for the
array reference, but we were not clearing the path that represents the array
reference.

Then, when processing another array reference, the path for the new array
reference would contain spurious information left over from the path of the
earlier array reference.  This spurious information caused an assertion to
fail.

I fixed this by just clearing the path after lowering the array reference.