### PR TITLE
Lower lbound/ubound with non constant DIM argument

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -409,6 +409,18 @@ llvm::SmallVector<mlir::Value> getExtents(fir::FirOpBuilder &builder,
 fir::ExtendedValue readBoxValue(fir::FirOpBuilder &builder, mlir::Location loc,
                                 const fir::BoxValue &box);
 
+/// Get non default (not all ones) lower bounds of \p exv. Returns empty
+/// vector if the lower bounds are all ones.
+llvm::SmallVector<mlir::Value>
+getNonDefaultLowerBounds(fir::FirOpBuilder &builder, mlir::Location loc,
+                         const fir::ExtendedValue &exv);
+
+/// Return length parameters associated to \p exv that are not deferred (that
+/// are available without having to read any fir.box values).
+/// Empty if \p exv has no length parameters or if they are all deferred.
+llvm::SmallVector<mlir::Value>
+getNonDeferredLengthParams(const fir::ExtendedValue &exv);
+
 //===--------------------------------------------------------------------===//
 // String literal helper helpers
 //===--------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -646,6 +646,46 @@ fir::ExtendedValue fir::factory::readBoxValue(fir::FirOpBuilder &builder,
                             box.getLBounds());
 }
 
+llvm::SmallVector<mlir::Value>
+fir::factory::getNonDefaultLowerBounds(fir::FirOpBuilder &builder,
+                                       mlir::Location loc,
+                                       const fir::ExtendedValue &exv) {
+  return exv.match(
+      [&](const fir::ArrayBoxValue &array) -> llvm::SmallVector<mlir::Value> {
+        return {array.getLBounds().begin(), array.getLBounds().end()};
+      },
+      [&](const fir::CharArrayBoxValue &array)
+          -> llvm::SmallVector<mlir::Value> {
+        return {array.getLBounds().begin(), array.getLBounds().end()};
+      },
+      [&](const fir::BoxValue &box) -> llvm::SmallVector<mlir::Value> {
+        return {box.getLBounds().begin(), box.getLBounds().end()};
+      },
+      [&](const fir::MutableBoxValue &box) -> llvm::SmallVector<mlir::Value> {
+        auto load = fir::factory::genMutableBoxRead(builder, loc, box);
+        return fir::factory::getNonDefaultLowerBounds(builder, loc, load);
+      },
+      [&](const auto &) -> llvm::SmallVector<mlir::Value> { return {}; });
+}
+
+llvm::SmallVector<mlir::Value>
+fir::factory::getNonDeferredLengthParams(const fir::ExtendedValue &exv) {
+  return exv.match(
+      [&](const fir::CharArrayBoxValue &character)
+          -> llvm::SmallVector<mlir::Value> { return {character.getLen()}; },
+      [&](const fir::CharBoxValue &character)
+          -> llvm::SmallVector<mlir::Value> { return {character.getLen()}; },
+      [&](const fir::MutableBoxValue &box) -> llvm::SmallVector<mlir::Value> {
+        return {box.nonDeferredLenParams().begin(),
+                box.nonDeferredLenParams().end()};
+      },
+      [&](const fir::BoxValue &box) -> llvm::SmallVector<mlir::Value> {
+        return {box.getExplicitParameters().begin(),
+                box.getExplicitParameters().end()};
+      },
+      [&](const auto &) -> llvm::SmallVector<mlir::Value> { return {}; });
+}
+
 std::string fir::factory::uniqueCGIdent(llvm::StringRef prefix,
                                         llvm::StringRef name) {
   // For "long" identifiers use a hash value

--- a/flang/test/Lower/intrinsic-procedures/lbound.f90
+++ b/flang/test/Lower/intrinsic-procedures/lbound.f90
@@ -1,0 +1,66 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+
+! CHECK-LABEL: func @_QPlbound_test(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine lbound_test(a, dim, res)
+  real, dimension(:, :) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i64
+! CHECK:         fir.store %[[VAL_3]] to %[[VAL_2]] : !fir.ref<i64>
+  res = lbound(a, dim, 8)
+end subroutine
+
+! CHECK-LABEL: func @_QPlbound_test_2(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine lbound_test_2(a, dim, res)
+  real, dimension(:, 2:) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
+! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 2 : i64
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
+! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[VAL_9:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_10:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_9]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_11]] to %[[VAL_10]] : !fir.ref<i64>
+! CHECK:         %[[VAL_12:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_12]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_7]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_14]] to %[[VAL_13]] : !fir.ref<i64>
+! CHECK:         %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_8]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
+! CHECK:         %[[VAL_16:.*]] = fir.load %[[VAL_15]] : !fir.ref<i64>
+! CHECK:         fir.store %[[VAL_16]] to %[[VAL_2]] : !fir.ref<i64>
+  res = lbound(a, dim, 8)
+end subroutine
+
+! CHECK-LABEL: func @_QPlbound_test_3(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<9x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine lbound_test_3(a, dim, res)
+  real, dimension(2:10, 3:*) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
+! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_5:.*]] = arith.constant 3 : index
+! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_8:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_7]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_4]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_9]] to %[[VAL_8]] : !fir.ref<i64>
+! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_11:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_10]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_12]] to %[[VAL_11]] : !fir.ref<i64>
+! CHECK:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_6]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
+! CHECK:         %[[VAL_14:.*]] = fir.load %[[VAL_13]] : !fir.ref<i64>
+! CHECK:         fir.store %[[VAL_14]] to %[[VAL_2]] : !fir.ref<i64>
+  res = lbound(a, dim, 8)
+end subroutine

