### PR TITLE
Conditional cycle statement rewriting

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -471,7 +471,8 @@ private:
       bool isCycleStmt = false;
     };
     llvm::SmallVector<T> ifCandidateStack;
-    auto *doStmt = evaluationList.begin()->getIf<parser::NonLabelDoStmt>();
+    const auto *doStmt =
+        evaluationList.begin()->getIf<parser::NonLabelDoStmt>();
     std::string doName = doStmt ? getConstructName(*doStmt) : std::string{};
     for (auto it = evaluationList.begin(), end = evaluationList.end();
          it != end; ++it) {
@@ -483,10 +484,10 @@ private:
       auto firstStmt = [](lower::pft::Evaluation *e) {
         return e->isConstruct() ? &*e->evaluationList->begin() : e;
       };
-      auto &targetEval = *firstStmt(&eval);
+      const auto &targetEval = *firstStmt(&eval);
       bool targetEvalIsEndDoStmt = targetEval.isA<parser::EndDoStmt>();
       auto branchTargetMatch = [&]() {
-        if (auto targetLabel = ifCandidateStack.back().ifTargetLabel)
+        if (const auto targetLabel = ifCandidateStack.back().ifTargetLabel)
           if (targetLabel == *targetEval.label)
             return true; // goto target match
         if (targetEvalIsEndDoStmt && ifCandidateStack.back().isCycleStmt)
@@ -518,11 +519,11 @@ private:
         }
       }
       if (eval.isA<parser::IfConstruct>() && eval.evaluationList->size() == 3) {
-        auto bodyEval = std::next(eval.evaluationList->begin());
-        if (auto *gotoStmt = bodyEval->getIf<parser::GotoStmt>()) {
+        const auto bodyEval = std::next(eval.evaluationList->begin());
+        if (const auto *gotoStmt = bodyEval->getIf<parser::GotoStmt>()) {
           ifCandidateStack.push_back({it, gotoStmt->v});
         } else if (doStmt) {
-          if (auto *cycleStmt = bodyEval->getIf<parser::CycleStmt>()) {
+          if (const auto *cycleStmt = bodyEval->getIf<parser::CycleStmt>()) {
             std::string cycleName = getConstructName(*cycleStmt);
             if (cycleName.empty() || cycleName == doName)
               // This candidate will match doStmt's EndDoStmt.

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -462,13 +462,17 @@ private:
   /// not significant, but could be changed.
   ///
   void rewriteIfGotos() {
+    auto &evaluationList = *evaluationListStack.back();
+    if (!evaluationList.size())
+      return;
     struct T {
       lower::pft::EvaluationList::iterator ifConstructIt;
       parser::Label ifTargetLabel;
       bool isCycleStmt = false;
     };
     llvm::SmallVector<T> ifCandidateStack;
-    auto &evaluationList = *evaluationListStack.back();
+    auto *doStmt = evaluationList.begin()->getIf<parser::NonLabelDoStmt>();
+    std::string doName = doStmt ? getConstructName(*doStmt) : std::string{};
     for (auto it = evaluationList.begin(), end = evaluationList.end();
          it != end; ++it) {
       auto &eval = *it;
@@ -485,16 +489,8 @@ private:
         if (auto targetLabel = ifCandidateStack.back().ifTargetLabel)
           if (targetLabel == *targetEval.label)
             return true; // goto target match
-        if (targetEvalIsEndDoStmt && ifCandidateStack.back().isCycleStmt) {
-          auto cycleName = ifCandidateStack.back().ifConstructIt->visit(
-              [&](const auto &stmt) { return getConstructName(stmt); });
-          if (cycleName.empty())
-            return true; // anonymous cycle target match
-          auto doName = eval.visit(
-              [&](const auto &stmt) { return getConstructName(stmt); });
-          if (cycleName == doName)
-            return true; // named cycle target match
-        }
+        if (targetEvalIsEndDoStmt && ifCandidateStack.back().isCycleStmt)
+          return true; // cycle target match
         return false;
       };
       if (targetEval.label || targetEvalIsEndDoStmt) {
@@ -522,12 +518,17 @@ private:
         }
       }
       if (eval.isA<parser::IfConstruct>() && eval.evaluationList->size() == 3) {
-        if (auto *gotoStmt = std::next(eval.evaluationList->begin())
-                                 ->getIf<parser::GotoStmt>())
+        auto bodyEval = std::next(eval.evaluationList->begin());
+        if (auto *gotoStmt = bodyEval->getIf<parser::GotoStmt>()) {
           ifCandidateStack.push_back({it, gotoStmt->v});
-        else if (std::next(eval.evaluationList->begin())
-                     ->isA<parser::CycleStmt>())
-          ifCandidateStack.push_back({it, {}, true});
+        } else if (doStmt) {
+          if (auto *cycleStmt = bodyEval->getIf<parser::CycleStmt>()) {
+            std::string cycleName = getConstructName(*cycleStmt);
+            if (cycleName.empty() || cycleName == doName)
+              // This candidate will match doStmt's EndDoStmt.
+              ifCandidateStack.push_back({it, {}, true});
+          }
+        }
       }
     }
   }
@@ -659,18 +660,18 @@ private:
         parser::MaskedElsewhereStmt, parser::NonLabelDoStmt,
         parser::SelectCaseStmt, parser::SelectRankCaseStmt,
         parser::TypeGuardStmt, parser::WhereConstructStmt>;
-
     if constexpr (common::HasMember<A, MaybeConstructNameInTuple>) {
       if (auto name = std::get<std::optional<parser::Name>>(stmt.t))
         return name->ToString();
     }
 
-    // These statements have several std::optional<parser::Name>
+    // These statements have multiple std::optional<parser::Name> elements.
     if constexpr (std::is_same_v<A, parser::SelectRankStmt> ||
                   std::is_same_v<A, parser::SelectTypeStmt>) {
       if (auto name = std::get<0>(stmt.t))
         return name->ToString();
     }
+
     return {};
   }
 

--- a/flang/test/Lower/ifconvert.f90
+++ b/flang/test/Lower/ifconvert.f90
@@ -41,43 +41,53 @@
   ! CHECK:   15 PrintStmt: print*
   print*
 
-  ! CHECK:   <<DoConstruct>> -> 25
-  ! CHECK:     16 NonLabelDoStmt -> 24: abc: do i = 1, 5
-  ! CHECK:     <<IfConstruct>> -> 24
-  ! CHECK:       17 ^IfStmt [negate] -> 24: if(i <= 1 .or. i >= 5) cycle abc
-  ! CHECK:       <<IfConstruct>> -> 24
-  ! CHECK:         20 ^IfStmt [negate] -> 24: if(i == 3) goto 3
-  ! CHECK:         23 ^PrintStmt: print*, i
-  ! CHECK:         22 EndIfStmt
-  ! CHECK:       <<End IfConstruct>>
-  ! CHECK:       19 EndIfStmt
-  ! CHECK:     <<End IfConstruct>>
-  ! CHECK:     24 EndDoStmt -> 16: 3 end do abc
-  ! CHECK:   <<End DoConstruct>>
-  abc: do i = 1, 5
-     if (i <= 1 .or. i >= 5) cycle abc
-     if (i == 3) goto 3
-     print*, i
-3 end do abc
+  ! CHECK:<<DoConstruct!>> -> 30
+  ! CHECK:  16 NonLabelDoStmt -> 29: outer: do i = 1, 3
+  ! CHECK:  <<DoConstruct!>> -> 29
+  ! CHECK:    17 ^NonLabelDoStmt -> 28: inner: do j = 1, 5
+  ! CHECK:    <<IfConstruct!>> -> 28
+  ! CHECK:      18 ^IfStmt [negate] -> 28: if(j <= 1 .or. j >= 5) cycle inner
+  ! CHECK:      <<IfConstruct!>> -> 28
+  ! CHECK:        21 ^IfStmt [negate] -> 28: if(j == 3) goto 3
+  ! CHECK:        <<IfConstruct!>> -> 27
+  ! CHECK:          24 ^IfStmt -> 27: if(j == 4) cycle outer
+  ! CHECK:          25 ^CycleStmt! -> 29: cycle outer
+  ! CHECK:          26 EndIfStmt
+  ! CHECK:        <<End IfConstruct!>>
+  ! CHECK:        27 ^PrintStmt: print*, j
+  ! CHECK:        23 EndIfStmt
+  ! CHECK:      <<End IfConstruct!>>
+  ! CHECK:      20 EndIfStmt
+  ! CHECK:    <<End IfConstruct!>>
+  ! CHECK:    28 ^EndDoStmt -> 17: 3 end do inner
+  ! CHECK:  <<End DoConstruct!>>
+  ! CHECK:  29 ^EndDoStmt -> 16: end do outer
+  ! CHECK:<<End DoConstruct!>>
+  outer: do i = 1, 3
+    inner: do j = 1, 5
+             if (j <= 1 .or. j >= 5) cycle inner
+             if (j == 3) goto 3
+             if (j == 4) cycle outer
+             print*, j
+  3        end do inner
+         end do outer
 
-  ! CHECK:   25 PrintStmt: print*
+  ! CHECK:   30 ^PrintStmt: print*
   print*
 
-  ! CHECK:   <<DoConstruct>> -> 35
-  ! CHECK:     26 NonLabelDoStmt -> 34: do i = 1, 5
-  ! CHECK:     <<IfConstruct>> -> 34
-  ! CHECK:       27 ^IfStmt [negate] -> 34: if(i == 3) goto 4
-  ! CHECK:       <<IfConstruct>> -> 34
-  ! CHECK:         30 ^IfStmt [negate] -> 34: if(i <= 1 .or. i >= 5) cycle
-  ! CHECK:         33 ^PrintStmt: print*, i
-  ! CHECK:         32 EndIfStmt
-  ! CHECK:       <<End IfConstruct>>
-  ! CHECK:       29 EndIfStmt
-  ! CHECK:     <<End IfConstruct>>
-  ! CHECK:     34 EndDoStmt -> 26: 4 end do
-  ! CHECK:   <<End DoConstruct>>
-  ! CHECK:   35 EndProgramStmt: end
-  ! CHECK: End Program <anonymous>
+  ! CHECK:<<DoConstruct>> -> 40
+  ! CHECK:  31 NonLabelDoStmt -> 39: do i = 1, 5
+  ! CHECK:  <<IfConstruct>> -> 39
+  ! CHECK:    32 ^IfStmt [negate] -> 39: if(i == 3) goto 4
+  ! CHECK:    <<IfConstruct>> -> 39
+  ! CHECK:      35 ^IfStmt [negate] -> 39: if(i <= 1 .or. i >= 5) cycle
+  ! CHECK:      38 ^PrintStmt: print*, i
+  ! CHECK:      37 EndIfStmt
+  ! CHECK:    <<End IfConstruct>>
+  ! CHECK:    34 EndIfStmt
+  ! CHECK:  <<End IfConstruct>>
+  ! CHECK:  39 EndDoStmt -> 31: 4 end do
+  ! CHECK:<<End DoConstruct>>
   do i = 1, 5
      if (i == 3) goto 4
      if (i <= 1 .or. i >= 5) cycle


### PR DESCRIPTION
When rewriting an "if (cond) cycle [name]" statement as a structured
branch, an initial NonLabelDoStmt at the head of the evaluation list
supplies information to determine in advance if the cycle statement is
a match or not.  So make a cycle statement a rewrite candidate only if
the corresponding EndDoStmt, when visited, is guaranteed to match.