### PR TITLE
[flang] Make `bbc`, `tco` and `flang-new` share pass pipeline creation

### DIFF
--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -70,6 +70,37 @@ inline void addCSE(mlir::PassManager &pm) {
       pm, disableFirCse, fir::createCSEPass);
 }
 
+/// Create a basic pass pipeline for simplyfing the FIR dialect
+///
+/// \param pm - MLIR pass manager that will hold the pipeline definition
+inline void createBasicFirPassPipeline(mlir::PassManager &pm)
+{
+  // simplify the IR
+  fir::addCSE(pm);
+  pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
+  pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  fir::addCSE(pm);
+  // The default inliner pass adds the canonicalizer pass with the default
+  // configuration. Create the inliner pass with tco config.
+  llvm::StringMap<mlir::OpPassManager> pipelines;
+  pm.addPass(
+      mlir::createInlinerPass(pipelines, defaultFlangInlinerOptPipeline));
+  pm.addPass(mlir::createCSEPass());
+
+  // convert control flow to CFG form
+  fir::addCfgConversionPass(pm);
+  pm.addNestedPass<mlir::FuncOp>(fir::createControlFlowLoweringPass());
+  pm.addPass(mlir::createLowerToCFGPass());
+
+  mlir::GreedyRewriteConfig config;
+  config.enableRegionSimplification = false;
+  pm.addPass(mlir::createCanonicalizerPass(config));
+  pm.addPass(fir::createSimplifyRegionLitePass());
+  fir::addCSE(pm);
+}
+
+
 #if !defined(FLANG_EXCLUDE_CODEGEN)
 inline void addCodeGenRewritePass(mlir::PassManager &pm) {
   addPassConditionally(
@@ -92,35 +123,8 @@ inline void addLLVMDialectToLLVMPass(
       [&]() { return fir::createLLVMDialectToLLVMPass(output); });
 }
 
-/// Create a pass pipeline for lowering from MLIR to LLVM IR
-///
-/// \param pm - MLIR pass manager that will hold the pipeline definition
-inline void createMLIRToLLVMPassPipeline(mlir::PassManager &pm)
+inline void addCodeGenPasses(mlir::PassManager &pm)
 {
-  // simplify the IR
-  mlir::GreedyRewriteConfig config;
-  config.enableRegionSimplification = false;
-  fir::addCSE(pm);
-  pm.addNestedPass<mlir::FuncOp>(fir::createArrayValueCopyPass());
-  pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
-  pm.addPass(mlir::createCanonicalizerPass(config));
-  fir::addCSE(pm);
-  // The default inliner pass adds the canonicalizer pass with the default
-  // configuration. Create the inliner pass with tco config.
-  llvm::StringMap<mlir::OpPassManager> pipelines;
-  pm.addPass(
-      mlir::createInlinerPass(pipelines, defaultFlangInlinerOptPipeline));
-  pm.addPass(mlir::createCSEPass());
-
-  // convert control flow to CFG form
-  fir::addCfgConversionPass(pm);
-  pm.addNestedPass<mlir::FuncOp>(fir::createControlFlowLoweringPass());
-  pm.addPass(mlir::createLowerToCFGPass());
-
-  pm.addPass(mlir::createCanonicalizerPass(config));
-  pm.addPass(fir::createSimplifyRegionLitePass());
-  fir::addCSE(pm);
-
   pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
   fir::addCodeGenRewritePass(pm);
   fir::addTargetRewritePass(pm);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -465,7 +465,8 @@ void CodeGenAction::GenerateLLVMIR() {
   mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
   // Create the pass pipeline
-  fir::createMLIRToLLVMPassPipeline(pm);
+  fir::createBasicFirPassPipeline(pm);
+  fir::addCodeGenPasses(pm);
 
   // Run the pass manager
   if (!mlir::succeeded(pm.run(mlirMod))) {

--- a/flang/test/Driver/emit-llvm-2.f90
+++ b/flang/test/Driver/emit-llvm-2.f90
@@ -1,0 +1,17 @@
+! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s
+
+! Extracted from: https://github.com/flang-compiler/f18-llvm-project/issues/1280
+
+! CHECK: ; ModuleID = 'FIRModule'
+
+MODULE test_module
+    REAL(8_4), ALLOCATABLE, DIMENSION(:) :: mu
+    CONTAINS
+    SUBROUTINE test_subr ( istat )
+
+        INTEGER(4_4), INTENT(INOUT) :: istat
+        IF ( istat > 0 ) RETURN
+        w = zero
+
+    END SUBROUTINE test_subr
+END MODULE test_module

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -112,7 +112,8 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
       return mlir::failure();
     });
   } else {
-    fir::createMLIRToLLVMPassPipeline(pm);
+    fir::createBasicFirPassPipeline(pm);
+    fir::addCodeGenPasses(pm);
     fir::addLLVMDialectToLLVMPass(pm, out.os());
   }
 


### PR DESCRIPTION
As noted in [1], after [2] `flang-new -fc1 -emit-llvm` started failing
for a sample input source file. That's because a pass pipeline for
simplifying FIR was modified inconsistently in `bbc` and in
CLOptions.inc. This patch fixes that inconsistency and makes sure that
`bbc`, `tco` and `flang-new` share the code for generating pass
pipelines.

In summary:
* `createMLIRToLLVMPassPipeline` is reduced and renamed as
  `createBasicFirPassPipeline` (so that it can be shared with `bbc`)
* passes for generating code from `createMLIRToLLVMPassPipeline` are
  extracted into `addCodeGenPasses` (only to be used in `tco` and
  `flang-new`)
* the pass pipeline in `bbc` is not changed, the pass pipelines in `tco`
  and `flang-new` are made consistent with `bbc`

[1] https://github.com/flang-compiler/f18-llvm-project/issues/1280
[2] https://github.com/flang-compiler/f18-llvm-project/pull/1126