### PR TITLE
[flang] Audit use of "auto" in lowering headers

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -63,7 +63,7 @@ public:
   }
   template <typename B>
   constexpr BaseType<B> *getIf() const {
-    auto *ptr = std::get_if<Ref<B>>(&u);
+    const Ref<B> *ptr = std::get_if<Ref<B>>(&u);
     return ptr ? &ptr->get() : nullptr;
   }
   template <typename B>
@@ -615,7 +615,7 @@ struct FunctionLikeUnit : public ProgramUnit {
   /// This should not be called if the FunctionLikeUnit is the main program
   /// since anonymous main programs do not have a symbol.
   const semantics::Symbol &getSubprogramSymbol() const {
-    auto *symbol = entryPointList[activeEntry].first;
+    const semantics::Symbol *symbol = entryPointList[activeEntry].first;
     if (!symbol)
       llvm::report_fatal_error(
           "not inside a procedure; do not call on main program.");

--- a/flang/lib/Lower/IntervalSet.h
+++ b/flang/lib/Lower/IntervalSet.h
@@ -92,7 +92,7 @@ private:
   void fuse(std::size_t lo, std::size_t up, Iterator i) {
     auto j = m.upper_bound(up);
     // up < j->first
-    auto cu = std::prev(j)->second;
+    std::size_t cu = std::prev(j)->second;
     // cu < j->first
     if (cu > up)
       up = cu;

--- a/flang/lib/Lower/IterationSpace.h
+++ b/flang/lib/Lower/IterationSpace.h
@@ -227,7 +227,7 @@ public:
   }
 
   llvm::SmallVector<FrontEndMaskExpr> getExprs() const {
-    auto maskList = getMasks()[0];
+    llvm::SmallVector<FrontEndMaskExpr> maskList = getMasks()[0];
     for (size_t i = 1, d = getMasks().size(); i < d; ++i)
       maskList.append(getMasks()[i].begin(), getMasks()[i].end());
     return maskList;
@@ -493,7 +493,7 @@ public:
       loopCleanup = fn;
       return;
     }
-    auto oldFn = loopCleanup.getValue();
+    std::function<void(fir::FirOpBuilder &)> oldFn = loopCleanup.getValue();
     loopCleanup = [=](fir::FirOpBuilder &builder) {
       oldFn(builder);
       fn(builder);

--- a/flang/lib/Lower/StatementContext.h
+++ b/flang/lib/Lower/StatementContext.h
@@ -46,7 +46,7 @@ public:
     if (cleanupProhibited)
       llvm::report_fatal_error("expression cleanups disallowed");
     assert(!finalized);
-    auto oldCleanup = cleanup;
+    std::function<void()> oldCleanup = cleanup;
     cleanup = [=]() {
       cuf();
       oldCleanup();


### PR DESCRIPTION
As a first step to reviewing usage of C++ "auto" declarations
in fir-dev's lowering and replacing those not clearly in conformance
with LLVM's style guide, this patch clears all of the header files.
(Later patches will address the *.cpp files of lowering.)