### PR TITLE
[Unit Test] Move the declaration of kindMap to the class

### DIFF
--- a/flang/unittests/Optimizer/Builder/CharacterTest.cpp
+++ b/flang/unittests/Optimizer/Builder/CharacterTest.cpp
@@ -16,7 +16,7 @@
 struct CharacterTest : public testing::Test {
 public:
   void SetUp() override {
-    fir::KindMapping kindMap(&context,
+    kindMap = std::make_unique<fir::KindMapping>(&context,
         "i10:80,l3:24,a1:8,r54:Double,c20:X86_FP80,r11:PPC_FP128,"
         "r12:FP128,r13:X86_FP80,r14:Double,r15:Float,r16:Half,r23:BFloat");
     mlir::OpBuilder builder(&context);
@@ -32,12 +32,13 @@ public:
     builder.setInsertionPointToStart(entryBlock);
 
     fir::support::loadDialects(context);
-    firBuilder = std::make_unique<fir::FirOpBuilder>(mod, kindMap);
+    firBuilder = std::make_unique<fir::FirOpBuilder>(mod, *kindMap);
   }
 
   fir::FirOpBuilder &getBuilder() { return *firBuilder; }
 
   mlir::MLIRContext context;
+  std::unique_ptr<fir::KindMapping> kindMap;
   std::unique_ptr<fir::FirOpBuilder> firBuilder;
 };
 

--- a/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
+++ b/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
@@ -15,9 +15,9 @@
 struct DoLoopHelperTest : public testing::Test {
 public:
   void SetUp() {
-    fir::KindMapping kindMap(&context);
+    kindMap = std::make_unique<fir::KindMapping>(&context);
     mlir::OpBuilder builder(&context);
-    firBuilder = new fir::FirOpBuilder(builder, kindMap);
+    firBuilder = new fir::FirOpBuilder(builder, *kindMap);
     fir::support::loadDialects(context);
   }
   void TearDown() { delete firBuilder; }
@@ -25,6 +25,7 @@ public:
   fir::FirOpBuilder &getBuilder() { return *firBuilder; }
 
   mlir::MLIRContext context;
+  std::unique_ptr<fir::KindMapping> kindMap;
   fir::FirOpBuilder *firBuilder;
 };
 
@@ -44,7 +45,8 @@ TEST_F(DoLoopHelperTest, createLoopWithCountTest) {
   auto loop =
       helper.createLoop(c10, [&](fir::FirOpBuilder &, mlir::Value index) {});
   checkConstantValue(loop.lowerBound(), 0);
-  EXPECT_TRUE(mlir::isa<mlir::arith::SubIOp>(loop.upperBound().getDefiningOp()));
+  EXPECT_TRUE(
+      mlir::isa<mlir::arith::SubIOp>(loop.upperBound().getDefiningOp()));
   auto subOp = dyn_cast<mlir::arith::SubIOp>(loop.upperBound().getDefiningOp());
   EXPECT_EQ(c10, subOp.lhs());
   checkConstantValue(subOp.rhs(), 1);


### PR DESCRIPTION
kindMap variable is declared in the Setup function but passed as
a reference to the firBuilder class. The firBuilder is declared in
the class and hence its lifetime exceeds that of kindMap. This can
lead to undefined behaviour. Move the kindMap variable into the class
to avoid this.