### PR TITLE
Fix FirOps.cpp build error with clang-9 after PR 1219

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1404,7 +1404,7 @@ void fir::FieldIndexOp::build(mlir::OpBuilder &builder,
 }
 
 llvm::SmallVector<mlir::Attribute> fir::FieldIndexOp::getAttributes() {
-  llvm::SmallVector<mlir::Attribute, 2> attrs;
+  llvm::SmallVector<mlir::Attribute> attrs;
   attrs.push_back(field_idAttr());
   attrs.push_back(on_typeAttr());
   return attrs;


### PR DESCRIPTION
After https://github.com/flang-compiler/f18-llvm-project/pull/1219 clang 9 emits error:

```
flang/lib/Optimizer/Dialect/FIROps.cpp:1410:10: warning: local variable 'attrs' will be copied despite being returned by name [-Wreturn-std-move]
  return attrs;
flang/lib/Optimizer/Dialect/FIROps.cpp:1410:10: error: no viable conversion from returned value of type 'SmallVector<[...], 2>' to function return type 'SmallVector<[...], (default) CalculateSmallVectorDefaultInlinedElements<T>::value aka 6>'
  return attrs;
```

No fix is needed in upstream LLVM since `fir::FieldIndexOp::getAttributes` is not there.
