### PR TITLE
Remove mlir::ComplexType conversion

### DIFF
--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -58,8 +58,6 @@ public:
     addConversion(
         [&](fir::CharacterType charTy) { return convertCharType(charTy); });
     addConversion(
-        [&](mlir::ComplexType cmplx) { return convertComplexType(cmplx); });
-    addConversion(
         [&](fir::ComplexType cmplx) { return convertComplexType(cmplx); });
     addConversion(
         [&](fir::RecordType derived) { return convertRecordType(derived); });

--- a/flang/test/Fir/types-to-llvm.fir
+++ b/flang/test/Fir/types-to-llvm.fir
@@ -75,6 +75,34 @@ func private @foo4(%arg0: !fir.logical<16>)
 
 // -----
 
+// Test MLIR `complex<KIND>` conversion.
+
+func private @foo0(%arg0: complex<f16>)
+// CHECK-LABEL: foo0
+// CHECK-SAME: !llvm.struct<(f16, f16)>)
+
+func private @foo1(%arg0: complex<bf16>)
+// CHECK-LABEL: foo1
+// CHECK-SAME: !llvm.struct<(bf16, bf16)>)
+
+func private @foo2(%arg0: complex<f32>)
+// CHECK-LABEL: foo2
+// CHECK-SAME: !llvm.struct<(f32, f32)>)
+
+func private @foo3(%arg0: complex<f64>)
+// CHECK-LABEL: foo3
+// CHECK-SAME: !llvm.struct<(f64, f64)>)
+
+func private @foo4(%arg0: complex<f80>)
+// CHECK-LABEL: foo4
+// CHECK-SAME: !llvm.struct<(f80, f80)>)
+
+func private @foo5(%arg0: complex<f128>)
+// CHECK-LABEL: foo5
+// CHECK-SAME: !llvm.struct<(f128, f128)>)
+
+// -----
+
 // Test `!fir.complex<KIND>` conversion.
 
 func private @foo0(%arg0: !fir.complex<2>)


### PR DESCRIPTION
Complex types used in function signatures and calls are handled by the
TargetRewrite pass. For everything else, the regular MLIR type
conversion seems to be doing the right thing.

This patch removes the mlir::ComplexType conversion from the
TypeConverter and adds tests to make sure we get what we expect from the
MLIR conversion.

Corresponds to https://reviews.llvm.org/D113883