### PR TITLE
Fix assumed length character parameter lowering.

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1211,6 +1211,15 @@ void Fortran::lower::mapSymbolAttributes(
     }
   };
 
+  // Lower length expression for non deferred and non dummy assumed length
+  // characters.
+  auto genExplicitCharLen =
+      [&](llvm::Optional<Fortran::lower::SomeExpr> charLen) -> mlir::Value {
+    if (!charLen)
+      fir::emitFatalError(loc, "expected explicit character length");
+    return genValue(*charLen);
+  };
+
   ba.match(
       //===--------------------------------------------------------------===//
       // Trivial case.
@@ -1292,11 +1301,7 @@ void Fortran::lower::mapSymbolAttributes(
           return;
         }
         // local CHARACTER variable
-        mlir::Value len;
-        if (charLen)
-          len = genValue(*charLen);
-        else
-          len = builder.createIntegerConstant(loc, idxTy, sym.size());
+        mlir::Value len = genExplicitCharLen(charLen);
         if (preAlloc) {
           symMap.addCharSymbol(sym, preAlloc, len);
           return;
@@ -1461,10 +1466,7 @@ void Fortran::lower::mapSymbolAttributes(
           }
         } else {
           // local CHARACTER variable
-          if (charLen)
-            len = genValue(*charLen);
-          else
-            len = builder.createIntegerConstant(loc, idxTy, sym.size());
+          len = genExplicitCharLen(*charLen);
         }
         llvm::SmallVector<mlir::Value> lengths = {len};
 
@@ -1599,10 +1601,7 @@ void Fortran::lower::mapSymbolAttributes(
           }
         } else {
           // local CHARACTER variable
-          if (charLen)
-            len = genValue(*charLen);
-          else
-            len = builder.createIntegerConstant(loc, idxTy, sym.size());
+          len = genExplicitCharLen(*charLen);
         }
         llvm::SmallVector<mlir::Value> lengths = {len};
 

--- a/flang/test/Lower/character-local-variables.f90
+++ b/flang/test/Lower/character-local-variables.f90
@@ -80,7 +80,7 @@ subroutine dyn_array_cst_len_lb(n)
   ! CHECK: fir.alloca !fir.array<?x!fir.char<1,10>>, %[[extent]] {{{.*}}uniq_name = "_QFdyn_array_cst_len_lbEc"}
 end subroutine
 
-! CHECK: func @_QPdyn_array_dyn_len_lb
+! CHECK-LABEL: func @_QPdyn_array_dyn_len_lb
 ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>, %[[arg1:.*]]: !fir.ref<i64>
 subroutine dyn_array_dyn_len_lb(l, n)
   integer(8) :: l, n
@@ -92,3 +92,16 @@ subroutine dyn_array_dyn_len_lb(l, n)
   ! CHECK: %[[extent:.*]] = arith.addi %[[ni]], %[[cm10]] : index
   ! CHECK: fir.alloca !fir.array<?x!fir.char<1,?>>(%[[l]] : i64), %[[extent]] {{{.*}}uniq_name = "_QFdyn_array_dyn_len_lbEc"}
 end subroutine
+
+! Test that the length of assumed length parameter is correctly deduced in lowering.
+! CHECK-LABEL: func @_QPassumed_length_param
+subroutine assumed_length_param(n)
+  character(*), parameter :: c(1)=(/"abcd"/)
+  integer :: n
+  ! CHECK: %[[c4:.*]] = arith.constant 4 : index
+  ! CHECK: %[[len:.*]] = fir.convert %[[c4]] : (index) -> i64
+  ! CHECK: fir.store %[[len]] to %[[tmp:.*]] : !fir.ref<i64>
+  ! CHECK: fir.call @_QPtake_int(%[[tmp]]) : (!fir.ref<i64>) -> ()
+  call take_int(len(c(n), kind=8))
+end
+


### PR DESCRIPTION
Lowering was using the symbol size as the length, which is wrong
for arrays. Instead of using the size, just use update the helper
getting the length expression to look for the initialization expression
length for assumed length parameters.