### PR TITLE
Sync after upstreaming builder/runtime #1

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Assign.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Assign.h
@@ -1,4 +1,4 @@
-//===-- Assign.h - generate assignment runtime API calls     ----*- C++ -*-===//
+//===-- Assign.h - generate assignment runtime API calls --------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -28,7 +28,7 @@
 
 // Incomplete type indicating C99 complex ABI in interfaces. Beware, _Complex
 // and std::complex are layout compatible, but not compatible in all ABI call
-// interface (e.g. X86 32 bits). _Complex is not standard C++, so do not use
+// interfaces (e.g. X86 32 bits). _Complex is not standard C++, so do not use
 // it here.
 struct c_float_complex_t;
 struct c_double_complex_t;
@@ -108,14 +108,15 @@ constexpr TypeBuilderFunc getModel<signed char>() {
 template <>
 constexpr TypeBuilderFunc getModel<void *>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return fir::LLVMPointerType::get(mlir::IntegerType::get(context, 8));
+    return fir::LLVMPointerType::get(context,
+                                     mlir::IntegerType::get(context, 8));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<void **>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
     return fir::ReferenceType::get(
-        fir::LLVMPointerType::get(mlir::IntegerType::get(context, 8)));
+        fir::LLVMPointerType::get(context, mlir::IntegerType::get(context, 8)));
   };
 }
 template <>
@@ -138,7 +139,7 @@ constexpr TypeBuilderFunc getModel<long *>() {
 template <>
 constexpr TypeBuilderFunc getModel<long long>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, 8 * sizeof(std::size_t));
+    return mlir::IntegerType::get(context, 8 * sizeof(long long));
   };
 }
 template <>
@@ -346,33 +347,47 @@ struct RuntimeTableEntry<RuntimeTableKey<KT>, RuntimeIdentifier<Cs...>> {
   static constexpr const char name[sizeof...(Cs) + 1] = {Cs..., '\0'};
 };
 
-#undef E
-#define E(L, I) (I < sizeof(L) / sizeof(*L) ? L[I] : 0)
-#define QuoteKey(X) #X
-#define ExpandAndQuoteKey(X) QuoteKey(X)
-#define MacroExpandKey(X)                                                      \
-  E(X, 0), E(X, 1), E(X, 2), E(X, 3), E(X, 4), E(X, 5), E(X, 6), E(X, 7),      \
-      E(X, 8), E(X, 9), E(X, 10), E(X, 11), E(X, 12), E(X, 13), E(X, 14),      \
-      E(X, 15), E(X, 16), E(X, 17), E(X, 18), E(X, 19), E(X, 20), E(X, 21),    \
-      E(X, 22), E(X, 23), E(X, 24), E(X, 25), E(X, 26), E(X, 27), E(X, 28),    \
-      E(X, 29), E(X, 30), E(X, 31), E(X, 32), E(X, 33), E(X, 34), E(X, 35),    \
-      E(X, 36), E(X, 37), E(X, 38), E(X, 39), E(X, 40), E(X, 41), E(X, 42),    \
-      E(X, 43), E(X, 44), E(X, 45), E(X, 46), E(X, 47), E(X, 48), E(X, 49)
-#define ExpandKey(X) MacroExpandKey(QuoteKey(X))
-#define FullSeq(X) std::integer_sequence<char, ExpandKey(X)>
-#define AsSequence(X) decltype(fir::runtime::details::filter(FullSeq(X){}))
+/// These macros are used to create the RuntimeTableEntry for runtime function.
+///
+/// For example the runtime function `SumReal4` will be expanded as shown below
+/// (simplified version)
+///
+/// ```
+/// fir::runtime::RuntimeTableEntry<fir::runtime::RuntimeTableKey<
+///     decltype(_FortranASumReal4)>, "_FortranASumReal4"))>
+/// ```
+/// These entries are then used to to generate the MLIR FunctionType that
+/// correspond to the runtime function declaration in C++.
+#undef FirE
+#define FirE(L, I) (I < sizeof(L) / sizeof(*L) ? L[I] : 0)
+#define FirQuoteKey(X) #X
+#define ExpandAndQuoteKey(X) FirQuoteKey(X)
+#define FirMacroExpandKey(X)                                                   \
+  FirE(X, 0), FirE(X, 1), FirE(X, 2), FirE(X, 3), FirE(X, 4), FirE(X, 5),      \
+      FirE(X, 6), FirE(X, 7), FirE(X, 8), FirE(X, 9), FirE(X, 10),             \
+      FirE(X, 11), FirE(X, 12), FirE(X, 13), FirE(X, 14), FirE(X, 15),         \
+      FirE(X, 16), FirE(X, 17), FirE(X, 18), FirE(X, 19), FirE(X, 20),         \
+      FirE(X, 21), FirE(X, 22), FirE(X, 23), FirE(X, 24), FirE(X, 25),         \
+      FirE(X, 26), FirE(X, 27), FirE(X, 28), FirE(X, 29), FirE(X, 30),         \
+      FirE(X, 31), FirE(X, 32), FirE(X, 33), FirE(X, 34), FirE(X, 35),         \
+      FirE(X, 36), FirE(X, 37), FirE(X, 38), FirE(X, 39), FirE(X, 40),         \
+      FirE(X, 41), FirE(X, 42), FirE(X, 43), FirE(X, 44), FirE(X, 45),         \
+      FirE(X, 46), FirE(X, 47), FirE(X, 48), FirE(X, 49)
+#define FirExpandKey(X) FirMacroExpandKey(FirQuoteKey(X))
+#define FirFullSeq(X) std::integer_sequence<char, FirExpandKey(X)>
+#define FirAsSequence(X)                                                       \
+  decltype(fir::runtime::details::filter(FirFullSeq(X){}))
 #define mkKey(X)                                                               \
   fir::runtime::RuntimeTableEntry<fir::runtime::RuntimeTableKey<decltype(X)>,  \
