### PR TITLE
[flang] Implement BaseAddressValueAttribute in regular calls

### DIFF
--- a/flang/test/Lower/call-by-value.f90
+++ b/flang/test/Lower/call-by-value.f90
@@ -1,0 +1,20 @@
+! Test for PassBy::BaseAddressValueAttribute
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+program call_by_value
+  interface
+     subroutine omp_set_nested(enable) bind(c)
+       logical, value :: enable
+     end subroutine omp_set_nested
+  end interface
+
+  logical do_nested
+  do_nested = .FALSE.
+  call omp_set_nested(do_nested)
+end program call_by_value
+!CHECK-LABEL: func @_QQmain()
+!CHECK: %[[LOGICAL:.*]] = fir.alloca !fir.logical<4>
+!CHECK: %false = arith.constant false
+!CHECK: %[[VALUE:.*]] = fir.convert %false : (i1) -> !fir.logical<4>
+!CHECK: fir.store %[[VALUE]] to %[[LOGICAL]]
+!CHECK: %[[LOAD:.*]] = fir.load %[[LOGICAL]]
+!CHECK: fir.call @omp_set_nested(%[[LOAD]]) : {{.*}}


### PR DESCRIPTION
Trying to fix #918. However, as per #1364 I'm not sure exactly what is meant to happen - the elemental code I tried doesn't appear to work correctly when trying to use a C function.

The code in this patch works for the omp_set_nested and I have tested using a small test-case that sets and gets the nested value, that it can actually change it. When using the method used by the elemental (ConvertExpr.cpp:4100 or so), it produces "always true", presumably because the value is actually an address, which is never zero, so can't set nested to false.

There is a todo in the test-code, because it seems wrong that we're passing by value but the value is converted to a fir.ref<logical<4>> when it should just be a logcial value. This is related to #1364 
