### PR TITLE
Cherry pick semantic and runtime fixes made in LLVM since PR 1288

### DIFF
--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -61,9 +61,9 @@ To understand the status of various developments in Flang please join the respec
 ### LLVM Alias Analysis Technical Call
 
 -   For people working on improvements to LLVM alias analysis.
--   Join [LLVM Alias Analysis Technical Call](https://bluejeans.com/316886064)
+-   Join [LLVM Alias Analysis Technical Call](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGI1Zjc1MGItZjJjZS00ZmE5LTg0OGYtMmQzNDU5YjQwODA2%40thread.v2/0?context=%7b%22Tid%22%3a%220cfca185-25f7-49e3-8ae7-704d5326e285%22%2c%22Oid%22%3a%220cacfb51-1523-4455-a443-adca936d1af0%22%7d)
 -   Time: Tuesdays 10:00 AM Pacific Time, every 4 weeks.
--   The agenda is in this [Google Doc](https://docs.google.com/document/d/1ybwEKDVtIbhIhK50qYtwKsL50K-NvB6LfuBsfepBZ9Y/).
+-   The agenda is in this [Google Doc](https://docs.google.com/document/d/17U-WvX8qyKc3S36YUKr3xfF-GHunWyYowXbxEdpHscw).
 
 ### OpenMP in Flang Technical Call
 

--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1054,6 +1054,8 @@ bool IsProcedurePointer(const Symbol &);
 bool IsAutomatic(const Symbol &);
 bool IsSaved(const Symbol &); // saved implicitly or explicitly
 bool IsDummy(const Symbol &);
+bool IsAssumedShape(const Symbol &);
+bool IsDeferredShape(const Symbol &);
 bool IsFunctionResult(const Symbol &);
 bool IsKindTypeParameter(const Symbol &);
 bool IsLenTypeParameter(const Symbol &);

--- a/flang/include/flang/Lower/BoxAnalyzer.h
+++ b/flang/include/flang/Lower/BoxAnalyzer.h
@@ -397,7 +397,7 @@ public:
                 shapes.push_back(extent < 0 ? 0 : extent);
                 continue;
               }
-            } else if (subs.ubound().isAssumed()) {
+            } else if (subs.ubound().isStar()) {
               shapes.push_back(fir::SequenceType::getUnknownExtent());
               continue;
             }

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -188,11 +188,11 @@ public:
   }
   bool IsArray() const { return !shape_.empty(); }
   bool IsCoarray() const { return !coshape_.empty(); }
-  bool IsAssumedShape() const { return isDummy() && shape_.IsAssumedShape(); }
-  bool IsDeferredShape() const {
-    return !isDummy() && shape_.IsDeferredShape();
+  bool CanBeAssumedShape() const {
+    return isDummy() && shape_.CanBeAssumedShape();
   }
-  bool IsAssumedSize() const { return isDummy() && shape_.IsAssumedSize(); }
+  bool CanBeDeferredShape() const { return shape_.CanBeDeferredShape(); }
+  bool IsAssumedSize() const { return isDummy() && shape_.CanBeAssumedSize(); }
   bool IsAssumedRank() const { return isDummy() && shape_.IsAssumedRank(); }
 
 private:

--- a/flang/include/flang/Semantics/type.h
+++ b/flang/include/flang/Semantics/type.h
@@ -47,11 +47,17 @@ using SubscriptIntExpr = evaluate::Expr<evaluate::SubscriptInteger>;
 using MaybeSubscriptIntExpr = std::optional<SubscriptIntExpr>;
 using KindExpr = SubscriptIntExpr;
 
-// An array spec bound: an explicit integer expression or ASSUMED or DEFERRED
+// An array spec bound: an explicit integer expression, assumed size
+// or implied shape(*), or assumed or deferred shape(:).  In the absence
+// of explicit lower bounds it is not possible to distinguish assumed
+// shape bounds from deferred shape bounds without knowing whether the
+// particular symbol is an allocatable/pointer or a non-allocatable
+// non-pointer dummy; use the symbol-based predicates for those
+// determinations.
 class Bound {
 public:
-  static Bound Assumed() { return Bound(Category::Assumed); }
-  static Bound Deferred() { return Bound(Category::Deferred); }
+  static Bound Star() { return Bound(Category::Star); }
+  static Bound Colon() { return Bound(Category::Colon); }
   explicit Bound(MaybeSubscriptIntExpr &&expr) : expr_{std::move(expr)} {}
   explicit Bound(common::ConstantSubscript bound);
   Bound(const Bound &) = default;
@@ -59,8 +65,8 @@ public:
   Bound &operator=(const Bound &) = default;
   Bound &operator=(Bound &&) = default;
   bool isExplicit() const { return category_ == Category::Explicit; }
-  bool isAssumed() const { return category_ == Category::Assumed; }
-  bool isDeferred() const { return category_ == Category::Deferred; }
+  bool isStar() const { return category_ == Category::Star; }
+  bool isColon() const { return category_ == Category::Colon; }
   MaybeSubscriptIntExpr &GetExplicit() { return expr_; }
   const MaybeSubscriptIntExpr &GetExplicit() const { return expr_; }
   void SetExplicit(MaybeSubscriptIntExpr &&expr) {
@@ -69,7 +75,7 @@ public:
   }
 
 private:
-  enum class Category { Explicit, Deferred, Assumed };
+  enum class Category { Explicit, Star, Colon };
   Bound(Category category) : category_{category} {}
   Bound(Category category, MaybeSubscriptIntExpr &&expr)
       : category_{category}, expr_{std::move(expr)} {}
@@ -78,7 +84,8 @@ private:
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Bound &);
 };
 
