### PR TITLE
Remove builder that takes SSA value instead of Attribute on ExtractVa…

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Complex.h
+++ b/flang/include/flang/Optimizer/Builder/Complex.h
@@ -58,14 +58,18 @@ public:
 protected:
   template <Part partId>
   mlir::Value extract(mlir::Value cplx) {
-    return builder.create<fir::ExtractValueOp>(loc, getComplexPartType(cplx),
-                                               cplx, createPartId<partId>());
+    return builder.create<fir::ExtractValueOp>(
+        loc, getComplexPartType(cplx), cplx,
+        builder.getArrayAttr({builder.getIntegerAttr(
+            builder.getIndexType(), static_cast<int>(partId))}));
   }
 
   template <Part partId>
   mlir::Value insert(mlir::Value cplx, mlir::Value part) {
-    return builder.create<fir::InsertValueOp>(loc, cplx.getType(), cplx, part,
-                                              createPartId<partId>());
+    return builder.create<fir::InsertValueOp>(
+        loc, cplx.getType(), cplx, part,
+        builder.getArrayAttr({builder.getIntegerAttr(
+            builder.getIndexType(), static_cast<int>(partId))}));
   }
 
   template <Part partId>

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -1799,11 +1799,6 @@ def fir_ExtractValueOp : fir_OneResultOp<"extract_value", [NoSideEffect]> {
   let assemblyFormat = [{
     $adt `,` $coor attr-dict `:` functional-type(operands, results)
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt,
-      "llvm::ArrayRef<mlir::Value>":$vcoor)>
-  ];
 }
 
 def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
@@ -1839,6 +1834,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
     static constexpr llvm::StringRef getFieldAttrName() { return "field_id"; }
     static constexpr llvm::StringRef getTypeAttrName() { return "on_type"; }
     llvm::StringRef getFieldName() { return field_id(); }
+    llvm::SmallVector<mlir::Attribute> getAttributes();
   }];
 }
 
@@ -2048,11 +2044,6 @@ def fir_InsertValueOp : fir_OneResultOp<"insert_value", [NoSideEffect]> {
     $adt `,` $val `,` $coor attr-dict `:` functional-type(operands, results)
   }];
 
-  let builders = [
-    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt, "mlir::Value":$val,
-      "llvm::ArrayRef<mlir::Value>":$vcoor)>
-  ];
-
   let hasCanonicalizer = 1;
 }
 
@@ -2083,11 +2074,6 @@ def fir_InsertOnRangeOp : fir_OneResultOp<"insert_on_range", [NoSideEffect]> {
   let assemblyFormat = [{
     $seq `,` $val `,` $coor attr-dict `:` functional-type(operands, results)
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::Type":$rty, "mlir::Value":$adt, "mlir::Value":$val,
-      "llvm::ArrayRef<mlir::Value>":$vcoor)>
-  ];
 
   let verifier = "return ::verify(*this);";
 }

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -322,30 +322,31 @@ static mlir::Value genDefaultInitializerValue(
     assert(componentValue && "must have been computed");
     componentValue = builder.createConvert(loc, componentTy, componentValue);
     // FIXME: type parameters must come from the derived-type-spec
-    mlir::Value field = builder.create<fir::FieldIndexOp>(
+    auto field = builder.create<fir::FieldIndexOp>(
         loc, fieldTy, name, scalarType,
         /*typeParams=*/mlir::ValueRange{} /*TODO*/);
-    initialValue = builder.create<fir::InsertValueOp>(loc, recTy, initialValue,
-                                                      componentValue, field);
+    initialValue = builder.create<fir::InsertValueOp>(
+        loc, recTy, initialValue, componentValue,
+        builder.getArrayAttr(field.getAttributes()));
   }
 
   if (sequenceType) {
     // For arrays, duplicate the scalar value to all elements with an
     // fir.insert_range covering the whole array.
     auto arrayInitialValue = builder.create<fir::UndefOp>(loc, sequenceType);
-    llvm::SmallVector<mlir::Value> rangeBounds;
+    llvm::SmallVector<mlir::Attribute> rangeBounds;
     auto idxTy = builder.getIndexType();
-    auto zero = builder.createIntegerConstant(loc, idxTy, 0);
+    auto zero = builder.getIntegerAttr(idxTy, 0);
     for (auto extent : sequenceType.getShape()) {
       if (extent == fir::SequenceType::getUnknownExtent())
         TODO(loc,
              "default initial value of array component with length parameters");
       rangeBounds.push_back(zero);
-      rangeBounds.push_back(
-          builder.createIntegerConstant(loc, idxTy, extent - 1));
+      rangeBounds.push_back(builder.getIntegerAttr(idxTy, extent - 1));
     }
     return builder.create<fir::InsertOnRangeOp>(
-        loc, sequenceType, arrayInitialValue, initialValue, rangeBounds);
+        loc, sequenceType, arrayInitialValue, initialValue,
+        builder.getArrayAttr(rangeBounds));
   }
   return initialValue;
 }
