### PR TITLE
Fix passing substrings to elemental functions

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -504,6 +504,11 @@ mlir::Value genLenOfCharacter(fir::FirOpBuilder &builder, mlir::Location loc,
                               fir::ArrayLoadOp arrLoad,
                               llvm::ArrayRef<mlir::Value> path,
                               llvm::ArrayRef<mlir::Value> substring);
+mlir::Value genLenOfCharacter(fir::FirOpBuilder &builder, mlir::Location loc,
+                              fir::SequenceType seqTy, mlir::Value memref,
+                              llvm::ArrayRef<mlir::Value> typeParams,
+                              llvm::ArrayRef<mlir::Value> path,
+                              llvm::ArrayRef<mlir::Value> substring);
 
 } // namespace fir::factory
 

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -4912,6 +4912,19 @@ private:
         mlir::Value coor = builder.create<fir::ArrayCoorOp>(
             loc, refEleTy, memref, shape, slice, indices,
             fir::getTypeParams(extMemref));
+        if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
+          llvm::SmallVector<mlir::Value> substringBounds;
+          populateBounds(substringBounds, components.substring);
+          if (!substringBounds.empty()) {
+            mlir::Value dstLen = fir::factory::genLenOfCharacter(
+                builder, loc, arrTy.cast<fir::SequenceType>(), memref,
+                fir::getTypeParams(extMemref), iters.iterVec(),
+                substringBounds);
+            fir::CharBoxValue dstChar(coor, dstLen);
+            return fir::factory::CharacterExprHelper{builder, loc}
+                .createSubstring(dstChar, substringBounds);
+          }
+        }
         return fir::factory::arraySectionElementToExtendedValue(
             builder, loc, extMemref, coor, slice);
       };

--- a/flang/test/Lower/character-elemental.f90
+++ b/flang/test/Lower/character-elemental.f90
@@ -1,0 +1,39 @@
+! RUN: bbc %s -o - | FileCheck %s
+
+! CHECK-LABEL: substring_main
+subroutine substring_main
+  character*7 :: string(2) = ['12     ', '12     ']
+  integer :: result(2)
+  integer :: ival
+
+  ival = 1
+  ! CHECK: %[[a0:.*]] = fir.alloca i32 {bindc_name = "ival", uniq_name = "_QFsubstring_mainEival"}
+  ! CHECK: %[[a2:.*]] = fir.address_of(@_QFsubstring_mainEstring) : !fir.ref<!fir.array<2x!fir.char<1,7>>>
+  ! CHECK: fir.store {{.*}} to %[[a0]] : !fir.ref<i32>
+  ! CHECK: %[[a3:.*]] = fir.shape {{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[a4:.*]] = fir.slice {{.*}}, {{.*}}, {{.*}} : (index, index, index) -> !fir.slice<1>
+  ! CHECK: br ^bb1({{.*}}, {{.*}} : index, index)
+  ! CHECK: ^bb1(%[[a5:.*]]: index, %[[a6:.*]]: index):  // 2 preds: ^bb0, ^bb2
+  ! CHECK: %[[a7:.*]] = arith.cmpi sgt, %[[a6]], {{.*}} : index
+  ! CHECK: cond_br %[[a7]], ^bb2, ^bb3
+  ! CHECK: ^bb2:  // pred: ^bb1
+  ! CHECK: %[[a8:.*]] = arith.addi %[[a5]], {{.*}} : index
+  ! CHECK: %[[a9:.*]] = fir.array_coor %[[a2]](%[[a3]]) [%[[a4]]] %[[a8]] : (!fir.ref<!fir.array<2x!fir.char<1,7>>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<!fir.char<1,7>>
+  ! CHECK: %[[a10:.*]] = fir.load %[[a0]] : !fir.ref<i32>
+  ! CHECK: %[[a11:.*]] = fir.convert %[[a10]] : (i32) -> index
+  ! CHECK: %[[a12:.*]] = arith.subi %[[a11]], {{.*}} : index
+  ! CHECK: %[[a13:.*]] = fir.convert %[[a9]] : (!fir.ref<!fir.char<1,7>>) -> !fir.ref<!fir.array<7x!fir.char<1>>>
+  ! CHECK: %[[a14:.*]] = fir.coordinate_of %[[a13]], %[[a12]] : (!fir.ref<!fir.array<7x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK: %[[a15:.*]] = fir.convert %[[a14]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK: %[[a16:.*]] = fir.emboxchar %[[a15]], {{.*}} : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[a17:.*]] = fir.call @_QFsubstring_mainPinner(%[[a16]]) : (!fir.boxchar<1>) -> i32
+  result = inner(string(1:2)(ival:ival))
+  print *, result
+contains
+  elemental function inner(arg)
+    character(len=*), intent(in) :: arg
+    integer :: inner
+
+    inner = len(arg)
+  end function inner
+end subroutine substring_main


### PR DESCRIPTION
We were not generating correct code to lower passing substrings to elemental functions.  We were failing in the case where we were passing an array of characters with a substring operation performed on the array.  Here's a test case that fails without this change:
```
program mine
  character*7 :: string(2) = ['12     ', '12     ']
  integer :: result(2)
  integer :: scalar
  integer :: ival

  ival = 1
  result = inner(string(1:2)(ival:ival))
contains
  elemental function inner(arg)
    character(len=*), intent(in) :: arg
    integer :: inner

    inner = len(arg)
  end function inner
end
```
