### PR TITLE
[Sync] [Flang] Add a factory class for creating Complex Ops

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Complex.h
+++ b/flang/include/flang/Optimizer/Builder/Complex.h
@@ -29,8 +29,8 @@ public:
   enum class Part { Real = 0, Imag = 1 };
 
   /// Get the Complex Type. Determine the type. Do not create MLIR operations.
-  mlir::Type getComplexPartType(mlir::Value cplx);
-  mlir::Type getComplexPartType(mlir::Type complexType);
+  mlir::Type getComplexPartType(mlir::Value cplx) const;
+  mlir::Type getComplexPartType(mlir::Type complexType) const;
 
   /// Complex operation creation. They create MLIR operations.
   mlir::Value createComplex(fir::KindTy kind, mlir::Value real,
@@ -40,6 +40,7 @@ public:
   mlir::Value createComplex(mlir::Type complexType, mlir::Value real,
                             mlir::Value imag);
 
+  /// Returns the Real/Imag part of \p cplx
   mlir::Value extractComplexPart(mlir::Value cplx, bool isImagPart) {
     return isImagPart ? extract<Part::Imag>(cplx) : extract<Part::Real>(cplx);
   }

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -62,7 +62,9 @@ public:
   /// The LHS and RHS are not always in agreement in terms of
   /// type. In some cases, the disagreement is between COMPLEX and other scalar
   /// types. In that case, the conversion must insert/extract out of a COMPLEX
-  /// value to have the proper semantics and be strongly typed.
+  /// value to have the proper semantics and be strongly typed. For e.g for
+  /// converting an integer/real to a complex, the real part is filled using
+  /// the integer/real after type conversion and the imaginary part is zero.
   mlir::Value convertWithSemantics(mlir::Location loc, mlir::Type toTy,
                                    mlir::Value val);
 

--- a/flang/lib/Optimizer/Builder/Complex.cpp
+++ b/flang/lib/Optimizer/Builder/Complex.cpp
@@ -12,11 +12,12 @@
 // Complex Factory implementation
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::factory::Complex::getComplexPartType(mlir::Type complexType) {
+mlir::Type
+fir::factory::Complex::getComplexPartType(mlir::Type complexType) const {
   return builder.getRealType(complexType.cast<fir::ComplexType>().getFKind());
 }
 
-mlir::Type fir::factory::Complex::getComplexPartType(mlir::Value cplx) {
+mlir::Type fir::factory::Complex::getComplexPartType(mlir::Value cplx) const {
   return getComplexPartType(cplx.getType());
 }
 
@@ -24,8 +25,7 @@ mlir::Value fir::factory::Complex::createComplex(fir::KindTy kind,
                                                  mlir::Value real,
                                                  mlir::Value imag) {
   auto complexTy = fir::ComplexType::get(builder.getContext(), kind);
-  mlir::Value und = builder.create<fir::UndefOp>(loc, complexTy);
-  return insert<Part::Imag>(insert<Part::Real>(und, real), imag);
+  return createComplex(complexTy, real, imag);
 }
 
 mlir::Value fir::factory::Complex::createComplex(mlir::Type cplxTy,


### PR DESCRIPTION
Note: Changes include the following:
-> Marking getComplexPartType as const
-> Expanding comments of function convertWithSemantics
-> Calling createComplex (version with type) inside createComplex (version with kind)
-> Updates to unittest. Now includes test for convertWithSemantics

Use the factory class in the FIRBuilder.
Add unit tests for the factory class function and the convert function
of the Complex class.

Reviewed By: clementval, rovka

Differential Revision: https://reviews.llvm.org/D114125

Co-authored-by: Jean Perier <jperier@nvidia.com>
Co-authored-by: Eric Schweitz <eschweitz@nvidia.com>