@@ -883,11 +884,11 @@ defineCommonBlock(Fortran::lower::AbstractConverter &converter,
                   ? Fortran::lower::genInitialDataTarget(
                         converter, loc, converter.genType(*mem), initExpr)
                   : genInitializerExprValue(converter, loc, initExpr, stmtCtx);
-          auto offVal = builder.createIntegerConstant(loc, idxTy, tupIdx);
+          auto offVal = builder.getIntegerAttr(idxTy, tupIdx);
           auto castVal = builder.createConvert(loc, commonTy.getType(tupIdx),
                                                fir::getBase(initVal));
           cb = builder.create<fir::InsertValueOp>(loc, commonTy, cb, castVal,
-                                                  offVal);
+                                                  builder.getArrayAttr(offVal));
           ++tupIdx;
           offset = mem->offset() + mem->size();
         }

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -692,8 +692,9 @@ fir::factory::CharacterExprHelper::createSingletonFromCode(mlir::Value code,
   auto intType = builder.getIntegerType(bits);
   auto cast = builder.createConvert(loc, intType, code);
   auto undef = builder.create<fir::UndefOp>(loc, charType);
-  auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
-  return builder.create<fir::InsertValueOp>(loc, charType, undef, cast, zero);
+  auto zero = builder.getIntegerAttr(builder.getIndexType(), 0);
+  return builder.create<fir::InsertValueOp>(loc, charType, undef, cast,
+                                            builder.getArrayAttr(zero));
 }
 
 mlir::Value fir::factory::CharacterExprHelper::extractCodeFromSingleton(
@@ -702,8 +703,9 @@ mlir::Value fir::factory::CharacterExprHelper::extractCodeFromSingleton(
   assert(type.getLen() == 1);
   auto bits = builder.getKindMap().getCharacterBitsize(type.getFKind());
   auto intType = builder.getIntegerType(bits);
-  auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);
-  return builder.create<fir::ExtractValueOp>(loc, intType, singleton, zero);
+  auto zero = builder.getIntegerAttr(builder.getIndexType(), 0);
+  return builder.create<fir::ExtractValueOp>(loc, intType, singleton,
+                                             builder.getArrayAttr(zero));
 }
 
 mlir::Value

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -158,7 +158,6 @@ end subroutine
 
 !CHECK-LABEL: func private @fir.aimag.f32.ref_z4(%arg0: !fir.ref<!fir.complex<4>>)
   !CHECK: %[[load:.*]] = fir.load %arg0
-  !CHECK: %[[cst1:.*]] = arith.constant 1
   !CHECK: %[[imag:.*]] = fir.extract_value %[[load]], [1 : index] : (!fir.complex<4>) -> f32
   !CHECK: return %[[imag]] : f32
 


### PR DESCRIPTION
…lueOp, InsetValueOp, and InsertOnRangeOp

This builder exposed a somehow "unsafe" API: it pretends we can
construct an InsertOnRangeOp from a range of SSA values, even though
this will crash if these aren't the result of `arith.constant` since
the operation actually needs attribute values (a build method can't
fail gracefully).
That means that the caller must check for the producer, at which
point they can just assemble the attribute array directly and call
the existing builder.

The existing call-sites were even in a worse state here: they would
actually create a constant operation that wouldn't be used and only
serve to carry the attribute through the builder API.

A getter method was added to get the attributes of the FieldIndexOp.

Co-authored-by: Kiran Chandramohan <kiran.chandramohan@arm.com>

Differential Revision: https://reviews.llvm.org/D112946