### PR TITLE
Cherry-pick front-end and runtime changes since PR 1243

### DIFF
--- a/flang/include/flang/Decimal/decimal.h
+++ b/flang/include/flang/Decimal/decimal.h
@@ -105,17 +105,17 @@ ConversionToBinaryResult<PREC> ConvertToBinary(const char *&,
     enum FortranRounding = RoundNearest, const char *end = nullptr);
 
 extern template ConversionToBinaryResult<8> ConvertToBinary<8>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 extern template ConversionToBinaryResult<11> ConvertToBinary<11>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 extern template ConversionToBinaryResult<24> ConvertToBinary<24>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 extern template ConversionToBinaryResult<53> ConvertToBinary<53>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 extern template ConversionToBinaryResult<64> ConvertToBinary<64>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 extern template ConversionToBinaryResult<113> ConvertToBinary<113>(
-    const char *&, enum FortranRounding, const char *end = nullptr);
+    const char *&, enum FortranRounding, const char *end);
 } // namespace Fortran::decimal
 extern "C" {
 #define NS(x) Fortran::decimal::x

--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -236,7 +236,7 @@ auto UnwrapConvertedExpr(B &x) -> common::Constify<A, B> * {
 // a pointer to the Symbol with TypeParamDetails.
 template <typename A> const Symbol *ExtractBareLenParameter(const A &expr) {
   if (const auto *typeParam{
-          evaluate::UnwrapConvertedExpr<evaluate::TypeParamInquiry>(expr)}) {
+          UnwrapConvertedExpr<evaluate::TypeParamInquiry>(expr)}) {
     if (!typeParam->base()) {
       const Symbol &symbol{typeParam->parameter()};
       if (const auto *tpd{symbol.detailsIf<semantics::TypeParamDetails>()}) {

--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -678,8 +678,15 @@ public:
     if (!(*this)(symbol).has_value()) {
       return false;
     } else if (auto rank{CheckSubscripts(x.subscript())}) {
-      // a(:)%b(1,1) is not contiguous; a(1)%b(:,:) is
-      return *rank > 0 || x.Rank() == 0;
+      if (x.Rank() == 0) {
+        return true;
+      } else if (*rank > 0) {
+        // a(1)%b(:,:) is contiguous if an only if a(1)%b is contiguous.
+        return (*this)(x.base());
+      } else {
+        // a(:)%b(1,1) is not contiguous.
+        return false;
+      }
     } else {
       return false;
     }

--- a/flang/lib/Evaluate/variable.cpp
+++ b/flang/lib/Evaluate/variable.cpp
@@ -264,13 +264,18 @@ static std::optional<Expr<SubscriptInteger>> SymbolLEN(const Symbol &symbol) {
     if (const auto *chExpr{UnwrapExpr<Expr<SomeCharacter>>(assoc->expr())}) {
       return chExpr->LEN();
     }
-  } else if (auto dyType{DynamicType::From(ultimate)}) {
+  }
+  if (auto dyType{DynamicType::From(ultimate)}) {
     if (auto len{dyType->GetCharLength()}) {
-      return len;
-    } else if (IsDescriptor(ultimate) && !ultimate.owner().IsDerivedType()) {
-      return Expr<SubscriptInteger>{DescriptorInquiry{
-          NamedEntity{symbol}, DescriptorInquiry::Field::Len}};
+      if (ultimate.owner().IsDerivedType() || IsScopeInvariantExpr(*len)) {
+        return AsExpr(Extremum<SubscriptInteger>{
+            Ordering::Greater, Expr<SubscriptInteger>{0}, std::move(*len)});
+      }
     }
+  }
+  if (IsDescriptor(ultimate) && !ultimate.owner().IsDerivedType()) {
+    return Expr<SubscriptInteger>{
+        DescriptorInquiry{NamedEntity{symbol}, DescriptorInquiry::Field::Len}};
   }
   return std::nullopt;
 }

--- a/flang/lib/Semantics/runtime-type-info.cpp
+++ b/flang/lib/Semantics/runtime-type-info.cpp
@@ -679,6 +679,14 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
     len = Fold(foldingContext, std::move(len));
   }
   if (dyType.category() == TypeCategory::Character && len) {
+    // Ignore IDIM(x) (represented as MAX(0, x))
+    if (const auto *clamped{evaluate::UnwrapExpr<
+            evaluate::Extremum<evaluate::SubscriptInteger>>(*len)}) {
+      if (clamped->ordering == evaluate::Ordering::Greater &&
+          clamped->left() == evaluate::Expr<evaluate::SubscriptInteger>{0}) {
+        len = clamped->right();
+      }
+    }
     AddValue(values, componentSchema_, "characterlen"s,
         evaluate::AsGenericExpr(GetValue(len, parameters)));
   } else {

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -25,17 +25,11 @@ bool IoStatementBase::Emit(const char *, std::size_t, std::size_t) {
   return false;
 }
 
-bool IoStatementBase::Emit(const char *, std::size_t) {
-  return false;
-}
+bool IoStatementBase::Emit(const char *, std::size_t) { return false; }
 
-bool IoStatementBase::Emit(const char16_t *, std::size_t) {
-  return false;
-}
+bool IoStatementBase::Emit(const char16_t *, std::size_t) { return false; }
 
-bool IoStatementBase::Emit(const char32_t *, std::size_t) {
-  return false;
-}
+bool IoStatementBase::Emit(const char32_t *, std::size_t) { return false; }
 
 std::size_t IoStatementBase::GetNextInputBytes(const char *&p) {
   p = nullptr;
@@ -71,9 +65,7 @@ bool IoStatementBase::Inquire(InquiryKeywordHash, char *, std::size_t) {
   return false;
 }
 
-bool IoStatementBase::Inquire(InquiryKeywordHash, bool &) {
-  return false;
-}
+bool IoStatementBase::Inquire(InquiryKeywordHash, bool &) { return false; }
 
 bool IoStatementBase::Inquire(InquiryKeywordHash, std::int64_t, bool &) {
   return false;
@@ -1248,9 +1240,8 @@ InquireIOLengthState::InquireIOLengthState(
     const char *sourceFile, int sourceLine)
     : NoUnitIoStatementState{sourceFile, sourceLine, *this} {}
 
-bool InquireIOLengthState::Emit(
-    const char *, std::size_t n, std::size_t elementBytes) {
-  bytes_ += n * elementBytes;
+bool InquireIOLengthState::Emit(const char *, std::size_t n, std::size_t) {
+  bytes_ += n;
   return true;
 }
 

--- a/flang/test/Semantics/assign03.f90
+++ b/flang/test/Semantics/assign03.f90
@@ -277,6 +277,8 @@ contains
     logical, parameter :: l4 = is_contiguous(x%a(:,v))
     !ERROR: Must be a constant value
     logical, parameter :: l5 = is_contiguous(y(v,1)%a(1,1))
+    !ERROR: Must be a constant value
+    logical, parameter :: l6 = is_contiguous(p(:))
   end
   subroutine test3(b)
     integer, intent(inout) :: b(..)


### PR DESCRIPTION
78d6009 [flang] Deal with negative character lengths in semantics
394d6fc [flang] Check ArrayRef base for contiguity in IsSimplyContiguousHelper
d2124bf [flang] Remove default argument from function template specialization. NFC.
ea8cdf3 [flang] Fix a bug in INQUIRE(IOLENGTH=) output
