### PR TITLE
Fix for host stmt func used in internal proc

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1756,6 +1756,11 @@ struct SymbolVisitor {
 
   void visitSymbol(const Fortran::semantics::Symbol &symbol) {
     callBack(symbol);
+    // Visit statement function body since it will be inlined in lowering.
+    if (const auto *subprogramDetails =
+            symbol.detailsIf<Fortran::semantics::SubprogramDetails>())
+      if (const auto &maybeExpr = subprogramDetails->stmtFunction())
+        visitExpr(*maybeExpr);
   }
 
   template <typename A>


### PR DESCRIPTION
Fixes another "symbol is not mapped to any IR value" assert
related to internal procedure and statement functions.

I omitted the case where the statement function using host variables
is actually define in the host.

Since lowering inline the statement function expression, the related
expression must be considered in the internal procedure parse tree
visit that look for symbol references.