### PR TITLE
Intrinsic calls may create temporaries (heap allocations) on an

### DIFF
--- a/flang/include/flang/Lower/IterationSpace.h
+++ b/flang/include/flang/Lower/IterationSpace.h
@@ -63,7 +63,8 @@ namespace Fortran::lower {
 
 /// Abstraction of the iteration space for building the elemental compute loop
 /// of an array(-like) statement.
-struct IterationSpace {
+class IterationSpace {
+public:
   IterationSpace() = default;
 
   template <typename A>


### PR DESCRIPTION
elemental basis. Cleaning them up after the loop executes violates SSA
dominance, but is also incorrect as it would be a resource leak. This
adds an "elemental context" to allow cleanups to be attached on an
elemental computation basis and performed in the appropriate manner.