### PR TITLE
Fix visibility issue with interdependent module variables

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -468,11 +468,11 @@ static void instantiateGlobal(Fortran::lower::AbstractConverter &converter,
       mlir::StringAttr externalLinkage;
       global = declareGlobal(converter, var, globalName, externalLinkage);
     } else {
-      // Module and common globals are defined elsewhere.
-      // The only globals defined here are the globals owned by procedures
-      // and they do not need to be visible in other compilation unit.
-      auto internalLinkage = builder.createInternalLinkage();
-      global = defineGlobal(converter, var, globalName, internalLinkage);
+      mlir::StringAttr linkage; // external if remains empty.
+      if (!sym.owner().IsModule() &&
+          !Fortran::semantics::FindCommonBlockContaining(sym))
+        linkage = builder.createInternalLinkage();
+      global = defineGlobal(converter, var, globalName, linkage);
     }
   }
   auto addrOf = builder.create<fir::AddrOfOp>(loc, global.resultType(),

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -49,3 +49,21 @@ end module
 ! CHECK-LABEL: fir.global @_QBnamed2 : tuple<i32> {
   ! CHECK: %[[init:.*]] = fir.insert_value %{{.*}}, %c42{{.*}}, [0 : index] : (tuple<i32>, i32) -> tuple<i32>
   ! CHECK: fir.has_value %[[init]] : tuple<i32>
+
+! Test defining two module variables whose initializers depend on each others
+! addresses.
+module global_init_depending_on_each_other_address
+  type a
+    type(b), pointer :: pb
+  end type
+  type b
+    type(a), pointer :: pa
+  end type
+  type(a), target :: xa
+  type(b), target :: xb
+  data xa, xb/a(xb), b(xa)/
+end module
+! CHECK-LABEL: fir.global @_QMglobal_init_depending_on_each_other_addressExb
+  ! CHECK: fir.address_of(@_QMglobal_init_depending_on_each_other_addressExa)
+! CHECK-LABEL: fir.global @_QMglobal_init_depending_on_each_other_addressExa
+  ! CHECK: fir.address_of(@_QMglobal_init_depending_on_each_other_addressExb)


### PR DESCRIPTION
The function `instantiateGlobal` was wrongfully assuming it would never be
called on module variables being defined (as opposed to used) in the
current scope.

This is wrong since module variable may take each other addresses in
their initializer, causing instantiateGlobal to be called in order to
instantiate the module variable (create the global if needed +
fir.address_of) in the initializer region of the other module variable.

This caused some module symbols to be given local visibility, which
was an issue when they are used in other compilation units.

Remove this assumption and test if the variable requires external
visibility in instantiateGlobal.