### PR TITLE
Add missing dependency in FrontendTool Cmake

### DIFF
--- a/flang/lib/FrontendTool/CMakeLists.txt
+++ b/flang/lib/FrontendTool/CMakeLists.txt
@@ -2,6 +2,9 @@ add_flang_library(flangFrontendTool
   ExecuteCompilerInvocation.cpp
 
   DEPENDS
+  # This makes sure that the MLIR dependencies of flangFrontend (which are
+  # transitively required here) are generated before this target is build.
+  flangFrontend
   clangBasic
 
   LINK_LIBS


### PR DESCRIPTION
FrontendTool cpp files use headers from lib/Frontend that themselves
uses MLIR headers containing tablegen generated content.

In parallel builds, if FrontendTool is built before the headers required
by Frontend, the build may fail with message like:

```
Building CXX object tools/flang/lib/FrontendTool/CMakeFiles/obj.flangFrontendTool.dir/ExecuteCompilerInvocation.cpp.o
In file included from mlir/include/mlir/IR/BuiltinTypes.h:13,
                 from mlir/include/mlir/IR/FunctionSupport.h:17,
                 from mlir/include/mlir/IR/BuiltinOps.h:16,
                 from flang/include/flang/Frontend/CompilerInstance.h:11,
                 from flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:14:
mlir/include/mlir/IR/SubElementInterfaces.h:21:10: fatal error: mlir/IR/SubElementAttrInterfaces.h.inc: No such file or directory
   21 | #include "mlir/IR/SubElementAttrInterfaces.h.inc"
      |
```

Make Frontend a dependency of FrontendTool so that all the headers
from Frontend are ready to be used when building FrontendTool.

