### PR TITLE
Change host associations so they are not "promoted" to !fir.ptr

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -206,7 +206,8 @@ mlir::Value createSubroutineCall(AbstractConverter &converter,
 // pass-by-ref semantics for a VALUE parameter. The optimizer may be able to
 // eliminate these.
 inline mlir::NamedAttribute getAdaptToByRefAttr(fir::FirOpBuilder &builder) {
-  return {mlir::Identifier::get("adapt.valuebyref", builder.getContext()),
+  return {mlir::Identifier::get(fir::getAdaptToByRefAttrName(),
+                                builder.getContext()),
           builder.getUnitAttr()};
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -38,6 +38,14 @@ mlir::ParseResult parseSelector(mlir::OpAsmParser &parser,
                                 mlir::OpAsmParser::OperandType &selector,
                                 mlir::Type &type);
 
+static constexpr llvm::StringRef getAdaptToByRefAttrName() {
+  return "adapt.valuebyref";
+}
+
+static constexpr llvm::StringRef getNormalizedLowerBoundAttrName() {
+  return "normalized.lb";
+}
+
 } // namespace fir
 
 #define GET_OP_CLASSES

--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -182,15 +182,13 @@ llvm::raw_ostream &fir::operator<<(llvm::raw_ostream &os,
 /// always be called, so it should not have any functional side effects,
 /// the const is here to enforce that.
 bool fir::MutableBoxValue::verify() const {
-  auto type = fir::dyn_cast_ptrEleTy(getAddr().getType());
+  mlir::Type type = fir::dyn_cast_ptrEleTy(getAddr().getType());
   if (!type)
     return false;
   auto box = type.dyn_cast<fir::BoxType>();
   if (!box)
     return false;
-  auto eleTy = box.getEleTy();
-  if (!eleTy.isa<fir::PointerType>() && !eleTy.isa<fir::HeapType>())
-    return false;
+  // A boxed value always takes a memory reference,
 
   auto nParams = lenParams.size();
   if (isCharacter()) {

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1482,13 +1482,18 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::cg::XEmboxOp> {
         }
       }
       if (!skipNext) {
-        // store lower bound (normally 0)
+        // store lower bound (normally 0 for BIND(C) interoperability)
         auto lb = zero;
-        if (eleTy.isa<fir::PointerType>() || eleTy.isa<fir::HeapType>()) {
+        bool isaPointerOrAllocatable =
+            eleTy.isa<fir::PointerType>() || eleTy.isa<fir::HeapType>();
+        if (isaPointerOrAllocatable)
           lb = one;
-          if (hasShift)
-            lb = operands[shiftOff];
-        }
+        // Normally, allow a non-zero lower bound to be encoded in the box. For
+        // C interoperability however, the lower bound should be normalized to 0
+        // unless the boxed object is a pointer or allocatable.
+        if (hasShift &&
+            (isaPointerOrAllocatable || !normalizedLowerBound(xbox)))
+          lb = operands[shiftOff];
         dest = insertLowerBound(rewriter, loc, dest, descIdx, lb);
 
         // store extent
@@ -1546,6 +1551,13 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::cg::XEmboxOp> {
     auto result = placeInMemoryIfNotGlobalInit(rewriter, loc, dest);
     rewriter.replaceOp(xbox, result);
     return success();
+  }
+
+  /// Return true if `xbox` has a normalized lower bounds attribute. A box value
+  /// that is neither a POINTER nor an ALLOCATABLE should be normalized to a
+  /// zero origin lower bound for interoperability with BIND(C).
+  inline static bool normalizedLowerBound(fir::cg::XEmboxOp xbox) {
+    return xbox->hasAttr(fir::getNormalizedLowerBoundAttrName());
   }
 };
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1482,15 +1482,16 @@ struct XEmboxOpConversion : public EmboxCommonConversion<fir::cg::XEmboxOp> {
         }
       }
       if (!skipNext) {
-        // store lower bound (normally 0 for BIND(C) interoperability)
+        // Lower bound is normalized to 0 for BIND(C) interoperability.
         auto lb = zero;
         bool isaPointerOrAllocatable =
             eleTy.isa<fir::PointerType>() || eleTy.isa<fir::HeapType>();
-        if (isaPointerOrAllocatable)
+        // Lower bound is defaults to 1 for POINTER, ALLOCATABLE, and
+        // denormalized descriptors.
+        if (isaPointerOrAllocatable || !normalizedLowerBound(xbox))
           lb = one;
-        // Normally, allow a non-zero lower bound to be encoded in the box. For
-        // C interoperability however, the lower bound should be normalized to 0
-        // unless the boxed object is a pointer or allocatable.
+        // If there is a shifted origin and this is not a normalized descriptor
+        // then use the value from the shift op as the lower bound.
         if (hasShift &&
             (isaPointerOrAllocatable || !normalizedLowerBound(xbox)))
           lb = operands[shiftOff];

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -145,10 +145,10 @@ func @box6(%0 : !fir.ref<!fir.array<?x?x?x?xf32>>, %1 : index, %2 : index) -> i3
   // CHECK: %[[sdp2:.*]] = sdiv i64 %[[dp2]], 2
   // CHECK: %[[cmp:.*]] = icmp sgt i64 %[[sdp2]], 0
   // CHECK: %[[extent:.*]] = select i1 %[[cmp]], i64 %[[sdp2]], i64 0
-  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 25, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 0, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[extent]], 7, 0, 1
+  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 25, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 1, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[extent]], 7, 0, 1
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 800, 7, 0, 2
   // CHECK: %[[op25:.*]] = add i64 25000, %[[i100p40]]
-  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 0, 7, 1, 0
+  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 1, 7, 1, 0
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 4, 7, 1, 1
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 120000, 7, 1, 2
   // CHECK: %[[op300:.*]] = add i64 300000, %[[op25]]

--- a/flang/test/Fir/embox.fir
+++ b/flang/test/Fir/embox.fir
@@ -13,7 +13,7 @@ func @_QPtest_slice() {
 // CHECK:  %[[a3:.*]] = getelementptr [20 x i32], [20 x i32]* %[[a2]], i64 0, i64 0, 
 // CHECK:  %[[a4:.*]] = insertvalue { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }  
 // CHECK:  { i32* undef, i64 4, i32 20180515, i8 1, i8 9, i8 0, i8 0, [1 x [3 x i64]] 
-// CHECK: [i64 0, i64 5, i64 8]] }, i32* %[[a3]], 0, 
+// CHECK: [i64 1, i64 5, i64 8]] }, i32* %[[a3]], 0, 
 // CHECK:  store { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } %[[a4]], { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[a1]], align 8
 // CHECK:  call void @_QPtest_callee({ i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[a1]]), 
   %c20 = arith.constant 20 : index
@@ -40,7 +40,7 @@ func @_QPtest_dt_slice() {
 // CHECK:  %[[a4:.*]] = getelementptr [20 x %_QFtest_dt_sliceTt], [20 x %_QFtest_dt_sliceTt]* %[[a3]], i64 0, i64 0, i32 0,
 // CHECK: %[[a5:.*]] = insertvalue { i32*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }
 // CHECK-SAME: { i32* undef, i64 4, i32 20180515, i8 1, i8 9, i8 0, i8 0, [1 x [3 x i64]]
-// CHECK-SAME: [i64 0, i64 5, i64 mul
+// CHECK-SAME: [i64 1, i64 5, i64 mul
 // CHECK-SAME: (i64 ptrtoint (%_QFtest_dt_sliceTt* getelementptr (%_QFtest_dt_sliceTt, %_QFtest_dt_sliceTt* null, i64 1) to i64), i64 2)]] }
 // CHECK-SAME: , i32* %[[a4]], 0
 

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -12,19 +12,18 @@ subroutine test1
   implicit none
   integer i
   ! CHECK-DAG: %[[i:.*]] = fir.alloca i32 {{.*}}uniq_name = "_QFtest1Ei"
-  ! CHECK-DAG: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<i32>>
+  ! CHECK-DAG: %[[tup:.*]] = fir.alloca tuple<!fir.ref<i32>>
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[tup]], %c0
-  ! CHECK: %[[ii:.*]] = fir.convert %[[i]]
-  ! CHECK: fir.store %[[ii]] to %[[addr]] : !fir.ref<!fir.ptr<i32>>
-  ! CHECK: fir.call @_QFtest1Ptest1_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ptr<i32>>>) -> ()
+  ! CHECK: fir.store %[[i]] to %[[addr]] : !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: fir.call @_QFtest1Ptest1_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ref<i32>>>) -> ()
   call test1_internal
   print *, i
 contains
-  ! CHECK: func @_QFtest1Ptest1_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<i32>>> {fir.host_assoc}) {
+  ! CHECK: func @_QFtest1Ptest1_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
   ! CHECK: %[[iaddr:.*]] = fir.coordinate_of %[[arg]], %c0
-  ! CHECK: %[[i:.*]] = fir.load %[[iaddr]] : !fir.ref<!fir.ptr<i32>>
+  ! CHECK: %[[i:.*]] = fir.load %[[iaddr]] : !fir.llvm_ptr<!fir.ref<i32>>
   ! CHECK: %[[val:.*]] = fir.call @_QPifoo() : () -> i32
-  ! CHECK: fir.store %[[val]] to %[[i]] : !fir.ptr<i32>
+  ! CHECK: fir.store %[[val]] to %[[i]] : !fir.ref<i32>
   subroutine test1_internal
     integer, external :: ifoo
     i = ifoo()
@@ -37,39 +36,37 @@ end subroutine test1
 subroutine test2
   a = 1.0
   b = 2.0
-  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<f32>, !fir.ptr<f32>>
-  ! CHECK-DAG: %[[a0:.*]] = fir.coordinate_of %[[tup]], %c0
-  ! CHECK-DAG: %[[p0:.*]] = fir.convert %{{.*}} : (!fir.ref<f32>) -> !fir.ptr<f32>
-  ! CHECK: fir.store %[[p0]] to %[[a0]] : !fir.ref<!fir.ptr<f32>>
-  ! CHECK-DAG: %[[b0:.*]] = fir.coordinate_of %[[tup]], %c1
-  ! CHECK-DAG: %[[p1:.*]] = fir.convert %{{.*}} : (!fir.ref<f32>) -> !fir.ptr<f32>
-  ! CHECK: fir.store %[[p1]] to %[[b0]] : !fir.ref<!fir.ptr<f32>>
-  ! CHECK: fir.call @_QFtest2Ptest2_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>>) -> ()
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ref<f32>, !fir.ref<f32>>
+  ! CHECK: %[[a0:.*]] = fir.coordinate_of %[[tup]], %c0
+  ! CHECK: fir.store %{{.*}} to %[[a0]] : !fir.llvm_ptr<!fir.ref<f32>>
+  ! CHECK: %[[b0:.*]] = fir.coordinate_of %[[tup]], %c1
+  ! CHECK: fir.store %{{.*}} to %[[b0]] : !fir.llvm_ptr<!fir.ref<f32>>
+  ! CHECK: fir.call @_QFtest2Ptest2_internal(%[[tup]]) : (!fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>>) -> ()
   call test2_internal
   print *, a, b
 contains
