### PR TITLE
Use undef when extent of array is non-constant or simply undefined (r…

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Array.h
+++ b/flang/include/flang/Optimizer/Builder/Array.h
@@ -1,0 +1,27 @@
+//===-- Array.h -------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_BUILDER_ARRAY_H
+#define FORTRAN_OPTIMIZER_BUILDER_ARRAY_H
+
+#include "flang/Optimizer/Dialect/FIROps.h"
+
+namespace fir::factory {
+
+/// Return true if and only if the extents are those of an assumed-size array.
+/// An assumed-size array in Fortran is declared with `*` as the upper bound of
+/// the last dimension of the array. Lowering converts the asterisk to an
+/// undefined value.
+inline bool isAssumedSize(const llvm::SmallVectorImpl<mlir::Value> &extents) {
+  return !extents.empty() &&
+         mlir::isa_and_nonnull<UndefOp>(extents.back().getDefiningOp());
+}
+
+} // namespace fir::factory
+
+#endif // FORTRAN_OPTIMIZER_BUILDER_ARRAY_H

--- a/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
+++ b/flang/lib/Optimizer/Transforms/ArrayValueCopy.cpp
@@ -8,6 +8,7 @@
 
 #include "PassDetail.h"
 #include "flang/Lower/Todo.h" // delete!
+#include "flang/Optimizer/Builder/Array.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
@@ -134,7 +135,7 @@ public:
   // dominance information to find the array_access ops or by scanning the
   // transitive closure of the amending array_access's users and the defs that
   // reach them.
-  void collectAccesses(llvm::SmallVector<fir::ArrayAccessOp> &result,
+  void collectAccesses(llvm::SmallVector<ArrayAccessOp> &result,
                        mlir::Block *block) {
     for (auto &op : *block) {
       if (auto access = mlir::dyn_cast<ArrayAccessOp>(op)) {
@@ -554,7 +555,7 @@ conservativeCallConflict(llvm::ArrayRef<mlir::Operation *> reaches) {
       if (auto callee =
               call.getCallableForCallee().dyn_cast<mlir::SymbolRefAttr>()) {
         auto module = op->getParentOfType<mlir::ModuleOp>();
-        return fir::hasHostAssociationArgument(
+        return hasHostAssociationArgument(
             module.lookupSymbol<mlir::FuncOp>(callee));
       }
     return false;
@@ -657,49 +658,69 @@ static mlir::Type getEleTy(mlir::Type ty) {
 }
 
 // Extract extents from the ShapeOp/ShapeShiftOp into the result vector.
-static void getExtents(llvm::SmallVectorImpl<mlir::Value> &result,
-                       mlir::Value shape) {
+static bool getAdjustedExtents(mlir::Location loc,
+                               mlir::PatternRewriter &rewriter,
+                               ArrayLoadOp arrLoad,
+                               llvm::SmallVectorImpl<mlir::Value> &result,
+                               mlir::Value shape) {
+  bool copyUsingSlice = false;
   auto *shapeOp = shape.getDefiningOp();
-  if (auto s = mlir::dyn_cast<ShapeOp>(shapeOp)) {
+  if (auto s = mlir::dyn_cast_or_null<ShapeOp>(shapeOp)) {
     auto e = s.getExtents();
     result.insert(result.end(), e.begin(), e.end());
-    return;
-  }
-  if (auto s = mlir::dyn_cast<ShapeShiftOp>(shapeOp)) {
+  } else if (auto s = mlir::dyn_cast_or_null<ShapeShiftOp>(shapeOp)) {
     auto e = s.getExtents();
     result.insert(result.end(), e.begin(), e.end());
-    return;
+  } else {
+    emitFatalError(loc, "not a fir.shape/fir.shape_shift op");
   }
-  llvm::report_fatal_error("not a fir.shape/fir.shape_shift op");
+  auto idxTy = rewriter.getIndexType();
+  if (factory::isAssumedSize(result)) {
+    // Use slice information to compute the extent of the column.
+    auto one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
+    mlir::Value size = one;
+    if (mlir::Value sliceArg = arrLoad.slice())
+      if (auto sliceOp =
+              mlir::dyn_cast_or_null<SliceOp>(sliceArg.getDefiningOp())) {
+        auto triples = sliceOp.triples();
+        const std::size_t tripleSize = triples.size();
+        auto module = arrLoad->getParentOfType<mlir::ModuleOp>();
+        FirOpBuilder builder(rewriter, getKindMapping(module));
+        size = builder.genExtentFromTriplet(loc, triples[tripleSize - 3],
+                                            triples[tripleSize - 2],
+                                            triples[tripleSize - 1], idxTy);
+        copyUsingSlice = true;
+      }
+    result[result.size() - 1] = size;
+  }
+  return copyUsingSlice;
 }
 
-// Place the extents of the array loaded by an ArrayLoadOp into the result
-// vector and return a ShapeOp/ShapeShiftOp with the corresponding extents. If
-// the ArrayLoadOp is loading a fir.box, code will be generated to read the
-// extents from the fir.box, and a the retunred ShapeOp is built with the read
-// extents.
-// Otherwise, the extents will be extracted from the ShapeOp/ShapeShiftOp
-// argument of the ArrayLoadOp that is returned.
-static mlir::Value
-getOrReadExtentsAndShapeOp(mlir::Location loc, mlir::PatternRewriter &rewriter,
-                           ArrayLoadOp loadOp,
-                           llvm::SmallVectorImpl<mlir::Value> &result) {
+/// Place the extents of the array loaded by an ArrayLoadOp into the result
+/// vector and return a ShapeOp/ShapeShiftOp with the corresponding extents. If
+/// the ArrayLoadOp is loading a fir.box, code will be generated to read the
+/// extents from the fir.box, and a the retunred ShapeOp is built with the read
+/// extents. Otherwise, the extents will be extracted from the
+/// ShapeOp/ShapeShiftOp argument of the ArrayLoadOp that is returned.
+static mlir::Value getOrReadExtentsAndShapeOp(
+    mlir::Location loc, mlir::PatternRewriter &rewriter, ArrayLoadOp arrLoad,
+    llvm::SmallVectorImpl<mlir::Value> &result, bool &copyUsingSlice) {
   assert(result.empty());
-  if (auto boxTy = loadOp.memref().getType().dyn_cast<BoxType>()) {
+  if (auto boxTy = arrLoad.memref().getType().dyn_cast<BoxType>()) {
     auto rank =
         dyn_cast_ptrOrBoxEleTy(boxTy).cast<SequenceType>().getDimension();
     auto idxTy = rewriter.getIndexType();
     for (decltype(rank) dim = 0; dim < rank; ++dim) {
       auto dimVal = rewriter.create<mlir::arith::ConstantIndexOp>(loc, dim);
       auto dimInfo = rewriter.create<BoxDimsOp>(loc, idxTy, idxTy, idxTy,
-                                                loadOp.memref(), dimVal);
+                                                arrLoad.memref(), dimVal);
       result.emplace_back(dimInfo.getResult(1));
     }
-    if (!loadOp.shape()) {
+    if (!arrLoad.shape()) {
       auto shapeType = ShapeType::get(rewriter.getContext(), rank);
       return rewriter.create<ShapeOp>(loc, shapeType, result);
     }
-    auto shiftOp = loadOp.shape().getDefiningOp<fir::ShiftOp>();
+    auto shiftOp = arrLoad.shape().getDefiningOp<ShiftOp>();
     auto shapeShiftType = ShapeShiftType::get(rewriter.getContext(), rank);
     llvm::SmallVector<mlir::Value> shapeShiftOperands;
     for (auto [lb, extent] : llvm::zip(shiftOp.getOrigins(), result)) {
@@ -709,8 +730,9 @@ getOrReadExtentsAndShapeOp(mlir::Location loc, mlir::PatternRewriter &rewriter,
     return rewriter.create<ShapeShiftOp>(loc, shapeShiftType,
                                          shapeShiftOperands);
   }
-  getExtents(result, loadOp.shape());
-  return loadOp.shape();
+  copyUsingSlice =
+      getAdjustedExtents(loc, rewriter, arrLoad, result, arrLoad.shape());
+  return arrLoad.shape();
 }
 
 static mlir::Type toRefType(mlir::Type ty) {
@@ -744,17 +766,19 @@ genCoorOp(mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Type eleTy,
   return result;
 }
 
-/// Generate an array copy. This is used for both copy-in and copy-out.
-static void genArrayCopy(mlir::Location loc, mlir::PatternRewriter &rewriter,
-                         mlir::Value dst, mlir::Value src, mlir::Value shapeOp,
-                         ArrayLoadOp arrLoad) {
+/// Generate a shallow array copy. This is used for both copy-in and copy-out.
+template <bool CopyIn>
+void genArrayCopy(mlir::Location loc, mlir::PatternRewriter &rewriter,
+                  mlir::Value dst, mlir::Value src, mlir::Value shapeOp,
+                  mlir::Value sliceOp, ArrayLoadOp arrLoad) {
   auto insPt = rewriter.saveInsertionPoint();
   llvm::SmallVector<mlir::Value> indices;
   llvm::SmallVector<mlir::Value> extents;
-  getExtents(extents, shapeOp);
+  bool copyUsingSlice =
+      getAdjustedExtents(loc, rewriter, arrLoad, extents, shapeOp);
+  auto idxTy = rewriter.getIndexType();
   // Build loop nest from column to row.
   for (auto sh : llvm::reverse(extents)) {
-    auto idxTy = rewriter.getIndexType();
     auto ubi = rewriter.create<ConvertOp>(loc, idxTy, sh);
     auto zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
     auto one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
@@ -767,29 +791,32 @@ static void genArrayCopy(mlir::Location loc, mlir::PatternRewriter &rewriter,
   std::reverse(indices.begin(), indices.end());
   auto typeparams = arrLoad.typeparams();
   auto fromAddr = rewriter.create<ArrayCoorOp>(
-      loc, getEleTy(src.getType()), src, shapeOp, mlir::Value{},
+      loc, getEleTy(src.getType()), src, shapeOp,
+      CopyIn && copyUsingSlice ? sliceOp : mlir::Value{},
       factory::originateIndices(loc, rewriter, src.getType(), shapeOp, indices),
       typeparams);
   auto toAddr = rewriter.create<ArrayCoorOp>(
-      loc, getEleTy(dst.getType()), dst, shapeOp, mlir::Value{},
+      loc, getEleTy(dst.getType()), dst, shapeOp,
+      !CopyIn && copyUsingSlice ? sliceOp : mlir::Value{},
       factory::originateIndices(loc, rewriter, dst.getType(), shapeOp, indices),
       typeparams);
   auto eleTy = unwrapSequenceType(unwrapPassByRefType(dst.getType()));
   if (hasDynamicSize(eleTy)) {
-    if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
+    if (auto charTy = eleTy.dyn_cast<CharacterType>()) {
       assert(charTy.hasDynamicLen() && "dynamic size and constant length");
       // Copy from (to) object to (from) temp copy of same object.
       auto len = typeparams.back();
       CharBoxValue toChar(toAddr, len);
       CharBoxValue fromChar(fromAddr, len);
       auto module = toAddr->getParentOfType<mlir::ModuleOp>();
-      FirOpBuilder builder{rewriter, getKindMapping(module)};
+      FirOpBuilder builder(rewriter, getKindMapping(module));
       factory::CharacterExprHelper helper{builder, loc};
       helper.createAssign(ExtendedValue{toChar}, ExtendedValue{fromChar});
     } else {
       TODO(loc, "copy element of dynamic size");
     }
   } else {
+    // TODO: Should this check if the size of the element is "too big"?
     auto load = rewriter.create<fir::LoadOp>(loc, fromAddr);
     rewriter.create<fir::StoreOp>(loc, load, toAddr);
   }
@@ -824,32 +851,34 @@ public:
     rewriter.setInsertionPoint(loadOp);
     // Copy in.
     llvm::SmallVector<mlir::Value> extents;
-    auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents);
+    bool copyUsingSlice = false;
+    auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents,
+                                              copyUsingSlice);
     auto allocmem = rewriter.create<AllocMemOp>(
         loc, dyn_cast_ptrOrBoxEleTy(load.memref().getType()), load.typeparams(),
         extents);
-    genArrayCopy(load.getLoc(), rewriter, allocmem, load.memref(), shapeOp,
-                 load);
+    genArrayCopy</*copyIn=*/true>(load.getLoc(), rewriter, allocmem,
+                                  load.memref(), shapeOp, load.slice(), load);
     // Generate the reference for the access.
     rewriter.setInsertionPoint(op);
-    auto coor =
-        genCoorOp(rewriter, loc, getEleTy(load.getType()), eleTy, allocmem,
-                  shapeOp, load.slice(), access.indices(), load.typeparams(),
-                  access->hasAttr(factory::attrFortranArrayOffsets()));
+    auto coor = genCoorOp(
+        rewriter, loc, getEleTy(load.getType()), eleTy, allocmem, shapeOp,
+        copyUsingSlice ? mlir::Value{} : load.slice(), access.indices(),
+        load.typeparams(), access->hasAttr(factory::attrFortranArrayOffsets()));
     // Copy out.
     auto *storeOp = useMap.lookup(loadOp);
     auto store = mlir::cast<ArrayMergeStoreOp>(storeOp);
     rewriter.setInsertionPoint(storeOp);
     // Copy out.
-    genArrayCopy(store.getLoc(), rewriter, store.memref(), allocmem, shapeOp,
-                 load);
+    genArrayCopy</*copyIn=*/false>(store.getLoc(), rewriter, store.memref(),
+                                   allocmem, shapeOp, store.slice(), load);
     rewriter.create<FreeMemOp>(loc, allocmem);
     return coor;
   }
 
   /// Copy the RHS element into the LHS and insert copy-in/copy-out between a
   /// temp and the LHS if the analysis found potential overlaps between the RHS
-  /// and LHS arrays. The element copy generator must be provided through \p
+  /// and LHS arrays. The element copy generator must be provided in \p
   /// assignElement. \p update must be the ArrayUpdateOp or the ArrayModifyOp.
   /// Returns the address of the LHS element inside the loop and the LHS
   /// ArrayLoad result.
@@ -871,30 +900,32 @@ public:
       // Copy in.
       llvm::SmallVector<mlir::Value> extents;
       llvm::SmallVector<mlir::Value> nonconstantExtents;
-      auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents);
-      auto arrTy = fir::unwrapPassByRefType(load.memref().getType());
-      auto seqTy = arrTy.template dyn_cast<fir::SequenceType>();
-      assert(seqTy && "expecting sequence type");
+      bool copyUsingSlice = false;
+      auto shapeOp = getOrReadExtentsAndShapeOp(loc, rewriter, load, extents,
+                                                copyUsingSlice);
+      auto arrTy = unwrapPassByRefType(load.memref().getType());
+      auto seqTy = arrTy.template cast<SequenceType>();
       for (auto [s, x] : llvm::zip(seqTy.getShape(), extents))
-        if (s == fir::SequenceType::getUnknownExtent())
+        if (s == SequenceType::getUnknownExtent())
           nonconstantExtents.emplace_back(x);
       auto allocmem = rewriter.create<AllocMemOp>(
           loc, dyn_cast_ptrOrBoxEleTy(load.memref().getType()),
           load.typeparams(), nonconstantExtents);
-      genArrayCopy(load.getLoc(), rewriter, allocmem, load.memref(), shapeOp,
-                   load);
+      genArrayCopy</*copyIn=*/true>(load.getLoc(), rewriter, allocmem,
+                                    load.memref(), shapeOp, load.slice(), load);
       rewriter.setInsertionPoint(op);
       auto coor = genCoorOp(
           rewriter, loc, getEleTy(load.getType()), lhsEltRefType, allocmem,
-          shapeOp, load.slice(), update.indices(), load.typeparams(),
+          shapeOp, copyUsingSlice ? mlir::Value{} : load.slice(),
+          update.indices(), load.typeparams(),
           update->hasAttr(factory::attrFortranArrayOffsets()));
       assignElement(coor);
       auto *storeOp = useMap.lookup(loadOp);
       auto store = mlir::cast<ArrayMergeStoreOp>(storeOp);
       rewriter.setInsertionPoint(storeOp);
       // Copy out.
-      genArrayCopy(store.getLoc(), rewriter, store.memref(), allocmem, shapeOp,
-                   load);
+      genArrayCopy</*copyIn=*/false>(store.getLoc(), rewriter, store.memref(),
+                                     allocmem, shapeOp, store.slice(), load);
       rewriter.create<FreeMemOp>(loc, allocmem);
       return {coor, load.getResult()};
     }

--- a/flang/test/Lower/array-expression-assumed-size.f90
+++ b/flang/test/Lower/array-expression-assumed-size.f90
@@ -1,0 +1,298 @@
+! RUN: bbc --emit-fir %s -o - | FileCheck %s
+! RUN: bbc %s -o - | FileCheck --check-prefix=PostOpt %s
+
+
+subroutine assumed_size_test(a)
+  integer :: a(10,*)
+  a(:, 1:2) = a(:, 3:4)
+end subroutine assumed_size_test
+
+subroutine assumed_size_forall_test(b)
+  integer :: b(10,*)
+  forall (i=2:6)
+     b(i, 1:2) = b(i, 3:4)
+  end forall
+end subroutine assumed_size_forall_test
+
+! CHECK-LABEL: func @_QPassumed_size_test(
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_2:.*]] = fir.undefined index
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:         %[[VAL_6:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
+! CHECK:         %[[VAL_7:.*]] = arith.subi %[[VAL_6]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_9:.*]] = arith.subi %[[VAL_7]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_11:.*]] = arith.divsi %[[VAL_10]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_12:.*]] = arith.cmpi sgt, %[[VAL_11]], %[[VAL_8]] : index
+! CHECK:         %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_11]], %[[VAL_8]] : index
+! CHECK:         %[[VAL_14:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i64) -> index
+! CHECK:         %[[VAL_16:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i64) -> index
+! CHECK:         %[[VAL_18:.*]] = arith.constant 2 : i64
+! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i64) -> index
+! CHECK:         %[[VAL_20:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_21:.*]] = arith.subi %[[VAL_19]], %[[VAL_15]] : index
+! CHECK:         %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_17]] : index
+! CHECK:         %[[VAL_23:.*]] = arith.divsi %[[VAL_22]], %[[VAL_17]] : index
+! CHECK:         %[[VAL_24:.*]] = arith.cmpi sgt, %[[VAL_23]], %[[VAL_20]] : index
+! CHECK:         %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_23]], %[[VAL_20]] : index
+! CHECK:         %[[VAL_26:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_27:.*]] = fir.slice %[[VAL_3]], %[[VAL_7]], %[[VAL_5]], %[[VAL_15]], %[[VAL_19]], %[[VAL_17]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_28:.*]] = fir.array_load %[[VAL_0]](%[[VAL_26]]) {{\[}}%[[VAL_27]]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.array<10x?xi32>
+! CHECK:         %[[VAL_29:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_30:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (i64) -> index
+! CHECK:         %[[VAL_32:.*]] = arith.addi %[[VAL_29]], %[[VAL_1]] : index
+! CHECK:         %[[VAL_33:.*]] = arith.subi %[[VAL_32]], %[[VAL_29]] : index
+! CHECK:         %[[VAL_34:.*]] = arith.constant 3 : i64
+! CHECK:         %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i64) -> index
+! CHECK:         %[[VAL_36:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
+! CHECK:         %[[VAL_38:.*]] = arith.constant 4 : i64
+! CHECK:         %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i64) -> index
+! CHECK:         %[[VAL_40:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_41:.*]] = fir.slice %[[VAL_29]], %[[VAL_33]], %[[VAL_31]], %[[VAL_35]], %[[VAL_39]], %[[VAL_37]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_42:.*]] = fir.array_load %[[VAL_0]](%[[VAL_40]]) {{\[}}%[[VAL_41]]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.array<10x?xi32>
+! CHECK:         %[[VAL_43:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_44:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_45:.*]] = arith.subi %[[VAL_13]], %[[VAL_43]] : index
+! CHECK:         %[[VAL_46:.*]] = arith.subi %[[VAL_25]], %[[VAL_43]] : index
+! CHECK:         %[[VAL_47:.*]] = fir.do_loop %[[VAL_48:.*]] = %[[VAL_44]] to %[[VAL_46]] step %[[VAL_43]] unordered iter_args(%[[VAL_49:.*]] = %[[VAL_28]]) -> (!fir.array<10x?xi32>) {
+! CHECK:           %[[VAL_50:.*]] = fir.do_loop %[[VAL_51:.*]] = %[[VAL_44]] to %[[VAL_45]] step %[[VAL_43]] unordered iter_args(%[[VAL_52:.*]] = %[[VAL_49]]) -> (!fir.array<10x?xi32>) {
+! CHECK:             %[[VAL_53:.*]] = fir.array_fetch %[[VAL_42]], %[[VAL_51]], %[[VAL_48]] : (!fir.array<10x?xi32>, index, index) -> i32
+! CHECK:             %[[VAL_54:.*]] = fir.array_update %[[VAL_52]], %[[VAL_53]], %[[VAL_51]], %[[VAL_48]] : (!fir.array<10x?xi32>, i32, index, index) -> !fir.array<10x?xi32>
+! CHECK:             fir.result %[[VAL_54]] : !fir.array<10x?xi32>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_55:.*]] : !fir.array<10x?xi32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_28]], %[[VAL_56:.*]] to %[[VAL_0]]{{\[}}%[[VAL_27]]] : !fir.array<10x?xi32>, !fir.array<10x?xi32>, !fir.ref<!fir.array<10x?xi32>>, !fir.slice<2>
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func @_QPassumed_size_forall_test(
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! CHECK:         %[[VAL_2:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_3:.*]] = fir.undefined index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : i32
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 6 : i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:         %[[VAL_8:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_2]], %[[VAL_3]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_0]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>) -> !fir.array<10x?xi32>
+! CHECK:         %[[VAL_11:.*]] = fir.shape %[[VAL_2]], %[[VAL_3]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_12:.*]] = fir.array_load %[[VAL_0]](%[[VAL_11]]) : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>) -> !fir.array<10x?xi32>
+! CHECK:         %[[VAL_13:.*]] = fir.do_loop %[[VAL_14:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_8]] unordered iter_args(%[[VAL_15:.*]] = %[[VAL_10]]) -> (!fir.array<10x?xi32>) {
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_14]] : (index) -> i32
+! CHECK:           fir.store %[[VAL_16]] to %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_17:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
+! CHECK:           %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_17]] : index
+! CHECK:           %[[VAL_22:.*]] = arith.constant 1 : i64
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i64) -> index
+! CHECK:           %[[VAL_24:.*]] = arith.constant 1 : i64
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (i64) -> index
+! CHECK:           %[[VAL_26:.*]] = arith.constant 2 : i64
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (i64) -> index
+! CHECK:           %[[VAL_28:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_29:.*]] = arith.subi %[[VAL_27]], %[[VAL_23]] : index
+! CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_25]] : index
+! CHECK:           %[[VAL_31:.*]] = arith.divsi %[[VAL_30]], %[[VAL_25]] : index
+! CHECK:           %[[VAL_32:.*]] = arith.cmpi sgt, %[[VAL_31]], %[[VAL_28]] : index
+! CHECK:           %[[VAL_33:.*]] = select %[[VAL_32]], %[[VAL_31]], %[[VAL_28]] : index
+! CHECK:           %[[VAL_34:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
+! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index
+! CHECK:           %[[VAL_38:.*]] = arith.subi %[[VAL_37]], %[[VAL_34]] : index
+! CHECK:           %[[VAL_39:.*]] = arith.constant 3 : i64
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]] : (i64) -> index
+! CHECK:           %[[VAL_41:.*]] = arith.constant 1 : i64
+! CHECK:           %[[VAL_42:.*]] = fir.convert %[[VAL_41]] : (i64) -> index
+! CHECK:           %[[VAL_43:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_44:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_45:.*]] = arith.subi %[[VAL_33]], %[[VAL_43]] : index
+! CHECK:           %[[VAL_46:.*]] = fir.do_loop %[[VAL_47:.*]] = %[[VAL_44]] to %[[VAL_45]] step %[[VAL_43]] unordered iter_args(%[[VAL_48:.*]] = %[[VAL_15]]) -> (!fir.array<10x?xi32>) {
+! CHECK:             %[[VAL_49:.*]] = arith.subi %[[VAL_40]], %[[VAL_34]] : index
+! CHECK:             %[[VAL_50:.*]] = arith.muli %[[VAL_47]], %[[VAL_42]] : index
+! CHECK:             %[[VAL_51:.*]] = arith.addi %[[VAL_49]], %[[VAL_50]] : index
+! CHECK:             %[[VAL_52:.*]] = fir.array_fetch %[[VAL_12]], %[[VAL_38]], %[[VAL_51]] : (!fir.array<10x?xi32>, index, index) -> i32
+! CHECK:             %[[VAL_53:.*]] = arith.subi %[[VAL_23]], %[[VAL_17]] : index
+! CHECK:             %[[VAL_54:.*]] = arith.muli %[[VAL_47]], %[[VAL_25]] : index
+! CHECK:             %[[VAL_55:.*]] = arith.addi %[[VAL_53]], %[[VAL_54]] : index
+! CHECK:             %[[VAL_56:.*]] = fir.array_update %[[VAL_48]], %[[VAL_52]], %[[VAL_21]], %[[VAL_55]] : (!fir.array<10x?xi32>, i32, index, index) -> !fir.array<10x?xi32>
+! CHECK:             fir.result %[[VAL_56]] : !fir.array<10x?xi32>
+! CHECK:           }
+! CHECK:           fir.result %[[VAL_57:.*]] : !fir.array<10x?xi32>
+! CHECK:         }
+! CHECK:         fir.array_merge_store %[[VAL_10]], %[[VAL_58:.*]] to %[[VAL_0]] : !fir.array<10x?xi32>, !fir.array<10x?xi32>, !fir.ref<!fir.array<10x?xi32>>
+! CHECK:         return
+! CHECK:       }
+
+! PostOpt-LABEL: func @_QPassumed_size_test(
+! PostOpt-SAME:                             %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! PostOpt:         %[[VAL_1:.*]] = arith.constant 2 : index
+! PostOpt:         %[[VAL_2:.*]] = arith.constant 1 : index
+! PostOpt:         %[[VAL_3:.*]] = arith.constant 0 : index
+! PostOpt:         %[[VAL_4:.*]] = arith.constant 4 : index
+! PostOpt:         %[[VAL_5:.*]] = arith.constant 3 : index
+! PostOpt:         %[[VAL_6:.*]] = arith.constant 10 : index
+! PostOpt:         %[[VAL_7:.*]] = fir.undefined index
+! PostOpt:         %[[VAL_8:.*]] = fir.shape %[[VAL_6]], %[[VAL_7]] : (index, index) -> !fir.shape<2>
+! PostOpt:         %[[VAL_9:.*]] = fir.slice %[[VAL_2]], %[[VAL_6]], %[[VAL_2]], %[[VAL_2]], %[[VAL_1]], %[[VAL_2]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! PostOpt:         %[[VAL_10:.*]] = fir.allocmem !fir.array<10x?xi32>, %[[VAL_1]]
+! PostOpt:         br ^bb1(%[[VAL_3]], %[[VAL_1]] : index, index)
+! PostOpt:       ^bb1(%[[VAL_11:.*]]: index, %[[VAL_12:.*]]: index):
+! PostOpt:         %[[VAL_13:.*]] = arith.cmpi sgt, %[[VAL_12]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_13]], ^bb2(%[[VAL_3]], %[[VAL_6]] : index, index), ^bb5
+! PostOpt:       ^bb2(%[[VAL_14:.*]]: index, %[[VAL_15:.*]]: index):
+! PostOpt:         %[[VAL_16:.*]] = arith.cmpi sgt, %[[VAL_15]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_16]], ^bb3, ^bb4
+! PostOpt:       ^bb3:
+! PostOpt:         %[[VAL_17:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_18:.*]] = arith.addi %[[VAL_11]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_19:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_8]]) {{\[}}%[[VAL_9]]] %[[VAL_17]], %[[VAL_18]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_20:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_8]]) %[[VAL_17]], %[[VAL_18]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_21:.*]] = fir.load %[[VAL_19]] : !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_21]] to %[[VAL_20]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_22:.*]] = arith.subi %[[VAL_15]], %[[VAL_2]] : index
+! PostOpt:         br ^bb2(%[[VAL_17]], %[[VAL_22]] : index, index)
+! PostOpt:       ^bb4:
+! PostOpt:         %[[VAL_23:.*]] = arith.addi %[[VAL_11]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_24:.*]] = arith.subi %[[VAL_12]], %[[VAL_2]] : index
+! PostOpt:         br ^bb1(%[[VAL_23]], %[[VAL_24]] : index, index)
+! PostOpt:       ^bb5:
+! PostOpt:         %[[VAL_25:.*]] = fir.slice %[[VAL_2]], %[[VAL_6]], %[[VAL_2]], %[[VAL_5]], %[[VAL_4]], %[[VAL_2]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! PostOpt:         br ^bb6(%[[VAL_3]], %[[VAL_1]] : index, index)
+! PostOpt:       ^bb6(%[[VAL_26:.*]]: index, %[[VAL_27:.*]]: index):
+! PostOpt:         %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_28]], ^bb7(%[[VAL_3]], %[[VAL_6]] : index, index), ^bb10(%[[VAL_3]], %[[VAL_1]] : index, index)
+! PostOpt:       ^bb7(%[[VAL_29:.*]]: index, %[[VAL_30:.*]]: index):
+! PostOpt:         %[[VAL_31:.*]] = arith.cmpi sgt, %[[VAL_30]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_31]], ^bb8, ^bb9
+! PostOpt:       ^bb8:
+! PostOpt:         %[[VAL_32:.*]] = arith.addi %[[VAL_29]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_33:.*]] = arith.addi %[[VAL_26]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_34:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_8]]) {{\[}}%[[VAL_25]]] %[[VAL_32]], %[[VAL_33]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_35:.*]] = fir.load %[[VAL_34]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_36:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_8]]) %[[VAL_32]], %[[VAL_33]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_35]] to %[[VAL_36]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_37:.*]] = arith.subi %[[VAL_30]], %[[VAL_2]] : index
+! PostOpt:         br ^bb7(%[[VAL_32]], %[[VAL_37]] : index, index)
+! PostOpt:       ^bb9:
+! PostOpt:         %[[VAL_38:.*]] = arith.addi %[[VAL_26]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_39:.*]] = arith.subi %[[VAL_27]], %[[VAL_2]] : index
+! PostOpt:         br ^bb6(%[[VAL_38]], %[[VAL_39]] : index, index)
+! PostOpt:       ^bb10(%[[VAL_40:.*]]: index, %[[VAL_41:.*]]: index):
+! PostOpt:         %[[VAL_42:.*]] = arith.cmpi sgt, %[[VAL_41]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_42]], ^bb11(%[[VAL_3]], %[[VAL_6]] : index, index), ^bb14
+! PostOpt:       ^bb11(%[[VAL_43:.*]]: index, %[[VAL_44:.*]]: index):
+! PostOpt:         %[[VAL_45:.*]] = arith.cmpi sgt, %[[VAL_44]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_45]], ^bb12, ^bb13
+! PostOpt:       ^bb12:
+! PostOpt:         %[[VAL_46:.*]] = arith.addi %[[VAL_43]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_47:.*]] = arith.addi %[[VAL_40]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_48:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_8]]) %[[VAL_46]], %[[VAL_47]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_49:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_8]]) {{\[}}%[[VAL_9]]] %[[VAL_46]], %[[VAL_47]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_50:.*]] = fir.load %[[VAL_48]] : !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_50]] to %[[VAL_49]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_51:.*]] = arith.subi %[[VAL_44]], %[[VAL_2]] : index
+! PostOpt:         br ^bb11(%[[VAL_46]], %[[VAL_51]] : index, index)
+! PostOpt:       ^bb13:
+! PostOpt:         %[[VAL_52:.*]] = arith.addi %[[VAL_40]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_53:.*]] = arith.subi %[[VAL_41]], %[[VAL_2]] : index
+! PostOpt:         br ^bb10(%[[VAL_52]], %[[VAL_53]] : index, index)
+! PostOpt:       ^bb14:
+! PostOpt:         fir.freemem %[[VAL_10]] : !fir.heap<!fir.array<10x?xi32>>
+! PostOpt:         return
+! PostOpt:       }
+
+! PostOpt-LABEL: func @_QPassumed_size_forall_test(
+! PostOpt-SAME:                                    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! PostOpt:         %[[VAL_1:.*]] = arith.constant 5 : index
+! PostOpt:         %[[VAL_2:.*]] = arith.constant 1 : index
+! PostOpt:         %[[VAL_3:.*]] = arith.constant 0 : index
+! PostOpt:         %[[VAL_4:.*]] = arith.constant 3 : index
+! PostOpt:         %[[VAL_5:.*]] = arith.constant 2 : index
+! PostOpt:         %[[VAL_6:.*]] = arith.constant 10 : index
+! PostOpt:         %[[VAL_7:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
+! PostOpt:         %[[VAL_8:.*]] = fir.undefined index
+! PostOpt:         %[[VAL_9:.*]] = fir.shape %[[VAL_6]], %[[VAL_8]] : (index, index) -> !fir.shape<2>
+! PostOpt:         %[[VAL_10:.*]] = fir.allocmem !fir.array<10x?xi32>, %[[VAL_2]]
+! PostOpt:         br ^bb1(%[[VAL_3]], %[[VAL_2]] : index, index)
+! PostOpt:       ^bb1(%[[VAL_11:.*]]: index, %[[VAL_12:.*]]: index):
+! PostOpt:         %[[VAL_13:.*]] = arith.cmpi sgt, %[[VAL_12]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_13]], ^bb2(%[[VAL_3]], %[[VAL_6]] : index, index), ^bb5(%[[VAL_5]], %[[VAL_1]] : index, index)
+! PostOpt:       ^bb2(%[[VAL_14:.*]]: index, %[[VAL_15:.*]]: index):
+! PostOpt:         %[[VAL_16:.*]] = arith.cmpi sgt, %[[VAL_15]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_16]], ^bb3, ^bb4
+! PostOpt:       ^bb3:
+! PostOpt:         %[[VAL_17:.*]] = arith.addi %[[VAL_14]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_18:.*]] = arith.addi %[[VAL_11]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_19:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_9]]) %[[VAL_17]], %[[VAL_18]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_20:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_9]]) %[[VAL_17]], %[[VAL_18]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_21:.*]] = fir.load %[[VAL_19]] : !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_21]] to %[[VAL_20]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_22:.*]] = arith.subi %[[VAL_15]], %[[VAL_2]] : index
+! PostOpt:         br ^bb2(%[[VAL_17]], %[[VAL_22]] : index, index)
+! PostOpt:       ^bb4:
+! PostOpt:         %[[VAL_23:.*]] = arith.addi %[[VAL_11]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_24:.*]] = arith.subi %[[VAL_12]], %[[VAL_2]] : index
+! PostOpt:         br ^bb1(%[[VAL_23]], %[[VAL_24]] : index, index)
+! PostOpt:       ^bb5(%[[VAL_25:.*]]: index, %[[VAL_26:.*]]: index):
+! PostOpt:         %[[VAL_27:.*]] = arith.cmpi sgt, %[[VAL_26]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_27]], ^bb6, ^bb10(%[[VAL_3]], %[[VAL_2]] : index, index)
+! PostOpt:       ^bb6:
+! PostOpt:         %[[VAL_28:.*]] = fir.convert %[[VAL_25]] : (index) -> i32
+! PostOpt:         fir.store %[[VAL_28]] to %[[VAL_7]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_29:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i32) -> index
+! PostOpt:         br ^bb7(%[[VAL_3]], %[[VAL_5]] : index, index)
+! PostOpt:       ^bb7(%[[VAL_31:.*]]: index, %[[VAL_32:.*]]: index):
+! PostOpt:         %[[VAL_33:.*]] = arith.cmpi sgt, %[[VAL_32]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_33]], ^bb8, ^bb9
+! PostOpt:       ^bb8:
+! PostOpt:         %[[VAL_34:.*]] = arith.addi %[[VAL_31]], %[[VAL_4]] : index
+! PostOpt:         %[[VAL_35:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_9]]) %[[VAL_30]], %[[VAL_34]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_36:.*]] = fir.load %[[VAL_35]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_37:.*]] = arith.addi %[[VAL_31]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_38:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_9]]) %[[VAL_30]], %[[VAL_37]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_36]] to %[[VAL_38]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_39:.*]] = arith.subi %[[VAL_32]], %[[VAL_2]] : index
+! PostOpt:         br ^bb7(%[[VAL_37]], %[[VAL_39]] : index, index)
+! PostOpt:       ^bb9:
+! PostOpt:         %[[VAL_40:.*]] = arith.addi %[[VAL_25]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_41:.*]] = arith.subi %[[VAL_26]], %[[VAL_2]] : index
+! PostOpt:         br ^bb5(%[[VAL_40]], %[[VAL_41]] : index, index)
+! PostOpt:       ^bb10(%[[VAL_42:.*]]: index, %[[VAL_43:.*]]: index):
+! PostOpt:         %[[VAL_44:.*]] = arith.cmpi sgt, %[[VAL_43]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_44]], ^bb11(%[[VAL_3]], %[[VAL_6]] : index, index), ^bb14
+! PostOpt:       ^bb11(%[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index):
+! PostOpt:         %[[VAL_47:.*]] = arith.cmpi sgt, %[[VAL_46]], %[[VAL_3]] : index
+! PostOpt:         cond_br %[[VAL_47]], ^bb12, ^bb13
+! PostOpt:       ^bb12:
+! PostOpt:         %[[VAL_48:.*]] = arith.addi %[[VAL_45]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_49:.*]] = arith.addi %[[VAL_42]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_50:.*]] = fir.array_coor %[[VAL_10]](%[[VAL_9]]) %[[VAL_48]], %[[VAL_49]] : (!fir.heap<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_51:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_9]]) %[[VAL_48]], %[[VAL_49]] : (!fir.ref<!fir.array<10x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+! PostOpt:         %[[VAL_52:.*]] = fir.load %[[VAL_50]] : !fir.ref<i32>
+! PostOpt:         fir.store %[[VAL_52]] to %[[VAL_51]] : !fir.ref<i32>
+! PostOpt:         %[[VAL_53:.*]] = arith.subi %[[VAL_46]], %[[VAL_2]] : index
+! PostOpt:         br ^bb11(%[[VAL_48]], %[[VAL_53]] : index, index)
+! PostOpt:       ^bb13:
+! PostOpt:         %[[VAL_54:.*]] = arith.addi %[[VAL_42]], %[[VAL_2]] : index
+! PostOpt:         %[[VAL_55:.*]] = arith.subi %[[VAL_43]], %[[VAL_2]] : index
+! PostOpt:         br ^bb10(%[[VAL_54]], %[[VAL_55]] : index, index)
+! PostOpt:       ^bb14:
+! PostOpt:         fir.freemem %[[VAL_10]] : !fir.heap<!fir.array<10x?xi32>>
+! PostOpt:         return
+! PostOpt:       }
+


### PR DESCRIPTION
…ather than -1).

Add code to handle copy-in/copy-out of assumed-size arrays.

Add test. Check before and after array value copy.