### PR TITLE
Allow passing optional assumed shape or pointers to optional explicit shape

### DIFF
--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -272,6 +272,11 @@ public:
   // TODO: check contiguous attribute of addr
   bool isContiguous() const { return false; }
 
+  // Replace the fir.box, keeping any non-deferred parameters.
+  BoxValue clone(mlir::Value newBox) const {
+    return {newBox, lbounds, explicitParams, extents};
+  }
+
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const BoxValue &);
   LLVM_DUMP_METHOD void dump() const { llvm::errs() << *this; }
 
@@ -347,6 +352,10 @@ public:
   /// Is this an allocatable ?
   bool isAllocatable() const {
     return getBoxTy().getEleTy().isa<fir::HeapType>();
+  }
+  // Replace the fir.ref<fir.box>, keeping any non-deferred parameters.
+  MutableBoxValue clone(mlir::Value newBox) const {
+    return {newBox, lenParams, mutableProperties};
   }
   /// Does this entity has any non deferred length parameters ?
   bool hasNonDeferredLenParams() const { return !lenParams.empty(); }

--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -661,10 +661,15 @@ public:
       return true;
     } else if (semantics::IsPointer(ultimate)) {
       return false;
+    } else if (semantics::IsAllocatable(ultimate)) {
+      // TODO: this could be merged with the case below if
+      // details->IsAssumedShape() did not return true for allocatables. Current
+      // ArraySpec building in semantics does not allow making a difference
+      // between some_assumed_shape(:) and some_allocatable(:). Both
+      // isDeferredShape() and isAssumedShape() are true in each case.
+      return true;
     } else if (const auto *details{
                    ultimate.detailsIf<semantics::ObjectEntityDetails>()}) {
-      // N.B. ALLOCATABLEs are deferred shape, not assumed, and
-      // are obviously contiguous.
       return !details->IsAssumedShape() && !details->IsAssumedRank();
     } else if (auto assoc{Base::operator()(ultimate)}) {
       return assoc;

--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -39,12 +39,6 @@ fir::ExtendedValue fir::substBase(const fir::ExtendedValue &exv,
                                   mlir::Value base) {
   return exv.match(
       [=](const fir::UnboxedValue &x) { return fir::ExtendedValue(base); },
-      [=](const fir::BoxValue &) -> fir::ExtendedValue {
-        llvm::report_fatal_error("TODO: substbase of BoxValue");
-      },
-      [=](const fir::MutableBoxValue &) -> fir::ExtendedValue {
-        llvm::report_fatal_error("TODO: substbase of MutableBoxValue");
-      },
       [=](const auto &x) { return fir::ExtendedValue(x.clone(base)); });
 }
 

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -305,16 +305,16 @@ mlir::Value
 fir::factory::createUnallocatedBox(fir::FirOpBuilder &builder,
                                    mlir::Location loc, mlir::Type boxType,
                                    mlir::ValueRange nonDeferredParams) {
-  auto heapType = boxType.dyn_cast<fir::BoxType>().getEleTy();
-  auto type = fir::dyn_cast_ptrEleTy(heapType);
-  auto eleTy = type;
-  if (auto seqType = eleTy.dyn_cast<fir::SequenceType>())
-    eleTy = seqType.getEleTy();
+  auto baseAddrType = boxType.dyn_cast<fir::BoxType>().getEleTy();
+  if (!fir::isa_ref_type(baseAddrType))
+    baseAddrType = builder.getRefType(baseAddrType);
+  auto type = fir::unwrapRefType(baseAddrType);
+  auto eleTy = fir::unwrapSequenceType(type);
   if (auto recTy = eleTy.dyn_cast<fir::RecordType>())
     if (recTy.getNumLenParams() > 0)
       TODO(loc, "creating unallocated fir.box of derived type with length "
                 "parameters");
-  auto nullAddr = builder.createNullConstant(loc, heapType);
+  auto nullAddr = builder.createNullConstant(loc, baseAddrType);
   mlir::Value shape;
   if (auto seqTy = type.dyn_cast<fir::SequenceType>()) {
     auto zero = builder.createIntegerConstant(loc, builder.getIndexType(), 0);

--- a/flang/test/Evaluate/folding09.f90
+++ b/flang/test/Evaluate/folding09.f90
@@ -9,9 +9,10 @@ module m
     real, pointer, contiguous :: f(:)
     f => hosted
   end function
-  subroutine test(arr1, arr2, arr3, mat)
+  subroutine test(arr1, arr2, arr3, mat, alloc)
     real, intent(in) :: arr1(:), arr2(10), mat(10, 10)
     real, intent(in), contiguous :: arr3(:)
+    real, allocatable :: alloc(:)
     real :: scalar
     logical, parameter :: test_isc01 = is_contiguous(0)
     logical, parameter :: test_isc02 = is_contiguous(scalar)
@@ -24,5 +25,6 @@ module m
     logical, parameter :: test_isc09 = is_contiguous(arr2(1:10:1))
     logical, parameter :: test_isc10 = is_contiguous(arr3)
     logical, parameter :: test_isc11 = is_contiguous(f())
+    logical, parameter :: test_isc12 = is_contiguous(alloc)
   end subroutine
 end module

--- a/flang/test/Lower/call-copy-in-out.f90
+++ b/flang/test/Lower/call-copy-in-out.f90
@@ -90,6 +90,7 @@ subroutine test_parenthesis(x)
 ! CHECK:  fir.call @_QPbar(%[[cast]]) : (!fir.ref<!fir.array<?xf32>>) -> ()
   call bar((x))
 ! CHECK-NOT:  fir.array_merge_store
+! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?xf32>>
 ! CHECK: return
 end subroutine
 
@@ -110,6 +111,7 @@ subroutine test_intent_out(x)
 ! CHECK:  fir.call @_QPbar_intent_out(%[[cast]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
   call bar_intent_out(x)
 ! CHECK:  fir.array_merge_store %{{.*}}, %{{.*}} to %[[x]]
+! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?xf32>>
 ! CHECK: return
 end subroutine
 
@@ -130,6 +132,7 @@ subroutine test_intent_in(x)
 ! CHECK:  fir.call @_QPbar_intent_in(%[[cast]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
   call bar_intent_in(x)
 ! CHECK-NOT:  fir.array_merge_store
+! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?xf32>>
 ! CHECK: return
 end subroutine
 
@@ -150,6 +153,7 @@ subroutine test_intent_inout(x)
 ! CHECK:  fir.call @_QPbar_intent_inout(%[[cast]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
   call bar_intent_inout(x)
 ! CHECK:  fir.array_merge_store %{{.*}}, %{{.*}} to %[[x]]
+! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?xf32>>
 ! CHECK: return
 end subroutine
 

--- a/flang/test/Lower/dummy-argument-optional-2.f90
+++ b/flang/test/Lower/dummy-argument-optional-2.f90
@@ -1,0 +1,427 @@
+! Test passing pointer, allocatables, and optional assumed shapes to optional
+! explicit shapes (see F2018 15.5.2.12).
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+module optional_tests
+implicit none
+interface
+subroutine takes_opt_scalar(i)
+  integer, optional :: i
+end subroutine
+subroutine takes_opt_scalar_char(c)
+  character(*), optional :: c
+end subroutine
+subroutine takes_opt_explicit_shape(x)
+  real, optional :: x(100)
+end subroutine
+subroutine takes_opt_explicit_shape_intentout(x)
+  real, optional, intent(out) :: x(100)
+end subroutine
+subroutine takes_opt_explicit_shape_intentin(x)
+  real, optional, intent(in) :: x(100)
+end subroutine
+subroutine takes_opt_explicit_shape_char(c)
+  character(*), optional :: c(100)
+end subroutine
+function returns_pointer()
+  real, pointer :: returns_pointer(:)
+end function
+end interface
+contains
+
+! -----------------------------------------------------------------------------
+!     Test passing scalar pointers and allocatables to an optional
+! -----------------------------------------------------------------------------
+! Here, nothing optional specific is expected, the address is passed, and its
+! allocation/association status match the dummy presence status.
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_scalar(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>>) {
+subroutine pass_pointer_scalar(i)
+  integer, pointer :: i
+  call takes_opt_scalar(i)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ptr<i32>) -> !fir.ref<i32>
+! CHECK:         fir.call @_QPtakes_opt_scalar(%[[VAL_3]]) : (!fir.ref<i32>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_scalar(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>) {
+subroutine pass_allocatable_scalar(i)
+  integer, allocatable :: i
+  call takes_opt_scalar(i)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<i32>) -> !fir.ref<i32>
+! CHECK:         fir.call @_QPtakes_opt_scalar(%[[VAL_3]]) : (!fir.ref<i32>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_scalar_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) {
+subroutine pass_pointer_scalar_char(c)
+  character(:), pointer :: c
+  call takes_opt_scalar_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.char<1,?>>>) -> index
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.char<1,?>>>) -> !fir.ptr<!fir.char<1,?>>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ptr<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_5:.*]] = fir.emboxchar %[[VAL_4]], %[[VAL_2]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_scalar_char(%[[VAL_5]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_scalar_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) {
+subroutine pass_allocatable_scalar_char(c)
+  character(:), allocatable :: c
+  call takes_opt_scalar_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.heap<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_5:.*]] = fir.emboxchar %[[VAL_4]], %[[VAL_2]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_scalar_char(%[[VAL_5]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test passing non contiguous pointers to explicit shape optional
+! -----------------------------------------------------------------------------
+! The pointer descriptor can be unconditionally read, but the copy-in/copy-out
+! must be conditional on the pointer association status in order to get the
+! correct present/absent aspect.
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_array(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+subroutine pass_pointer_array(i)
+  real, pointer :: i(:)
+  call takes_opt_explicit_shape(i)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.ptr<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ptr<!fir.array<?xf32>>) -> i64
+! CHECK:         %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_9:.*]] = fir.if %[[VAL_5]] -> (!fir.heap<!fir.array<?xf32>>) {
+! CHECK:           %[[VAL_10:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_6]], %[[VAL_10]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_12:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_11]]#1 {uniq_name = ".copyinout"}
+! CHECK:           %[[VAL_20:.*]] = fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_20]] to %[[VAL_12]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_12]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_26:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_26]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+! CHECK:         %[[VAL_29:.*]] = fir.convert %[[VAL_9]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_29]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+! CHECK:         fir.if %[[VAL_5]] {
+! CHECK:           %[[VAL_40:.*]] = fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_40]] to %[[VAL_6]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:           fir.freemem %[[VAL_9]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_array_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) {
+subroutine pass_pointer_array_char(c)
+  character(:), pointer :: c(:)
+  call takes_opt_explicit_shape_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>) -> !fir.ptr<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>) -> i64
+! CHECK:         %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:         %[[VAL_9:.*]] = fir.if %[[VAL_5]] -> (!fir.heap<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK:           %[[VAL_10:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_6]], %[[VAL_10]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_12:.*]] = fir.box_elesize %[[VAL_6]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:           %[[VAL_13:.*]] = fir.allocmem !fir.array<?x!fir.char<1,?>>(%[[VAL_12]] : index), %[[VAL_11]]#1 {uniq_name = ".copyinout"}
+! CHECK:           %[[VAL_21:.*]] = fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_21]] to %[[VAL_13]] typeparams %[[VAL_12]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.heap<!fir.array<?x!fir.char<1,?>>>, index
+! CHECK:           fir.result %[[VAL_13]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_46:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:           fir.result %[[VAL_46]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         }
+! CHECK:         %[[VAL_47:.*]] = fir.box_elesize %[[VAL_6]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:         %[[VAL_50:.*]] = fir.convert %[[VAL_9]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_52:.*]] = fir.emboxchar %[[VAL_50]], %[[VAL_47]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_char(%[[VAL_52]]) : (!fir.boxchar<1>) -> ()
+! CHECK:         fir.if %[[VAL_5]] {
+! CHECK:           %[[VAL_62:.*]] = fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_62]] to %[[VAL_6]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+! CHECK:           fir.freemem %[[VAL_9]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         }
+! CHECK:         return
+! CHECK:       }
+end subroutine
+
+! This case is bit special because the pointer is not a symbol but a function
+! result. Test that the copy-in/copy-out is the same as with normal pointers.
+
+! CHECK-LABEL: func @_QMoptional_testsPforward_pointer_array() {
+subroutine forward_pointer_array()
+  call takes_opt_explicit_shape(returns_pointer())
+! CHECK:         %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xf32>>> {bindc_name = ".result"}
+! CHECK:         %[[VAL_1:.*]] = fir.call @_QPreturns_pointer() : () -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:         fir.save_result %[[VAL_1]] to %[[VAL_0]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.ptr<!fir.array<?xf32>>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ptr<!fir.array<?xf32>>) -> i64
+! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_5]] : i64
+! CHECK:         %[[VAL_7:.*]] = fir.if %[[VAL_6]] -> (!fir.heap<!fir.array<?xf32>>) {
+! CHECK:           %[[VAL_10:.*]] = fir.allocmem !fir.array<?xf32>
+! CHECK:           fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_10]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_11:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_11]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_7]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_14]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+! CHECK:         fir.if %[[VAL_6]] {
+! CHECK:           fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.freemem %[[VAL_7]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+end subroutine
+
+! -----------------------------------------------------------------------------
+!    Test passing assumed shape optional to explicit shape optional
+! -----------------------------------------------------------------------------
+! The fix.box can only be read if the assumed shape is present,
+! and the copy-in/copy-out must also be conditional on the assumed
+! shape presence.
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+subroutine pass_opt_assumed_shape(x)
+  real, optional :: x(:)
+  call takes_opt_explicit_shape(x)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?xf32>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_6:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_5]] : !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_7:.*]] = fir.if %[[VAL_1]] -> (!fir.heap<!fir.array<?xf32>>) {
+! CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_9:.*]]:3 = fir.box_dims %[[VAL_6]], %[[VAL_8]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_10:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_9]]#1 {uniq_name = ".copyinout"}
+! CHECK:           %[[VAL_17:.*]] = fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_17]] to %[[VAL_10]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_10]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_23:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_23]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_27:.*]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_26]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+! CHECK:         fir.if %[[VAL_1]] {
+! CHECK:           %[[VAL_36:.*]] = fir.do_loop {{.*}} { 
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_36]] to %[[VAL_6]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.box<!fir.array<?xf32>>
+! CHECK:           fir.freemem %[[VAL_27]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.optional}) {
+subroutine pass_opt_assumed_shape_char(c)
+  character(*), optional :: c(:)
+  call takes_opt_explicit_shape_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) typeparams %[[VAL_5]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_7:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_6]] : !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_8:.*]] = fir.if %[[VAL_1]] -> (!fir.heap<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK:           %[[VAL_19:.*]] = fir.do_loop  {{.*}} {
+! CHECK:           }
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_19]] to %[[VAL_12]] typeparams %[[VAL_11]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.heap<!fir.array<?x!fir.char<1,?>>>, index
+! CHECK:           fir.result %[[VAL_12]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_44:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:           fir.result %[[VAL_44]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         }
+! CHECK:         %[[VAL_45:.*]] = fir.box_elesize %[[VAL_7]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:         %[[VAL_48:.*]] = fir.convert %[[VAL_49:.*]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_50:.*]] = fir.emboxchar %[[VAL_48]], %[[VAL_45]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_char(%[[VAL_50]]) : (!fir.boxchar<1>) -> ()
+! CHECK:         fir.if %[[VAL_1]] {
+! CHECK:           %[[VAL_59:.*]] = fir.do_loop {{.*}} {
+! CHECK:           fir.array_merge_store %{{.*}}, %[[VAL_59]] to %[[VAL_7]] : !fir.array<?x!fir.char<1,?>>, !fir.array<?x!fir.char<1,?>>, !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:           fir.freemem %[[VAL_49]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         }
+end subroutine
+
+! -----------------------------------------------------------------------------
+!    Test passing contiguous optional assumed shape to explicit shape optional
+! -----------------------------------------------------------------------------
+! The fix.box can only be read if the assumed shape is present.
+! There should be no copy-in/copy-out
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_contiguous_assumed_shape(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.contiguous, fir.optional}) {
+subroutine pass_opt_contiguous_assumed_shape(x)
+  real, optional, contiguous :: x(:)
+  call takes_opt_explicit_shape(x)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?xf32>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_6:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_5]] : !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_7:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_8]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_contiguous_assumed_shape_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.contiguous, fir.optional}) {
+subroutine pass_opt_contiguous_assumed_shape_char(c)
+  character(*), optional, contiguous :: c(:)
+  call takes_opt_explicit_shape_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) typeparams %[[VAL_5]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_7:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_6]] : !fir.box<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_8:.*]] = fir.box_addr %[[VAL_7]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_9:.*]] = fir.box_elesize %[[VAL_7]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_11:.*]] = fir.emboxchar %[[VAL_10]], %[[VAL_9]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_char(%[[VAL_11]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! -----------------------------------------------------------------------------
+!    Test passing allocatables and contiguous pointers to explicit shape optional
+! -----------------------------------------------------------------------------
+! The fix.box can be read and its address directly passed. There should be no
+! copy-in/copy-out.
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_array(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {
+subroutine pass_allocatable_array(i)
+  real, allocatable :: i(:)
+  call takes_opt_explicit_shape(i)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_3]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_array_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) {
+subroutine pass_allocatable_array_char(c)
+  character(:), allocatable :: c(:)
+  call takes_opt_explicit_shape_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_5:.*]] = fir.emboxchar %[[VAL_4]], %[[VAL_2]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_char(%[[VAL_5]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_contiguous_pointer_array(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.contiguous}) {
+subroutine pass_contiguous_pointer_array(i)
+  real, pointer, contiguous :: i(:)
+  call takes_opt_explicit_shape(i)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.ptr<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ptr<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape(%[[VAL_3]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_contiguous_pointer_array_char(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>> {fir.contiguous}) {
+subroutine pass_contiguous_pointer_array_char(c)
+  character(:), pointer, contiguous :: c(:)
+  call takes_opt_explicit_shape_char(c)
+! CHECK:         %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:         %[[VAL_2:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>) -> !fir.ptr<!fir.array<?x!fir.char<1,?>>>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ptr<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_5:.*]] = fir.emboxchar %[[VAL_4]], %[[VAL_2]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_char(%[[VAL_5]]) : (!fir.boxchar<1>) -> ()
+end subroutine
+
+! -----------------------------------------------------------------------------
+!    Test passing assumed shape optional to explicit shape optional with intents
+! -----------------------------------------------------------------------------
+! The fix.box can only be read if the assumed shape is present,
+! and the copy-in/copy-out must also be conditional on the assumed
+! shape presence. For intent(in), there should be no copy-out while for
+! intent(out), there should be no copy-in.
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_to_intentin(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+subroutine pass_opt_assumed_shape_to_intentin(x)
+  real, optional :: x(:)
+  call takes_opt_explicit_shape_intentin(x)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?xf32>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_6:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_5]] : !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_7:.*]] = fir.if %[[VAL_1]] -> (!fir.heap<!fir.array<?xf32>>) {
+! CHECK:           %[[VAL_10:.*]] = fir.allocmem !fir.array<?xf32>
+! CHECK:           fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_10]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_23:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_23]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+! CHECK:         %[[VAL_24:.*]] = fir.convert %[[VAL_7]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_intentin(%[[VAL_24]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+! CHECK:         fir.if %[[VAL_1]] {
+! CHECK-NOT:       fir.do_loop
+! CHECK:           fir.freemem %[[VAL_7]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+end subroutine
+
+! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_to_intentout(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+subroutine pass_opt_assumed_shape_to_intentout(x)
+  real, optional :: x(:)
+  call takes_opt_explicit_shape_intentout(x)
+! CHECK:         %[[VAL_1:.*]] = fir.is_present %[[VAL_0]] : (!fir.box<!fir.array<?xf32>>) -> i1
+! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ref<!fir.array<?xf32>>
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_2]](%[[VAL_4]]) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_6:.*]] = select %[[VAL_1]], %[[VAL_0]], %[[VAL_5]] : !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_7:.*]] = fir.if %[[VAL_1]] -> (!fir.heap<!fir.array<?xf32>>) {
+! CHECK:           %[[VAL_10:.*]] = fir.allocmem !fir.array<?xf32>
+! CHECK-NOT:       fir.do_loop
+! CHECK:           fir.result %[[VAL_10]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         } else {
+! CHECK:           %[[VAL_11:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.result %[[VAL_11]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_7]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
+! CHECK:         fir.call @_QPtakes_opt_explicit_shape_intentout(%[[VAL_14]]) : (!fir.ref<!fir.array<100xf32>>) -> ()
+! CHECK:         fir.if %[[VAL_1]] {
+! CHECK:           fir.do_loop {{.*}} {
+! CHECK:           }
+! CHECK:           fir.freemem %[[VAL_7]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         }
+end subroutine
+end module
+


### PR DESCRIPTION
Passing assumed shapes and pointers to explicit shape requires
copy-in/copy-out. This was already implemented, but did not account for
the fact the argument may be optional, in which case:

- If the argument is itself an optional, care must be taken to only
  read its descriptors if it is present. The copy-in/copy-out must
  be conditional on its presence.

- If the argument is a pointer, its descriptor can be read, but care
  must be taken not to allocate and pass a zero sized temp if it is
  un-allocated because it is fine to pass a disassociated pointer to
  a non-pointer optional argument, and the passed argument must be
  absent in this case. This point also applies to allocatables,
  although these are not problematic since they are contiguous and
  no copy-in/copy-out is done.

While writing the tests, it appeared allocatables were getting copied-in/copied-out. The root cause was found in semantics and a fix for it is part of this patch in its own commit that will be up-streamed directly to LLVM.