### PR TITLE
[flang] Add Fortran runtime libs to the linker invocation

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -546,6 +546,13 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     ToolChain.addFastMathRuntimeIfAvailable(Args, CmdArgs);
   }
 
+  if (D.IsFlangMode()) {
+    CmdArgs.push_back("-lFortran_main");
+    CmdArgs.push_back("-lFortranRuntime");
+    CmdArgs.push_back("-lFortranDecimal");
+    CmdArgs.push_back("-lm");
+  }
+
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   Args.AddAllArgs(CmdArgs, options::OPT_u);
 

--- a/flang/test/Driver/flang-linker-flags.f90
+++ b/flang/test/Driver/flang-linker-flags.f90
@@ -8,9 +8,10 @@
 ! on Windows. Ideally we should find a more robust way of testing this.
 ! REQUIRES: shell
 
-! RUN: %flang -### %S/Inputs/hello.f90 2>&1 | FileCheck %s
+! RUN: %flang -### --ld-path=/usr/bin/ld %S/Inputs/hello.f90 2>&1 | FileCheck %s
 
-! CHECK: -lFortran_main
-! CHECK: -lFortranRuntime
-! CHECK: -lFortranDecimal
-! CHECK: -lm
+! CHECK-LABEL:  /usr/bin/ld
+! CHECK-SAME: -lFortran_main
+! CHECK-SAME: -lFortranRuntime
+! CHECK-SAME: -lFortranDecimal
+! CHECK-SAME: -lm

--- a/flang/test/Driver/flang-linker-flags.f90
+++ b/flang/test/Driver/flang-linker-flags.f90
@@ -10,7 +10,6 @@
 
 ! RUN: %flang -### %S/Inputs/hello.f90 2>&1 | FileCheck %s
 
-! CHECK-LABEL: "/usr/bin/ld"
 ! CHECK: -lFortran_main
 ! CHECK: -lFortranRuntime
 ! CHECK: -lFortranDecimal

--- a/flang/test/Driver/flang-linker-flags.f90
+++ b/flang/test/Driver/flang-linker-flags.f90
@@ -1,0 +1,17 @@
+! Verify that the Fortran runtime libraries are present in the linker
+! invocation. These libraries are added on top of other standard runtime
+! libraries that the Clang driver will include.
+
+! NOTE: The additional linker flags tested here are currently specified in
+! clang/lib/Driver/Toolchains/Gnu.cpp. This makes the current implementation GNU
+! (Linux) specific. The following line will make sure that this test is skipped
+! on Windows. Ideally we should find a more robust way of testing this.
+! REQUIRES: shell
+
+! RUN: %flang -### %S/Inputs/hello.f90 2>&1 | FileCheck %s
+
+! CHECK-LABEL: "/usr/bin/ld"
+! CHECK: -lFortran_main
+! CHECK: -lFortranRuntime
+! CHECK: -lFortranDecimal
+! CHECK: -lm


### PR DESCRIPTION
This patch adds the Fortran runtime libraries to the linker
invocation generated by `clangDriver`.

With this change, the following invocation will generate an executable:
```
flang-new hello.f90
```