### PR TITLE
Update ConstcOpConversion after upstreaming

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -778,6 +778,12 @@ struct CallOpConversion : public FIROpConversion<fir::CallOp> {
   }
 };
 
+static mlir::Type getComplexEleTy(mlir::Type complex) {
+  if (auto cc = complex.dyn_cast<mlir::ComplexType>())
+    return cc.getElementType();
+  return complex.cast<fir::ComplexType>().getElementType();
+}
+
 /// Compare complex values
 ///
 /// Per 10.1, the only comparisons available are .EQ. (oeq) and .NE. (une).
@@ -823,28 +829,30 @@ struct CmpcOpConversion : public FIROpConversion<fir::CmpcOp> {
     return success();
   }
 };
-
+/// Lower complex constants
 struct ConstcOpConversion : public FIROpConversion<fir::ConstcOp> {
   using FIROpConversion::FIROpConversion;
 
   mlir::LogicalResult
   matchAndRewrite(fir::ConstcOp conc, OperandTy,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto loc = conc.getLoc();
-    auto *ctx = conc.getContext();
-    auto ty = convertType(conc.getType());
-    auto ct = conc.getType().cast<fir::ComplexType>();
-    auto ety = lowerTy().convertComplexPartType(ct.getFKind());
-    auto ri = mlir::FloatAttr::get(ety, getValue(conc.getReal()));
-    auto rp = rewriter.create<mlir::LLVM::ConstantOp>(loc, ety, ri);
-    auto ii = mlir::FloatAttr::get(ety, getValue(conc.getImaginary()));
-    auto ip = rewriter.create<mlir::LLVM::ConstantOp>(loc, ety, ii);
-    auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
-    auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
-    auto r = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-    auto rr = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, r, rp, c0);
-    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(conc, ty, rr, ip,
-                                                           c1);
+    mlir::Location loc = conc.getLoc();
+    mlir::MLIRContext *ctx = conc.getContext();
+    mlir::Type ty = convertType(conc.getType());
+    mlir::Type ety = convertType(getComplexEleTy(conc.getType()));
+    auto realFloatAttr = mlir::FloatAttr::get(ety, getValue(conc.getReal()));
+    auto realPart =
+        rewriter.create<mlir::LLVM::ConstantOp>(loc, ety, realFloatAttr);
+    auto imFloatAttr = mlir::FloatAttr::get(ety, getValue(conc.getImaginary()));
+    auto imPart =
+        rewriter.create<mlir::LLVM::ConstantOp>(loc, ety, imFloatAttr);
+    auto realIndex = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
+    auto imIndex = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
+    auto undef = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
+    auto setReal = rewriter.create<mlir::LLVM::InsertValueOp>(
+        loc, ty, undef, realPart, realIndex);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(conc, ty, setReal,
+                                                           imPart, imIndex);
     return success();
   }
 
@@ -852,12 +860,6 @@ struct ConstcOpConversion : public FIROpConversion<fir::ConstcOp> {
     return attr.cast<fir::RealAttr>().getValue();
   }
 };
-
-static mlir::Type getComplexEleTy(mlir::Type complex) {
-  if (auto cc = complex.dyn_cast<mlir::ComplexType>())
-    return cc.getElementType();
-  return complex.cast<fir::ComplexType>().getElementType();
-}
 
 /// convert value of from-type to value of to-type
 struct ConvertOpConversion : public FIROpConversion<fir::ConvertOp> {

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -347,6 +347,38 @@ func @convert_complex16(%arg0 : !fir.complex<16>) -> !fir.complex<2> {
 
 // -----
 
+// Test constc.
+
+func @test_constc4() -> !fir.complex<4> {
+  %0 = fir.constc (#fir.real<4, 1.4>, #fir.real<4, 2.3>) : !fir.complex<4>
+  return %0 : !fir.complex<4>
+}
+
+// CHECK-LABEL: @test_constc4
+// CHECK_SAME: () -> !llvm.struct<(f32, f32)>
+// CHECK-DAG: [[rp:%.*]] = llvm.mlir.constant(1.400000e+00 : f32) : f32
+// CHECK-DAG: [[ip:%.*]] = llvm.mlir.constant(2.300000e+00 : f32) : f32
+// CHECK: [[undef:%.*]] = llvm.mlir.undef : !llvm.struct<(f32, f32)>
+// CHECK: [[withr:%.*]] = llvm.insertvalue [[rp]], [[undef]][0 : i32] : !llvm.struct<(f32, f32)>
+// CHECK: [[full:%.*]] = llvm.insertvalue [[ip]], [[withr]][1 : i32] : !llvm.struct<(f32, f32)>
+// CHECK: return [[full]] : !llvm.struct<(f32, f32)>
+
+func @test_constc8() -> !fir.complex<8> {
+  %0 = fir.constc (#fir.real<8, 1.8>, #fir.real<8, 2.3>) : !fir.complex<8>
+  return %0 : !fir.complex<8>
+}
+
+// CHECK-LABEL: @test_constc8
+// CHECK_SAME: () -> !llvm.struct<(f64, f64)>
+// CHECK-DAG: [[rp:%.*]] = llvm.mlir.constant(1.800000e+00 : f64) : f64
+// CHECK-DAG: [[ip:%.*]] = llvm.mlir.constant(2.300000e+00 : f64) : f64
+// CHECK: [[undef:%.*]] = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+// CHECK: [[withr:%.*]] = llvm.insertvalue [[rp]], [[undef]][0 : i32] : !llvm.struct<(f64, f64)>
+// CHECK: [[full:%.*]] = llvm.insertvalue [[ip]], [[withr]][1 : i32] : !llvm.struct<(f64, f64)>
+// CHECK: return [[full]] : !llvm.struct<(f64, f64)>
+
+// -----
+
 // Test `fir.select_case` operation conversion with INTEGER.
 
 func @select_case_integer(%arg0: !fir.ref<i32>) -> i32 {


### PR DESCRIPTION
Spell out some types.
Rename variables.
Add tests.
Use getComplexEleTy helper.

Corresponds to https://reviews.llvm.org/D114063