### PR TITLE
[flang][driver] Fix the runtime library order

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -546,13 +546,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     ToolChain.addFastMathRuntimeIfAvailable(Args, CmdArgs);
   }
 
-  if (D.IsFlangMode()) {
-    CmdArgs.push_back("-lFortran_main");
-    CmdArgs.push_back("-lFortranRuntime");
-    CmdArgs.push_back("-lFortranDecimal");
-    CmdArgs.push_back("-lm");
-  }
-
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   Args.AddAllArgs(CmdArgs, options::OPT_u);
 
@@ -571,6 +564,15 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   bool NeedsXRayDeps = addXRayRuntime(ToolChain, Args, CmdArgs);
   addLinkerCompressDebugSectionsOption(ToolChain, Args, CmdArgs);
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);
+
+  if (D.IsFlangMode()) {
+    CmdArgs.push_back("-lFortran_main");
+    CmdArgs.push_back("-lFortranRuntime");
+    CmdArgs.push_back("-lFortranDecimal");
+    CmdArgs.push_back("-lFortranRuntime");
+    CmdArgs.push_back("-lm");
+  }
+
   // The profile runtime also needs access to system libraries.
   getToolChain().addProfileRTLibs(Args, CmdArgs);
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -569,7 +569,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-lFortran_main");
     CmdArgs.push_back("-lFortranRuntime");
     CmdArgs.push_back("-lFortranDecimal");
-    CmdArgs.push_back("-lFortranRuntime");
     CmdArgs.push_back("-lm");
   }
 

--- a/flang/test/Driver/flang-linker-flags.f90
+++ b/flang/test/Driver/flang-linker-flags.f90
@@ -10,7 +10,13 @@
 
 ! RUN: %flang -### --ld-path=/usr/bin/ld %S/Inputs/hello.f90 2>&1 | FileCheck %s
 
-! CHECK-LABEL:  /usr/bin/ld
+! Compiler invocation to generate the object file
+! CHECK-LABEL: {{.*}} "-emit-obj"
+! CHECK-SAME:  "-o" "[[object_file:.*]]" {{.*}}Inputs/hello.f90
+
+! Linker invocation to generate the executable
+! CHECK-LABEL:  "/usr/bin/ld"
+! CHECK-SAME: "[[object_file]]"
 ! CHECK-SAME: -lFortran_main
 ! CHECK-SAME: -lFortranRuntime
 ! CHECK-SAME: -lFortranDecimal


### PR DESCRIPTION
This patch makes sure that in the generated linker invocation, the input
object file, temp.o, is listed before the runtime libs:
```
ld temp.o -lFortran_main -lFortranRuntime -lFortranDecimal -lm -o a.out
```

Currently the following incorrect invocation is generated:
```
ld -lFortran_main -lFortranRuntime -lFortranDecimal -lm temp.o -o a.out
```