### PR TITLE
Remove slice op creation. Creating a slice for a vector subscript

### DIFF
--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -255,41 +255,38 @@
 ! CHECK:         fir.store %[[VAL_202]] to %[[VAL_201]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_203:.*]] = arith.subi %[[VAL_197]], %[[VAL_5]] : index
 ! CHECK:         br ^bb28(%[[VAL_199]], %[[VAL_203]] : index, index)
-! CHECK:       ^bb30:
-! CHECK:         %[[VAL_204:.*]] = fir.slice %[[VAL_5]], %[[VAL_11]], %[[VAL_5]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         br ^bb31(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb31(%[[VAL_205:.*]]: index, %[[VAL_206:.*]]: index):
+! CHECK:       ^bb30(%[[VAL_205:.*]]: index, %[[VAL_206:.*]]: index):
 ! CHECK:         %[[VAL_207:.*]] = arith.cmpi sgt, %[[VAL_206]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_207]], ^bb32, ^bb33(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb32:
+! CHECK:         cond_br %[[VAL_207]], ^bb31, ^bb32(%[[VAL_6]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb31:
 ! CHECK:         %[[VAL_208:.*]] = arith.addi %[[VAL_205]], %[[VAL_5]] : index
 ! CHECK:         %[[VAL_209:.*]] = fir.array_coor %[[VAL_29]](%[[VAL_65]]) %[[VAL_208]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
 ! CHECK:         %[[VAL_210:.*]] = fir.load %[[VAL_209]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_211:.*]] = fir.convert %[[VAL_210]] : (i32) -> index
-! CHECK:         %[[VAL_212:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) {{\[}}%[[VAL_204]]] %[[VAL_211]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_212:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_211]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
 ! CHECK:         %[[VAL_213:.*]] = fir.load %[[VAL_212]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_214:.*]] = fir.array_coor %[[VAL_195]](%[[VAL_65]]) %[[VAL_208]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
 ! CHECK:         fir.store %[[VAL_213]] to %[[VAL_214]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_215:.*]] = arith.subi %[[VAL_206]], %[[VAL_5]] : index
-! CHECK:         br ^bb31(%[[VAL_208]], %[[VAL_215]] : index, index)
-! CHECK:       ^bb33(%[[VAL_216:.*]]: index, %[[VAL_217:.*]]: index):
+! CHECK:         br ^bb30(%[[VAL_208]], %[[VAL_215]] : index, index)
+! CHECK:       ^bb32(%[[VAL_216:.*]]: index, %[[VAL_217:.*]]: index):
 ! CHECK:         %[[VAL_218:.*]] = arith.cmpi sgt, %[[VAL_217]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_218]], ^bb34, ^bb35
-! CHECK:       ^bb34:
+! CHECK:         cond_br %[[VAL_218]], ^bb33, ^bb34
+! CHECK:       ^bb33:
 ! CHECK:         %[[VAL_219:.*]] = arith.addi %[[VAL_216]], %[[VAL_5]] : index
 ! CHECK:         %[[VAL_220:.*]] = fir.array_coor %[[VAL_195]](%[[VAL_65]]) %[[VAL_219]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
 ! CHECK:         %[[VAL_221:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_219]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
 ! CHECK:         %[[VAL_222:.*]] = fir.load %[[VAL_220]] : !fir.ref<f32>
 ! CHECK:         fir.store %[[VAL_222]] to %[[VAL_221]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_223:.*]] = arith.subi %[[VAL_217]], %[[VAL_5]] : index
-! CHECK:         br ^bb33(%[[VAL_219]], %[[VAL_223]] : index, index)
-! CHECK:       ^bb35:
+! CHECK:         br ^bb32(%[[VAL_219]], %[[VAL_223]] : index, index)
+! CHECK:       ^bb34:
 ! CHECK:         fir.freemem %[[VAL_195]] : !fir.heap<!fir.array<3xf32>>
 ! CHECK:         %[[VAL_224:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_225:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_226:.*]] = arith.cmpf une, %[[VAL_224]], %[[VAL_225]] : f32
-! CHECK:         cond_br %[[VAL_226]], ^bb36, ^bb37
-! CHECK:       ^bb36:
+! CHECK:         cond_br %[[VAL_226]], ^bb35, ^bb36
+! CHECK:       ^bb35:
 ! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_228:.*]] = fir.convert %[[VAL_227]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_229:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_228]], %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -302,13 +299,13 @@
 ! CHECK:         %[[VAL_236:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_237:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_229]], %[[VAL_236]]) : (!fir.ref<i8>, f32) -> i1
 ! CHECK:         %[[VAL_238:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_229]]) : (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb37
-! CHECK:       ^bb37:
+! CHECK:         br ^bb36
+! CHECK:       ^bb36:
 ! CHECK:         %[[VAL_239:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_240:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_241:.*]] = arith.cmpf une, %[[VAL_239]], %[[VAL_240]] : f32
-! CHECK:         cond_br %[[VAL_241]], ^bb38, ^bb39
-! CHECK:       ^bb38:
+! CHECK:         cond_br %[[VAL_241]], ^bb37, ^bb38
+! CHECK:       ^bb37:
 ! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_243:.*]] = fir.convert %[[VAL_242]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_244:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_243]], %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -321,13 +318,13 @@
 ! CHECK:         %[[VAL_251:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_252:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_244]], %[[VAL_251]]) : (!fir.ref<i8>, f32) -> i1
 ! CHECK:         %[[VAL_253:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_244]]) : (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb39
-! CHECK:       ^bb39:
+! CHECK:         br ^bb38
+! CHECK:       ^bb38:
 ! CHECK:         %[[VAL_254:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_255:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_256:.*]] = arith.cmpf une, %[[VAL_254]], %[[VAL_255]] : f32
-! CHECK:         cond_br %[[VAL_256]], ^bb40, ^bb41
-! CHECK:       ^bb40:
+! CHECK:         cond_br %[[VAL_256]], ^bb39, ^bb40
+! CHECK:       ^bb39:
 ! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_258:.*]] = fir.convert %[[VAL_257]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_259:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_258]], %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -340,8 +337,8 @@
 ! CHECK:         %[[VAL_266:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
 ! CHECK:         %[[VAL_267:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_259]], %[[VAL_266]]) : (!fir.ref<i8>, f32) -> i1
 ! CHECK:         %[[VAL_268:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_259]]) : (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb41
-! CHECK:       ^bb41:
+! CHECK:         br ^bb40
+! CHECK:       ^bb40:
 ! CHECK:         return
 ! CHECK:       }
 

