### PR TITLE
Never load/store fir.record and character type objects

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -466,6 +466,11 @@ fir::ExtendedValue arraySectionElementToExtendedValue(
     fir::FirOpBuilder &builder, mlir::Location loc,
     const fir::ExtendedValue &array, mlir::Value element, mlir::Value slice);
 
+/// Assign \p rhs to \p lhs. Both \p rhs and \p lhs must be scalars. The
+/// assignment follows Fortran intrinsic assignment semantic (10.2.1.3).
+void genScalarAssignment(fir::FirOpBuilder &builder, mlir::Location loc,
+                         const fir::ExtendedValue &lhs,
+                         const fir::ExtendedValue &rhs);
 /// Assign \p rhs to \p lhs. Both \p rhs and \p lhs must be scalar derived
 /// types. The assignment follows Fortran intrinsic assignment semantic for
 /// derived types (10.2.1.3 point 13).

--- a/flang/test/Fir/array-value-copy.f90
+++ b/flang/test/Fir/array-value-copy.f90
@@ -34,8 +34,11 @@ func @derived_type_component_overlap(%arg0: !fir.ref<!fir.array<100x!fir.type<t{
 // CHECK:             %[[VAL_18:.*]] = arith.constant 1 : index
 // CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_14]], %[[VAL_18]] : index
 // CHECK:             %[[VAL_20:.*]] = fir.array_coor %[[VAL_9]](%[[VAL_6]]) %[[VAL_19]] : (!fir.heap<!fir.array<100x!fir.type<t{i:i32}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<t{i:i32}>>
-// CHECK:             %[[VAL_21:.*]] = fir.load %[[VAL_17]] : !fir.ref<!fir.type<t{i:i32}>>
-// CHECK:             fir.store %[[VAL_21]] to %[[VAL_20]] : !fir.ref<!fir.type<t{i:i32}>>
+// CHECK:             %[[VAL_21:.*]] = fir.field_index i, !fir.type<t{i:i32}>
+// CHECK:             %[[VAL_22:.*]] = fir.coordinate_of %[[VAL_17]], %[[VAL_21]] : (!fir.ref<!fir.type<t{i:i32}>>, !fir.field) -> !fir.ref<i32>
+// CHECK:             %[[VAL_23:.*]] = fir.coordinate_of %[[VAL_20]], %[[VAL_21]] : (!fir.ref<!fir.type<t{i:i32}>>, !fir.field) -> !fir.ref<i32>
+// CHECK:             %[[VAL_24:.*]] = fir.load %[[VAL_22]] : !fir.ref<i32>
+// CHECK:             fir.store %[[VAL_24]] to %[[VAL_23]] : !fir.ref<i32>
 // CHECK:           }
 
 // Actual assignment and copy-out

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -244,14 +244,17 @@ subroutine test_derived_scalar(x, s)
 ! CHECK:    %[[VAL_13:.*]] = fir.allocmem !fir.type<_QMalloc_assignTt{i:i32}> {uniq_name = ".auto.alloc"}
 ! CHECK:    fir.result %[[VAL_12]], %[[VAL_13]] : i1, !fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>
 ! CHECK:  }
-! CHECK:  %[[VAL_14:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.type<_QMalloc_assignTt{i:i32}>>
-! CHECK:  fir.store %[[VAL_14]] to %[[VAL_7]]#1 : !fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>
+! CHECK:  %[[VAL_14:.*]] = fir.field_index i, !fir.type<_QMalloc_assignTt{i:i32}>
+! CHECK:  %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_14]] : (!fir.ref<!fir.type<_QMalloc_assignTt{i:i32}>>, !fir.field) -> !fir.ref<i32>
+! CHECK:  %[[VAL_16:.*]] = fir.coordinate_of %[[VAL_7]]#1, %[[VAL_14]] : (!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>, !fir.field) -> !fir.ref<i32>
+! CHECK:  %[[VAL_17:.*]] = fir.load %[[VAL_15]] : !fir.ref<i32>
+! CHECK:  fir.store %[[VAL_17]] to %[[VAL_16]] : !fir.ref<i32
 ! CHECK:  fir.if %[[VAL_7]]#0 {
 ! CHECK:    fir.if %[[VAL_6]] {
 ! CHECK:      fir.freemem %[[VAL_3]] : !fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>
 ! CHECK:    }
-! CHECK:    %[[VAL_16:.*]] = fir.embox %[[VAL_7]]#1 : (!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>) -> !fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>
-! CHECK:    fir.store %[[VAL_16]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>
+! CHECK:    %[[VAL_19:.*]] = fir.embox %[[VAL_7]]#1 : (!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>) -> !fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>
+! CHECK:    fir.store %[[VAL_19]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>
 ! CHECK:  }
 end subroutine
 

--- a/flang/test/Lower/array-derived-assignments.f90
+++ b/flang/test/Lower/array-derived-assignments.f90
@@ -13,28 +13,57 @@ module array_derived_assign
   end type
 contains
 
-! Simple copies are implemented inline.
+! Simple copies are implemented inline component by component.
 ! CHECK-LABEL: func @_QMarray_derived_assignPtest_simple_copy(
 ! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>,
 ! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>) {
 subroutine test_simple_copy(t1, t2)
-  ! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 10 : index
-  ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 1 : index
-  ! CHECK:         %[[VAL_5:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
-  ! CHECK:         br ^bb1(%[[VAL_3]], %[[VAL_2]] : index, index)
-  ! CHECK:       ^bb1(%[[VAL_6:.*]]: index, %[[VAL_7:.*]]: index):
-  ! CHECK:         %[[VAL_8:.*]] = arith.cmpi sgt, %[[VAL_7]], %[[VAL_3]] : index
-  ! CHECK:         cond_br %[[VAL_8]], ^bb2, ^bb3
-  ! CHECK:       ^bb2:
-  ! CHECK:         %[[VAL_9:.*]] = arith.addi %[[VAL_6]], %[[VAL_4]] : index
-  ! CHECK:         %[[VAL_10:.*]] = fir.array_coor %[[VAL_1]](%[[VAL_5]]) %[[VAL_9]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-  ! CHECK:         %[[VAL_11:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_5]]) %[[VAL_9]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-  ! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_10]] : !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-  ! CHECK:         fir.store %[[VAL_12]] to %[[VAL_11]] : !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-  ! CHECK:         %[[VAL_13:.*]] = arith.subi %[[VAL_7]], %[[VAL_4]] : index
-  ! CHECK:         br ^bb1(%[[VAL_9]], %[[VAL_13]] : index, index)
   type(simple_copy) :: t1(10), t2(10)
+  ! CHECK-DAG:         %[[VAL_2:.*]] = arith.constant 20 : index
+  ! CHECK-DAG:         %[[VAL_3:.*]] = arith.constant 10 : index
+  ! CHECK-DAG:         %[[VAL_4:.*]] = arith.constant false
+  ! CHECK-DAG:         %[[VAL_5:.*]] = arith.constant 0 : index
+  ! CHECK-DAG:         %[[VAL_6:.*]] = arith.constant 1 : index
+  ! CHECK-DAG:         %[[VAL_7:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+  ! CHECK:         br ^bb1(%[[VAL_5]], %[[VAL_3]] : index, index)
+  ! CHECK:       ^bb1(%[[VAL_8:.*]]: index, %[[VAL_9:.*]]: index):
+  ! CHECK:         %[[VAL_10:.*]] = arith.cmpi sgt, %[[VAL_9]], %[[VAL_5]] : index
+  ! CHECK:         cond_br %[[VAL_10]], ^bb2, ^bb6
+  ! CHECK:       ^bb2:
+  ! CHECK:         %[[VAL_11:.*]] = arith.addi %[[VAL_8]], %[[VAL_6]] : index
+  ! CHECK:         %[[VAL_12:.*]] = fir.array_coor %[[VAL_1]](%[[VAL_7]]) %[[VAL_11]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK:         %[[VAL_13:.*]] = fir.array_coor %[[VAL_0]](%[[VAL_7]]) %[[VAL_11]] : (!fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.shape<1>, index) -> !fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+  ! CHECK:         %[[VAL_14:.*]] = fir.field_index i, !fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK:         %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_12]], %[[VAL_14]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:         %[[VAL_16:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_14]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:         %[[VAL_17:.*]] = fir.load %[[VAL_15]] : !fir.ref<i32>
+  ! CHECK:         fir.store %[[VAL_17]] to %[[VAL_16]] : !fir.ref<i32>
+  ! CHECK:         %[[VAL_18:.*]] = fir.field_index c, !fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK:         %[[VAL_19:.*]] = fir.coordinate_of %[[VAL_12]], %[[VAL_18]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.array<20x!fir.char<1,10>>>
+  ! CHECK:         %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_18]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.array<20x!fir.char<1,10>>>
+  ! CHECK:         br ^bb3(%[[VAL_5]], %[[VAL_2]] : index, index)
+  ! CHECK:       ^bb3(%[[VAL_21:.*]]: index, %[[VAL_22:.*]]: index):
+  ! CHECK:         %[[VAL_23:.*]] = arith.cmpi sgt, %[[VAL_22]], %[[VAL_5]] : index
+  ! CHECK:         cond_br %[[VAL_23]], ^bb4, ^bb5
+  ! CHECK:       ^bb4:
+  ! CHECK:         %[[VAL_24:.*]] = fir.coordinate_of %[[VAL_20]], %[[VAL_21]] : (!fir.ref<!fir.array<20x!fir.char<1,10>>>, index) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK:         %[[VAL_25:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_21]] : (!fir.ref<!fir.array<20x!fir.char<1,10>>>, index) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_3]] : (index) -> i64
+  ! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_24]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
+  ! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_25]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
+  ! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_27]], %[[VAL_28]], %[[VAL_26]], %[[VAL_4]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK:         %[[VAL_29:.*]] = arith.addi %[[VAL_21]], %[[VAL_6]] : index
+  ! CHECK:         %[[VAL_30:.*]] = arith.subi %[[VAL_22]], %[[VAL_6]] : index
+  ! CHECK:         br ^bb3(%[[VAL_29]], %[[VAL_30]] : index, index)
+  ! CHECK:       ^bb5:
+  ! CHECK:         %[[VAL_31:.*]] = fir.field_index p, !fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
+  ! CHECK:         %[[VAL_32:.*]] = fir.coordinate_of %[[VAL_12]], %[[VAL_31]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK:         %[[VAL_33:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_31]] : (!fir.ref<!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK:         %[[VAL_34:.*]] = fir.load %[[VAL_32]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK:         fir.store %[[VAL_34]] to %[[VAL_33]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK:         %[[VAL_35:.*]] = arith.subi %[[VAL_9]], %[[VAL_6]] : index
+  ! CHECK:         br ^bb1(%[[VAL_11]], %[[VAL_35]] : index, index)
+  ! CHECK:       ^bb6:
   t1 = t2
   ! CHECK:         return
   ! CHECK:       }

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -9,11 +9,18 @@ subroutine test1
      integer b
   end type t
   type(t) :: t1, t2
-  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et1"}
-  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et2"}
-
-  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest1Tt{{.*}}>
-  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest1Tt{{.*}}>
+  ! CHECK-DAG:  %[[VAL_0:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et1"}
+  ! CHECK-DAG:  %[[VAL_1:.*]] = fir.alloca !fir.type<_QFtest1Tt{a:i32,b:i32}> {{{.*}}uniq_name = "_QFtest1Et2"}
+  ! CHECK:  %[[VAL_2:.*]] = fir.field_index a, !fir.type<_QFtest1Tt{a:i32,b:i32}>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_5]] to %[[VAL_4]] : !fir.ref<i32>
+  ! CHECK:  %[[VAL_6:.*]] = fir.field_index b, !fir.type<_QFtest1Tt{a:i32,b:i32}>
+  ! CHECK:  %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_6]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_8:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_6]] : (!fir.ref<!fir.type<_QFtest1Tt{a:i32,b:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_9:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_9]] to %[[VAL_8]] : !fir.ref<i32>
   t1 = t2
 end subroutine test1
 
@@ -67,18 +74,31 @@ subroutine test3
      integer :: m_i
   end type t
   type(t) :: t1, t2
-  ! CHECK-DAG: %[[t1:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et1"}
-  ! CHECK-DAG: %[[t2:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et2"}
-
-  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest3Tt{{.*}}>
-  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest3Tt{{.*}}>
+  ! CHECK-DAG:  %[[VAL_0:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et1"}
+  ! CHECK-DAG:  %[[VAL_1:.*]] = fir.alloca !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}> {{{.*}}uniq_name = "_QFtest3Et2"}
+  ! CHECK:  %[[VAL_2:.*]] = fir.field_index m_c, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK:  %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.char<1,20>>
+  ! CHECK:  %[[VAL_5:.*]] = arith.constant 20 : index
+  ! CHECK:  %[[VAL_6:.*]] = arith.constant 1 : i64
+  ! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
+  ! CHECK:  %[[VAL_8:.*]] = arith.muli %[[VAL_6]], %[[VAL_7]] : i64
+  ! CHECK:  %[[VAL_9:.*]] = arith.constant false
+  ! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
+  ! CHECK:  %[[VAL_11:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,20>>) -> !fir.ref<i8>
+  ! CHECK:  fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_10]], %[[VAL_11]], %[[VAL_8]], %[[VAL_9]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK:  %[[VAL_12:.*]] = fir.field_index m_i, !fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>
+  ! CHECK:  %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_12]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_12]] : (!fir.ref<!fir.type<_QFtest3Tt{m_c:!fir.char<1,20>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_15:.*]] = fir.load %[[VAL_13]] : !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_15]] to %[[VAL_14]] : !fir.ref<i32>
   t1 = t2
   ! CHECK: return
 end subroutine test3
 
 ! CHECK-LABEL: func @_QPtest_array_comp(
-! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>,
-! CHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>)
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>,
+! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>)
 subroutine test_array_comp(t1, t2)
   type t
      real :: m_x(10)
@@ -86,14 +106,29 @@ subroutine test_array_comp(t1, t2)
   end type t
   type(t) :: t1, t2
 
-  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest_array_compTt{{.*}}>
-  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest_array_compTt{{.*}}>
+  ! CHECK:  %[[VAL_2:.*]] = fir.field_index m_x, !fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.array<10xf32>>
+  ! CHECK:  %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.array<10xf32>>
+  ! CHECK:  %[[VAL_5:.*]] = arith.constant 0 : index
+  ! CHECK:  %[[VAL_6:.*]] = arith.constant 1 : index
+  ! CHECK:  %[[VAL_7:.*]] = arith.constant 9 : index
+  ! CHECK:  fir.do_loop %[[VAL_8:.*]] = %[[VAL_5]] to %[[VAL_7]] step %[[VAL_6]] {
+  ! CHECK:    %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_4]], %[[VAL_8]] : (!fir.ref<!fir.array<10xf32>>, index) -> !fir.ref<f32>
+  ! CHECK:    %[[VAL_10:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_8]] : (!fir.ref<!fir.array<10xf32>>, index) -> !fir.ref<f32>
+  ! CHECK:    %[[VAL_11:.*]] = fir.load %[[VAL_10]] : !fir.ref<f32>
+  ! CHECK:    fir.store %[[VAL_11]] to %[[VAL_9]] : !fir.ref<f32>
+  ! CHECK:  }
+  ! CHECK:  %[[VAL_12:.*]] = fir.field_index m_i, !fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>
+  ! CHECK:  %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_12]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_12]] : (!fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_15:.*]] = fir.load %[[VAL_13]] : !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_15]] to %[[VAL_14]] : !fir.ref<i32>
   t1 = t2
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_ptr_comp(
-! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>,
-! CHECK-SAME: %[[t2]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>)
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>,
+! CHECK-SAME: %[[VAL_1]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>)
 subroutine test_ptr_comp(t1, t2)
   type t
      complex, pointer :: ptr(:)
@@ -101,8 +136,16 @@ subroutine test_ptr_comp(t1, t2)
   end type t
   type(t) :: t1, t2
 
-  ! CHECK: %[[ld:.*]] = fir.load %[[t2]] : !fir.ref<!fir.type<_QFtest_ptr_compTt{{.*}}>
-  ! CHECK: fir.store %[[ld]] to %[[t1]] : !fir.ref<!fir.type<_QFtest_ptr_compTt{{.*}}>
+  ! CHECK:  %[[VAL_2:.*]] = fir.field_index ptr, !fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
+  ! CHECK:  %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
+  ! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
+  ! CHECK:  fir.store %[[VAL_5]] to %[[VAL_4]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>>
+  ! CHECK:  %[[VAL_6:.*]] = fir.field_index m_i, !fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>
+  ! CHECK:  %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_6]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_8:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_6]] : (!fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>, !fir.field) -> !fir.ref<i32>
+  ! CHECK:  %[[VAL_9:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
+  ! CHECK:  fir.store %[[VAL_9]] to %[[VAL_8]] : !fir.ref<i32>
   t1 = t2
 end subroutine
 

--- a/flang/test/Lower/structure-constructors.f90
+++ b/flang/test/Lower/structure-constructors.f90
@@ -31,7 +31,6 @@ contains
   ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>)
   subroutine test_simple(x)
     real :: x
-    ! CHECK: %[[tmp0:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_simple{x:f32}>
     ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_simple{x:f32}>
     ! CHECK: %[[field:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_simple{x:f32}>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[tmp]], %[[field]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_simple{x:f32}>>, !fir.field) -> !fir.ref<f32>
@@ -43,7 +42,6 @@ contains
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_char_scalar(
   ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>)
   subroutine test_char_scalar(x)
-    ! CHECK: %[[tmp0:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>
     ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>
     ! CHECK: %[[xfield:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[tmp]], %[[xfield]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>>, !fir.field) -> !fir.ref<f32>
@@ -66,7 +64,6 @@ contains
     real :: x
     integer :: j(5)
     call print_simple_array(t_array(x=x, i=2*j))
-    ! CHECK: %[[tmp0:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>
     ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>
     ! CHECK: %[[xfield:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[tmp]], %[[xfield]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>, !fir.field) -> !fir.ref<f32>
@@ -90,7 +87,6 @@ contains
 ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<f32>,
 ! CHECK-SAME:  %[[VAL_1:.*]]: !fir.boxchar<1>) {
   subroutine test_char_array(x, c1)
-  ! CHECK: %[[VAL_2:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>
   ! CHECK: %[[VAL_3:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>
   ! CHECK: %[[VAL_4:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[VAL_5:.*]] = fir.convert %[[VAL_4]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<5x!fir.char<1,3>>>
@@ -124,9 +120,7 @@ contains
   ! CHECK: fir.result %[[VAL_32]] : !fir.array<5x!fir.char<1,3>>
   ! CHECK: }
   ! CHECK: fir.array_merge_store %[[VAL_14]], %[[VAL_33:.*]] to %[[VAL_11]] : !fir.array<5x!fir.char<1,3>>, !fir.array<5x!fir.char<1,3>>, !fir.ref<!fir.array<5x!fir.char<1,3>>>
-  ! CHECK: %[[VAL_34:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>>
-  ! CHECK: fir.store %[[VAL_34]] to %[[VAL_2]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>>
-  ! CHECK: fir.call @_QMm_struct_ctorPprint_char_array(%[[VAL_2]]) : (!fir.ref<!fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>>) -> ()
+  ! CHECK: fir.call @_QMm_struct_ctorPprint_char_array(%[[VAL_3]]) : (!fir.ref<!fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>>) -> ()
 
     real :: x
     character(3) :: c1(5)
@@ -138,7 +132,6 @@ contains
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_ptr(
   ! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<f32>,
   ! CHECK-SAME:    %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xi32>> {fir.target}) {
-  ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>
   ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>
   ! CHECK:         %[[VAL_4:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>
   ! CHECK:         %[[VAL_5:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_4]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>, !fir.field) -> !fir.ref<f32>
@@ -162,9 +155,7 @@ contains
   ! CHECK:         %[[VAL_22:.*]] = fir.rebox %[[VAL_1]] {{\[}}%[[VAL_21]]] : (!fir.box<!fir.array<?x?xi32>>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xi32>>
   ! CHECK:         %[[VAL_23:.*]] = fir.rebox %[[VAL_22]] : (!fir.box<!fir.array<?x?xi32>>) -> !fir.box<!fir.ptr<!fir.array<?x?xi32>>>
   ! CHECK:         fir.store %[[VAL_23]] to %[[VAL_8]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xi32>>>>
-  ! CHECK:         %[[VAL_24:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>
-  ! CHECK:         fir.store %[[VAL_24]] to %[[VAL_2]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>
-  ! CHECK:         fir.call @_QMm_struct_ctorPprint_ptr(%[[VAL_2]]) : (!fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>) -> ()
+  ! CHECK:         fir.call @_QMm_struct_ctorPprint_ptr(%[[VAL_3]]) : (!fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>) -> ()
   ! CHECK:         return
   ! CHECK:       }
 
@@ -175,19 +166,35 @@ contains
   end subroutine
 
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_nested(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>,
-  ! CHECK-SAME: %[[d:.*]]: !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
+  ! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>,
+  ! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
   subroutine test_nested(x, d)
     real :: x
     type(t_array) :: d
-    ! CHECK: %[[tmp0:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
-    ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
-    ! CHECK: fir.field_index x, !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
-
-    ! CHECK: %[[dtfield:.*]] = fir.field_index dt, !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
-    ! CHECK: %[[dtcoor:.*]] = fir.coordinate_of %[[tmp]], %[[dtfield]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>>, !fir.field) -> !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
-    ! CHECK: %[[dload:.*]] = fir.load %[[d]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
-    ! CHECK: fir.store %[[dload]] to %[[dtcoor]] : !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
+  ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
+  ! CHECK:         %[[VAL_3:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
+  ! CHECK:         %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_3]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>>, !fir.field) -> !fir.ref<f32>
+  ! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
+  ! CHECK:         fir.store %[[VAL_5]] to %[[VAL_4]] : !fir.ref<f32>
+  ! CHECK:         %[[VAL_6:.*]] = fir.field_index dt, !fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>
+  ! CHECK:         %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_6]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_nested{x:f32,dt:!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>}>>, !fir.field) -> !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
+  ! CHECK:         %[[VAL_8:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>
+  ! CHECK:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_8]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>, !fir.field) -> !fir.ref<f32>
+  ! CHECK:         %[[VAL_10:.*]] = fir.coordinate_of %[[VAL_7]], %[[VAL_8]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>, !fir.field) -> !fir.ref<f32>
+  ! CHECK:         %[[VAL_11:.*]] = fir.load %[[VAL_9]] : !fir.ref<f32>
+  ! CHECK:         fir.store %[[VAL_11]] to %[[VAL_10]] : !fir.ref<f32>
+  ! CHECK:         %[[VAL_12:.*]] = fir.field_index i, !fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>
+  ! CHECK:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_12]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>, !fir.field) -> !fir.ref<!fir.array<5xi32>>
+  ! CHECK:         %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_7]], %[[VAL_12]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>, !fir.field) -> !fir.ref<!fir.array<5xi32>>
+  ! CHECK:         %[[VAL_15:.*]] = arith.constant 0 : index
+  ! CHECK:         %[[VAL_16:.*]] = arith.constant 1 : index
+  ! CHECK:         %[[VAL_17:.*]] = arith.constant 4 : index
+  ! CHECK:         fir.do_loop %[[VAL_18:.*]] = %[[VAL_15]] to %[[VAL_17]] step %[[VAL_16]] {
+  ! CHECK:           %[[VAL_19:.*]] = fir.coordinate_of %[[VAL_14]], %[[VAL_18]] : (!fir.ref<!fir.array<5xi32>>, index) -> !fir.ref<i32>
+  ! CHECK:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_18]] : (!fir.ref<!fir.array<5xi32>>, index) -> !fir.ref<i32>
+  ! CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i32>
+  ! CHECK:           fir.store %[[VAL_21]] to %[[VAL_19]] : !fir.ref<i32>
+  ! CHECK:         }
     call print_nested(t_nested(x=x, dt=d))
   end subroutine
 


### PR DESCRIPTION
So far, there were places where lowering was loading/stroring
fir.record type to copy them. This works, but hits LLVM limitations
when the derived type storage size is big.
LLVM advise against loading/storing big aggregates types here:
https://llvm.org/docs/Frontend/PerformanceTips.html#avoid-loads-and-stores-of-large-aggregate-type
but falls short of defining what is big.

Simply always copy derived types component by components when a
load/store was previously used.

Note that it was considered keeping load/stores in fir, and transforming
this to element by element copies in codegen, but it is not possible to
ensure the load/store will still be pairs after fir transformation
passes.

Hence, generalize the use of genRecordAssignment helper, and add a new
fir::factory::genScalarAssignement to centralize scalar assignment as
much as possible.

Also prevents the load/store of constant size fir.characters in places
where it was happening (array value copy) since these too are aggregate
types that can grow big.