### PR TITLE
Fix module variables definition vs declaration

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2699,8 +2699,13 @@ private:
         fir::NameUniquer::doGenerated("ModuleSham"),
         mlir::FunctionType::get(context, llvm::None, llvm::None));
     builder = new fir::FirOpBuilder(func, bridge.getKindMap());
-    for (const Fortran::lower::pft::Variable &var : mod.getOrderedSymbolTable())
-      Fortran::lower::defineModuleVariable(*this, var);
+    for (const Fortran::lower::pft::Variable &var :
+         mod.getOrderedSymbolTable()) {
+      // Only define the variables owned by this module.
+      const Fortran::semantics::Scope *owningScope = var.getOwningScope();
+      if (!owningScope || mod.getScope() == *owningScope)
+        Fortran::lower::defineModuleVariable(*this, var);
+    }
     if (mlir::Region *region = func.getCallableRegion())
       region->dropAllReferences();
     func.erase();

--- a/flang/test/Lower/module-single-point-of-def.f90
+++ b/flang/test/Lower/module-single-point-of-def.f90
@@ -1,0 +1,67 @@
+! Test that module variables with an initializer are only defined once,
+! even in context where this is compiler generated symbols/namelists (*).
+
+! RUN: split-file %s %t
+! RUN: bbc -emit-fir %t/definition-a.f90 -o - | FileCheck %s --check-prefix=CHECK-A-DEF
+! RUN: bbc -emit-fir %t/definition-b.f90 -o - | FileCheck %s --check-prefix=CHECK-B-DEF
+! RUN: bbc -emit-fir %t/use.f90 -o - | FileCheck %s --check-prefix=CHECK-USE
+
+
+! (*) compiler generated symbols, namelist members are special because
+! the symbol on the use site are not symbols with semantics::UseDetails,
+! but directly the symbols from the module scope.
+
+!--- definition-a.f90
+
+! Test definition of `atype` derived type descriptor.
+module define_a
+  type atype
+    real :: x
+  end type
+end module
+
+! CHECK-A-DEF: fir.global @_QMdefine_aE.dt.atype : !fir.type<{{.*}}> {
+! CHECK-A-DEF: fir.has_value
+! CHECK-A-DEF: }
+
+!--- definition-b.f90
+
+! Test define_b `i` is defined here as well as `btype` derived type
+! descriptor, but ensure `atype` derived type descriptor is not redefined
+! (only declared) while defining `btype` descriptors that depends on it.
+module define_b
+  use :: define_a
+  type btype
+    type(atype) :: atype
+  end type
+  integer :: i = 42
+  namelist /some_namelist/ i
+end module
+
+! CHECK-B-DEF: fir.global @_QMdefine_bEi : i32 {
+! CHECK-B-DEF: fir.has_value %{{.*}} : i32
+! CHECK-B-DEF: }
+
+! CHECK-B-DEF: fir.global @_QMdefine_bE.dt.btype : !fir.type<{{.*}}> {
+! CHECK-B-DEF: fir.has_value
+! CHECK-B-DEF: }
+
+! CHECK-B-DEF: fir.global @_QMdefine_aE.dt.atype : !fir.type<{{.*}}>{{$}}
+
+
+!--- use.f90
+
+! Test  define_b `i` is declared but not defined here and that derived types
+! descriptors are not redefined here.
+subroutine foo()
+  use :: define_b
+  type(btype) :: somet
+  print *, somet
+  write(*, some_namelist)
+end subroutine
+! CHECK-USE-NOT: fir.global @_QMdefine_bE.dt.btype
+
+! CHECK-USE: fir.global @_QMdefine_bEi : i32{{$}}
+! CHECK-USE-NOT: fir.has_value %{{.*}} : i32
+
+! CHECK-USE-NOT: fir.global @_QMdefine_bE.dt.btype


### PR DESCRIPTION
The initializer of module variables (if any) must only be emitted when
lowering the compilation unit that defines the module, otherwise, this
lead to conflict at link time.

Current lowering was already accounting for this with the
`var.isDeclaration()` helper to tell if a variable was owned by another
module.

However, it was based on a core assumption that turned out to be wrong.
The core assumption was that any module symbols that was instantiated
and had not `semantics::UseAssoc` details was necessarily being lowered
in the compilation unit defining the module.
It turned out to be wrong for at least the members of a module namelist used
in a another compilation unit, as well as for the type descriptor symbol
of a derived type from another compilation unit used to defined a new
derived type in a module. Both cases have valid reasons to not come
as use associated symbols (in both cases, the user never really used
them).

Part of the need for isDeclaration() came from a "create fir::GlobalOp
once per compilation unit and do not touch it anymore" approach that was
tough because global op initializer can depend on each other in
circular ways.
Instead of relying on this assumption (that might be broken in other
non trivial cases too) change the approach to define module globals. When using
a module variable (in a when instantiating variables to lower a
function, or the initializer or another variable), do not try to define
it (i.e. create its initializer), only create the globalOp with the right linkage if it does not exist
already.
Only create initializer body for module globals when actually lowering
the module. If the fir.global already exist (its address was required
before the it was itself lowered), just create the initializer body/attribute at
that point.

This removes some assumptions and allows simplifying the PFT symbol
analysis that was trying to keep track of the "declaration vs definition"
aspects for aggregates.
