### PR TITLE
Move select-case and io option temp clean-ups at the right place

### DIFF
--- a/flang/test/Lower/io-statement-clean-ups.f90
+++ b/flang/test/Lower/io-statement-clean-ups.f90
@@ -1,0 +1,43 @@
+! Test that any temps generated for IO options are deallocated at the right
+! time (after they are used, but before exiting the block where they were
+! created).
+! RUN: bbc -emit-fir -o - %s | FileCheck %s
+
+! CHECK-LABEL: func @_QPtest_temp_io_options(
+! CHECK-SAME:   %[[VAL_0:.*]]: !fir.ref<i32>) {
+subroutine test_temp_io_options(status)
+  interface
+    function gen_temp_character()
+      character(:), allocatable :: gen_temp_character
+    end function
+  end interface
+  integer :: status
+  open (10, encoding=gen_temp_character(), file=gen_temp_character(), pad=gen_temp_character(), iostat=status)
+! CHECK:  %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:  %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:  %[[VAL_3:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:  fir.call @_FortranAioBeginOpenUnit
+! CHECK:  %[[VAL_15:.*]] = fir.call @_QPgen_temp_character() : () -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:  fir.save_result %[[VAL_15]] to %[[VAL_3]] : !fir.box<!fir.heap<!fir.char<1,?>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:  %[[VAL_21:.*]] = fir.call @_FortranAioSetEncoding
+! CHECK:  %[[VAL_22:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:  %[[VAL_23:.*]] = fir.box_addr %[[VAL_22]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:  fir.freemem %[[VAL_23]] : !fir.heap<!fir.char<1,?>>
+! CHECK:  fir.if %[[VAL_21]] {
+! CHECK:    %[[VAL_27:.*]] = fir.call @_QPgen_temp_character() : () -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:    fir.save_result %[[VAL_27]] to %[[VAL_2]] : !fir.box<!fir.heap<!fir.char<1,?>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:    %[[VAL_33:.*]] = fir.call @_FortranAioSetFile
+! CHECK:    %[[VAL_34:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:    %[[VAL_35:.*]] = fir.box_addr %[[VAL_34]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:    fir.freemem %[[VAL_35]] : !fir.heap<!fir.char<1,?>>
+! CHECK:    fir.if %[[VAL_33]] {
+! CHECK:      %[[VAL_39:.*]] = fir.call @_QPgen_temp_character() : () -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:      fir.save_result %[[VAL_39]] to %[[VAL_1]] : !fir.box<!fir.heap<!fir.char<1,?>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:      fir.call @_FortranAioSetPad
+! CHECK:      %[[VAL_46:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:      %[[VAL_47:.*]] = fir.box_addr %[[VAL_46]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:      fir.freemem %[[VAL_47]] : !fir.heap<!fir.char<1,?>>
+! CHECK:    }
+! CHECK:  }
+! CHECK:  fir.call @_FortranAioEndIoStatement
+end subroutine


### PR DESCRIPTION
Both Select-Case and IO options lowering lowers character expressions
that may be temp and generates control flow. This requires care
to not deallocate the character temp before it is used and to not
deallocate it after the if/block region where it lives.

For Select case, finalize the statement context in the construct
exit block to ensure it is still alive in the blocks where it is
used in character compare.

For IO options, add a statement context argument to `lowerStringLit`
so that the temp can survive until it is used. However, remove
the StatementContext threading from genIOOptions since the temp
won't be used afterwards and the code above genIOOptions may generates
if-then regions that makes temp clean-up outside of the region where
it lives an error.