### PR TITLE
[flang] Allow mixed argument types for implicit interfaces

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -204,6 +204,11 @@ public:
   /// Must the MLIR result be saved with a fir.save_result ?
   bool mustSaveResult() const { return saveResult; }
 
+  /// Can the associated procedure be called via an implicit interface?
+  bool canBeCalledViaImplicitInterface() const {
+    return characteristic && characteristic->CanBeCalledViaImplicitInterface();
+  }
+
 protected:
   CallInterface(Fortran::lower::AbstractConverter &c) : converter{c} {}
   /// CRTP handle.

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -66,7 +66,8 @@ public:
   /// converting an integer/real to a complex, the real part is filled using
   /// the integer/real after type conversion and the imaginary part is zero.
   mlir::Value convertWithSemantics(mlir::Location loc, mlir::Type toTy,
-                                   mlir::Value val);
+                                   mlir::Value val,
+                                   bool allowConversionsWithCharacters = false);
 
   /// Get the entry block of the current Function
   mlir::Block *getEntryBlock() { return &getFunction().front(); }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2105,9 +2105,14 @@ public:
 
     // Deal with potential mismatches in arguments types. Passing an array to a
     // scalar argument should for instance be tolerated here.
+    bool callingImplicitInterface = caller.canBeCalledViaImplicitInterface();
     for (auto [fst, snd] :
          llvm::zip(caller.getInputs(), funcType.getInputs())) {
-      mlir::Value cast = builder.convertWithSemantics(getLoc(), snd, fst);
+      // When passing arguments to a procedure that can be called an implicit
+      // interface, allow character actual arguments to be passed to dummy
+      // arguments of any type and vice versa
+      mlir::Value cast = builder.convertWithSemantics(getLoc(), snd, fst,
+                                                      callingImplicitInterface);
       operands.push_back(cast);
     }
 

--- a/flang/test/Lower/call-implicit.f90
+++ b/flang/test/Lower/call-implicit.f90
@@ -1,0 +1,14 @@
+! RUN: bbc %s -o "-" -emit-fir | FileCheck %s
+! Test lowering of calls to procedures with implicit interfaces using different
+! calls with different argument types, one of which is character
+subroutine s2
+  integer i(3)
+! CHECK:  %[[a0:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "i", uniq_name = "_QFs2Ei"}
+  ! CHECK: fir.call @_QPsub2(%[[a0]]) : (!fir.ref<!fir.array<3xi32>>) -> ()
+  call sub2(i)
+! CHECK:  %[[a1:.*]] = fir.address_of(@_QQcl.3031323334) : !fir.ref<!fir.char<1,5>>
+! CHECK:  %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:  %[[a3:.*]] = fir.convert %[[a2]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<3xi32>>
+  ! CHECK: fir.call @_QPsub2(%[[a3]]) : (!fir.ref<!fir.array<3xi32>>) -> ()
+  call sub2("01234")
+end


### PR DESCRIPTION
We've seen a test that calls procedures with implicit interfaces where the test
calls the same procedure one time with a string and next with some other
argument type.  We've also seen the opposite case where the procedure is first
called with a non-string argument followed by a call with a string argument.

It's unclear what runtime behavior is expected from this since it's possible
that the representations of strings and other types will vary among
implementations.  This change allows the compilation and code generation
for multiple calls to implicit interfaces where the types of the actual
arguments vary.

Note that, for procedures with implicit interfaces, the lowering code creates
an interface for the called procedure based on the first call.

This change keeps track of whether the procedure being called has an implicit
interface.  If it does, and one of the arguments is a string, it does the
necessary conversions to create a string from a non-string argument and vice
versa.

With these changes, NAG test kj4 passes.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
