### PR TITLE
Fix the lowering of the MERGE intrinsic so it can accept character arguments

### DIFF
--- a/flang/test/Lower/intrinsic-procedures/merge.f90
+++ b/flang/test/Lower/intrinsic-procedures/merge.f90
@@ -1,0 +1,35 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: merge_test
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1,?>>, 
+! CHECK-SAME: %[[arg1:.*]]: index, 
+! CHECK-SAME: %[[arg2:[^:]+]]: !fir.boxchar<1>, 
+! CHECK-SAME: %[[arg3:[^:]+]]: !fir.boxchar<1>, 
+! CHECK-SAME: %[[arg4:.*]]: !fir.ref<!fir.logical<4>>) -> !fir.boxchar<1> {
+function merge_test(o1, o2, mask)
+character :: o1, o2, merge_test
+logical :: mask
+merge_test = merge(o1, o2, mask)
+! CHECK:  %[[a0:.*]]:2 = fir.unboxchar %[[arg2]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-DAG:  %[[a1:.*]]:2 = fir.unboxchar %[[arg3]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index) 
+! CHECK: %[[a2:.*]] = fir.load %[[arg4]] : !fir.ref<!fir.logical<4>>
+! CHECK: %[[a3:.*]] = fir.convert %[[a2]] : (!fir.logical<4>) -> i1
+! CHECK: %[[a4:.*]] = select %[[a3]], %[[a0]]#0, %[[a1]]#0 : !fir.ref<!fir.char<1,?>>
+! CHECK-DAG:  %{{.*}} = fir.convert %[[a4]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+end
+
+! CHECK-LABEL: merge_test2
+! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<i32>, 
+! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<i32>, 
+! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.logical<4>>) -> i32 {
+function merge_test2(o1, o2, mask)
+integer :: o1, o2, merge_test2
+logical :: mask
+merge_test2 = merge(o1, o2, mask)
+! CHECK:  %[[a1:.*]] = fir.load %[[arg0]] : !fir.ref<i32>
+! CHECK:  %[[a2:.*]] = fir.load %[[arg1]] : !fir.ref<i32>
+! CHECK:  %[[a3:.*]] = fir.load %[[arg2]] : !fir.ref<!fir.logical<4>>
+! CHECK:  %[[a4:.*]] = fir.convert %[[a3]] : (!fir.logical<4>) -> i1
+! CHECK:  %{{.*}} = select %[[a4]], %[[a1]], %[[a2]] : i32
+end
+


### PR DESCRIPTION
Prior to this change, code like the following example would not compile:

function merge_test(o1, o2, mask)
character :: o1, o2, merge_test
logical :: mask
merge_test = merge(o1, o2, mask)
end