-                                  AsSequence(X)>
+                                  FirAsSequence(X)>
 #define mkRTKey(X) mkKey(RTNAME(X))
 
 /// Get (or generate) the MLIR FuncOp for a given runtime function. Its template
-/// argument is intended to be of the form: <mkRTKey(runtime function name)>
-/// Clients should add "using namespace Fortran::runtime"
-/// in order to use this function.
+/// argument is intended to be of the form: <mkRTKey(runtime function name)>.
 template <typename RuntimeEntry>
 static mlir::FuncOp getRuntimeFunc(mlir::Location loc,
                                    fir::FirOpBuilder &builder) {
+  using namespace Fortran::runtime;
   auto name = RuntimeEntry::name;
   auto func = builder.getNamedFunction(name);
   if (func)

--- a/flang/unittests/Optimizer/Builder/Runtime/AssignTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/AssignTest.cpp
@@ -1,0 +1,21 @@
+//===- AssignTest.cpp -- assignment runtime builder unit tests ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/Runtime/Assign.h"
+#include "RuntimeCallTestBase.h"
+#include "gtest/gtest.h"
+
+TEST_F(RuntimeCallTest, genDerivedTypeAssign) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value dest = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genAssign(*firBuilder, loc, dest, source);
+  checkCallOpFromResultBox(dest, "_FortranAAssign", 2);
+}

