### PR TITLE
Add main program host in mangling

### DIFF
--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -46,8 +46,14 @@ hostName(const Fortran::semantics::Symbol &symbol) {
   const auto &scope = symbol.owner();
   if (scope.kind() == Fortran::semantics::Scope::Kind::Subprogram) {
     assert(scope.symbol() && "subprogram scope must have a symbol");
-    return {toStringRef(scope.symbol()->name())};
+    return toStringRef(scope.symbol()->name());
   }
+  if (scope.kind() == Fortran::semantics::Scope::Kind::MainProgram)
+    // Do not use the main program name, if any, because it may lead to name
+    // collision with procedures with the same name in other compilation units
+    // (technically illegal, but all compilers are able to compile and link
+    // properly these programs).
+    return llvm::StringRef("");
   return {};
 }
 

--- a/flang/test/Lower/OpenMP/omp-wsloop-collapse.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-collapse.f90
@@ -13,13 +13,13 @@ program wsloop_collapse
   integer :: i, j, k
   integer :: a, b, c
   integer :: x
-! FIRDialect:         %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "a", uniq_name = "_QEa"}
-! FIRDialect:         %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "b", uniq_name = "_QEb"}
-! FIRDialect:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "c", uniq_name = "_QEc"}
-! FIRDialect:         %[[VAL_3:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QEi"}
-! FIRDialect:         %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QEj"}
-! FIRDialect:         %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QEk"}
-! FIRDialect:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QEx"}
+! FIRDialect:         %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "a", uniq_name = "_QFEa"}
+! FIRDialect:         %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "b", uniq_name = "_QFEb"}
+! FIRDialect:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "c", uniq_name = "_QFEc"}
+! FIRDialect:         %[[VAL_3:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
+! FIRDialect:         %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFEj"}
+! FIRDialect:         %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QFEk"}
+! FIRDialect:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFEx"}
 ! LLVMIRDialect:           %[[VAL_4:.*]] = llvm.mlir.constant(1 : i32) : i32
 ! LLVMIRDialect:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i32) : i32
 ! LLVMIRDialect:           %[[VAL_2:.*]] = llvm.mlir.constant(5 : i32) : i32
@@ -38,19 +38,19 @@ program wsloop_collapse
   x=0
 ! FIRDialect:         %[[VAL_10:.*]] = arith.constant 0 : i32
 ! FIRDialect:         fir.store %[[VAL_10]] to %[[VAL_6]] : !fir.ref<i32>
-! LLVMIRDialect:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x i32 {{{.*}} uniq_name = "_QEa"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x i32 {{{.*}} uniq_name = "_QFEa"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_9:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_9]] x i32 {{{.*}} uniq_name = "_QEb"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_9]] x i32 {{{.*}} uniq_name = "_QFEb"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_12:.*]] = llvm.alloca %[[VAL_11]] x i32 {{{.*}} uniq_name = "_QEc"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_12:.*]] = llvm.alloca %[[VAL_11]] x i32 {{{.*}} uniq_name = "_QFEc"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_13:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_14:.*]] = llvm.alloca %[[VAL_13]] x i32 {{{.*}} uniq_name = "_QEi"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_14:.*]] = llvm.alloca %[[VAL_13]] x i32 {{{.*}} uniq_name = "_QFEi"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_15:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_16:.*]] = llvm.alloca %[[VAL_15]] x i32 {{{.*}} uniq_name = "_QEj"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_16:.*]] = llvm.alloca %[[VAL_15]] x i32 {{{.*}} uniq_name = "_QFEj"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_17:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_18:.*]] = llvm.alloca %[[VAL_17]] x i32 {{{.*}} uniq_name = "_QEk"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_18:.*]] = llvm.alloca %[[VAL_17]] x i32 {{{.*}} uniq_name = "_QFEk"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           %[[VAL_19:.*]] = llvm.mlir.constant(1 : i64) : i64
-! LLVMIRDialect:           %[[VAL_20:.*]] = llvm.alloca %[[VAL_19]] x i32 {{{.*}} uniq_name = "_QEx"} : (i64) -> !llvm.ptr<i32>
+! LLVMIRDialect:           %[[VAL_20:.*]] = llvm.alloca %[[VAL_19]] x i32 {{{.*}} uniq_name = "_QFEx"} : (i64) -> !llvm.ptr<i32>
 ! LLVMIRDialect:           llvm.store %[[VAL_0]], %[[VAL_8]] : !llvm.ptr<i32>
 ! LLVMIRDialect:           llvm.store %[[VAL_1]], %[[VAL_10]] : !llvm.ptr<i32>
 ! LLVMIRDialect:           llvm.store %[[VAL_2]], %[[VAL_12]] : !llvm.ptr<i32>

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -58,8 +58,8 @@ program p
   ! CHECK-DAG: %[[VAL_0:.*]] = arith.constant 4 : index
   ! CHECK-DAG: %[[VAL_1:.*]] = arith.constant 3 : index
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant -1 : i32
-  ! CHECK: %[[VAL_5:.*]] = fir.address_of(@_QEc1) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
-  ! CHECK: %[[VAL_6:.*]] = fir.address_of(@_QEc2) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
+  ! CHECK: %[[VAL_5:.*]] = fir.address_of(@_QFEc1) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
+  ! CHECK: %[[VAL_6:.*]] = fir.address_of(@_QFEc2) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
   ! CHECK: %[[VAL_7:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK: %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
   ! CHECK: %[[VAL_9:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_8]], %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -17,13 +17,13 @@
 ! CHECK-DAG:         %[[VAL_22:.*]] = arith.constant 4 : index
 ! CHECK-DAG:         %[[VAL_23:.*]] = arith.constant 1 : i32
 ! CHECK-DAG:         %[[VAL_24:.*]] = arith.constant 0 : i32
-! CHECK-DAG:         %[[VAL_25:.*]] = fir.address_of(@_QEa1) : !fir.ref<!fir.array<10x10xf32>>
-! CHECK-DAG:         %[[VAL_26:.*]] = fir.address_of(@_QEa2) : !fir.ref<!fir.array<3xf32>>
-! CHECK-DAG:         %[[VAL_27:.*]] = fir.address_of(@_QEa3) : !fir.ref<!fir.array<10xf32>>
-! CHECK-DAG:         %[[VAL_28:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QEi"}
-! CHECK-DAG:         %[[VAL_29:.*]] = fir.address_of(@_QEiv) : !fir.ref<!fir.array<3xi32>>
-! CHECK-DAG:         %[[VAL_30:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QEj"}
-! CHECK-DAG:         %[[VAL_31:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QEk"}
+! CHECK-DAG:         %[[VAL_25:.*]] = fir.address_of(@_QFEa1) : !fir.ref<!fir.array<10x10xf32>>
+! CHECK-DAG:         %[[VAL_26:.*]] = fir.address_of(@_QFEa2) : !fir.ref<!fir.array<3xf32>>
+! CHECK-DAG:         %[[VAL_27:.*]] = fir.address_of(@_QFEa3) : !fir.ref<!fir.array<10xf32>>
+! CHECK-DAG:         %[[VAL_28:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
+! CHECK-DAG:         %[[VAL_29:.*]] = fir.address_of(@_QFEiv) : !fir.ref<!fir.array<3xi32>>
+! CHECK-DAG:         %[[VAL_30:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFEj"}
+! CHECK-DAG:         %[[VAL_31:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QFEk"}
 ! CHECK:         fir.store %[[VAL_24]] to %[[VAL_31]] : !fir.ref<i32>
 ! CHECK:         br ^bb1(%[[VAL_5]], %[[VAL_0]] : index, index)
 ! CHECK:       ^bb1(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index):

--- a/flang/test/Lower/array-expression-slice-2.f90
+++ b/flang/test/Lower/array-expression-slice-2.f90
@@ -42,7 +42,7 @@ program main
   A(2) = 2
   A(3) = 3
   print *, A
-  ! CHECK: %[[A:.*]] = fir.address_of(@_QEa)
+  ! CHECK: %[[A:.*]] = fir.address_of(@_QFEa)
   ! CHECK: %[[shape:.*]] = fir.shape %c10
   ! CHECK: %[[slice:.*]] = fir.slice %
   ! CHECK: fir.embox %[[A]](%[[shape]]) [%[[slice]]] :

--- a/flang/test/Lower/associate-construct.f90
+++ b/flang/test/Lower/associate-construct.f90
@@ -2,8 +2,8 @@
 
 ! CHECK-LABEL: func @_QQmain
 program p
-  ! CHECK: [[N:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QEn"}
-  ! CHECK: [[T:%[0-9]+]] = fir.address_of(@_QEt) : !fir.ref<!fir.array<3xi32>>
+  ! CHECK: [[N:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QFEn"}
+  ! CHECK: [[T:%[0-9]+]] = fir.address_of(@_QFEt) : !fir.ref<!fir.array<3xi32>>
   integer :: n, foo, t(3)
   ! CHECK: [[N]]
   ! CHECK-COUNT-3: fir.coordinate_of [[T]]

--- a/flang/test/Lower/dummy-arguments.f90
+++ b/flang/test/Lower/dummy-arguments.f90
@@ -5,11 +5,11 @@ program test1
   ! CHECK-DAG: %[[TMP:.*]] = fir.alloca
   ! CHECK-DAG: %[[TEN:.*]] = arith.constant
   ! CHECK: fir.store %[[TEN]] to %[[TMP]]
-  ! CHECK-NEXT: fir.call @_QPfoo
+  ! CHECK-NEXT: fir.call @_QFPfoo
   call foo(10)
 contains
 
-! CHECK-LABEL: func @_QPfoo
+! CHECK-LABEL: func @_QFPfoo
 subroutine foo(avar1)
   integer :: avar1
 !  integer :: my_data, my_data2

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -56,7 +56,7 @@ SUBROUTINE s3
 END SUBROUTINE s3
   
 ! test that equivalence in main program containing arrays are placed in global memory.
-! CHECK: fir.global internal @_QEa : !fir.array<400000000xi8>
+! CHECK: fir.global internal @_QFEa : !fir.array<400000000xi8>
   integer :: a, b(100000000)
   equivalence (a, b)
   b(1) = 42

--- a/flang/test/Lower/global-initialization.f90
+++ b/flang/test/Lower/global-initialization.f90
@@ -6,14 +6,14 @@ program bar
   print *, my_data
 contains
 
-! CHECK-LABEL: func @_QPfoo
+! CHECK-LABEL: func @_QFPfoo
 subroutine foo()
 ! CHECK: fir.address_of(@[[name2:.*foo.*my_data]])
   integer, save :: my_data = 2
   print *, my_data + 1
 end subroutine
 
-! CHECK-LABEL: func @_QPfoo2
+! CHECK-LABEL: func @_QFPfoo2
 subroutine foo2()
 ! CHECK: fir.address_of(@[[name3:.*foo2.*my_data]])
   integer, save :: my_data
@@ -21,7 +21,7 @@ subroutine foo2()
   print *, my_data
 end subroutine
 
-! CHECK-LABEL: func @_QPfoo3
+! CHECK-LABEL: func @_QFPfoo3
 subroutine foo3()
 ! CHECK-DAG: fir.address_of(@[[name4:.*foo3.*idata]]){{.*}}fir.array<5xi32>
 ! CHECK-DAG: fir.address_of(@[[name5:.*foo3.*rdata]]){{.*}}fir.array<3xf16>

--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -2,8 +2,8 @@
 
 ! CHECK-LABEL: func @_QQmain
 program p
-  ! CHECK-DAG: [[ccc:%[0-9]+]] = fir.address_of(@_QEccc) : !fir.ref<!fir.array<4x!fir.char<1,3>>>
-  ! CHECK-DAG: [[jjj:%[0-9]+]] = fir.alloca i32 {bindc_name = "jjj", uniq_name = "_QEjjj"}
+  ! CHECK-DAG: [[ccc:%[0-9]+]] = fir.address_of(@_QFEccc) : !fir.ref<!fir.array<4x!fir.char<1,3>>>
+  ! CHECK-DAG: [[jjj:%[0-9]+]] = fir.alloca i32 {bindc_name = "jjj", uniq_name = "_QFEjjj"}
   character*3 ccc(4)
   namelist /nnn/ jjj, ccc
   jjj = 17
@@ -17,7 +17,7 @@ program p
   ! CHECK: fir.insert_value
   ! CHECK: fir.address_of
   ! CHECK: fir.insert_value
-  ! CHECK: fir.address_of(@_QEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
+  ! CHECK: fir.address_of(@_QFEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
   ! CHECK: fir.insert_value
   ! CHECK: fir.alloca tuple<!fir.ref<i8>, i64, !fir.ref<!fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>>>>
   ! CHECK: fir.address_of
@@ -37,7 +37,7 @@ program p
   ! CHECK: fir.insert_value
   ! CHECK: fir.address_of
   ! CHECK: fir.insert_value
-  ! CHECK: fir.address_of(@_QEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
+  ! CHECK: fir.address_of(@_QFEccc.desc) : !fir.ref<!fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>>
   ! CHECK: fir.insert_value
   ! CHECK: fir.alloca tuple<!fir.ref<i8>, i64, !fir.ref<!fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>>>>
   ! CHECK: fir.address_of
@@ -72,4 +72,4 @@ end
   ! CHECK-DAG: fir.global linkonce @_QQcl.6A6A6A00 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.63636300 constant : !fir.char<1,4>
   ! CHECK-DAG: fir.global linkonce @_QQcl.6E6E6E00 constant : !fir.char<1,4>
-  ! CHECK-DAG: fir.global linkonce @_QEccc.desc constant : !fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>
+  ! CHECK-DAG: fir.global linkonce @_QFEccc.desc constant : !fir.box<!fir.ptr<!fir.array<4x!fir.char<1,3>>>>

--- a/flang/test/Lower/nested-where.f90
+++ b/flang/test/Lower/nested-where.f90
@@ -8,11 +8,11 @@ program nested_where
   ! CHECK:  %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
   ! CHECK:  %[[VAL_3:.*]] = fir.alloca tuple<i64, !fir.heap<!fir.array<?xi8>>, !fir.heap<!fir.array<?xi64>>>
   ! CHECK:  %[[VAL_4:.*]] = fir.alloca tuple<i64, !fir.heap<!fir.array<?xi8>>, !fir.heap<!fir.array<?xi64>>>
-  ! CHECK:  %[[VAL_5:.*]] = fir.address_of(@_QEa) : !fir.ref<!fir.array<3xi32>>
+  ! CHECK:  %[[VAL_5:.*]] = fir.address_of(@_QFEa) : !fir.ref<!fir.array<3xi32>>
   ! CHECK:  %[[VAL_6:.*]] = arith.constant 3 : index
-  ! CHECK:  %[[VAL_7:.*]] = fir.address_of(@_QEmask1) : !fir.ref<!fir.array<3x!fir.logical<4>>>
+  ! CHECK:  %[[VAL_7:.*]] = fir.address_of(@_QFEmask1) : !fir.ref<!fir.array<3x!fir.logical<4>>>
   ! CHECK:  %[[VAL_8:.*]] = arith.constant 3 : index
-  ! CHECK:  %[[VAL_9:.*]] = fir.address_of(@_QEmask2) : !fir.ref<!fir.array<3x!fir.logical<4>>>
+  ! CHECK:  %[[VAL_9:.*]] = fir.address_of(@_QFEmask2) : !fir.ref<!fir.array<3x!fir.logical<4>>>
   ! CHECK:  %[[VAL_10:.*]] = arith.constant 3 : index
   ! CHECK:  %[[VAL_11:.*]] = arith.constant 0 : i32
   ! CHECK:  %[[VAL_12:.*]] = arith.constant 0 : i64

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -119,10 +119,19 @@ contains
   end procedure
 end submodule
 
+! CHECK-LABEL: func @_QPshould_not_collide() {
+subroutine should_not_collide()
+! CHECK: }
+end subroutine
 
 ! CHECK-LABEL: func @_QQmain() {
 program test
 ! CHECK: }
+contains
+! CHECK-LABEL: func @_QFPshould_not_collide() {
+subroutine should_not_collide()
+! CHECK: }
+end subroutine
 end program
 
 ! CHECK-LABEL: func @omp_get_num_threads() -> f32 attributes {fir.sym_name = "_QPomp_get_num_threads"} {

--- a/flang/test/Lower/where.f90
+++ b/flang/test/Lower/where.f90
@@ -1,9 +1,9 @@
   ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
   ! CHECK-LABEL: func @_QQmain() {
-  ! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QEa) : !fir.ref<!fir.array<10xf32>>
+  ! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFEa) : !fir.ref<!fir.array<10xf32>>
   ! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
-  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QEb) : !fir.ref<!fir.array<10xf32>>
+  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QFEb) : !fir.ref<!fir.array<10xf32>>
   ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
   ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : i64
   ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index

--- a/flang/unittests/Optimizer/InternalNamesTest.cpp
+++ b/flang/unittests/Optimizer/InternalNamesTest.cpp
@@ -154,6 +154,11 @@ TEST(InternalNamesTest, doVariableTest) {
       {"mod1", "mod2"}, {}, "intVariable"); // Function is not present.
   std::string expectedMangledName2 = "_QMmod1Smod2Eintvariable";
   ASSERT_EQ(actual2, expectedMangledName2);
+
+  std::string actual3 = NameUniquer::doVariable(
+      {}, {""}, "intvar"); // Function is present and is blank
+  std::string expectedMangledName3 = "_QFEintvar";
+  ASSERT_EQ(actual3, expectedMangledName3);
 }
 
 TEST(InternalNamesTest, doProgramEntry) {
@@ -218,6 +223,12 @@ TEST(InternalNamesTest, complexdeconstructTest) {
   actual = NameUniquer::deconstruct("_QFmstartGmpitop");
   expectedNameKind = NameKind::NAMELIST_GROUP;
   expectedComponents = {{}, {"mstart"}, "mpitop", {}};
+  validateDeconstructedName(actual, expectedNameKind, expectedComponents);
+
+  // Empty host name represents the main program.
+  actual = NameUniquer::deconstruct("_QFPfoo");
+  expectedNameKind = NameKind::PROCEDURE;
+  expectedComponents = {{}, {""}, "foo", {}};
   validateDeconstructedName(actual, expectedNameKind, expectedComponents);
 }
 


### PR DESCRIPTION
The internal mangling was skipping the host info for procedures and
object inside main programs. This led to several issues:

- Collision of internal and external procedure with same name in
lowering.
- Collision of common block and external functions after the external-name-interop
pass.

There is not always a name for main programs, so add the main program mangled name: _qqmain has
being the host of procedures and objects inside the main program.