--- a/flang/test/Lower/array-expression-subscript.f90
+++ b/flang/test/Lower/array-expression-subscript.f90
@@ -25,15 +25,8 @@
 ! CHECK:         %[[VAL_23:.*]] = fir.array_load %[[VAL_2]](%[[VAL_21]]) {{\[}}%[[VAL_22]]] : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<20xi32>
 ! CHECK:         %[[VAL_24:.*]] = arith.cmpi sgt, %[[VAL_20]], %[[VAL_3]] : index
 ! CHECK:         %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_3]], %[[VAL_20]] : index
-! CHECK:         %[[VAL_26:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_27:.*]] = arith.subi %[[VAL_14]], %[[VAL_10]] : index
-! CHECK:         %[[VAL_28:.*]] = arith.addi %[[VAL_27]], %[[VAL_12]] : index
-! CHECK:         %[[VAL_29:.*]] = arith.divsi %[[VAL_28]], %[[VAL_12]] : index
-! CHECK:         %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_26]] : index
-! CHECK:         %[[VAL_31:.*]] = select %[[VAL_30]], %[[VAL_29]], %[[VAL_26]] : index
 ! CHECK:         %[[VAL_32:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_33:.*]] = fir.slice %[[VAL_8]], %[[VAL_31]], %[[VAL_8]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_34:.*]] = fir.array_load %[[VAL_1]](%[[VAL_32]]) {{\[}}%[[VAL_33]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_34:.*]] = fir.array_load %[[VAL_1]](%[[VAL_32]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_35:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_36:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_37:.*]] = arith.subi %[[VAL_25]], %[[VAL_35]] : index