--- a/flang/unittests/Optimizer/Builder/Runtime/RuntimeCallTestBase.h
+++ b/flang/unittests/Optimizer/Builder/Runtime/RuntimeCallTestBase.h
@@ -1,0 +1,118 @@
+//===- RuntimeCallTestBase.cpp -- Base for runtime call generation tests --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_BUILDER_RUNTIME_RUNTIMECALLTESTBASE_H
+#define FORTRAN_OPTIMIZER_BUILDER_RUNTIME_RUNTIMECALLTESTBASE_H
+
+#include "gtest/gtest.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Support/InitFIR.h"
+#include "flang/Optimizer/Support/KindMapping.h"
+
+struct RuntimeCallTest : public testing::Test {
+public:
+  void SetUp() override {
+    mlir::OpBuilder builder(&context);
+    auto loc = builder.getUnknownLoc();
+
+    // Set up a Module with a dummy function operation inside.
+    // Set the insertion point in the function entry block.
+    mlir::ModuleOp mod = builder.create<mlir::ModuleOp>(loc);
+    mlir::FuncOp func = mlir::FuncOp::create(loc, "runtime_unit_tests_func",
+        builder.getFunctionType(llvm::None, llvm::None));
+    auto *entryBlock = func.addEntryBlock();
+    mod.push_back(mod);
+    builder.setInsertionPointToStart(entryBlock);
+
+    fir::support::loadDialects(context);
+    kindMap = std::make_unique<fir::KindMapping>(&context);
+    firBuilder = std::make_unique<fir::FirOpBuilder>(mod, *kindMap);
+
+    i8Ty = firBuilder->getI8Type();
+    i16Ty = firBuilder->getIntegerType(16);
+    i32Ty = firBuilder->getI32Type();
+    i64Ty = firBuilder->getI64Type();
+    i128Ty = firBuilder->getIntegerType(128);
+
+    f32Ty = firBuilder->getF32Type();
+    f64Ty = firBuilder->getF64Type();
+    f80Ty = firBuilder->getF80Type();
+    f128Ty = firBuilder->getF128Type();
+
+    c4Ty = fir::ComplexType::get(firBuilder->getContext(), 4);
+    c8Ty = fir::ComplexType::get(firBuilder->getContext(), 8);
+    c10Ty = fir::ComplexType::get(firBuilder->getContext(), 10);
+    c16Ty = fir::ComplexType::get(firBuilder->getContext(), 16);
+  }
+
+  mlir::MLIRContext context;
+  std::unique_ptr<fir::KindMapping> kindMap;
+  std::unique_ptr<fir::FirOpBuilder> firBuilder;
+
+  // Commonly used types
+  mlir::Type i8Ty;
+  mlir::Type i16Ty;
+  mlir::Type i32Ty;
+  mlir::Type i64Ty;
+  mlir::Type i128Ty;
+  mlir::Type f32Ty;
+  mlir::Type f64Ty;
+  mlir::Type f80Ty;
+  mlir::Type f128Ty;
+  mlir::Type c4Ty;
+  mlir::Type c8Ty;
+  mlir::Type c10Ty;
+  mlir::Type c16Ty;
+};
+
+/// Check that the \p op is a `fir::CallOp` operation and its name matches
+/// \p fctName and the number of arguments is equal to \p nbArgs.
+/// Most runtime calls have two additional location arguments added. These are
+/// added in this check when \p addLocArgs is true.
+static void checkCallOp(mlir::Operation *op, llvm::StringRef fctName,
+    unsigned nbArgs, bool addLocArgs = true) {
+  EXPECT_TRUE(mlir::isa<fir::CallOp>(*op));
+  auto callOp = mlir::dyn_cast<fir::CallOp>(*op);
+  EXPECT_TRUE(callOp.callee().hasValue());
+  mlir::SymbolRefAttr callee = *callOp.callee();
+  EXPECT_EQ(fctName, callee.getRootReference().getValue());
+  // sourceFile and sourceLine are added arguments.
+  if (addLocArgs)
+    nbArgs += 2;
+  EXPECT_EQ(nbArgs, callOp.args().size());
+}
+
+/// Check the call operation from the \p result value. In some cases the
+/// value is directly used in the call and sometimes there is an indirection
+/// through a `fir.convert` operation. Once the `fir.call` operation is
+/// retrieved the check is made by `checkCallOp`.
+///
+/// Directly used in `fir.call`.
+/// ```
+/// %result = arith.constant 1 : i32
+/// %0 = fir.call @foo(%result) : (i32) -> i1
+/// ```
+///
+/// Value used in `fir.call` through `fir.convert` indirection.
+/// ```
+/// %result = arith.constant 1 : i32
+/// %arg = fir.convert %result : (i32) -> i16
+/// %0 = fir.call @foo(%arg) : (i16) -> i1
+/// ```
+static void checkCallOpFromResultBox(mlir::Value result,
+    llvm::StringRef fctName, unsigned nbArgs, bool addLocArgs = true) {
+  EXPECT_TRUE(result.hasOneUse());
+  const auto &u = result.user_begin();
+  if (mlir::isa<fir::CallOp>(*u))
+    return checkCallOp(*u, fctName, nbArgs, addLocArgs);
+  auto convOp = mlir::dyn_cast<fir::ConvertOp>(*u);
+  EXPECT_NE(nullptr, convOp);
+  checkCallOpFromResultBox(convOp.getResult(), fctName, nbArgs, addLocArgs);
+}
+
+#endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_RUNTIMECALLTESTBASE_H