-// A type parameter value: integer expression or assumed or deferred.
+// A type parameter value: integer expression, assumed/implied(*),
+// or deferred(:).
 class ParamValue {
 public:
   static ParamValue Assumed(common::TypeParamAttr attr) {
@@ -176,28 +183,26 @@ public:
     return MakeExplicit(Bound{1}, std::move(ub));
   }
   // 1:
-  static ShapeSpec MakeAssumed() {
-    return ShapeSpec(Bound{1}, Bound::Deferred());
+  static ShapeSpec MakeAssumedShape() {
+    return ShapeSpec(Bound{1}, Bound::Colon());
   }
   // lb:
-  static ShapeSpec MakeAssumed(Bound &&lb) {
-    return ShapeSpec(std::move(lb), Bound::Deferred());
+  static ShapeSpec MakeAssumedShape(Bound &&lb) {
+    return ShapeSpec(std::move(lb), Bound::Colon());
   }
   // :
   static ShapeSpec MakeDeferred() {
-    return ShapeSpec(Bound::Deferred(), Bound::Deferred());
+    return ShapeSpec(Bound::Colon(), Bound::Colon());
   }
   // 1:*
-  static ShapeSpec MakeImplied() {
-    return ShapeSpec(Bound{1}, Bound::Assumed());
-  }
+  static ShapeSpec MakeImplied() { return ShapeSpec(Bound{1}, Bound::Star()); }
   // lb:*
   static ShapeSpec MakeImplied(Bound &&lb) {
-    return ShapeSpec(std::move(lb), Bound::Assumed());
+    return ShapeSpec(std::move(lb), Bound::Star());
   }
   // ..
   static ShapeSpec MakeAssumedRank() {
-    return ShapeSpec(Bound::Assumed(), Bound::Assumed());
+    return ShapeSpec(Bound::Star(), Bound::Star());
   }
 
   ShapeSpec(const ShapeSpec &) = default;
@@ -220,11 +225,15 @@ private:
 struct ArraySpec : public std::vector<ShapeSpec> {
   ArraySpec() {}
   int Rank() const { return size(); }
+  // These names are not exclusive, as some categories cannot be
+  // distinguished without knowing whether the particular symbol
+  // is allocatable, pointer, or a non-allocatable non-pointer dummy.
+  // Use the symbol-based predicates for exact results.
   inline bool IsExplicitShape() const;
-  inline bool IsAssumedShape() const;
-  inline bool IsDeferredShape() const;
-  inline bool IsImpliedShape() const;
-  inline bool IsAssumedSize() const;
+  inline bool CanBeAssumedShape() const;
+  inline bool CanBeDeferredShape() const;
+  inline bool CanBeImpliedShape() const;
+  inline bool CanBeAssumedSize() const;
   inline bool IsAssumedRank() const;
 
 private:
@@ -399,25 +408,25 @@ private:
 inline bool ArraySpec::IsExplicitShape() const {
   return CheckAll([](const ShapeSpec &x) { return x.ubound().isExplicit(); });
 }
-inline bool ArraySpec::IsAssumedShape() const {
-  return CheckAll([](const ShapeSpec &x) { return x.ubound().isDeferred(); });
+inline bool ArraySpec::CanBeAssumedShape() const {
+  return CheckAll([](const ShapeSpec &x) { return x.ubound().isColon(); });
 }
-inline bool ArraySpec::IsDeferredShape() const {
+inline bool ArraySpec::CanBeDeferredShape() const {
   return CheckAll([](const ShapeSpec &x) {
-    return x.lbound().isDeferred() && x.ubound().isDeferred();
+    return x.lbound().isColon() && x.ubound().isColon();
   });
 }
-inline bool ArraySpec::IsImpliedShape() const {
+inline bool ArraySpec::CanBeImpliedShape() const {
   return !IsAssumedRank() &&
-      CheckAll([](const ShapeSpec &x) { return x.ubound().isAssumed(); });
+      CheckAll([](const ShapeSpec &x) { return x.ubound().isStar(); });
 }
-inline bool ArraySpec::IsAssumedSize() const {
-  return !empty() && !IsAssumedRank() && back().ubound().isAssumed() &&
+inline bool ArraySpec::CanBeAssumedSize() const {
+  return !empty() && !IsAssumedRank() && back().ubound().isStar() &&
       std::all_of(begin(), end() - 1,
           [](const ShapeSpec &x) { return x.ubound().isExplicit(); });
 }
 inline bool ArraySpec::IsAssumedRank() const {
-  return Rank() == 1 && front().lbound().isAssumed();
+  return Rank() == 1 && front().lbound().isStar();
 }
 
 inline IntrinsicTypeSpec *DeclTypeSpec::AsIntrinsic() {

--- a/flang/lib/Evaluate/characteristics.cpp
+++ b/flang/lib/Evaluate/characteristics.cpp
@@ -189,20 +189,20 @@ std::optional<Expr<SubscriptInteger>> TypeAndShape::MeasureSizeInBytes(
 }
 
 void TypeAndShape::AcquireAttrs(const semantics::Symbol &symbol) {
+  if (IsAssumedShape(symbol)) {
+    attrs_.set(Attr::AssumedShape);
+  }
+  if (IsDeferredShape(symbol)) {
+    attrs_.set(Attr::DeferredShape);
+  }
   if (const auto *object{
           symbol.GetUltimate().detailsIf<semantics::ObjectEntityDetails>()}) {
     corank_ = object->coshape().Rank();
     if (object->IsAssumedRank()) {
       attrs_.set(Attr::AssumedRank);
     }
-    if (object->IsAssumedShape()) {
-      attrs_.set(Attr::AssumedShape);
-    }
     if (object->IsAssumedSize()) {
       attrs_.set(Attr::AssumedSize);
-    }
-    if (object->IsDeferredShape()) {
-      attrs_.set(Attr::DeferredShape);
     }
     if (object->IsCoarray()) {
       attrs_.set(Attr::Coarray);

--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -659,18 +659,12 @@ public:
       // simple contiguity to allow their use in contexts like
       // data targets in pointer assignments with remapping.
       return true;
-    } else if (semantics::IsPointer(ultimate)) {
+    } else if (semantics::IsPointer(ultimate) ||
+        semantics::IsAssumedShape(ultimate)) {
       return false;
-    } else if (semantics::IsAllocatable(ultimate)) {
-      // TODO: this could be merged with the case below if
-      // details->IsAssumedShape() did not return true for allocatables. Current
-      // ArraySpec building in semantics does not allow making a difference
-      // between some_assumed_shape(:) and some_allocatable(:). Both
-      // isDeferredShape() and isAssumedShape() are true in each case.
-      return true;
     } else if (const auto *details{
                    ultimate.detailsIf<semantics::ObjectEntityDetails>()}) {
-      return !details->IsAssumedShape() && !details->IsAssumedRank();
+      return !details->IsAssumedRank();
     } else if (auto assoc{Base::operator()(ultimate)}) {
       return assoc;
     } else {

--- a/flang/lib/Evaluate/shape.cpp
+++ b/flang/lib/Evaluate/shape.cpp
@@ -27,7 +27,7 @@ bool IsImpliedShape(const Symbol &original) {
   const Symbol &symbol{ResolveAssociations(original)};
   const auto *details{symbol.detailsIf<semantics::ObjectEntityDetails>()};
   return details && symbol.attrs().test(semantics::Attr::PARAMETER) &&
-      details->shape().IsImpliedShape();
+      details->shape().CanBeImpliedShape();
 }
 
 bool IsExplicitShape(const Symbol &original) {

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1252,6 +1252,20 @@ bool IsDummy(const Symbol &symbol) {
       ResolveAssociations(symbol).details());
 }
 
+bool IsAssumedShape(const Symbol &symbol) {
+  const Symbol &ultimate{ResolveAssociations(symbol)};
+  const auto *object{ultimate.detailsIf<ObjectEntityDetails>()};
+  return object && object->CanBeAssumedShape() &&
+      !evaluate::IsAllocatableOrPointer(ultimate);
+}
+
+bool IsDeferredShape(const Symbol &symbol) {
+  const Symbol &ultimate{ResolveAssociations(symbol)};
+  const auto *object{ultimate.detailsIf<ObjectEntityDetails>()};
+  return object && object->CanBeDeferredShape() &&
+      evaluate::IsAllocatableOrPointer(ultimate);
+}
+
 bool IsFunctionResult(const Symbol &original) {
   const Symbol &symbol{GetAssociationRoot(original)};
   return (symbol.has<ObjectEntityDetails>() &&

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -531,15 +531,15 @@ void PutEntity(llvm::raw_ostream &os, const Symbol &symbol) {
 }
 
 void PutShapeSpec(llvm::raw_ostream &os, const ShapeSpec &x) {
-  if (x.lbound().isAssumed()) {
-    CHECK(x.ubound().isAssumed());
-    os << "..";
+  if (x.lbound().isStar()) {
+    CHECK(x.ubound().isStar());
+    os << ".."; // assumed rank
   } else {
-    if (!x.lbound().isDeferred()) {
+    if (!x.lbound().isColon()) {
       PutBound(os, x.lbound());
     }
     os << ':';
-    if (!x.ubound().isDeferred()) {
+    if (!x.ubound().isColon()) {
       PutBound(os, x.ubound());
     }
   }
@@ -639,9 +639,9 @@ void PutInit(llvm::raw_ostream &os, const MaybeIntExpr &init) {
 }
 
 void PutBound(llvm::raw_ostream &os, const Bound &x) {
-  if (x.isAssumed()) {
+  if (x.isStar()) {
     os << '*';
-  } else if (x.isDeferred()) {
+  } else if (x.isColon()) {
     os << ':';
   } else {
     x.GetExplicit()->AsFortran(os);

--- a/flang/lib/Semantics/resolve-names-utils.cpp
+++ b/flang/lib/Semantics/resolve-names-utils.cpp
@@ -303,7 +303,7 @@ ArraySpec ArraySpecAnalyzer::Analyze(const parser::CoarraySpec &x) {
 }
 
 void ArraySpecAnalyzer::Analyze(const parser::AssumedShapeSpec &x) {
-  arraySpec_.push_back(ShapeSpec::MakeAssumed(GetBound(x.v)));
+  arraySpec_.push_back(ShapeSpec::MakeAssumedShape(GetBound(x.v)));
 }
 void ArraySpecAnalyzer::Analyze(const parser::ExplicitShapeSpec &x) {
   MakeExplicit(std::get<std::optional<parser::SpecificationExpr>>(x.t),

--- a/flang/lib/Semantics/type.cpp
+++ b/flang/lib/Semantics/type.cpp
@@ -531,9 +531,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const DerivedTypeSpec &x) {
 Bound::Bound(common::ConstantSubscript bound) : expr_{bound} {}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Bound &x) {
-  if (x.isAssumed()) {
+  if (x.isStar()) {
     o << '*';
-  } else if (x.isDeferred()) {
+  } else if (x.isColon()) {
     o << ':';
   } else if (x.expr_) {
     x.expr_->AsFortran(o);
@@ -544,15 +544,15 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Bound &x) {
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const ShapeSpec &x) {
-  if (x.lb_.isAssumed()) {
-    CHECK(x.ub_.isAssumed());
+  if (x.lb_.isStar()) {
+    CHECK(x.ub_.isStar());
     o << "..";
   } else {
-    if (!x.lb_.isDeferred()) {
+    if (!x.lb_.isColon()) {
       o << x.lb_;
     }
     o << ':';
-    if (!x.ub_.isDeferred()) {
+    if (!x.ub_.isColon()) {
       o << x.ub_;
     }
   }

--- a/flang/runtime/file.h
+++ b/flang/runtime/file.h
@@ -85,6 +85,7 @@ private:
     position_ = pos;
     openPosition_.reset();
   }
+  void CloseFd(IoErrorHandler &);
 
   int fd_{-1};
   OwningPtr<char> path_;

--- a/flang/runtime/misc-intrinsic.cpp
+++ b/flang/runtime/misc-intrinsic.cpp
@@ -11,33 +11,19 @@
 #include "flang/Runtime/descriptor.h"
 #include <algorithm>
 #include <cstring>
+#include <optional>
 
 namespace Fortran::runtime {
-extern "C" {
 
-void RTNAME(Transfer)(Descriptor &result, const Descriptor &source,
-    const Descriptor &mold, const char *sourceFile, int line) {
-  if (mold.rank() > 0) {
-    std::size_t moldElementBytes{mold.ElementBytes()};
-    std::size_t elements{
-        (source.Elements() * source.ElementBytes() + moldElementBytes - 1) /
-        moldElementBytes};
-    return RTNAME(TransferSize)(result, source, mold, sourceFile, line,
-        static_cast<std::int64_t>(elements));
-  } else {
-    return RTNAME(TransferSize)(result, source, mold, sourceFile, line, 1);
-  }
-}
-
-void RTNAME(TransferSize)(Descriptor &result, const Descriptor &source,
+static void TransferImpl(Descriptor &result, const Descriptor &source,
     const Descriptor &mold, const char *sourceFile, int line,
-    std::int64_t size) {
-  int rank{mold.rank() > 0 ? 1 : 0};
+    std::optional<std::int64_t> resultExtent) {
+  int rank{resultExtent.has_value() ? 1 : 0};
   std::size_t elementBytes{mold.ElementBytes()};
   result.Establish(mold.type(), elementBytes, nullptr, rank, nullptr,
       CFI_attribute_allocatable, mold.Addendum() != nullptr);
-  if (rank > 0) {
-    result.GetDimension(0).SetBounds(1, size);
+  if (resultExtent) {
+    result.GetDimension(0).SetBounds(1, *resultExtent);
   }
   if (const DescriptorAddendum * addendum{mold.Addendum()}) {
     *result.Addendum() = *addendum;
@@ -47,7 +33,7 @@ void RTNAME(TransferSize)(Descriptor &result, const Descriptor &source,
         "TRANSFER: could not allocate memory for result; STAT=%d", stat);
   }
   char *to{result.OffsetElement<char>()};
-  std::size_t resultBytes{size * elementBytes};
+  std::size_t resultBytes{result.Elements() * result.ElementBytes()};
   const std::size_t sourceElementBytes{source.ElementBytes()};
   std::size_t sourceElements{source.Elements()};
   SubscriptValue sourceAt[maxRank];
@@ -63,6 +49,28 @@ void RTNAME(TransferSize)(Descriptor &result, const Descriptor &source,
   if (resultBytes > 0) {
     std::memset(to, 0, resultBytes);
   }
+}
+
+extern "C" {
+
+void RTNAME(Transfer)(Descriptor &result, const Descriptor &source,
+    const Descriptor &mold, const char *sourceFile, int line) {
+  if (mold.rank() > 0) {
+    std::size_t moldElementBytes{mold.ElementBytes()};
+    std::size_t elements{
+        (source.Elements() * source.ElementBytes() + moldElementBytes - 1) /
+        moldElementBytes};
+    return TransferImpl(result, source, mold, sourceFile, line,
+        static_cast<std::int64_t>(elements));
+  } else {
+    return TransferImpl(result, source, mold, sourceFile, line, {});
+  }
+}
+
+void RTNAME(TransferSize)(Descriptor &result, const Descriptor &source,
+    const Descriptor &mold, const char *sourceFile, int line,
+    std::int64_t size) {
+  return TransferImpl(result, source, mold, sourceFile, line, size);
 }
 
 } // extern "C"

--- a/flang/unittests/Runtime/MiscIntrinsic.cpp
+++ b/flang/unittests/Runtime/MiscIntrinsic.cpp
@@ -68,3 +68,21 @@ TEST(MiscIntrinsic, TransferSize) {
   EXPECT_EQ(result.OffsetElement<float>()[1], 2.2F);
   result.Destroy();
 }
+TEST(MiscIntrinsic, TransferSizeScalarMold) {
+  StaticDescriptor<2, true, 2> staticDesc[2];
+  auto &result{staticDesc[0].descriptor()};
+  std::complex<float> sourecStorage{1.1F, -2.2F};
+  auto source{Descriptor::Create(TypeCategory::Complex, 4,
+      reinterpret_cast<void *>(&sourecStorage), 0, nullptr,
+      CFI_attribute_pointer)};
+  auto &mold{staticDesc[1].descriptor()};
+  mold.Establish(TypeCategory::Real, 4, nullptr, 0, nullptr);
+  RTNAME(TransferSize)(result, *source, mold, __FILE__, __LINE__, 2);
+  EXPECT_EQ(result.rank(), 1);
+  EXPECT_EQ(result.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(result.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(result.type().raw(), (TypeCode{TypeCategory::Real, 4}.raw()));
+  EXPECT_EQ(result.OffsetElement<float>()[0], 1.1F);
+  EXPECT_EQ(result.OffsetElement<float>()[1], -2.2F);
+  result.Destroy();
+}


### PR DESCRIPTION
Note: commit 6c6a1ae433896e648ef3cba599a1f611feb86b07 was added to adapt lowering to name changes in ce000a22a4b850ec728b1aafb281e102e79899a4.