### PR TITLE
Cherry-pick front-end and runtime changes since PR 1248

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -188,6 +188,8 @@ end
   if an actual argument acceptable to one could not be passed to
   the other & vice versa because exactly one is polymorphic or
   exactly one is unlimited polymorphic).
+* External unit 0 is predefined and connected to the standard error output,
+  and defined as `ERROR_UNIT` in the intrinsic `ISO_FORTRAN_ENV` module.
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Evaluate/real.h
+++ b/flang/include/flang/Evaluate/real.h
@@ -150,8 +150,8 @@ public:
   static constexpr int DIGITS{binaryPrecision};
   static constexpr int PRECISION{Details::decimalPrecision};
   static constexpr int RANGE{Details::decimalRange};
-  static constexpr int MAXEXPONENT{maxExponent - 1 - exponentBias};
-  static constexpr int MINEXPONENT{1 - exponentBias};
+  static constexpr int MAXEXPONENT{maxExponent - exponentBias};
+  static constexpr int MINEXPONENT{2 - exponentBias};
 
   constexpr Real FlushSubnormalToZero() const {
     if (IsSubnormal()) {

--- a/flang/module/iso_fortran_env.f90
+++ b/flang/module/iso_fortran_env.f90
@@ -129,7 +129,7 @@ module iso_fortran_env
   integer, parameter :: current_team = -1, initial_team = -2, parent_team = -3
 
   integer, parameter :: input_unit = 5, output_unit = 6
-  integer, parameter :: error_unit = output_unit
+  integer, parameter :: error_unit = 0
   integer, parameter :: iostat_end = -1, iostat_eor = -2
   integer, parameter :: iostat_inquire_internal_unit = -1
 

--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -915,7 +915,7 @@ bool InquireUnitState::Inquire(
       auto pos{unit().position()};
       if (pos == size.value_or(pos + 1)) {
         str = "APPEND";
-      } else if (pos == 0) {
+      } else if (pos == 0 && unit().mayPosition()) {
         str = "REWIND";
       } else {
         str = "ASIS"; // processor-dependent & no common behavior

--- a/flang/runtime/stop.cpp
+++ b/flang/runtime/stop.cpp
@@ -71,11 +71,19 @@ static void CloseAllExternalUnits(const char *why) {
     const char *code, std::size_t length, bool isErrorStop, bool quiet) {
   CloseAllExternalUnits("STOP statement");
   if (!quiet) {
-    std::fprintf(stderr, "Fortran %s: %.*s\n",
-        isErrorStop ? "ERROR STOP" : "STOP", static_cast<int>(length), code);
+    if (Fortran::runtime::executionEnvironment.noStopMessage && !isErrorStop) {
+      std::fprintf(stderr, "%.*s\n", static_cast<int>(length), code);
+    } else {
+      std::fprintf(stderr, "Fortran %s: %.*s\n",
+          isErrorStop ? "ERROR STOP" : "STOP", static_cast<int>(length), code);
+    }
     DescribeIEEESignaledExceptions();
   }
-  std::exit(EXIT_FAILURE);
+  if (isErrorStop) {
+    std::exit(EXIT_FAILURE);
+  } else {
+    std::exit(EXIT_SUCCESS);
+  }
 }
 
 static bool StartPause() {

--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -215,11 +215,13 @@ UnitMap &ExternalFileUnit::GetUnitMap() {
   RUNTIME_CHECK(terminator, !wasExtant);
   out.Predefine(1);
   out.SetDirection(Direction::Output, handler);
+  out.isUnformatted = false;
   defaultOutput = &out;
   ExternalFileUnit &in{newUnitMap->LookUpOrCreate(5, terminator, wasExtant)};
   RUNTIME_CHECK(terminator, !wasExtant);
   in.Predefine(0);
   in.SetDirection(Direction::Input, handler);
+  in.isUnformatted = false;
   defaultInput = &in;
   // TODO: Set UTF-8 mode from the environment
   unitMap = newUnitMap;

--- a/flang/test/Evaluate/folding07.f90
+++ b/flang/test/Evaluate/folding07.f90
@@ -204,12 +204,12 @@ module m
     max8 = maxexponent(0._8), &
     max10 = maxexponent(0._10), &
     max16 = maxexponent(0._16)
-  logical, parameter :: test_max2 = max2 == 15
-  logical, parameter :: test_max3 = max3 == 127
-  logical, parameter :: test_max4 = max4 == 127
-  logical, parameter :: test_max8 = max8 == 1023
-  logical, parameter :: test_max10 = max10 == 16383
-  logical, parameter :: test_max16 = max16 == 16383
+  logical, parameter :: test_max2 = max2 == 16
+  logical, parameter :: test_max3 = max3 == 128
+  logical, parameter :: test_max4 = max4 == 128
+  logical, parameter :: test_max8 = max8 == 1024
+  logical, parameter :: test_max10 = max10 == 16384
+  logical, parameter :: test_max16 = max16 == 16384
 
   integer, parameter :: &
     min2 = minexponent(0._2), &
@@ -218,12 +218,12 @@ module m
     min8 = minexponent(0._8), &
     min10 = minexponent(0._10), &
     min16 = minexponent(0._16)
-  logical, parameter :: test_min2 = min2 == -14
-  logical, parameter :: test_min3 = min3 == -126
-  logical, parameter :: test_min4 = min4 == -126
-  logical, parameter :: test_min8 = min8 == -1022
-  logical, parameter :: test_min10 = min10 == -16382
-  logical, parameter :: test_min16 = min16 == -16382
+  logical, parameter :: test_min2 = min2 == -13
+  logical, parameter :: test_min3 = min3 == -125
+  logical, parameter :: test_min4 = min4 == -125
+  logical, parameter :: test_min8 = min8 == -1021
+  logical, parameter :: test_min10 = min10 == -16381
+  logical, parameter :: test_min16 = min16 == -16381
 
   integer, parameter :: &
     irange1 = range(0_1), &

--- a/flang/test/Semantics/collectives01.f90
+++ b/flang/test/Semantics/collectives01.f90
@@ -1,0 +1,46 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! XFAIL: *
+! Check for semantic errors in co_sum() subroutine calls
+! To Do: add co_sum to the evaluation stage
+
+module test_co_sum
+  implicit none
+
+contains
+
+  subroutine test
+  
+    integer i, status
+    real array(1)
+    complex z(1,1,1, 1,1,1, 1,1,1, 1,1,1, 1,1,1) 
+    character(len=1) message
+  
+    ! correct calls, should produce no errors
+    call co_sum(i)
+    call co_sum(i,   1)
+    call co_sum(i,   1,              status)
+    call co_sum(i,   1,              stat=status)
+    call co_sum(i,   1,                           errmsg=message)
+    call co_sum(i,   1,              stat=status, errmsg=message)
+    call co_sum(i,   result_image=1, stat=status, errmsg=message)
+    call co_sum(a=i, result_image=1, stat=status, errmsg=message)
+    call co_sum(i,   result_image=1, stat=status, errmsg=message)
+  
+    call co_sum(array, result_image=1, stat=status, errmsg=message)
+    call co_sum(z, result_image=1, stat=status, errmsg=message)
+ 
+    ! the error is seen as an incorrect type for the stat= argument
+    !ERROR: Actual argument for 'stat=' has bad type 'CHARACTER(KIND=1,LEN=1_8)'
+    call co_sum(i, 1, message)
+ 
+    ! the error is seen as too many arguments to the co_sum() call
+    !ERROR: too many actual arguments for intrinsic 'co_sum'
+    call co_sum(i,   result_image=1, stat=status, errmsg=message, 3.4)
+  
+    ! keyword argument with incorrect type
+    !ERROR: unknown keyword argument to intrinsic 'co_sum'
+    call co_sum(fake=3.4)
+  
+  end subroutine
+
+end module test_co_sum

--- a/flang/unittests/Runtime/CMakeLists.txt
+++ b/flang/unittests/Runtime/CMakeLists.txt
@@ -14,6 +14,7 @@ add_flang_unittest(FlangRuntimeTests
   Random.cpp
   Reduction.cpp
   RuntimeCrashTest.cpp
+  Stop.cpp
   Time.cpp
   Transformational.cpp
 )

--- a/flang/unittests/Runtime/RuntimeCrashTest.cpp
+++ b/flang/unittests/Runtime/RuntimeCrashTest.cpp
@@ -13,7 +13,6 @@
 #include "CrashHandlerFixture.h"
 #include "../../runtime/terminator.h"
 #include "flang/Runtime/io-api.h"
-#include "flang/Runtime/stop.h"
 #include <gtest/gtest.h>
 
 using namespace Fortran::runtime;
@@ -156,21 +155,3 @@ TEST(TestIOCrash, OverwriteBufferIntegerTest) {
   ASSERT_DEATH(IONAME(OutputInteger64)(cookie, 0xdeadbeef),
       "Internal write overran available records");
 }
-
-TEST(TestIOCrash, StopTest) {
-  EXPECT_EXIT(RTNAME(StopStatement)(), testing::ExitedWithCode(EXIT_SUCCESS),
-      "Fortran STOP");
-}
-
-TEST(TestIOCrash, FailImageTest) {
-  EXPECT_EXIT(
-      RTNAME(FailImageStatement)(), testing::ExitedWithCode(EXIT_FAILURE), "");
-}
-
-TEST(TestIOCrash, ExitTest) {
-  EXPECT_EXIT(RTNAME(Exit)(), testing::ExitedWithCode(EXIT_SUCCESS), "");
-  EXPECT_EXIT(
-      RTNAME(Exit)(EXIT_FAILURE), testing::ExitedWithCode(EXIT_FAILURE), "");
-}
-
-TEST(TestIOCrash, AbortTest) { EXPECT_DEATH(RTNAME(Abort)(), ""); }

--- a/flang/unittests/Runtime/Stop.cpp
+++ b/flang/unittests/Runtime/Stop.cpp
@@ -1,0 +1,85 @@
+//===-- flang/unittests/Runtime/Stop.cpp ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// Test runtime API for STOP statement and runtime API to kill the program.
+//
+//===----------------------------------------------------------------------===//
+#include "flang/Runtime/stop.h"
+#include "CrashHandlerFixture.h"
+#include "../../runtime/environment.h"
+#include <cstdlib>
+#include <gtest/gtest.h>
+
+using namespace Fortran::runtime;
+
+struct TestProgramEnd : CrashHandlerFixture {};
+
+TEST(TestProgramEnd, StopTest) {
+  EXPECT_EXIT(RTNAME(StopStatement)(), testing::ExitedWithCode(EXIT_SUCCESS),
+      "Fortran STOP");
+}
+
+TEST(TestProgramEnd, StopTestNoStopMessage) {
+  putenv(const_cast<char *>("NO_STOP_MESSAGE=1"));
+  Fortran::runtime::executionEnvironment.Configure(0, nullptr, nullptr);
+  EXPECT_EXIT(
+      RTNAME(StopStatement)(), testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+
+TEST(TestProgramEnd, StopMessageTest) {
+  static const char *message{"bye bye"};
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/false, /*quiet=*/false),
+      testing::ExitedWithCode(EXIT_SUCCESS), "Fortran STOP: bye bye");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/false, /*quiet=*/true),
+      testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/true, /*quiet=*/false),
+      testing::ExitedWithCode(EXIT_FAILURE), "Fortran ERROR STOP: bye bye");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/true, /*quiet=*/true),
+      testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(TestProgramEnd, NoStopMessageTest) {
+  putenv(const_cast<char *>("NO_STOP_MESSAGE=1"));
+  Fortran::runtime::executionEnvironment.Configure(0, nullptr, nullptr);
+  static const char *message{"bye bye"};
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/false, /*quiet=*/false),
+      testing::ExitedWithCode(EXIT_SUCCESS), "bye bye");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/false, /*quiet=*/true),
+      testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/true, /*quiet=*/false),
+      testing::ExitedWithCode(EXIT_FAILURE), "Fortran ERROR STOP: bye bye");
+
+  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
+                  /*isErrorStop=*/true, /*quiet=*/true),
+      testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(TestProgramEnd, FailImageTest) {
+  EXPECT_EXIT(
+      RTNAME(FailImageStatement)(), testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(TestProgramEnd, ExitTest) {
+  EXPECT_EXIT(RTNAME(Exit)(), testing::ExitedWithCode(EXIT_SUCCESS), "");
+  EXPECT_EXIT(
+      RTNAME(Exit)(EXIT_FAILURE), testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(TestProgramEnd, AbortTest) { EXPECT_DEATH(RTNAME(Abort)(), ""); }


### PR DESCRIPTION
 a62b601 [flang] Predefine unit 0 connected to stderr
 7796d81 [flang] Skip `Fortran STOP:` before message when NO_STOP_MESSAGE is set
 1e954a1 [flang] Fix off-by-one results from folding MAXEXPONENT and MINEXPONENT
 c1becf4 [flang] Add a semantics test for co_sum
 d6b7576 [flang] Fix INQUIRE(PAD=) and (POSITION=) for predefined units