--- a/flang/test/Lower/intrinsic-procedures/size.f90
+++ b/flang/test/Lower/intrinsic-procedures/size.f90
@@ -1,6 +1,10 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPsize_test() {
+subroutine size_test()
+  real, dimension(1:10, -10:10) :: a
+  integer :: dim = 1
+  integer :: iSize
 ! CHECK:         %[[VAL_0:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_2:.*]] = arith.constant -10 : index
@@ -8,58 +12,28 @@
 ! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.array<10x21xf32> {bindc_name = "a", uniq_name = "_QFsize_testEa"}
 ! CHECK:         %[[VAL_5:.*]] = fir.address_of(@_QFsize_testEdim) : !fir.ref<i32>
 ! CHECK:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "isize", uniq_name = "_QFsize_testEisize"}
-! CHECK:         %[[VAL_7:.*]] = arith.constant 4 : i64
+! CHECK:         %[[VAL_7:.*]] = arith.constant 2 : i64
 ! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
-! CHECK:         %[[VAL_9:.*]] = arith.constant 3 : i64
+! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : i64
 ! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i64) -> index
-! CHECK:         %[[VAL_11:.*]] = arith.constant 2 : i64
+! CHECK:         %[[VAL_11:.*]] = arith.constant 5 : i64
 ! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
-! CHECK:         %[[VAL_13:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_13:.*]] = arith.constant -1 : i64
 ! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i64) -> index
-! CHECK:         %[[VAL_15:.*]] = arith.constant 5 : i64
+! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i64
 ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i64) -> index
-! CHECK:         %[[VAL_17:.*]] = arith.constant -1 : i64
+! CHECK:         %[[VAL_17:.*]] = arith.constant 1 : i64
 ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