--- a/flang/unittests/Optimizer/Builder/Runtime/TransformationalTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/TransformationalTest.cpp
@@ -1,0 +1,129 @@
+//===- TransformationalTest.cpp -- Transformational intrinsic generation --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/Runtime/Transformational.h"
+#include "RuntimeCallTestBase.h"
+#include "gtest/gtest.h"
+
+TEST_F(RuntimeCallTest, genCshiftTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genCshift(*firBuilder, loc, result, array, shift, dim);
+  checkCallOpFromResultBox(result, "_FortranACshift", 4);
+}
+
+TEST_F(RuntimeCallTest, genCshiftVectorTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genCshiftVector(*firBuilder, loc, result, array, shift);
+  checkCallOpFromResultBox(result, "_FortranACshiftVector", 3);
+}
+
+TEST_F(RuntimeCallTest, genEoshiftTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value bound = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genEoshift(*firBuilder, loc, result, array, shift, bound, dim);
+  checkCallOpFromResultBox(result, "_FortranAEoshift", 5);
+}
+
+TEST_F(RuntimeCallTest, genEoshiftVectorTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value bound = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genEoshiftVector(*firBuilder, loc, result, array, shift, bound);
+  checkCallOpFromResultBox(result, "_FortranAEoshiftVector", 4);
+}
+
+TEST_F(RuntimeCallTest, genMatmulTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value matrixA = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value matrixB = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genMatmul(*firBuilder, loc, matrixA, matrixB, result);
+  checkCallOpFromResultBox(result, "_FortranAMatmul", 3);
+}
+
+TEST_F(RuntimeCallTest, genPackTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value vector = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genPack(*firBuilder, loc, result, array, mask, vector);
+  checkCallOpFromResultBox(result, "_FortranAPack", 4);
+}
+
+TEST_F(RuntimeCallTest, genReshapeTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value shape = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value pad = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value order = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genReshape(*firBuilder, loc, result, source, shape, pad, order);
+  checkCallOpFromResultBox(result, "_FortranAReshape", 5);
+}
+
+TEST_F(RuntimeCallTest, genSpreadTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value ncopies = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genSpread(*firBuilder, loc, result, source, dim, ncopies);
+  checkCallOpFromResultBox(result, "_FortranASpread", 4);
+}
+
+TEST_F(RuntimeCallTest, genTransposeTest) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genTranspose(*firBuilder, loc, result, source);
+  checkCallOpFromResultBox(result, "_FortranATranspose", 2);
+}
+
+TEST_F(RuntimeCallTest, genUnpack) {
+  auto loc = firBuilder->getUnknownLoc();
+  mlir::Type seqTy =
+      fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
+  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value vector = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value field = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  fir::runtime::genUnpack(*firBuilder, loc, result, vector, mask, field);
+  checkCallOpFromResultBox(result, "_FortranAUnpack", 4);
+}

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -13,6 +13,8 @@ add_flang_unittest(FlangOptimizerTests
   Builder/ComplexTest.cpp
   Builder/DoLoopHelperTest.cpp
   Builder/FIRBuilderTest.cpp
+  Builder/Runtime/AssignTest.cpp
+  Builder/Runtime/TransformationalTest.cpp
   FIRContextTest.cpp
   InternalNamesTest.cpp
   KindMappingTest.cpp


### PR DESCRIPTION
Sync back after upstreaming of the following patches:

https://reviews.llvm.org/D114557
https://reviews.llvm.org/D114475
https://reviews.llvm.org/D114470

It mainly adds unittests used to upstream the files and some minor updates. 