-  ! CHECK: func @_QFtest2Ptest2_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>> {fir.host_assoc}) {
+  ! CHECK: func @_QFtest2Ptest2_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
   subroutine test2_internal
     ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
-    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.llvm_ptr<!fir.ref<f32>>
     ! CHECK: %[[b:.*]] = fir.coordinate_of %[[arg]], %c1
-    ! CHECK: %{{.*}} = fir.load %[[b]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: %{{.*}} = fir.load %[[b]] : !fir.llvm_ptr<!fir.ref<f32>>
     ! CHECK: fir.alloca
-    ! CHECK: fir.load %[[aa]] : !fir.ptr<f32>
+    ! CHECK: fir.load %[[aa]] : !fir.ref<f32>
     c = a
     a = b
     b = c
     call test2_inner
   end subroutine test2_internal
 
-  ! CHECK: func @_QFtest2Ptest2_inner(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ptr<f32>, !fir.ptr<f32>>> {fir.host_assoc}) {
+  ! CHECK: func @_QFtest2Ptest2_inner(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
   subroutine test2_inner
     ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
-    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.ref<!fir.ptr<f32>>
+    ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.llvm_ptr<!fir.ref<f32>>
     ! CHECK: %[[b:.*]] = fir.coordinate_of %[[arg]], %c1
-    ! CHECK: %[[bb:.*]] = fir.load %[[b]] : !fir.ref<!fir.ptr<f32>>
-    ! CHECK-DAG: %[[bd:.*]] = fir.load %[[bb]] : !fir.ptr<f32>
-    ! CHECK-DAG: %[[ad:.*]] = fir.load %[[aa]] : !fir.ptr<f32>
+    ! CHECK: %[[bb:.*]] = fir.load %[[b]] : !fir.llvm_ptr<!fir.ref<f32>>
+    ! CHECK-DAG: %[[bd:.*]] = fir.load %[[bb]] : !fir.ref<f32>
+    ! CHECK-DAG: %[[ad:.*]] = fir.load %[[aa]] : !fir.ref<f32>
     ! CHECK: %{{.*}} = arith.cmpf ogt, %[[ad]], %[[bd]] : f32
     if (a > b) then
        b = b + 2.0
@@ -119,19 +116,19 @@ subroutine test3(p,q,i)
   real :: q(:)
   ! CHECK: %[[iload:.*]] = fir.load %[[i]] : !fir.ref<i64>
   ! CHECK: %[[icast:.*]] = fir.convert %[[iload]] : (i64) -> index
-  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<?xf32>>>
   ! CHECK: %[[pshift:.*]] = fir.shift %[[icast]] : (index) -> !fir.shift<1>
-  ! CHECK: %[[pbox:.*]] = fir.rebox %[[p]](%[[pshift]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-  ! CHECK: %[[qbox:.*]] = fir.rebox %[[q]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  ! CHECK: %[[pbox:.*]] = fir.rebox %[[p]](%[[pshift]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
+  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<?xf32>>>
+  ! CHECK: %[[qbox:.*]] = fir.rebox %[[q]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
+  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
 
   i = i + 1
   q = -42.0
 
-  ! CHECK: fir.call @_QFtest3Ptest3_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>) -> ()
+  ! CHECK: fir.call @_QFtest3Ptest3_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>>) -> ()
   call test3_inner
 
   if (p(2) .ne. -42.0) then
@@ -140,23 +137,23 @@ subroutine test3(p,q,i)
   
 contains
   ! CHECK-LABEL: func @_QFtest3Ptest3_inner(
-  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>> {fir.host_assoc}) {
+  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>> {fir.host_assoc}) {
   subroutine test3_inner
-    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-    ! CHECK: %[[pbounds:.]]:3 = fir.box_dims %[[p]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
-    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<?xf32>>>, !fir.box<!fir.ptr<!fir.array<?xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-    ! CHECK: %[[qbounds:.]]:3 = fir.box_dims %[[q]], %c0{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, index) -> (index, index, index)
+    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<?xf32>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
+    ! CHECK: %[[pbounds:.]]:3 = fir.box_dims %[[p]], %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<?xf32>>>
+    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
+    ! CHECK: %[[qbounds:.]]:3 = fir.box_dims %[[q]], %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 
 
     ! CHECK: %[[qlb:.*]] = fir.convert %[[qbounds]]#0 : (index) -> i64
     ! CHECK: %[[qoffset:.*]] = arith.subi %c1{{.*}}, %[[qlb]] : i64
-    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[q]], %[[qoffset]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[q]], %[[qoffset]] : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
     ! CHECK: %[[qload:.*]] = fir.load %[[qelt]] : !fir.ref<f32>
     ! CHECK: %[[plb:.*]] = fir.convert %[[pbounds]]#0 : (index) -> i64
     ! CHECK: %[[poffset:.*]] = arith.subi %c2{{.*}}, %[[plb]] : i64
-    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[p]], %[[poffset]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[p]], %[[poffset]] : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
     ! CHECK: fir.store %[[qload]] to %[[pelt]] : !fir.ref<f32>
     p(2) = q(1)
   end subroutine test3_inner
@@ -168,17 +165,17 @@ subroutine test3a(p)
   real :: p(10)
   real :: q(10)
   ! CHECK: %[[q:.*]] = fir.alloca !fir.array<10xf32> {bindc_name = "q", uniq_name = "_QFtest3aEq"}
-  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>
-  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>
+  ! CHECK: %[[ptup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<10xf32>>>
   ! CHECK: %[[shape:.*]] = fir.shape %c10{{.*}} : (index) -> !fir.shape<1>
-  ! CHECK: %[[pbox:.*]] = fir.embox %[[p]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<10xf32>>>
-  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-  ! CHECK: %[[qbox:.*]] = fir.embox %[[q]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<10xf32>>>
-  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
+  ! CHECK: %[[pbox:.*]] = fir.embox %[[p]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  ! CHECK: fir.store %[[pbox]] to %[[ptup]] : !fir.ref<!fir.box<!fir.array<10xf32>>>
+  ! CHECK: %[[qtup:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<10xf32>>>
+  ! CHECK: %[[qbox:.*]] = fir.embox %[[q]](%[[shape]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+  ! CHECK: fir.store %[[qbox]] to %[[qtup]] : !fir.ref<!fir.box<!fir.array<10xf32>>>
 
   q = -42.0
-  ! CHECK: fir.call @_QFtest3aPtest3a_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>) -> ()
+  ! CHECK: fir.call @_QFtest3aPtest3a_inner(%[[tup]]) : (!fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>>) -> ()
   call test3a_inner
 
   if (p(1) .ne. -42.0) then
@@ -187,18 +184,18 @@ subroutine test3a(p)
   
 contains
   ! CHECK: func @_QFtest3aPtest3a_inner(
-  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>> {fir.host_assoc}) {
+  ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>> {fir.host_assoc}) {
   subroutine test3a_inner
-    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-    ! CHECK: %[[paddr:.*]] = fir.box_addr %[[p]] : (!fir.box<!fir.ptr<!fir.array<10xf32>>>) -> !fir.ptr<!fir.array<10xf32>>
-    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.ptr<!fir.array<10xf32>>>, !fir.box<!fir.ptr<!fir.array<10xf32>>>>>, i32) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<10xf32>>>>
-    ! CHECK: %[[qaddr:.*]] = fir.box_addr %[[q]] : (!fir.box<!fir.ptr<!fir.array<10xf32>>>) -> !fir.ptr<!fir.array<10xf32>>
+    ! CHECK: %[[pcoor:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<10xf32>>>
+    ! CHECK: %[[p:.*]] = fir.load %[[pcoor]] : !fir.ref<!fir.box<!fir.array<10xf32>>>
+    ! CHECK: %[[paddr:.*]] = fir.box_addr %[[p]] : (!fir.box<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>>
+    ! CHECK: %[[qcoor:.*]] = fir.coordinate_of %[[tup]], %c1{{.*}} : (!fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>>, i32) -> !fir.ref<!fir.box<!fir.array<10xf32>>>
+    ! CHECK: %[[q:.*]] = fir.load %[[qcoor]] : !fir.ref<!fir.box<!fir.array<10xf32>>>
+    ! CHECK: %[[qaddr:.*]] = fir.box_addr %[[q]] : (!fir.box<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>>
 
-    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[qaddr]], %c0{{.*}} : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[qelt:.*]] = fir.coordinate_of %[[qaddr]], %c0{{.*}} : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
     ! CHECK: %[[qload:.*]] = fir.load %[[qelt]] : !fir.ref<f32>
-    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[paddr]], %c0{{.*}} : (!fir.ptr<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+    ! CHECK: %[[pelt:.*]] = fir.coordinate_of %[[paddr]], %c0{{.*}} : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
     ! CHECK: fir.store %[[qload]] to %[[pelt]] : !fir.ref<f32>
     p(1) = q(1)
   end subroutine test3a_inner
@@ -302,26 +299,25 @@ subroutine test7(j, k)
   implicit none
   integer :: j
   integer :: k(:)
-  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ptr<i32>>
-  ! CHECK: %[[jtup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ptr<i32>>>, i32) -> !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[jptr:.*]] = fir.convert %[[j]] : (!fir.ref<i32>) -> !fir.ptr<i32>
-  ! CHECK: fir.store %[[jptr]] to %[[jtup]] : !fir.ref<!fir.ptr<i32>>
+  ! CHECK: %[[tup:.*]] = fir.alloca tuple<!fir.ref<i32>>
+  ! CHECK: %[[jtup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: fir.store %[[j]] to %[[jtup]] : !fir.llvm_ptr<!fir.ref<i32>>
 
   ! CHECK: %[[kelem:.*]] = fir.array_coor %[[k]] %{{.*}} : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-  ! CHECK: fir.call @_QFtest7Ptest7_inner(%[[kelem]], %[[tup]]) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ptr<i32>>>) -> i32
+  ! CHECK: fir.call @_QFtest7Ptest7_inner(%[[kelem]], %[[tup]]) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> i32
   k = test7_inner(k)
 contains
 
 ! CHECK-LABEL: func @_QFtest7Ptest7_inner(
 ! CHECK-SAME: %[[i:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ptr<i32>>> {fir.host_assoc}) -> i32 {
+! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) -> i32 {
 elemental integer function test7_inner(i)
   implicit none
   integer, intent(in) :: i
-  ! CHECK: %[[jtup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ptr<i32>>>, i32) -> !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[jptr:.*]] = fir.load %[[jtup]] : !fir.ref<!fir.ptr<i32>>
+  ! CHECK: %[[jtup:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: %[[jptr:.*]] = fir.load %[[jtup]] : !fir.llvm_ptr<!fir.ref<i32>>
   ! CHECK-DAG: %[[iload:.*]] = fir.load %[[i]] : !fir.ref<i32>
-  ! CHECK-DAG: %[[jload:.*]] = fir.load %[[jptr]] : !fir.ptr<i32>
+  ! CHECK-DAG: %[[jload:.*]] = fir.load %[[jptr]] : !fir.ref<i32>
   ! CHECK: addi %[[iload]], %[[jload]] : i32
   test7_inner = i + j
 end function
@@ -335,13 +331,13 @@ subroutine issue990()
   call bar()
 contains
 ! CHECK-LABEL: func @_QFissue990Pbar(
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ptr<i32>>> {fir.host_assoc}) {
+! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
 subroutine bar()
   integer :: stmt_func, i
   stmt_func(i) = i + captured
-  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ptr<i32>>>, i32) -> !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[addr:.*]] = fir.load %[[tupAddr]] : !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[value:.*]] = fir.load %[[addr]] : !fir.ptr<i32>
+  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: %[[addr:.*]] = fir.load %[[tupAddr]] : !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: %[[value:.*]] = fir.load %[[addr]] : !fir.ref<i32>
   ! CHECK: arith.addi %{{.*}}, %[[value]] : i32
   print *, stmt_func(10)
 end subroutine
@@ -357,11 +353,11 @@ subroutine issue990b()
   call bar()
 contains
 ! CHECK-LABEL: func @_QFissue990bPbar(
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ptr<i32>>> {fir.host_assoc}) {
+! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
 subroutine bar()
-  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ptr<i32>>>, i32) -> !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[addr:.*]] = fir.load %[[tupAddr]] : !fir.ref<!fir.ptr<i32>>
-  ! CHECK: %[[value:.*]] = fir.load %[[addr]] : !fir.ptr<i32>
+  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: %[[addr:.*]] = fir.load %[[tupAddr]] : !fir.llvm_ptr<!fir.ref<i32>>
+  ! CHECK: %[[value:.*]] = fir.load %[[addr]] : !fir.ref<i32>
   ! CHECK: arith.addi %{{.*}}, %[[value]] : i32
   print *, captured_stmt_func(10)
 end subroutine


### PR DESCRIPTION
(POINTER) variables. The promotion negatively impacts alias analysis and
performance.

In the initial implementation of the feature, host associated variables
were always passed as if they had been declared with the POINTER
attribute even when they had not been. These changes allow non-pointer,
non-allocatable variables to be passed as !fir.ref or !fir.box and
maintain the non-aliasing properties of the original host associated
variable whenever appropriate.

This change also allows descriptors to be created which are not
interoperatble with BIND(C) but do allow a variable to be boxed with its
properties. These properties can then be passed to internal procedures
without loss of information from the host. An attribute can be used to
force a descriptor to be created in a normalized form compatible with
the BIND(C) requirements from the standard.

# **DO NOT FILE A PULL REQUEST**

We are in the process of a github migration.  Please do not create a pull request as this could interfere with the process.