@@ -78,15 +71,8 @@ end subroutine test1a
 ! CHECK:         %[[VAL_21:.*]] = fir.array_load %[[VAL_2]](%[[VAL_19]]) {{\[}}%[[VAL_20]]] : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<20xi32>
 ! CHECK:         %[[VAL_22:.*]] = arith.cmpi sgt, %[[VAL_18]], %[[VAL_4]] : index
 ! CHECK:         %[[VAL_23:.*]] = select %[[VAL_22]], %[[VAL_4]], %[[VAL_18]] : index
-! CHECK:         %[[VAL_24:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_25:.*]] = arith.subi %[[VAL_12]], %[[VAL_8]] : index
-! CHECK:         %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_10]] : index
-! CHECK:         %[[VAL_27:.*]] = arith.divsi %[[VAL_26]], %[[VAL_10]] : index
-! CHECK:         %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_24]] : index
-! CHECK:         %[[VAL_29:.*]] = select %[[VAL_28]], %[[VAL_27]], %[[VAL_24]] : index
 ! CHECK:         %[[VAL_30:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_31:.*]] = fir.slice %[[VAL_6]], %[[VAL_29]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_32:.*]] = fir.array_load %[[VAL_1]](%[[VAL_30]]) {{\[}}%[[VAL_31]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_32:.*]] = fir.array_load %[[VAL_1]](%[[VAL_30]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_33:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_34:.*]] = fir.array_load %[[VAL_0]](%[[VAL_33]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_35:.*]] = arith.constant 1 : index
@@ -100,7 +86,7 @@ end subroutine test1a
 ! CHECK:           %[[VAL_45:.*]] = fir.array_update %[[VAL_40]], %[[VAL_41]], %[[VAL_44]] : (!fir.array<10xi32>, i32, index) -> !fir.array<10xi32>
 ! CHECK:           fir.result %[[VAL_45]] : !fir.array<10xi32>
 ! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_32]], %[[VAL_46:.*]] to %[[VAL_1]]{{\[}}%[[VAL_31]]] : !fir.array<10xi32>, !fir.array<10xi32>, !fir.ref<!fir.array<10xi32>>, !fir.slice<1>
+! CHECK:         fir.array_merge_store %[[VAL_32]], %[[VAL_46:.*]] to %[[VAL_1]] : !fir.array<10xi32>, !fir.array<10xi32>, !fir.ref<!fir.array<10xi32>>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -125,19 +111,11 @@ end subroutine test1b
 ! CHECK:         %[[VAL_14:.*]] = arith.cmpi sgt, %[[VAL_7]], %[[VAL_6]] : index
 ! CHECK:         %[[VAL_15:.*]] = select %[[VAL_14]], %[[VAL_6]], %[[VAL_7]] : index
 ! CHECK:         %[[VAL_16:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_17:.*]] = fir.slice %[[VAL_11]], %[[VAL_7]], %[[VAL_11]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_18:.*]] = fir.array_load %[[VAL_2]](%[[VAL_16]]) {{\[}}%[[VAL_17]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_18:.*]] = fir.array_load %[[VAL_2]](%[[VAL_16]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_19:.*]] = arith.cmpi sgt, %[[VAL_15]], %[[VAL_4]] : index
 ! CHECK:         %[[VAL_20:.*]] = select %[[VAL_19]], %[[VAL_4]], %[[VAL_15]] : index
-! CHECK:         %[[VAL_21:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_22:.*]] = arith.subi %[[VAL_7]], %[[VAL_11]] : index
-! CHECK:         %[[VAL_23:.*]] = arith.addi %[[VAL_22]], %[[VAL_11]] : index
-! CHECK:         %[[VAL_24:.*]] = arith.divsi %[[VAL_23]], %[[VAL_11]] : index
-! CHECK:         %[[VAL_25:.*]] = arith.cmpi sgt, %[[VAL_24]], %[[VAL_21]] : index
-! CHECK:         %[[VAL_26:.*]] = select %[[VAL_25]], %[[VAL_24]], %[[VAL_21]] : index
 ! CHECK:         %[[VAL_27:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_28:.*]] = fir.slice %[[VAL_10]], %[[VAL_26]], %[[VAL_10]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_29:.*]] = fir.array_load %[[VAL_1]](%[[VAL_27]]) {{\[}}%[[VAL_28]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_29:.*]] = fir.array_load %[[VAL_1]](%[[VAL_27]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_30:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_31:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_32:.*]] = arith.subi %[[VAL_20]], %[[VAL_30]] : index
