### PR TITLE
[Sync][Flang] Add type conversion for FIR integer kind

### DIFF
--- a/flang/test/Fir/fir-int-conversion.fir
+++ b/flang/test/Fir/fir-int-conversion.fir
@@ -1,0 +1,35 @@
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,DEFAULT %s
+// RUN: fir-opt --kind-mapping="i1:4,i2:8,i4:16,i8:32,i16:64" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,ALL-CUSTOM %s
+// RUN: fir-opt --kind-mapping="i2:1,i4:8,i16:32" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,SOME-CUSTOM %s
+
+// Test `!fir.integer<KIND>` conversion with and without kind-mapping string
+
+func private @foo0(%arg0: !fir.int<1>)
+// COMMON-LABEL: foo0
+// DEFAULT-SAME: i8
+// ALL-CUSTOM-SAME: i4
+// SOME-CUSTOM-SAME: i8
+
+func private @foo1(%arg0: !fir.int<2>)
+// COMMON-LABEL: foo1
+// DEFAULT-SAME: i16
+// ALL-CUSTOM-SAME: i8
+// SOME-CUSTOM-SAME: i1
+
+func private @foo2(%arg0: !fir.int<4>)
+// COMMON-LABEL: foo2
+// DEFAULT-SAME: i32
+// ALL-CUSTOM-SAME: i16
+// SOME-CUSTOM-SAME: i8
+
+func private @foo3(%arg0: !fir.int<8>)
+// COMMON-LABEL: foo3
+// DEFAULT-SAME: i64
+// ALL-CUSTOM-SAME: i32
+// SOME-CUSTOM-SAME: i64
+
+func private @foo4(%arg0: !fir.int<16>)
+// COMMON-LABEL: foo4
+// DEFAULT-SAME: i128
+// ALL-CUSTOM-SAME: i64
+// SOME-CUSTOM-SAME: i32

--- a/flang/test/Fir/types-to-llvm.fir
+++ b/flang/test/Fir/types-to-llvm.fir
@@ -75,6 +75,30 @@ func private @foo4(%arg0: !fir.logical<16>)
 
 // -----
 
+// Test `!fir.integer<KIND>` conversion.
+
+func private @foo0(%arg0: !fir.int<1>)
+// CHECK-LABEL: foo0
+// CHECK-SAME: i8
+
+func private @foo1(%arg0: !fir.int<2>)
+// CHECK-LABEL: foo1
+// CHECK-SAME: i16
+
+func private @foo2(%arg0: !fir.int<4>)
+// CHECK-LABEL: foo2
+// CHECK-SAME: i32
+
+func private @foo3(%arg0: !fir.int<8>)
+// CHECK-LABEL: foo3
+// CHECK-SAME: i64
+
+func private @foo4(%arg0: !fir.int<16>)
+// CHECK-LABEL: foo4
+// CHECK-SAME: i128
+
+// -----
+
 // Test MLIR `complex<KIND>` conversion.
 
 func private @foo0(%arg0: complex<f16>)


### PR DESCRIPTION
Note: Only brings in tests

Convert fir.int<kind> to their llvm equivalent type

This patch is part of the upstreaming effort from fir-dev branch.

Reviewed By: clementval, awarzynski

Differential Revision: https://reviews.llvm.org/D113660

Co-authored-by: Eric Schweitz <eschweitz@nvidia.com>