### PR TITLE
Fix MacOS build/test failures

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -142,7 +142,7 @@ void createEmptyRegionBlocks(
 }
 
 static mlir::Type getLoopVarType(Fortran::lower::AbstractConverter &converter,
-                                 std::uint64_t loopVarTypeSize) {
+                                 std::size_t loopVarTypeSize) {
   // OpenMP runtime requires 32-bit or 64-bit loop variables.
   loopVarTypeSize = loopVarTypeSize * 8;
   if (loopVarTypeSize < 32) {
@@ -171,7 +171,7 @@ static void createBodyOfOp(
   // e.g. For loops the argument is the induction variable. And all further
   // uses of the induction variable should use this mlir value.
   if (args.size()) {
-    std::uint64_t loopVarTypeSize = 0;
+    std::size_t loopVarTypeSize = 0;
     for (const Fortran::semantics::Symbol *arg : args)
       loopVarTypeSize = std::max(loopVarTypeSize, arg->GetUltimate().size());
     mlir::Type loopVarType = getLoopVarType(converter, loopVarTypeSize);
@@ -558,7 +558,7 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
 
   std::int64_t collapseValue =
       Fortran::lower::getCollapseValue(wsLoopOpClauseList);
-  std::uint64_t loopVarTypeSize = 0;
+  std::size_t loopVarTypeSize = 0;
   SmallVector<const Fortran::semantics::Symbol *> iv;
   do {
     Fortran::lower::pft::Evaluation *doLoop =

--- a/flang/test/Driver/code-gen-x86.f90
+++ b/flang/test/Driver/code-gen-x86.f90
@@ -8,6 +8,8 @@
 ! RUN: llvm-objdump --disassemble-all %t.o | FileCheck %s
 
 ! REQUIRES: x86-registered-target
+! UNSUPPORTED: darwin, macos
+
 
 ! CHECK-LABEL: <_QQmain>:
 ! CHECK-NEXT:  	retq

--- a/flang/test/Driver/flang-linker-flags.f90
+++ b/flang/test/Driver/flang-linker-flags.f90
@@ -7,6 +7,7 @@
 ! (Linux) specific. The following line will make sure that this test is skipped
 ! on Windows. Ideally we should find a more robust way of testing this.
 ! REQUIRES: shell
+! UNSUPPORTED: darwin, macos
 
 ! RUN: %flang -### --ld-path=/usr/bin/ld %S/Inputs/hello.f90 2>&1 | FileCheck %s
 

--- a/flang/test/Fir/complex.fir
+++ b/flang/test/Fir/complex.fir
@@ -5,6 +5,7 @@
 // RUN: ./a.out | FileCheck %s --check-prefix=EXECHECK
 
 // REQUIRES: x86-registered-target
+// UNSUPPORTED: darwin, macos
 
 // EXECHECK: <0.935893, 2.252526>
 

--- a/flang/test/Lower/ifconvert.f90
+++ b/flang/test/Lower/ifconvert.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -fdebug-dump-pre-fir %s |& FileCheck %s
+! RUN: bbc -fdebug-dump-pre-fir %s 2>&1 | FileCheck %s
 
 ! Note: PFT dump output is fairly stable, including node indexes and
 !       annotations, so all output is CHECKed.

--- a/flang/test/lit.site.cfg.py.in
+++ b/flang/test/lit.site.cfg.py.in
@@ -22,6 +22,8 @@ config.cplusplus_executable = "@CMAKE_CXX_COMPILER@"
 config.macos_sysroot = "@CMAKE_OSX_SYSROOT@"
 config.flang_standalone_build = "@FLANG_STANDALONE_BUILD@"
 config.targets_to_build = "@TARGETS_TO_BUILD@"
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@TARGET_TRIPLE@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
-> Using static_cast in max to match types.
-> Using redirection which works in Mac in a lit test RUN line.
-> Marking a few tests as unsupported on Mac. Issue raised to fix these.
https://github.com/flang-compiler/f18-llvm-project/issues/1338