-! CHECK:         %[[VAL_19:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i64) -> index
-! CHECK:         %[[VAL_21:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (i64) -> index
-! CHECK:         %[[VAL_23:.*]] = fir.shape_shift %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index) -> !fir.shapeshift<2>
-! CHECK:         %[[VAL_24:.*]] = fir.slice %[[VAL_12]], %[[VAL_16]], %[[VAL_14]], %[[VAL_18]], %[[VAL_22]], %[[VAL_20]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:         %[[VAL_25:.*]] = fir.array_load %[[VAL_4]](%[[VAL_23]]) {{\[}}%[[VAL_24]]] : (!fir.ref<!fir.array<10x21xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.array<10x21xf32>
-! CHECK:         %[[VAL_26:.*]] = fir.allocmem !fir.array<4x3xf32>
-! CHECK:         %[[VAL_27:.*]] = fir.shape %[[VAL_8]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
-! CHECK:         %[[VAL_28:.*]] = fir.array_load %[[VAL_26]](%[[VAL_27]]) : (!fir.heap<!fir.array<4x3xf32>>, !fir.shape<2>) -> !fir.array<4x3xf32>
-! CHECK:         %[[VAL_29:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_30:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_31:.*]] = arith.subi %[[VAL_8]], %[[VAL_29]] : index
-! CHECK:         %[[VAL_32:.*]] = arith.subi %[[VAL_10]], %[[VAL_29]] : index
-! CHECK:         %[[VAL_33:.*]] = fir.do_loop %[[VAL_34:.*]] = %[[VAL_30]] to %[[VAL_32]] step %[[VAL_29]] unordered iter_args(%[[VAL_35:.*]] = %[[VAL_28]]) -> (!fir.array<4x3xf32>) {
-! CHECK:           %[[VAL_36:.*]] = fir.do_loop %[[VAL_37:.*]] = %[[VAL_30]] to %[[VAL_31]] step %[[VAL_29]] unordered iter_args(%[[VAL_38:.*]] = %[[VAL_35]]) -> (!fir.array<4x3xf32>) {
-! CHECK:             %[[VAL_39:.*]] = fir.array_fetch %[[VAL_25]], %[[VAL_37]], %[[VAL_34]] : (!fir.array<10x21xf32>, index, index) -> f32
-! CHECK:             %[[VAL_40:.*]] = fir.array_update %[[VAL_38]], %[[VAL_39]], %[[VAL_37]], %[[VAL_34]] : (!fir.array<4x3xf32>, f32, index, index) -> !fir.array<4x3xf32>
-! CHECK:             fir.result %[[VAL_40]] : !fir.array<4x3xf32>
-! CHECK:           }
-! CHECK:           fir.result %[[VAL_41:.*]] : !fir.array<4x3xf32>
-! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_28]], %[[VAL_42:.*]] to %[[VAL_26]] : !fir.array<4x3xf32>, !fir.array<4x3xf32>, !fir.heap<!fir.array<4x3xf32>>
-! CHECK:         %[[VAL_43:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-! CHECK:         %[[VAL_44:.*]] = fir.shape %[[VAL_8]], %[[VAL_10]] : (index, index) -> !fir.shape<2>
-! CHECK:         %[[VAL_45:.*]] = fir.embox %[[VAL_26]](%[[VAL_44]]) : (!fir.heap<!fir.array<4x3xf32>>, !fir.shape<2>) -> !fir.box<!fir.array<4x3xf32>>
-! CHECK:         %[[VAL_46:.*]] = fir.convert %[[VAL_43]] : (i32) -> index
-! CHECK:         %[[VAL_47:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_48:.*]] = arith.subi %[[VAL_46]], %[[VAL_47]] : index
-! CHECK:         %[[VAL_49:.*]]:3 = fir.box_dims %[[VAL_45]], %[[VAL_48]] : (!fir.box<!fir.array<4x3xf32>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_50:.*]] = fir.convert %[[VAL_49]]#1 : (index) -> i64
-! CHECK:         %[[VAL_51:.*]] = fir.convert %[[VAL_50]] : (i64) -> i32
-! CHECK:         fir.store %[[VAL_51]] to %[[VAL_6]] : !fir.ref<i32>
-! CHECK:         fir.freemem %[[VAL_26]] : !fir.heap<!fir.array<4x3xf32>>
-! CHECK:         return
-! CHECK:       }
-
-subroutine size_test()
-  real, dimension(1:10, -10:10) :: a
-  integer :: dim = 1
-  integer :: iSize
+! CHECK:         %[[VAL_19:.*]] = fir.shape_shift %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index) -> !fir.shapeshift<2>
+! CHECK:         %[[VAL_20:.*]] = fir.slice %[[VAL_8]], %[[VAL_12]], %[[VAL_10]], %[[VAL_14]], %[[VAL_18]], %[[VAL_16]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_21:.*]] = fir.embox %[[VAL_4]](%[[VAL_19]]) {{\[}}%[[VAL_20]]] : (!fir.ref<!fir.array<10x21xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_22:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+! CHECK:         %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i32) -> index
+! CHECK:         %[[VAL_24:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_25:.*]] = arith.subi %[[VAL_23]], %[[VAL_24]] : index
+! CHECK:         %[[VAL_26:.*]]:3 = fir.box_dims %[[VAL_21]], %[[VAL_25]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_26]]#1 : (index) -> i64
+! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i64) -> i32
+! CHECK:         fir.store %[[VAL_28]] to %[[VAL_6]] : !fir.ref<i32>
   iSize = size(a(2:5, -1:1), dim, 8)
 end subroutine size_test

