### PR TITLE
Use fir.ptr to denote that equivalenced variables are aliases in FIR

### DIFF
--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -92,8 +92,8 @@ contains
     integer :: zi
     ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
-    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
     ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
     ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
     equivalence (x, zi)
@@ -110,15 +110,15 @@ contains
     type(tseq) :: y
     ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
-    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
     ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
     ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
 
   
     ! CHECK: %[[ycoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[y:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
-    ! CHECK: %[[ybox:.*]] = fir.embox %[[y]] : (!fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[y:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>
+    ! CHECK: %[[ybox:.*]] = fir.embox %[[y]] : (!fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTtseq{i:i32}>>
     ! CHECK: %[[yboxNone:.*]] = fir.convert %[[ybox]]
     ! CHECK: fir.call @_FortranAInitialize(%[[yboxNone]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> none
     equivalence (x, y)

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -7,11 +7,11 @@ SUBROUTINE s1
   ! CHECK: = fir.alloca !fir.array<4xi8> {uniq_name = "_QFs1Ei"}
   EQUIVALENCE (r,i)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-  ! CHECK: %[[iloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i32>
-  ! CHECK-DAG: fir.store %{{.*}} to %[[iloc]] : !fir.ref<i32>
+  ! CHECK: %[[iloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ptr<i32>
+  ! CHECK-DAG: fir.store %{{.*}} to %[[iloc]] : !fir.ptr<i32>
   i = 4
-  ! CHECK-DAG: %[[floc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<f32>
-  ! CHECK: %[[ld:.*]] = fir.load %[[floc]] : !fir.ref<f32>
+  ! CHECK-DAG: %[[floc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ptr<f32>
+  ! CHECK: %[[ld:.*]] = fir.load %[[floc]] : !fir.ptr<f32>
   PRINT *, r
 END SUBROUTINE s1
 
@@ -21,13 +21,13 @@ SUBROUTINE s2
   REAL r(10)
   ! CHECK: %[[arr:.*]] = fir.alloca !fir.array<48xi8>
   EQUIVALENCE (r(3),i(5))
-  ! CHECK: %[[iarr:.*]] = fir.convert %{{.*}} : (!fir.ref<i8>) -> !fir.ref<!fir.array<10xi32>>
+  ! CHECK: %[[iarr:.*]] = fir.convert %{{.*}} : (!fir.ref<i8>) -> !fir.ptr<!fir.array<10xi32>>
   ! CHECK: %[[foff:.*]] = fir.coordinate_of %[[arr]], %{{.*}} : (!fir.ref<!fir.array<48xi8>>, index) -> !fir.ref<i8>
-  ! CHECK: %[[farr:.*]] = fir.convert %[[foff]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<10xf32>>
-  ! CHECK: %[[ia:.*]] = fir.coordinate_of %[[iarr]], %{{.*}} : (!fir.ref<!fir.array<10xi32>>, i64) -> !fir.ref<i32>
+  ! CHECK: %[[farr:.*]] = fir.convert %[[foff]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<10xf32>>
+  ! CHECK: %[[ia:.*]] = fir.coordinate_of %[[iarr]], %{{.*}} : (!fir.ptr<!fir.array<10xi32>>, i64) -> !fir.ref<i32>
   ! CHECK: fir.store %{{.*}} to %[[ia]] : !fir.ref<i32>
   i(5) = 18
-  ! CHECK: %[[fld:.*]] = fir.coordinate_of %[[farr]], %{{.*}} : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK: %[[fld:.*]] = fir.coordinate_of %[[farr]], %{{.*}} : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
   ! CHECK: = fir.load %[[fld]] : !fir.ref<f32>
   PRINT *, r(3)
 END SUBROUTINE s2
@@ -43,14 +43,14 @@ SUBROUTINE s3
   ! CHECK: %[[group:.*]] = fir.alloca !fir.array<40xi8>
   EQUIVALENCE (r,x)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[group]], %c0 : (!fir.ref<!fir.array<40xi8>>, index) -> !fir.ref<i8>
-  ! CHECK: %[[rloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<10xf32>>
-  ! CHECK: %[[xloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<!fir.type<_QFs3Tt{r:!fir.array<10xf32>}>>
+  ! CHECK: %[[rloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<10xf32>>
+  ! CHECK: %[[xloc:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QFs3Tt{r:!fir.array<10xf32>}>>
   ! CHECK: %[[fidx:.*]] = fir.field_index r, !fir.type<_QFs3Tt{r:!fir.array<10xf32>}>
   ! CHECK: %[[xrloc:.*]] = fir.coordinate_of %[[xloc]], %[[fidx]] :
   ! CHECK: %[[v1loc:.*]] = fir.coordinate_of %[[xrloc]], %c8_i64 : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
   ! CHECK: fir.store %{{.*}} to %[[v1loc]] : !fir.ref<f32>
   x%r(9) = 9.0
-  ! CHECK: %[[v2loc:.*]] = fir.coordinate_of %[[rloc]], %c8_i64 : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+  ! CHECK: %[[v2loc:.*]] = fir.coordinate_of %[[rloc]], %c8_i64 : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
   ! CHECK: %{{.*}} = fir.load %[[v2loc]] : !fir.ref<f32>
   PRINT *, r(9)
 END SUBROUTINE s3

--- a/flang/test/Lower/equivalence-2.f90
+++ b/flang/test/Lower/equivalence-2.f90
@@ -9,26 +9,27 @@ subroutine test_eq_sets
   EQUIVALENCE (Al(1), Bl(2))
   ! CHECK-DAG: %[[albl:.*]] = fir.alloca !fir.array<20xi8>
   ! CHECK-DAG: %[[alAddr:.*]] = fir.coordinate_of %[[albl]], %c4{{.*}} : (!fir.ref<!fir.array<20xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[al:.*]] = fir.convert %[[alAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<4xf32>>
+  ! CHECK-DAG: %[[al:.*]] = fir.convert %[[alAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<4xf32>>
   ! CHECK-DAG: %[[blAddr:.*]] = fir.coordinate_of %[[albl]], %c0{{.*}} : (!fir.ref<!fir.array<20xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[bl:.*]] = fir.convert %[[blAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<4xf32>>
+  ! CHECK-DAG: %[[bl:.*]] = fir.convert %[[blAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<4xf32>>
+
 
   DIMENSION Il(2), Xl(2)
   EQUIVALENCE (Il(2), Xl(1))
   ! CHECK-DAG: %[[ilxl:.*]] = fir.alloca !fir.array<12xi8>
   ! CHECK-DAG: %[[ilAddr:.*]] = fir.coordinate_of %[[ilxl]], %c0{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[il:.*]] = fir.convert %[[ilAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xi32>>
+  ! CHECK-DAG: %[[il:.*]] = fir.convert %[[ilAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xi32>>
   ! CHECK-DAG: %[[xlAddr:.*]] = fir.coordinate_of %[[ilxl]], %c4{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[xl:.*]] = fir.convert %[[xlAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[xl:.*]] = fir.convert %[[xlAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
 
   DIMENSION Ag(2), Bg(2)
   SAVE Ag, Bg
   EQUIVALENCE (Ag(1), Bg(2))
   ! CHECK-DAG: %[[agbg:.*]] = fir.address_of(@_QFtest_eq_setsEag) : !fir.ref<!fir.array<12xi8>>
   ! CHECK-DAG: %[[agAddr:.*]] = fir.coordinate_of %[[agbg]], %c4{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[ag:.*]] = fir.convert %[[agAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[ag:.*]] = fir.convert %[[agAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
   ! CHECK-DAG: %[[bgAddr:.*]] = fir.coordinate_of %[[agbg]], %c0{{.*}} : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[bg:.*]] = fir.convert %[[bgAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[bg:.*]] = fir.convert %[[bgAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
 
   DIMENSION Ig(2), Xg(2)
   SAVE Ig, Xg
@@ -36,12 +37,21 @@ subroutine test_eq_sets
   ! CHECK-DAG: %[[igxg:.*]] = fir.address_of(@_QFtest_eq_setsEig) : !fir.ref<!fir.array<8xi8>>
   ! CHECK-DAG: %[[igOffset:.*]] = arith.constant 0 : index
   ! CHECK-DAG: %[[igAddr:.*]] = fir.coordinate_of %[[igxg]], %c0{{.*}} : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[ig:.*]] = fir.convert %[[igAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xi32>>
+  ! CHECK-DAG: %[[ig:.*]] = fir.convert %[[igAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xi32>>
   ! CHECK-DAG: %[[xgAddr:.*]] = fir.coordinate_of %[[igxg]], %c0{{.*}} : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[xg:.*]] = fir.convert %[[xgAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[xg:.*]] = fir.convert %[[xgAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
+
+  ! CHECK: %[[alCast:.*]] = fir.convert %[[al]] : (!fir.ptr<!fir.array<4xf32>>) -> !fir.ref<!fir.array<4xf32>>
+  ! CHECK: %[[blCast:.*]] = fir.convert %[[bl]] : (!fir.ptr<!fir.array<4xf32>>) -> !fir.ref<!fir.array<4xf32>>
+  ! CHECK: %[[ilCast:.*]] = fir.convert %[[il]] : (!fir.ptr<!fir.array<2xi32>>) -> !fir.ref<!fir.array<2xi32>>
+  ! CHECK: %[[xlCast:.*]] = fir.convert %[[xl]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[agCast:.*]] = fir.convert %[[ag]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[bgCast:.*]] = fir.convert %[[bg]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[xgCast:.*]] = fir.convert %[[xg]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[igCast:.*]] = fir.convert %[[ig]] : (!fir.ptr<!fir.array<2xi32>>) -> !fir.ref<!fir.array<2xi32>>
 
   call fooc(Al, Bl, Il, Xl, Ag, Bg, Xg, Ig)
-  ! CHECK: fir.call @_QPfooc(%[[al]], %[[bl]], %[[il]], %[[xl]], %[[ag]], %[[bg]], %[[xg]], %[[ig]])
+  ! CHECK: fir.call @_QPfooc(%[[alCast]], %[[blCast]], %[[ilCast]], %[[xlCast]], %[[agCast]], %[[bgCast]], %[[xgCast]], %[[igCast]])
 
 end subroutine
 
@@ -57,16 +67,20 @@ subroutine eq_and_entry_foo
 
   ! CHECK-DAG: %[[iOffset:.*]] = arith.constant 4 : index
   ! CHECK-DAG: %[[iAddr:.*]] = fir.coordinate_of %[[xi]], %[[iOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[i:.*]] = fir.convert %[[iAddr]] : (!fir.ref<i8>) -> !fir.ref<i32>
+  ! CHECK-DAG: %[[i:.*]] = fir.convert %[[iAddr]] : (!fir.ref<i8>) -> !fir.ptr<i32>
 
   ! CHECK-DAG: %[[xOffset:.*]] = arith.constant 0 : index
   ! CHECK-DAG: %[[xAddr:.*]] = fir.coordinate_of %[[xi]], %[[xOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[x:.*]] = fir.convert %[[xAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[x:.*]] = fir.convert %[[xAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
   call foo2(x, i)
-  ! CHECK: fir.call @_QPfoo1(%[[x]], %[[i]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
+  ! CHECK: %[[xCast:.*]] = fir.convert %[[x]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[iCast:.*]] = fir.convert %[[i]] : (!fir.ptr<i32>) -> !fir.ref<i32>
+  ! CHECK: fir.call @_QPfoo1(%[[xCast]], %[[iCast]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
   entry eq_and_entry_bar
   call foo2(x, i)
-  ! CHECK: fir.call @_QPfoo2(%[[x]], %[[i]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
+  ! CHECK: %[[xCast2:.*]] = fir.convert %[[x]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[iCast2:.*]] = fir.convert %[[i]] : (!fir.ptr<i32>) -> !fir.ref<i32>
+  ! CHECK: fir.call @_QPfoo2(%[[xCast2]], %[[iCast2]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
 end
 
 ! CHECK-LABEL: @_QPeq_and_entry_bar()
@@ -74,11 +88,13 @@ end
 
   ! CHECK-DAG: %[[iOffset:.*]] = arith.constant 4 : index
   ! CHECK-DAG: %[[iAddr:.*]] = fir.coordinate_of %[[xi]], %[[iOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[i:.*]] = fir.convert %[[iAddr]] : (!fir.ref<i8>) -> !fir.ref<i32>
+  ! CHECK-DAG: %[[i:.*]] = fir.convert %[[iAddr]] : (!fir.ref<i8>) -> !fir.ptr<i32>
 
   ! CHECK-DAG: %[[xOffset:.*]] = arith.constant 0 : index
   ! CHECK-DAG: %[[xAddr:.*]] = fir.coordinate_of %[[xi]], %[[xOffset]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
-  ! CHECK-DAG: %[[x:.*]] = fir.convert %[[xAddr]] : (!fir.ref<i8>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK-DAG: %[[x:.*]] = fir.convert %[[xAddr]] : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2xf32>>
   ! CHECK-NOT: fir.call @_QPfoo1
-  ! CHECK: fir.call @_QPfoo2(%[[x]], %[[i]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
+  ! CHECK: %[[xCast:.*]] = fir.convert %[[x]] : (!fir.ptr<!fir.array<2xf32>>) -> !fir.ref<!fir.array<2xf32>>
+  ! CHECK: %[[iCast:.*]] = fir.convert %[[i]] : (!fir.ptr<i32>) -> !fir.ref<i32>
+  ! CHECK: fir.call @_QPfoo2(%[[xCast]], %[[iCast]]) : (!fir.ref<!fir.array<2xf32>>, !fir.ref<i32>) -> ()
 

--- a/flang/test/Lower/explicit-interface-results.f90
+++ b/flang/test/Lower/explicit-interface-results.f90
@@ -299,8 +299,8 @@ subroutine test_result_depends_on_equiv_sym()
   use m_with_equiv, only : result_depends_on_equiv_sym
   ! CHECK: %[[equiv:.*]] = fir.address_of(@_QMm_with_equivEarray) : !fir.ref<!fir.array<24xi8>>
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[equiv]], %c{{.*}} : (!fir.ref<!fir.array<24xi8>>, index) -> !fir.ref<i8>
-  ! CHECK: %[[l:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ref<i64>
-  ! CHECK: %[[load:.*]] = fir.load %[[l]] : !fir.ref<i64>
+  ! CHECK: %[[l:.*]] = fir.convert %[[coor]] : (!fir.ref<i8>) -> !fir.ptr<i64>
+  ! CHECK: %[[load:.*]] = fir.load %[[l]] : !fir.ptr<i64>
   ! CHECK: %[[lcast:.*]] = fir.convert %[[load]] : (i64) -> index
   ! CHECK: fir.alloca !fir.char<1,?>(%[[lcast]] : index)
   print *, result_depends_on_equiv_sym()


### PR DESCRIPTION
ArrayValueCopy pass was doing a copy elision on assignment involving
overlapping equivalenced variables. Use fir.ptr type when instantiating
equivalenced variables to indicate that they are aliases to FIR.