@@ -175,19 +153,11 @@ end subroutine test2a
 ! CHECK:         %[[VAL_12:.*]] = arith.cmpi sgt, %[[VAL_7]], %[[VAL_6]] : index
 ! CHECK:         %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_6]], %[[VAL_7]] : index
 ! CHECK:         %[[VAL_14:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_15:.*]] = fir.slice %[[VAL_9]], %[[VAL_7]], %[[VAL_9]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_16:.*]] = fir.array_load %[[VAL_2]](%[[VAL_14]]) {{\[}}%[[VAL_15]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_16:.*]] = fir.array_load %[[VAL_2]](%[[VAL_14]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_13]], %[[VAL_5]] : index
 ! CHECK:         %[[VAL_18:.*]] = select %[[VAL_17]], %[[VAL_5]], %[[VAL_13]] : index
-! CHECK:         %[[VAL_19:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_20:.*]] = arith.subi %[[VAL_7]], %[[VAL_9]] : index
-! CHECK:         %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_9]] : index
-! CHECK:         %[[VAL_22:.*]] = arith.divsi %[[VAL_21]], %[[VAL_9]] : index
-! CHECK:         %[[VAL_23:.*]] = arith.cmpi sgt, %[[VAL_22]], %[[VAL_19]] : index
-! CHECK:         %[[VAL_24:.*]] = select %[[VAL_23]], %[[VAL_22]], %[[VAL_19]] : index
 ! CHECK:         %[[VAL_25:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_26:.*]] = fir.slice %[[VAL_8]], %[[VAL_24]], %[[VAL_8]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_27:.*]] = fir.array_load %[[VAL_1]](%[[VAL_25]]) {{\[}}%[[VAL_26]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<10xi32>
+! CHECK:         %[[VAL_27:.*]] = fir.array_load %[[VAL_1]](%[[VAL_25]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_28:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_29:.*]] = fir.array_load %[[VAL_0]](%[[VAL_28]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
 ! CHECK:         %[[VAL_30:.*]] = arith.constant 1 : index
@@ -204,7 +174,7 @@ end subroutine test2a
 ! CHECK:           %[[VAL_43:.*]] = fir.array_update %[[VAL_35]], %[[VAL_36]], %[[VAL_42]] : (!fir.array<10xi32>, i32, index) -> !fir.array<10xi32>
 ! CHECK:           fir.result %[[VAL_43]] : !fir.array<10xi32>
 ! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_27]], %[[VAL_44:.*]] to %[[VAL_1]]{{\[}}%[[VAL_26]]] : !fir.array<10xi32>, !fir.array<10xi32>, !fir.ref<!fir.array<10xi32>>, !fir.slice<1>
+! CHECK:         fir.array_merge_store %[[VAL_27]], %[[VAL_44:.*]] to %[[VAL_1]] : !fir.array<10xi32>, !fir.array<10xi32>, !fir.ref<!fir.array<10xi32>>
 ! CHECK:         return
 ! CHECK:       }
 

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -89,7 +89,7 @@ subroutine pass_vector_subscript_write(x, j)
   integer :: j(10)
   real :: x(100)
   ! CHECK: %[[jload:.*]] = fir.array_load %[[j]](%{{.*}}) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
-  ! CHECK: %[[xload:.*]] = fir.array_load %[[x]](%{{.*}}) [%{{.*}}] : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<100xf32>
+  ! CHECK: %[[xload:.*]] = fir.array_load %[[x]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
   ! CHECK: %[[temp:.*]] = fir.allocmem !fir.array<10xf32>
   ! CHECK: %[[tempload:.*]] = fir.array_load %[[temp]](%{{.*}}) : (!fir.heap<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
   ! CHECK: %[[copy:.*]] = fir.do_loop


### PR DESCRIPTION
position is not needed and problematic. Create a placeholder of
undefined values instead, as the projected array in that dimension is
defined by the values of the vector, and eliminate creating a slice op
when it is not required.
Adapt tests since placeholder slice ops may not be created.