--- a/flang/test/Lower/intrinsic-procedures/ubound.f90
+++ b/flang/test/Lower/intrinsic-procedures/ubound.f90
@@ -1,0 +1,85 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+
+! CHECK-LABEL: func @_QPubound_test(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine ubound_test(a, dim, res)
+  real, dimension(:, :) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
+! CHECK:         %[[VAL_5:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_6:.*]] = arith.subi %[[VAL_4]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_7:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_6]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]]#1 : (index) -> i64
+! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
+! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_8]] : i64
+! CHECK:         fir.store %[[VAL_12]] to %[[VAL_2]] : !fir.ref<i64>
+  res = ubound(a, dim, 8)
+end subroutine
+
+! CHECK-LABEL: func @_QPubound_test_2(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine ubound_test_2(a, dim, res)
+  real, dimension(2:, 3:) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
+! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : i64
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 3 : i64
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
+! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
+! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
+! CHECK:         %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]]#1 : (index) -> i64
+! CHECK:         %[[VAL_14:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_14]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_16]] to %[[VAL_15]] : !fir.ref<i64>
+! CHECK:         %[[VAL_17:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_17]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
+! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_7]] : (index) -> i64
+! CHECK:         fir.store %[[VAL_19]] to %[[VAL_18]] : !fir.ref<i64>
+! CHECK:         %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_8]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
+! CHECK:         %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i64>
+! CHECK:         %[[VAL_22:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_23:.*]] = arith.subi %[[VAL_21]], %[[VAL_22]] : i64
+! CHECK:         %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_13]] : i64
+! CHECK:         fir.store %[[VAL_24]] to %[[VAL_2]] : !fir.ref<i64>
+  res = ubound(a, dim, 8)
+end subroutine
+
+! CHECK-LABEL: func @_QPubound_test_3(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x20x?xf32>>,
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+subroutine ubound_test_3(a, dim, res)
+  real, dimension(10, 20, *) :: a
+  integer(8):: dim, res
+! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 20 : index
+! CHECK:         %[[VAL_5:.*]] = fir.undefined index
+! CHECK:         %[[VAL_6:.*]] = fir.shape %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (index, index, index) -> !fir.shape<3>
+! CHECK:         %[[VAL_7:.*]] = fir.embox %[[VAL_0]](%[[VAL_6]]) : (!fir.ref<!fir.array<10x20x?xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<10x20x?xf32>>
+! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
+! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
+! CHECK:         %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_7]], %[[VAL_11]] : (!fir.box<!fir.array<10x20x?xf32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]]#1 : (index) -> i64
+! CHECK:         %[[VAL_14:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
+! CHECK:         %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : i64
+! CHECK:         fir.store %[[VAL_17]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:         return
+  res = ubound(a, dim, 8)
+end subroutine


### PR DESCRIPTION
Lower UBOUND with non compile time constant DIM argument using
LBOUND and SIZE (other cases are folded by the front-end to
descriptor inquiries). This required implementing LBOUND.

To get LBOUND correctly, the "asBox" intrinsic argument option needed
to be ramped-up a bit. It was not fulfilling its contract entirely
because it was not placing the fir.box in a fir::BoxValue ExtendedValue.
Ensure the correct category is created from the argument while ensuring
its non default lower bounds/non deferred parameters information are not
lost when emboxing the value.

Fix all the places that expected an "UnboxedValue" with the asBox
option, and use asBox in SIZE lowering to avoid evaluating array section
in temps to compute their size.