### PR TITLE
[flang][driver] Add support for `-S`

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -747,7 +747,7 @@ def Rpass_analysis_EQ : Joined<["-"], "Rpass-analysis=">, Group<R_value_Group>,
            "name matches the given POSIX regular expression">;
 def R_Joined : Joined<["-"], "R">, Group<R_Group>, Flags<[CC1Option, CoreOption]>,
   MetaVarName<"<remark>">, HelpText<"Enable the specified remark">;
-def S : Flag<["-"], "S">, Flags<[NoXarchOption,CC1Option]>, Group<Action_Group>,
+def S : Flag<["-"], "S">, Flags<[NoXarchOption,CC1Option,FlangOption,FC1Option]>, Group<Action_Group>,
   HelpText<"Only run preprocess and compilation steps">;
 def Tbss : JoinedOrSeparate<["-"], "Tbss">, Group<T_Group>,
   MetaVarName<"<addr>">, HelpText<"Set starting address of BSS to <addr>">;

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -168,8 +168,19 @@ class EmitLLVMAction : public CodeGenAction {
   void ExecuteAction() override;
 };
 
-class EmitObjAction : public CodeGenAction {
+class BackendAction : public CodeGenAction {
+  public:
+  enum class BackendAct {
+    Backend_EmitAssembly,  ///< Emit native assembly files
+    Backend_EmitObj        ///< Emit native object files
+  };
+
+  BackendAction(BackendAct act) : _act{act} {};
+
+  private:
   void ExecuteAction() override;
+
+  BackendAct _act;
 };
 
 } // namespace Fortran::frontend

--- a/flang/include/flang/Frontend/FrontendOptions.h
+++ b/flang/include/flang/Frontend/FrontendOptions.h
@@ -40,6 +40,9 @@ enum ActionKind {
   /// Emit a .o file.
   EmitObj,
 
+  /// Emit a .s file.
+  EmitAssembly,
+
   /// Parse, unparse the parse-tree and output a Fortran source file
   DebugUnparse,
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -132,6 +132,9 @@ static bool ParseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
     case clang::driver::options::OPT_emit_obj:
       opts.programAction = EmitObj;
       break;
+    case clang::driver::options::OPT_S:
+      opts.programAction = EmitAssembly;
+      break;
     case clang::driver::options::OPT_fdebug_unparse:
       opts.programAction = DebugUnparse;
       break;

--- a/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -38,7 +38,11 @@ static std::unique_ptr<FrontendAction> CreateFrontendBaseAction(
   case EmitLLVM:
     return std::make_unique<EmitLLVMAction>();
   case EmitObj:
-    return std::make_unique<EmitObjAction>();
+    return std::make_unique<BackendAction>(
+        BackendAction::BackendAct::Backend_EmitObj);
+  case EmitAssembly:
+    return std::make_unique<BackendAction>(
+        BackendAction::BackendAct::Backend_EmitAssembly);
   case DebugUnparse:
     return std::make_unique<DebugUnparseAction>();
   case DebugUnparseNoSema:

--- a/flang/test/Driver/driver-help-hidden.f90
+++ b/flang/test/Driver/driver-help-hidden.f90
@@ -53,6 +53,7 @@
 ! CHECK-NEXT: -pedantic              Warn on language extensions
 ! CHECK-NEXT: -P                     Disable linemarker output in -E mode
 ! CHECK-NEXT: -std=<value>           Language standard to compile for
+! CHECK-NEXT: -S                     Only run preprocess and compilation steps
 ! CHECK-NEXT: -U <macro>             Undefine macro <macro>
 ! CHECK-NEXT: --version Print version information
 ! CHECK-NEXT: -W<warning>            Enable the specified warning

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -53,6 +53,7 @@
 ! HELP-NEXT: -pedantic              Warn on language extensions
 ! HELP-NEXT: -P                     Disable linemarker output in -E mode
 ! HELP-NEXT: -std=<value>           Language standard to compile for
+! HELP-NEXT: -S                     Only run preprocess and compilation steps
 ! HELP-NEXT: -U <macro>             Undefine macro <macro>
 ! HELP-NEXT: --version              Print version information
 ! HELP-NEXT: -W<warning>            Enable the specified warning
@@ -124,6 +125,7 @@
 ! HELP-FC1-NEXT: -plugin <name>         Use the named plugin action instead of the default action (use "help" to list available options)
 ! HELP-FC1-NEXT: -P                     Disable linemarker output in -E mode
 ! HELP-FC1-NEXT: -std=<value>           Language standard to compile for
+! HELP-FC1-NEXT: -S                     Only run preprocess and compilation steps
 ! HELP-FC1-NEXT: -test-io               Run the InputOuputTest action. Use for development and testing only.
 ! HELP-FC1-NEXT: -U <macro>             Undefine macro <macro>
 ! HELP-FC1-NEXT: --version              Print version information

--- a/flang/test/Driver/emit-asm-aarch64.f90
+++ b/flang/test/Driver/emit-asm-aarch64.f90
@@ -1,0 +1,11 @@
+! TODO Add `-target <arch>` once that's available
+
+! RUN: %flang_fc1 -S %s -o - | FileCheck %s
+
+! REQUIRES: aarch64-registered-target
+
+! CHECK-LABEL: _QQmain:
+! CHECK-NEXT: .Lfunc_begin0:
+! CHECK: ret
+
+end program

--- a/flang/test/Driver/emit-asm-x86.f90
+++ b/flang/test/Driver/emit-asm-x86.f90
@@ -1,0 +1,11 @@
+! TODO Add `-target <arch>` once that's available
+
+! RUN: %flang_fc1 -S %s -o - | FileCheck %s
+
+! REQUIRES: x86-registered-target
+
+! CHECK-LABEL: _QQmain:
+! CHECK-NEXT: .Lfunc_begin0:
+! CHECK: ret
+
+end program


### PR DESCRIPTION
Support for `-S` is added in both `flang-new` and `flang-new -fc1`. The
semantics of this flag are consistent with Clang.

The `EmitObjAction` is renamed as `BackendAction`. The new name more
accurately reflects the fact that this action will primarily run the
code-gen/backend pipeline in LLVM. It also makes more sense as an action
implementing both `-emit-obj` and `-S` (originally it was just
`-emit-obj`).

File genneration in `BackendAction::ExecutionAction` is updated to allow
dumping into a pre-defined output stream (to allow e.g. unit testing).
The corresponding code was moved before the definition of the code-gen
pass pipeline. This change is required to make sure that the output
stream is managed more robustly.