### PR TITLE
[WIP] Lowering ordered clause in worksharing-loop directive

### DIFF
--- a/clang/test/OpenMP/cancel_codegen.cpp
+++ b/clang/test/OpenMP/cancel_codegen.cpp
@@ -1385,10 +1385,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK3-NEXT:    br label [[OMP_SECTION_LOOP_HEADER]]
 // CHECK3:       omp_section_loop.exit:
 // CHECK3-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM11]])
-// CHECK3-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK3-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK3-NEXT:    br label [[OMP_SECTION_LOOP_AFTER:%.*]]
 // CHECK3:       omp_section_loop.after:
+// CHECK3-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK3-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK3-NEXT:    br label [[OMP_SECTIONS_END:%.*]]
 // CHECK3:       omp_sections.end:
 // CHECK3-NEXT:    br label [[OMP_SECTION_LOOP_PREHEADER13:%.*]]
@@ -1422,10 +1422,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK3-NEXT:    br label [[OMP_SECTION_LOOP_HEADER14]]
 // CHECK3:       omp_section_loop.exit18:
 // CHECK3-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM31]])
-// CHECK3-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK3-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK3-NEXT:    br label [[OMP_SECTION_LOOP_AFTER19:%.*]]
 // CHECK3:       omp_section_loop.after19:
+// CHECK3-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK3-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK3-NEXT:    br label [[OMP_SECTIONS_END33:%.*]]
 // CHECK3:       omp_sections.end33:
 // CHECK3-NEXT:    [[TMP14:%.*]] = load i32, i32* [[ARGC_ADDR]], align 4
@@ -2012,10 +2012,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK4-NEXT:    br label [[OMP_SECTION_LOOP_HEADER]]
 // CHECK4:       omp_section_loop.exit:
 // CHECK4-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM11]])
-// CHECK4-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK4-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK4-NEXT:    br label [[OMP_SECTION_LOOP_AFTER:%.*]]
 // CHECK4:       omp_section_loop.after:
+// CHECK4-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK4-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK4-NEXT:    br label [[OMP_SECTIONS_END:%.*]]
 // CHECK4:       omp_sections.end:
 // CHECK4-NEXT:    br label [[OMP_SECTION_LOOP_PREHEADER13:%.*]]
@@ -2049,10 +2049,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK4-NEXT:    br label [[OMP_SECTION_LOOP_HEADER14]]
 // CHECK4:       omp_section_loop.exit18:
 // CHECK4-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM31]])
-// CHECK4-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK4-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK4-NEXT:    br label [[OMP_SECTION_LOOP_AFTER19:%.*]]
 // CHECK4:       omp_section_loop.after19:
+// CHECK4-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK4-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK4-NEXT:    br label [[OMP_SECTIONS_END33:%.*]]
 // CHECK4:       omp_sections.end33:
 // CHECK4-NEXT:    [[TMP14:%.*]] = load i32, i32* [[ARGC_ADDR]], align 4
@@ -3879,10 +3879,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK9-NEXT:    br label [[OMP_SECTION_LOOP_HEADER]]
 // CHECK9:       omp_section_loop.exit:
 // CHECK9-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM11]])
-// CHECK9-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK9-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK9-NEXT:    br label [[OMP_SECTION_LOOP_AFTER:%.*]]
 // CHECK9:       omp_section_loop.after:
+// CHECK9-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK9-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK9-NEXT:    br label [[OMP_SECTIONS_END:%.*]]
 // CHECK9:       omp_sections.end:
 // CHECK9-NEXT:    br label [[OMP_SECTION_LOOP_PREHEADER13:%.*]]
@@ -3916,10 +3916,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK9-NEXT:    br label [[OMP_SECTION_LOOP_HEADER14]]
 // CHECK9:       omp_section_loop.exit18:
 // CHECK9-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM31]])
-// CHECK9-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK9-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK9-NEXT:    br label [[OMP_SECTION_LOOP_AFTER19:%.*]]
 // CHECK9:       omp_section_loop.after19:
+// CHECK9-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK9-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK9-NEXT:    br label [[OMP_SECTIONS_END33:%.*]]
 // CHECK9:       omp_sections.end33:
 // CHECK9-NEXT:    [[TMP14:%.*]] = load i32, i32* [[ARGC_ADDR]], align 4
@@ -4506,10 +4506,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK10-NEXT:    br label [[OMP_SECTION_LOOP_HEADER]]
 // CHECK10:       omp_section_loop.exit:
 // CHECK10-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM11]])
-// CHECK10-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK10-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK10-NEXT:    br label [[OMP_SECTION_LOOP_AFTER:%.*]]
 // CHECK10:       omp_section_loop.after:
+// CHECK10-NEXT:    [[OMP_GLOBAL_THREAD_NUM12:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK10-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM12]])
 // CHECK10-NEXT:    br label [[OMP_SECTIONS_END:%.*]]
 // CHECK10:       omp_sections.end:
 // CHECK10-NEXT:    br label [[OMP_SECTION_LOOP_PREHEADER13:%.*]]
@@ -4543,10 +4543,10 @@ for (int i = 0; i < argc; ++i) {
 // CHECK10-NEXT:    br label [[OMP_SECTION_LOOP_HEADER14]]
 // CHECK10:       omp_section_loop.exit18:
 // CHECK10-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM31]])
-// CHECK10-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK10-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK10-NEXT:    br label [[OMP_SECTION_LOOP_AFTER19:%.*]]
 // CHECK10:       omp_section_loop.after19:
+// CHECK10-NEXT:    [[OMP_GLOBAL_THREAD_NUM32:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK10-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2]], i32 [[OMP_GLOBAL_THREAD_NUM32]])
 // CHECK10-NEXT:    br label [[OMP_SECTIONS_END33:%.*]]
 // CHECK10:       omp_sections.end33:
 // CHECK10-NEXT:    [[TMP14:%.*]] = load i32, i32* [[ARGC_ADDR]], align 4

--- a/clang/test/OpenMP/irbuilder_for_iterator.cpp
+++ b/clang/test/OpenMP/irbuilder_for_iterator.cpp
@@ -98,10 +98,10 @@ extern "C" void workshareloop_iterator(float *a, float *b, float *c) {
 // CHECK-NEXT:    br label [[OMP_LOOP_HEADER]]
 // CHECK:       omp_loop.exit:
 // CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM6:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM6]])
 // CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
 // CHECK:       omp_loop.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM6:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM6]])
 // CHECK-NEXT:    ret void
 //
 //

--- a/clang/test/OpenMP/irbuilder_for_rangefor.cpp
+++ b/clang/test/OpenMP/irbuilder_for_rangefor.cpp
@@ -114,10 +114,10 @@ extern "C" void workshareloop_rangefor(float *a, float *b, float *c) {
 // CHECK-NEXT:    br label [[OMP_LOOP_HEADER]]
 // CHECK:       omp_loop.exit:
 // CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM6:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM6]])
 // CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
 // CHECK:       omp_loop.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM6:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM6]])
 // CHECK-NEXT:    ret void
 //
 //

--- a/clang/test/OpenMP/irbuilder_for_unsigned.c
+++ b/clang/test/OpenMP/irbuilder_for_unsigned.c
@@ -90,10 +90,10 @@ extern "C" void workshareloop_unsigned(float *a, float *b, float *c, float *d) {
 // CHECK-NEXT:    br label [[OMP_LOOP_HEADER]]
 // CHECK:       omp_loop.exit:
 // CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM9:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM9]])
 // CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
 // CHECK:       omp_loop.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM9:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM9]])
 // CHECK-NEXT:    ret void
 //
 //

--- a/clang/test/OpenMP/irbuilder_nested_parallel_for.c
+++ b/clang/test/OpenMP/irbuilder_nested_parallel_for.c
@@ -23,15 +23,15 @@
 //
 // CHECK-DEBUG-LABEL: @_Z14parallel_for_0v(
 // CHECK-DEBUG-NEXT:  entry:
-// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]]), !dbg [[DBG12:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]]), !dbg [[DBG13:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PARALLEL:%.*]]
 // CHECK-DEBUG:       omp_parallel:
-// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB1]], i32 0, void (i32*, i32*, ...)* bitcast (void (i32*, i32*)* @_Z14parallel_for_0v..omp_par to void (i32*, i32*, ...)*)), !dbg [[DBG13:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB1]], i32 0, void (i32*, i32*, ...)* bitcast (void (i32*, i32*)* @_Z14parallel_for_0v..omp_par to void (i32*, i32*, ...)*)), !dbg [[DBG14:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_OUTLINED_EXIT:%.*]]
 // CHECK-DEBUG:       omp.par.outlined.exit:
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_EXIT_SPLIT:%.*]]
 // CHECK-DEBUG:       omp.par.exit.split:
-// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG17:![0-9]+]]
+// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG18:![0-9]+]]
 //
 void parallel_for_0(void) {
 #pragma omp parallel
@@ -66,20 +66,20 @@ void parallel_for_0(void) {
 // CHECK-DEBUG-NEXT:    [[A_ADDR:%.*]] = alloca i32, align 4
 // CHECK-DEBUG-NEXT:    [[B_ADDR:%.*]] = alloca double, align 8
 // CHECK-DEBUG-NEXT:    store float* [[R:%.*]], float** [[R_ADDR]], align 8
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata float** [[R_ADDR]], metadata [[META71:![0-9]+]], metadata !DIExpression()), !dbg [[DBG72:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata float** [[R_ADDR]], metadata [[META72:![0-9]+]], metadata !DIExpression()), !dbg [[DBG73:![0-9]+]]
 // CHECK-DEBUG-NEXT:    store i32 [[A:%.*]], i32* [[A_ADDR]], align 4
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[A_ADDR]], metadata [[META73:![0-9]+]], metadata !DIExpression()), !dbg [[DBG74:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[A_ADDR]], metadata [[META74:![0-9]+]], metadata !DIExpression()), !dbg [[DBG75:![0-9]+]]
 // CHECK-DEBUG-NEXT:    store double [[B:%.*]], double* [[B_ADDR]], align 8
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata double* [[B_ADDR]], metadata [[META75:![0-9]+]], metadata !DIExpression()), !dbg [[DBG76:![0-9]+]]
-// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB6:[0-9]+]]), !dbg [[DBG77:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata double* [[B_ADDR]], metadata [[META76:![0-9]+]], metadata !DIExpression()), !dbg [[DBG77:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB6:[0-9]+]]), !dbg [[DBG78:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PARALLEL:%.*]]
 // CHECK-DEBUG:       omp_parallel:
-// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB6]], i32 3, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, double*, float**)* @_Z14parallel_for_1Pfid..omp_par.4 to void (i32*, i32*, ...)*), i32* [[A_ADDR]], double* [[B_ADDR]], float** [[R_ADDR]]), !dbg [[DBG78:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB6]], i32 3, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, double*, float**)* @_Z14parallel_for_1Pfid..omp_par.4 to void (i32*, i32*, ...)*), i32* [[A_ADDR]], double* [[B_ADDR]], float** [[R_ADDR]]), !dbg [[DBG79:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_OUTLINED_EXIT16:%.*]]
 // CHECK-DEBUG:       omp.par.outlined.exit16:
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_EXIT_SPLIT:%.*]]
 // CHECK-DEBUG:       omp.par.exit.split:
-// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG80:![0-9]+]]
+// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG81:![0-9]+]]
 //
 void parallel_for_1(float *r, int a, double b) {
 #pragma omp parallel
@@ -161,10 +161,10 @@ void parallel_for_1(float *r, int a, double b) {
 // CHECK-NEXT:    br label [[OMP_LOOP_HEADER191]]
 // CHECK:       omp_loop.exit195:
 // CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM207]])
-// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM208:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM208]])
 // CHECK-NEXT:    br label [[OMP_LOOP_AFTER196:%.*]]
 // CHECK:       omp_loop.after196:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM208:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM208]])
 // CHECK-NEXT:    ret void
 //
 // CHECK-DEBUG-LABEL: @_Z14parallel_for_2Pfid(
@@ -181,68 +181,68 @@ void parallel_for_1(float *r, int a, double b) {
 // CHECK-DEBUG-NEXT:    [[P_UPPERBOUND205:%.*]] = alloca i32, align 4
 // CHECK-DEBUG-NEXT:    [[P_STRIDE206:%.*]] = alloca i32, align 4
 // CHECK-DEBUG-NEXT:    store float* [[R:%.*]], float** [[R_ADDR]], align 8
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata float** [[R_ADDR]], metadata [[META132:![0-9]+]], metadata !DIExpression()), !dbg [[DBG133:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata float** [[R_ADDR]], metadata [[META133:![0-9]+]], metadata !DIExpression()), !dbg [[DBG134:![0-9]+]]
 // CHECK-DEBUG-NEXT:    store i32 [[A:%.*]], i32* [[A_ADDR]], align 4
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[A_ADDR]], metadata [[META134:![0-9]+]], metadata !DIExpression()), !dbg [[DBG135:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[A_ADDR]], metadata [[META135:![0-9]+]], metadata !DIExpression()), !dbg [[DBG136:![0-9]+]]
 // CHECK-DEBUG-NEXT:    store double [[B:%.*]], double* [[B_ADDR]], align 8
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata double* [[B_ADDR]], metadata [[META136:![0-9]+]], metadata !DIExpression()), !dbg [[DBG137:![0-9]+]]
-// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB13:[0-9]+]]), !dbg [[DBG138:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata double* [[B_ADDR]], metadata [[META137:![0-9]+]], metadata !DIExpression()), !dbg [[DBG138:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB13:[0-9]+]]), !dbg [[DBG139:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PARALLEL:%.*]]
 // CHECK-DEBUG:       omp_parallel:
-// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB13]], i32 3, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, double*, float**)* @_Z14parallel_for_2Pfid..omp_par.23 to void (i32*, i32*, ...)*), i32* [[A_ADDR]], double* [[B_ADDR]], float** [[R_ADDR]]), !dbg [[DBG139:![0-9]+]]
+// CHECK-DEBUG-NEXT:    call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @[[GLOB13]], i32 3, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, double*, float**)* @_Z14parallel_for_2Pfid..omp_par.23 to void (i32*, i32*, ...)*), i32* [[A_ADDR]], double* [[B_ADDR]], float** [[R_ADDR]]), !dbg [[DBG140:![0-9]+]]
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_OUTLINED_EXIT184:%.*]]
 // CHECK-DEBUG:       omp.par.outlined.exit184:
 // CHECK-DEBUG-NEXT:    br label [[OMP_PAR_EXIT_SPLIT:%.*]]
 // CHECK-DEBUG:       omp.par.exit.split:
-// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[I185]], metadata [[META143:![0-9]+]], metadata !DIExpression()), !dbg [[DBG146:![0-9]+]]
-// CHECK-DEBUG-NEXT:    store i32 0, i32* [[I185]], align 4, !dbg [[DBG146]]
-// CHECK-DEBUG-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON_17]], %struct.anon.17* [[AGG_CAPTURED186]], i32 0, i32 0, !dbg [[DBG147:![0-9]+]]
-// CHECK-DEBUG-NEXT:    store i32* [[I185]], i32** [[TMP0]], align 8, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_18]], %struct.anon.18* [[AGG_CAPTURED187]], i32 0, i32 0, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP2:%.*]] = load i32, i32* [[I185]], align 4, !dbg [[DBG148:![0-9]+]]
-// CHECK-DEBUG-NEXT:    store i32 [[TMP2]], i32* [[TMP1]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    call void @__captured_stmt.19(i32* [[DOTCOUNT_ADDR188]], %struct.anon.17* [[AGG_CAPTURED186]]), !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[DOTCOUNT189:%.*]] = load i32, i32* [[DOTCOUNT_ADDR188]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_PREHEADER190:%.*]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    call void @llvm.dbg.declare(metadata i32* [[I185]], metadata [[META144:![0-9]+]], metadata !DIExpression()), !dbg [[DBG147:![0-9]+]]
+// CHECK-DEBUG-NEXT:    store i32 0, i32* [[I185]], align 4, !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON_17]], %struct.anon.17* [[AGG_CAPTURED186]], i32 0, i32 0, !dbg [[DBG148:![0-9]+]]
+// CHECK-DEBUG-NEXT:    store i32* [[I185]], i32** [[TMP0]], align 8, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_18]], %struct.anon.18* [[AGG_CAPTURED187]], i32 0, i32 0, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP2:%.*]] = load i32, i32* [[I185]], align 4, !dbg [[DBG149:![0-9]+]]
+// CHECK-DEBUG-NEXT:    store i32 [[TMP2]], i32* [[TMP1]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    call void @__captured_stmt.19(i32* [[DOTCOUNT_ADDR188]], %struct.anon.17* [[AGG_CAPTURED186]]), !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[DOTCOUNT189:%.*]] = load i32, i32* [[DOTCOUNT_ADDR188]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_PREHEADER190:%.*]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.preheader190:
-// CHECK-DEBUG-NEXT:    store i32 0, i32* [[P_LOWERBOUND204]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP3:%.*]] = sub i32 [[DOTCOUNT189]], 1, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    store i32 [[TMP3]], i32* [[P_UPPERBOUND205]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    store i32 1, i32* [[P_STRIDE206]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM207:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB42:[0-9]+]]), !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB42]], i32 [[OMP_GLOBAL_THREAD_NUM207]], i32 34, i32* [[P_LASTITER203]], i32* [[P_LOWERBOUND204]], i32* [[P_UPPERBOUND205]], i32* [[P_STRIDE206]], i32 1, i32 1), !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP4:%.*]] = load i32, i32* [[P_LOWERBOUND204]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP5:%.*]] = load i32, i32* [[P_UPPERBOUND205]], align 4, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP6:%.*]] = sub i32 [[TMP5]], [[TMP4]], !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP7:%.*]] = add i32 [[TMP6]], 1, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_HEADER191:%.*]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    store i32 0, i32* [[P_LOWERBOUND204]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP3:%.*]] = sub i32 [[DOTCOUNT189]], 1, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    store i32 [[TMP3]], i32* [[P_UPPERBOUND205]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    store i32 1, i32* [[P_STRIDE206]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM207:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB42:[0-9]+]]), !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB42]], i32 [[OMP_GLOBAL_THREAD_NUM207]], i32 34, i32* [[P_LASTITER203]], i32* [[P_LOWERBOUND204]], i32* [[P_UPPERBOUND205]], i32* [[P_STRIDE206]], i32 1, i32 1), !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP4:%.*]] = load i32, i32* [[P_LOWERBOUND204]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP5:%.*]] = load i32, i32* [[P_UPPERBOUND205]], align 4, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP6:%.*]] = sub i32 [[TMP5]], [[TMP4]], !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP7:%.*]] = add i32 [[TMP6]], 1, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_HEADER191:%.*]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.header191:
-// CHECK-DEBUG-NEXT:    [[OMP_LOOP_IV197:%.*]] = phi i32 [ 0, [[OMP_LOOP_PREHEADER190]] ], [ [[OMP_LOOP_NEXT199:%.*]], [[OMP_LOOP_INC194:%.*]] ], !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_COND192:%.*]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    [[OMP_LOOP_IV197:%.*]] = phi i32 [ 0, [[OMP_LOOP_PREHEADER190]] ], [ [[OMP_LOOP_NEXT199:%.*]], [[OMP_LOOP_INC194:%.*]] ], !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_COND192:%.*]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.cond192:
-// CHECK-DEBUG-NEXT:    [[OMP_LOOP_CMP198:%.*]] = icmp ult i32 [[OMP_LOOP_IV197]], [[TMP7]], !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    br i1 [[OMP_LOOP_CMP198]], label [[OMP_LOOP_BODY193:%.*]], label [[OMP_LOOP_EXIT195:%.*]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    [[OMP_LOOP_CMP198:%.*]] = icmp ult i32 [[OMP_LOOP_IV197]], [[TMP7]], !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br i1 [[OMP_LOOP_CMP198]], label [[OMP_LOOP_BODY193:%.*]], label [[OMP_LOOP_EXIT195:%.*]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.body193:
-// CHECK-DEBUG-NEXT:    [[TMP8:%.*]] = add i32 [[OMP_LOOP_IV197]], [[TMP4]], !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    call void @__captured_stmt.20(i32* [[I185]], i32 [[TMP8]], %struct.anon.18* [[AGG_CAPTURED187]]), !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[TMP9:%.*]] = load i32, i32* [[A_ADDR]], align 4, !dbg [[DBG149:![0-9]+]]
-// CHECK-DEBUG-NEXT:    [[CONV200:%.*]] = sitofp i32 [[TMP9]] to double, !dbg [[DBG149]]
-// CHECK-DEBUG-NEXT:    [[TMP10:%.*]] = load double, double* [[B_ADDR]], align 8, !dbg [[DBG150:![0-9]+]]
-// CHECK-DEBUG-NEXT:    [[ADD201:%.*]] = fadd double [[CONV200]], [[TMP10]], !dbg [[DBG151:![0-9]+]]
-// CHECK-DEBUG-NEXT:    [[CONV202:%.*]] = fptrunc double [[ADD201]] to float, !dbg [[DBG149]]
-// CHECK-DEBUG-NEXT:    [[TMP11:%.*]] = load float*, float** [[R_ADDR]], align 8, !dbg [[DBG152:![0-9]+]]
-// CHECK-DEBUG-NEXT:    store float [[CONV202]], float* [[TMP11]], align 4, !dbg [[DBG153:![0-9]+]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_INC194]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    [[TMP8:%.*]] = add i32 [[OMP_LOOP_IV197]], [[TMP4]], !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    call void @__captured_stmt.20(i32* [[I185]], i32 [[TMP8]], %struct.anon.18* [[AGG_CAPTURED187]]), !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    [[TMP9:%.*]] = load i32, i32* [[A_ADDR]], align 4, !dbg [[DBG150:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[CONV200:%.*]] = sitofp i32 [[TMP9]] to double, !dbg [[DBG150]]
+// CHECK-DEBUG-NEXT:    [[TMP10:%.*]] = load double, double* [[B_ADDR]], align 8, !dbg [[DBG151:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[ADD201:%.*]] = fadd double [[CONV200]], [[TMP10]], !dbg [[DBG152:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[CONV202:%.*]] = fptrunc double [[ADD201]] to float, !dbg [[DBG150]]
+// CHECK-DEBUG-NEXT:    [[TMP11:%.*]] = load float*, float** [[R_ADDR]], align 8, !dbg [[DBG153:![0-9]+]]
+// CHECK-DEBUG-NEXT:    store float [[CONV202]], float* [[TMP11]], align 4, !dbg [[DBG154:![0-9]+]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_INC194]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.inc194:
-// CHECK-DEBUG-NEXT:    [[OMP_LOOP_NEXT199]] = add nuw i32 [[OMP_LOOP_IV197]], 1, !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_HEADER191]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    [[OMP_LOOP_NEXT199]] = add nuw i32 [[OMP_LOOP_IV197]], 1, !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_HEADER191]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.exit195:
-// CHECK-DEBUG-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB42]], i32 [[OMP_GLOBAL_THREAD_NUM207]]), !dbg [[DBG147]]
-// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM208:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB42]]), !dbg [[DBG150]]
-// CHECK-DEBUG-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB43:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM208]]), !dbg [[DBG150]]
-// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_AFTER196:%.*]], !dbg [[DBG147]]
+// CHECK-DEBUG-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB42]], i32 [[OMP_GLOBAL_THREAD_NUM207]]), !dbg [[DBG148]]
+// CHECK-DEBUG-NEXT:    br label [[OMP_LOOP_AFTER196:%.*]], !dbg [[DBG148]]
 // CHECK-DEBUG:       omp_loop.after196:
-// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG154:![0-9]+]]
+// CHECK-DEBUG-NEXT:    [[OMP_GLOBAL_THREAD_NUM208:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB42]]), !dbg [[DBG151]]
+// CHECK-DEBUG-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB43:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM208]]), !dbg [[DBG151]]
+// CHECK-DEBUG-NEXT:    ret void, !dbg [[DBG155:![0-9]+]]
 //
 void parallel_for_2(float *r, int a, double b) {
 #pragma omp parallel

--- a/clang/test/OpenMP/irbuilder_unroll_partial_factor_for.c
+++ b/clang/test/OpenMP/irbuilder_unroll_partial_factor_for.c
@@ -5,141 +5,6 @@
 #ifndef HEADER
 #define HEADER
 
-// CHECK-LABEL: define {{.*}}@unroll_partial_heuristic_for(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[N_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[A_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[B_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[C_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[D_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[I:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[AGG_CAPTURED:.+]] = alloca %struct.anon, align 8
-// CHECK-NEXT:    %[[AGG_CAPTURED1:.+]] = alloca %struct.anon.0, align 4
-// CHECK-NEXT:    %[[DOTCOUNT_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LASTITER:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LOWERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_UPPERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_STRIDE:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32 %[[N:.+]], i32* %[[N_ADDR]], align 4
-// CHECK-NEXT:    store float* %[[A:.+]], float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[B:.+]], float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[C:.+]], float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[D:.+]], float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    store i32 0, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[TMP0:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 0
-// CHECK-NEXT:    store i32* %[[I]], i32** %[[TMP0]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 1
-// CHECK-NEXT:    store i32* %[[N_ADDR]], i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP2:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[AGG_CAPTURED1]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[TMP2]], align 4
-// CHECK-NEXT:    call void @__captured_stmt(i32* %[[DOTCOUNT_ADDR]], %struct.anon* %[[AGG_CAPTURED]])
-// CHECK-NEXT:    %[[DOTCOUNT:.+]] = load i32, i32* %[[DOTCOUNT_ADDR]], align 4
-// CHECK-NEXT:    br label %[[OMP_LOOP_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_PREHEADER]]:
-// CHECK-NEXT:    %[[TMP4:.+]] = udiv i32 %[[DOTCOUNT]], 13
-// CHECK-NEXT:    %[[TMP5:.+]] = urem i32 %[[DOTCOUNT]], 13
-// CHECK-NEXT:    %[[TMP6:.+]] = icmp ne i32 %[[TMP5]], 0
-// CHECK-NEXT:    %[[TMP7:.+]] = zext i1 %[[TMP6]] to i32
-// CHECK-NEXT:    %[[OMP_FLOOR0_TRIPCOUNT:.+]] = add nuw i32 %[[TMP4]], %[[TMP7]]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_PREHEADER]]:
-// CHECK-NEXT:    store i32 0, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP8:.+]] = sub i32 %[[OMP_FLOOR0_TRIPCOUNT]], 1
-// CHECK-NEXT:    store i32 %[[TMP8]], i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[P_STRIDE]], align 4
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* %[[P_LASTITER]], i32* %[[P_LOWERBOUND]], i32* %[[P_UPPERBOUND]], i32* %[[P_STRIDE]], i32 1, i32 1)
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = load i32, i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP11:.+]] = sub i32 %[[TMP10]], %[[TMP9]]
-// CHECK-NEXT:    %[[TMP12:.+]] = add i32 %[[TMP11]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_IV:.+]] = phi i32 [ 0, %[[OMP_FLOOR0_PREHEADER]] ], [ %[[OMP_FLOOR0_NEXT:.+]], %[[OMP_FLOOR0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_COND]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_CMP:.+]] = icmp ult i32 %[[OMP_FLOOR0_IV]], %[[TMP12]]
-// CHECK-NEXT:    br i1 %[[OMP_FLOOR0_CMP]], label %[[OMP_FLOOR0_BODY:.+]], label %[[OMP_FLOOR0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_BODY]]:
-// CHECK-NEXT:    %[[TMP13:.+]] = add i32 %[[OMP_FLOOR0_IV]], %[[TMP9]]
-// CHECK-NEXT:    %[[TMP14:.+]] = icmp eq i32 %[[TMP13]], %[[OMP_FLOOR0_TRIPCOUNT]]
-// CHECK-NEXT:    %[[TMP15:.+]] = select i1 %[[TMP14]], i32 %[[TMP5]], i32 13
-// CHECK-NEXT:    br label %[[OMP_TILE0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_PREHEADER]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_TILE0_IV:.+]] = phi i32 [ 0, %[[OMP_TILE0_PREHEADER]] ], [ %[[OMP_TILE0_NEXT:.+]], %[[OMP_TILE0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_TILE0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_COND]]:
-// CHECK-NEXT:    %[[OMP_TILE0_CMP:.+]] = icmp ult i32 %[[OMP_TILE0_IV]], %[[TMP15]]
-// CHECK-NEXT:    br i1 %[[OMP_TILE0_CMP]], label %[[OMP_TILE0_BODY:.+]], label %[[OMP_TILE0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_BODY]]:
-// CHECK-NEXT:    %[[TMP16:.+]] = mul nuw i32 13, %[[TMP13]]
-// CHECK-NEXT:    %[[TMP17:.+]] = add nuw i32 %[[TMP16]], %[[OMP_TILE0_IV]]
-// CHECK-NEXT:    br label %[[OMP_LOOP_BODY:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_BODY]]:
-// CHECK-NEXT:    call void @__captured_stmt.1(i32* %[[I]], i32 %[[TMP17]], %struct.anon.0* %[[AGG_CAPTURED1]])
-// CHECK-NEXT:    %[[TMP18:.+]] = load float*, float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP19:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM:.+]] = sext i32 %[[TMP19]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX:.+]] = getelementptr inbounds float, float* %[[TMP18]], i64 %[[IDXPROM]]
-// CHECK-NEXT:    %[[TMP20:.+]] = load float, float* %[[ARRAYIDX]], align 4
-// CHECK-NEXT:    %[[TMP21:.+]] = load float*, float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP22:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM2:.+]] = sext i32 %[[TMP22]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX3:.+]] = getelementptr inbounds float, float* %[[TMP21]], i64 %[[IDXPROM2]]
-// CHECK-NEXT:    %[[TMP23:.+]] = load float, float* %[[ARRAYIDX3]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = fmul float %[[TMP20]], %[[TMP23]]
-// CHECK-NEXT:    %[[TMP24:.+]] = load float*, float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP25:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM4:.+]] = sext i32 %[[TMP25]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX5:.+]] = getelementptr inbounds float, float* %[[TMP24]], i64 %[[IDXPROM4]]
-// CHECK-NEXT:    %[[TMP26:.+]] = load float, float* %[[ARRAYIDX5]], align 4
-// CHECK-NEXT:    %[[MUL6:.+]] = fmul float %[[MUL]], %[[TMP26]]
-// CHECK-NEXT:    %[[TMP27:.+]] = load float*, float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP28:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM7:.+]] = sext i32 %[[TMP28]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX8:.+]] = getelementptr inbounds float, float* %[[TMP27]], i64 %[[IDXPROM7]]
-// CHECK-NEXT:    store float %[[MUL6]], float* %[[ARRAYIDX8]], align 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_INC]]:
-// CHECK-NEXT:    %[[OMP_TILE0_NEXT]] = add nuw i32 %[[OMP_TILE0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER]], !llvm.loop ![[LOOP3:[0-9]+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_EXIT]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_INC]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_NEXT]] = add nuw i32 %[[OMP_FLOOR0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_EXIT]]:
-// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM9:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @2, i32 %[[OMP_GLOBAL_THREAD_NUM9]])
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_LOOP_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_AFTER]]:
-// CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
 
 void unroll_partial_heuristic_for(int n, float *a, float *b, float *c, float *d) {
 #pragma omp for
@@ -151,72 +16,186 @@ void unroll_partial_heuristic_for(int n, float *a, float *b, float *c, float *d)
 
 #endif // HEADER
 
-// CHECK-LABEL: define {{.*}}@__captured_stmt(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[DISTANCE_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon*, align 8
-// CHECK-NEXT:    %[[DOTSTART:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTOP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTEP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32* %[[DISTANCE:.+]], i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store %struct.anon* %[[__CONTEXT:.+]], %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon*, %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32*, i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[TMP2]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP4:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 1
-// CHECK-NEXT:    %[[TMP5:.+]] = load i32*, i32** %[[TMP4]], align 8
-// CHECK-NEXT:    %[[TMP6:.+]] = load i32, i32* %[[TMP5]], align 4
-// CHECK-NEXT:    store i32 %[[TMP6]], i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[CMP:.+]] = icmp slt i32 %[[TMP7]], %[[TMP8]]
-// CHECK-NEXT:    br i1 %[[CMP]], label %[[COND_TRUE:.+]], label %[[COND_FALSE:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_TRUE]]:
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[SUB:.+]] = sub nsw i32 %[[TMP9]], %[[TMP10]]
-// CHECK-NEXT:    %[[TMP11:.+]] = load i32, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[DIV:.+]] = udiv i32 %[[SUB]], %[[TMP11]]
-// CHECK-NEXT:    br label %[[COND_END:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_FALSE]]:
-// CHECK-NEXT:    br label %[[COND_END]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_END]]:
-// CHECK-NEXT:    %[[COND:.+]] = phi i32 [ %[[DIV]], %[[COND_TRUE]] ], [ 0, %[[COND_FALSE]] ]
-// CHECK-NEXT:    %[[TMP12:.+]] = load i32*, i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[COND]], i32* %[[TMP12]], align 4
+
+
+
+
+// CHECK-LABEL: define {{[^@]+}}@unroll_partial_heuristic_for
+// CHECK-SAME: (i32 [[N:%.*]], float* [[A:%.*]], float* [[B:%.*]], float* [[C:%.*]], float* [[D:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[N_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[A_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[B_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[C_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[D_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[AGG_CAPTURED:%.*]] = alloca [[STRUCT_ANON:%.*]], align 8
+// CHECK-NEXT:    [[AGG_CAPTURED1:%.*]] = alloca [[STRUCT_ANON_0:%.*]], align 4
+// CHECK-NEXT:    [[DOTCOUNT_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LASTITER:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LOWERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_UPPERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_STRIDE:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[N]], i32* [[N_ADDR]], align 4
+// CHECK-NEXT:    store float* [[A]], float** [[A_ADDR]], align 8
+// CHECK-NEXT:    store float* [[B]], float** [[B_ADDR]], align 8
+// CHECK-NEXT:    store float* [[C]], float** [[C_ADDR]], align 8
+// CHECK-NEXT:    store float* [[D]], float** [[D_ADDR]], align 8
+// CHECK-NEXT:    store i32 0, i32* [[I]], align 4
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 0
+// CHECK-NEXT:    store i32* [[I]], i32** [[TMP0]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 1
+// CHECK-NEXT:    store i32* [[N_ADDR]], i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds [[STRUCT_ANON_0]], %struct.anon.0* [[AGG_CAPTURED1]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[TMP2]], align 4
+// CHECK-NEXT:    call void @__captured_stmt(i32* [[DOTCOUNT_ADDR]], %struct.anon* [[AGG_CAPTURED]])
+// CHECK-NEXT:    [[DOTCOUNT:%.*]] = load i32, i32* [[DOTCOUNT_ADDR]], align 4
+// CHECK-NEXT:    br label [[OMP_LOOP_PREHEADER:%.*]]
+// CHECK:       omp_loop.preheader:
+// CHECK-NEXT:    [[TMP4:%.*]] = udiv i32 [[DOTCOUNT]], 13
+// CHECK-NEXT:    [[TMP5:%.*]] = urem i32 [[DOTCOUNT]], 13
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp ne i32 [[TMP5]], 0
+// CHECK-NEXT:    [[TMP7:%.*]] = zext i1 [[TMP6]] to i32
+// CHECK-NEXT:    [[OMP_FLOOR0_TRIPCOUNT:%.*]] = add nuw i32 [[TMP4]], [[TMP7]]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_PREHEADER:%.*]]
+// CHECK:       omp_floor0.preheader:
+// CHECK-NEXT:    store i32 0, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP8:%.*]] = sub i32 [[OMP_FLOOR0_TRIPCOUNT]], 1
+// CHECK-NEXT:    store i32 [[TMP8]], i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[P_STRIDE]], align 4
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]])
+// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* [[P_LASTITER]], i32* [[P_LOWERBOUND]], i32* [[P_UPPERBOUND]], i32* [[P_STRIDE]], i32 1, i32 1)
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = load i32, i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    [[TMP11:%.*]] = sub i32 [[TMP10]], [[TMP9]]
+// CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[TMP11]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER:%.*]]
+// CHECK:       omp_floor0.header:
+// CHECK-NEXT:    [[OMP_FLOOR0_IV:%.*]] = phi i32 [ 0, [[OMP_FLOOR0_PREHEADER]] ], [ [[OMP_FLOOR0_NEXT:%.*]], [[OMP_FLOOR0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_COND:%.*]]
+// CHECK:       omp_floor0.cond:
+// CHECK-NEXT:    [[OMP_FLOOR0_CMP:%.*]] = icmp ult i32 [[OMP_FLOOR0_IV]], [[TMP12]]
+// CHECK-NEXT:    br i1 [[OMP_FLOOR0_CMP]], label [[OMP_FLOOR0_BODY:%.*]], label [[OMP_FLOOR0_EXIT:%.*]]
+// CHECK:       omp_floor0.body:
+// CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[OMP_FLOOR0_IV]], [[TMP9]]
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp eq i32 [[TMP13]], [[OMP_FLOOR0_TRIPCOUNT]]
+// CHECK-NEXT:    [[TMP15:%.*]] = select i1 [[TMP14]], i32 [[TMP5]], i32 13
+// CHECK-NEXT:    br label [[OMP_TILE0_PREHEADER:%.*]]
+// CHECK:       omp_tile0.preheader:
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER:%.*]]
+// CHECK:       omp_tile0.header:
+// CHECK-NEXT:    [[OMP_TILE0_IV:%.*]] = phi i32 [ 0, [[OMP_TILE0_PREHEADER]] ], [ [[OMP_TILE0_NEXT:%.*]], [[OMP_TILE0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_TILE0_COND:%.*]]
+// CHECK:       omp_tile0.cond:
+// CHECK-NEXT:    [[OMP_TILE0_CMP:%.*]] = icmp ult i32 [[OMP_TILE0_IV]], [[TMP15]]
+// CHECK-NEXT:    br i1 [[OMP_TILE0_CMP]], label [[OMP_TILE0_BODY:%.*]], label [[OMP_TILE0_EXIT:%.*]]
+// CHECK:       omp_tile0.body:
+// CHECK-NEXT:    [[TMP16:%.*]] = mul nuw i32 13, [[TMP13]]
+// CHECK-NEXT:    [[TMP17:%.*]] = add nuw i32 [[TMP16]], [[OMP_TILE0_IV]]
+// CHECK-NEXT:    br label [[OMP_LOOP_BODY:%.*]]
+// CHECK:       omp_loop.body:
+// CHECK-NEXT:    call void @__captured_stmt.1(i32* [[I]], i32 [[TMP17]], %struct.anon.0* [[AGG_CAPTURED1]])
+// CHECK-NEXT:    [[TMP18:%.*]] = load float*, float** [[B_ADDR]], align 8
+// CHECK-NEXT:    [[TMP19:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[TMP19]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds float, float* [[TMP18]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP20:%.*]] = load float, float* [[ARRAYIDX]], align 4
+// CHECK-NEXT:    [[TMP21:%.*]] = load float*, float** [[C_ADDR]], align 8
+// CHECK-NEXT:    [[TMP22:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM2:%.*]] = sext i32 [[TMP22]] to i64
+// CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds float, float* [[TMP21]], i64 [[IDXPROM2]]
+// CHECK-NEXT:    [[TMP23:%.*]] = load float, float* [[ARRAYIDX3]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = fmul float [[TMP20]], [[TMP23]]
+// CHECK-NEXT:    [[TMP24:%.*]] = load float*, float** [[D_ADDR]], align 8
+// CHECK-NEXT:    [[TMP25:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM4:%.*]] = sext i32 [[TMP25]] to i64
+// CHECK-NEXT:    [[ARRAYIDX5:%.*]] = getelementptr inbounds float, float* [[TMP24]], i64 [[IDXPROM4]]
+// CHECK-NEXT:    [[TMP26:%.*]] = load float, float* [[ARRAYIDX5]], align 4
+// CHECK-NEXT:    [[MUL6:%.*]] = fmul float [[MUL]], [[TMP26]]
+// CHECK-NEXT:    [[TMP27:%.*]] = load float*, float** [[A_ADDR]], align 8
+// CHECK-NEXT:    [[TMP28:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM7:%.*]] = sext i32 [[TMP28]] to i64
+// CHECK-NEXT:    [[ARRAYIDX8:%.*]] = getelementptr inbounds float, float* [[TMP27]], i64 [[IDXPROM7]]
+// CHECK-NEXT:    store float [[MUL6]], float* [[ARRAYIDX8]], align 4
+// CHECK-NEXT:    br label [[OMP_TILE0_INC]]
+// CHECK:       omp_tile0.inc:
+// CHECK-NEXT:    [[OMP_TILE0_NEXT]] = add nuw i32 [[OMP_TILE0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER]], !llvm.loop [[LOOP3:![0-9]+]]
+// CHECK:       omp_tile0.exit:
+// CHECK-NEXT:    br label [[OMP_TILE0_AFTER:%.*]]
+// CHECK:       omp_tile0.after:
+// CHECK-NEXT:    br label [[OMP_FLOOR0_INC]]
+// CHECK:       omp_floor0.inc:
+// CHECK-NEXT:    [[OMP_FLOOR0_NEXT]] = add nuw i32 [[OMP_FLOOR0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER]]
+// CHECK:       omp_floor0.exit:
+// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
+// CHECK-NEXT:    br label [[OMP_FLOOR0_AFTER:%.*]]
+// CHECK:       omp_floor0.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM9:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM9]])
+// CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
+// CHECK:       omp_loop.after:
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK-LABEL: define {{.*}}@__captured_stmt.1(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[LOOPVAR_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[LOGICAL_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon.0*, align 8
-// CHECK-NEXT:    store i32* %[[LOOPVAR:.+]], i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[LOGICAL:.+]], i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    store %struct.anon.0* %[[__CONTEXT:.+]], %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon.0*, %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[TMP1]], align 4
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = mul i32 1, %[[TMP3]]
-// CHECK-NEXT:    %[[ADD:.+]] = add i32 %[[TMP2]], %[[MUL]]
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32*, i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[ADD]], i32* %[[TMP4]], align 4
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[DISTANCE:%.*]], %struct.anon* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[DISTANCE_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon*, align 8
+// CHECK-NEXT:    [[DOTSTART:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTOP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTEP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32* [[DISTANCE]], i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store %struct.anon* [[__CONTEXT]], %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon*, %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON:%.*]], %struct.anon* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32*, i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[TMP2]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[TMP0]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP5:%.*]] = load i32*, i32** [[TMP4]], align 8
+// CHECK-NEXT:    [[TMP6:%.*]] = load i32, i32* [[TMP5]], align 4
+// CHECK-NEXT:    store i32 [[TMP6]], i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP7]], [[TMP8]]
+// CHECK-NEXT:    br i1 [[CMP]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
+// CHECK:       cond.true:
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[SUB:%.*]] = sub nsw i32 [[TMP9]], [[TMP10]]
+// CHECK-NEXT:    [[TMP11:%.*]] = load i32, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[DIV:%.*]] = udiv i32 [[SUB]], [[TMP11]]
+// CHECK-NEXT:    br label [[COND_END:%.*]]
+// CHECK:       cond.false:
+// CHECK-NEXT:    br label [[COND_END]]
+// CHECK:       cond.end:
+// CHECK-NEXT:    [[COND:%.*]] = phi i32 [ [[DIV]], [[COND_TRUE]] ], [ 0, [[COND_FALSE]] ]
+// CHECK-NEXT:    [[TMP12:%.*]] = load i32*, i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[COND]], i32* [[TMP12]], align 4
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK: ![[META0:[0-9]+]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[META1:[0-9]+]] = !{i32 7, !"openmp", i32 51}
-// CHECK: ![[META2:[0-9]+]] =
-// CHECK: ![[LOOP3]] = distinct !{![[LOOP3]], ![[LOOPPROP4:[0-9]+]], ![[LOOPPROP5:[0-9]+]]}
-// CHECK: ![[LOOPPROP4]] = !{!"llvm.loop.unroll.enable"}
-// CHECK: ![[LOOPPROP5]] = !{!"llvm.loop.unroll.count", i32 13}
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt.1
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[LOOPVAR:%.*]], i32 [[LOGICAL:%.*]], %struct.anon.0* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[LOOPVAR_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[LOGICAL_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon.0*, align 8
+// CHECK-NEXT:    store i32* [[LOOPVAR]], i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[LOGICAL]], i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    store %struct.anon.0* [[__CONTEXT]], %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon.0*, %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0:%.*]], %struct.anon.0* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[TMP1]], align 4
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = mul i32 1, [[TMP3]]
+// CHECK-NEXT:    [[ADD:%.*]] = add i32 [[TMP2]], [[MUL]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32*, i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[ADD]], i32* [[TMP4]], align 4
+// CHECK-NEXT:    ret void
+//

--- a/clang/test/OpenMP/irbuilder_unroll_partial_heuristic_constant_for.c
+++ b/clang/test/OpenMP/irbuilder_unroll_partial_heuristic_constant_for.c
@@ -11,159 +11,6 @@
 
 double sind(double);
 
-// CHECK-LABEL: define {{.*}}@unroll_partial_heuristic_constant_for(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[A_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[B_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[C_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[D_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[E_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[OFFSET_ADDR:.+]] = alloca float, align 4
-// CHECK-NEXT:    %[[I:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[AGG_CAPTURED:.+]] = alloca %struct.anon, align 8
-// CHECK-NEXT:    %[[AGG_CAPTURED1:.+]] = alloca %struct.anon.0, align 4
-// CHECK-NEXT:    %[[DOTCOUNT_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LASTITER:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LOWERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_UPPERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_STRIDE:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store float* %[[A:.+]], float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[B:.+]], float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[C:.+]], float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[D:.+]], float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[E:.+]], float** %[[E_ADDR]], align 8
-// CHECK-NEXT:    store float %[[OFFSET:.+]], float* %[[OFFSET_ADDR]], align 4
-// CHECK-NEXT:    store i32 0, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[TMP0:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 0
-// CHECK-NEXT:    store i32* %[[I]], i32** %[[TMP0]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[AGG_CAPTURED1]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    store i32 %[[TMP2]], i32* %[[TMP1]], align 4
-// CHECK-NEXT:    call void @__captured_stmt(i32* %[[DOTCOUNT_ADDR]], %struct.anon* %[[AGG_CAPTURED]])
-// CHECK-NEXT:    %[[DOTCOUNT:.+]] = load i32, i32* %[[DOTCOUNT_ADDR]], align 4
-// CHECK-NEXT:    br label %[[OMP_LOOP_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_PREHEADER]]:
-// CHECK-NEXT:    %[[TMP3:.+]] = udiv i32 %[[DOTCOUNT]], 4
-// CHECK-NEXT:    %[[TMP4:.+]] = urem i32 %[[DOTCOUNT]], 4
-// CHECK-NEXT:    %[[TMP5:.+]] = icmp ne i32 %[[TMP4]], 0
-// CHECK-NEXT:    %[[TMP6:.+]] = zext i1 %[[TMP5]] to i32
-// CHECK-NEXT:    %[[OMP_FLOOR0_TRIPCOUNT:.+]] = add nuw i32 %[[TMP3]], %[[TMP6]]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_PREHEADER]]:
-// CHECK-NEXT:    store i32 0, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = sub i32 %[[OMP_FLOOR0_TRIPCOUNT]], 1
-// CHECK-NEXT:    store i32 %[[TMP7]], i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[P_STRIDE]], align 4
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* %[[P_LASTITER]], i32* %[[P_LOWERBOUND]], i32* %[[P_UPPERBOUND]], i32* %[[P_STRIDE]], i32 1, i32 1)
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = sub i32 %[[TMP9]], %[[TMP8]]
-// CHECK-NEXT:    %[[TMP11:.+]] = add i32 %[[TMP10]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_IV:.+]] = phi i32 [ 0, %[[OMP_FLOOR0_PREHEADER]] ], [ %[[OMP_FLOOR0_NEXT:.+]], %[[OMP_FLOOR0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_COND]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_CMP:.+]] = icmp ult i32 %[[OMP_FLOOR0_IV]], %[[TMP11]]
-// CHECK-NEXT:    br i1 %[[OMP_FLOOR0_CMP]], label %[[OMP_FLOOR0_BODY:.+]], label %[[OMP_FLOOR0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_BODY]]:
-// CHECK-NEXT:    %[[TMP12:.+]] = add i32 %[[OMP_FLOOR0_IV]], %[[TMP8]]
-// CHECK-NEXT:    %[[TMP13:.+]] = icmp eq i32 %[[TMP12]], %[[OMP_FLOOR0_TRIPCOUNT]]
-// CHECK-NEXT:    %[[TMP14:.+]] = select i1 %[[TMP13]], i32 %[[TMP4]], i32 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_PREHEADER]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_TILE0_IV:.+]] = phi i32 [ 0, %[[OMP_TILE0_PREHEADER]] ], [ %[[OMP_TILE0_NEXT:.+]], %[[OMP_TILE0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_TILE0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_COND]]:
-// CHECK-NEXT:    %[[OMP_TILE0_CMP:.+]] = icmp ult i32 %[[OMP_TILE0_IV]], %[[TMP14]]
-// CHECK-NEXT:    br i1 %[[OMP_TILE0_CMP]], label %[[OMP_TILE0_BODY:.+]], label %[[OMP_TILE0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_BODY]]:
-// CHECK-NEXT:    %[[TMP15:.+]] = mul nuw i32 4, %[[TMP12]]
-// CHECK-NEXT:    %[[TMP16:.+]] = add nuw i32 %[[TMP15]], %[[OMP_TILE0_IV]]
-// CHECK-NEXT:    br label %[[OMP_LOOP_BODY:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_BODY]]:
-// CHECK-NEXT:    call void @__captured_stmt.1(i32* %[[I]], i32 %[[TMP16]], %struct.anon.0* %[[AGG_CAPTURED1]])
-// CHECK-NEXT:    %[[TMP17:.+]] = load float*, float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP18:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM:.+]] = sext i32 %[[TMP18]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX:.+]] = getelementptr inbounds float, float* %[[TMP17]], i64 %[[IDXPROM]]
-// CHECK-NEXT:    %[[TMP19:.+]] = load float, float* %[[ARRAYIDX]], align 4
-// CHECK-NEXT:    %[[CONV:.+]] = fpext float %[[TMP19]] to double
-// CHECK-NEXT:    %[[CALL:.+]] = call double @sind(double %[[CONV]])
-// CHECK-NEXT:    %[[TMP20:.+]] = load float*, float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP21:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM2:.+]] = sext i32 %[[TMP21]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX3:.+]] = getelementptr inbounds float, float* %[[TMP20]], i64 %[[IDXPROM2]]
-// CHECK-NEXT:    %[[TMP22:.+]] = load float, float* %[[ARRAYIDX3]], align 4
-// CHECK-NEXT:    %[[CONV4:.+]] = fpext float %[[TMP22]] to double
-// CHECK-NEXT:    %[[MUL:.+]] = fmul double %[[CALL]], %[[CONV4]]
-// CHECK-NEXT:    %[[TMP23:.+]] = load float*, float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP24:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM5:.+]] = sext i32 %[[TMP24]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX6:.+]] = getelementptr inbounds float, float* %[[TMP23]], i64 %[[IDXPROM5]]
-// CHECK-NEXT:    %[[TMP25:.+]] = load float, float* %[[ARRAYIDX6]], align 4
-// CHECK-NEXT:    %[[CONV7:.+]] = fpext float %[[TMP25]] to double
-// CHECK-NEXT:    %[[MUL8:.+]] = fmul double %[[MUL]], %[[CONV7]]
-// CHECK-NEXT:    %[[TMP26:.+]] = load float*, float** %[[E_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP27:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM9:.+]] = sext i32 %[[TMP27]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX10:.+]] = getelementptr inbounds float, float* %[[TMP26]], i64 %[[IDXPROM9]]
-// CHECK-NEXT:    %[[TMP28:.+]] = load float, float* %[[ARRAYIDX10]], align 4
-// CHECK-NEXT:    %[[CONV11:.+]] = fpext float %[[TMP28]] to double
-// CHECK-NEXT:    %[[MUL12:.+]] = fmul double %[[MUL8]], %[[CONV11]]
-// CHECK-NEXT:    %[[TMP29:.+]] = load float, float* %[[OFFSET_ADDR]], align 4
-// CHECK-NEXT:    %[[CONV13:.+]] = fpext float %[[TMP29]] to double
-// CHECK-NEXT:    %[[ADD:.+]] = fadd double %[[MUL12]], %[[CONV13]]
-// CHECK-NEXT:    %[[TMP30:.+]] = load float*, float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP31:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM14:.+]] = sext i32 %[[TMP31]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX15:.+]] = getelementptr inbounds float, float* %[[TMP30]], i64 %[[IDXPROM14]]
-// CHECK-NEXT:    %[[TMP32:.+]] = load float, float* %[[ARRAYIDX15]], align 4
-// CHECK-NEXT:    %[[CONV16:.+]] = fpext float %[[TMP32]] to double
-// CHECK-NEXT:    %[[ADD17:.+]] = fadd double %[[CONV16]], %[[ADD]]
-// CHECK-NEXT:    %[[CONV18:.+]] = fptrunc double %[[ADD17]] to float
-// CHECK-NEXT:    store float %[[CONV18]], float* %[[ARRAYIDX15]], align 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_INC]]:
-// CHECK-NEXT:    %[[OMP_TILE0_NEXT]] = add nuw i32 %[[OMP_TILE0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER]], !llvm.loop ![[LOOP3:[0-9]+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_EXIT]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_INC]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_NEXT]] = add nuw i32 %[[OMP_FLOOR0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_EXIT]]:
-// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM19:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @2, i32 %[[OMP_GLOBAL_THREAD_NUM19]])
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_LOOP_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_AFTER]]:
-// CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
 
 void unroll_partial_heuristic_constant_for(float *a, float *b, float *c, float *d, float *e, float offset) {
 #pragma omp for
@@ -175,69 +22,201 @@ void unroll_partial_heuristic_constant_for(float *a, float *b, float *c, float *
 
 #endif // HEADER
 
-// CHECK-LABEL: define {{.*}}@__captured_stmt(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[DISTANCE_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon*, align 8
-// CHECK-NEXT:    %[[DOTSTART:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTOP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTEP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32* %[[DISTANCE:.+]], i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store %struct.anon* %[[__CONTEXT:.+]], %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon*, %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32*, i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[TMP2]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    store i32 128, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP5:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[CMP:.+]] = icmp slt i32 %[[TMP4]], %[[TMP5]]
-// CHECK-NEXT:    br i1 %[[CMP]], label %[[COND_TRUE:.+]], label %[[COND_FALSE:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_TRUE]]:
-// CHECK-NEXT:    %[[TMP6:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[SUB:.+]] = sub nsw i32 %[[TMP6]], %[[TMP7]]
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[DIV:.+]] = udiv i32 %[[SUB]], %[[TMP8]]
-// CHECK-NEXT:    br label %[[COND_END:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_FALSE]]:
-// CHECK-NEXT:    br label %[[COND_END]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_END]]:
-// CHECK-NEXT:    %[[COND:.+]] = phi i32 [ %[[DIV]], %[[COND_TRUE]] ], [ 0, %[[COND_FALSE]] ]
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32*, i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[COND]], i32* %[[TMP9]], align 4
+
+
+
+
+// CHECK-LABEL: define {{[^@]+}}@unroll_partial_heuristic_constant_for
+// CHECK-SAME: (float* [[A:%.*]], float* [[B:%.*]], float* [[C:%.*]], float* [[D:%.*]], float* [[E:%.*]], float [[OFFSET:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[A_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[B_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[C_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[D_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[E_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[OFFSET_ADDR:%.*]] = alloca float, align 4
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[AGG_CAPTURED:%.*]] = alloca [[STRUCT_ANON:%.*]], align 8
+// CHECK-NEXT:    [[AGG_CAPTURED1:%.*]] = alloca [[STRUCT_ANON_0:%.*]], align 4
+// CHECK-NEXT:    [[DOTCOUNT_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LASTITER:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LOWERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_UPPERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_STRIDE:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store float* [[A]], float** [[A_ADDR]], align 8
+// CHECK-NEXT:    store float* [[B]], float** [[B_ADDR]], align 8
+// CHECK-NEXT:    store float* [[C]], float** [[C_ADDR]], align 8
+// CHECK-NEXT:    store float* [[D]], float** [[D_ADDR]], align 8
+// CHECK-NEXT:    store float* [[E]], float** [[E_ADDR]], align 8
+// CHECK-NEXT:    store float [[OFFSET]], float* [[OFFSET_ADDR]], align 4
+// CHECK-NEXT:    store i32 0, i32* [[I]], align 4
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 0
+// CHECK-NEXT:    store i32* [[I]], i32** [[TMP0]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0]], %struct.anon.0* [[AGG_CAPTURED1]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    store i32 [[TMP2]], i32* [[TMP1]], align 4
+// CHECK-NEXT:    call void @__captured_stmt(i32* [[DOTCOUNT_ADDR]], %struct.anon* [[AGG_CAPTURED]])
+// CHECK-NEXT:    [[DOTCOUNT:%.*]] = load i32, i32* [[DOTCOUNT_ADDR]], align 4
+// CHECK-NEXT:    br label [[OMP_LOOP_PREHEADER:%.*]]
+// CHECK:       omp_loop.preheader:
+// CHECK-NEXT:    [[TMP3:%.*]] = udiv i32 [[DOTCOUNT]], 4
+// CHECK-NEXT:    [[TMP4:%.*]] = urem i32 [[DOTCOUNT]], 4
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ne i32 [[TMP4]], 0
+// CHECK-NEXT:    [[TMP6:%.*]] = zext i1 [[TMP5]] to i32
+// CHECK-NEXT:    [[OMP_FLOOR0_TRIPCOUNT:%.*]] = add nuw i32 [[TMP3]], [[TMP6]]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_PREHEADER:%.*]]
+// CHECK:       omp_floor0.preheader:
+// CHECK-NEXT:    store i32 0, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = sub i32 [[OMP_FLOOR0_TRIPCOUNT]], 1
+// CHECK-NEXT:    store i32 [[TMP7]], i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[P_STRIDE]], align 4
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]])
+// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* [[P_LASTITER]], i32* [[P_LOWERBOUND]], i32* [[P_UPPERBOUND]], i32* [[P_STRIDE]], i32 1, i32 1)
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = sub i32 [[TMP9]], [[TMP8]]
+// CHECK-NEXT:    [[TMP11:%.*]] = add i32 [[TMP10]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER:%.*]]
+// CHECK:       omp_floor0.header:
+// CHECK-NEXT:    [[OMP_FLOOR0_IV:%.*]] = phi i32 [ 0, [[OMP_FLOOR0_PREHEADER]] ], [ [[OMP_FLOOR0_NEXT:%.*]], [[OMP_FLOOR0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_COND:%.*]]
+// CHECK:       omp_floor0.cond:
+// CHECK-NEXT:    [[OMP_FLOOR0_CMP:%.*]] = icmp ult i32 [[OMP_FLOOR0_IV]], [[TMP11]]
+// CHECK-NEXT:    br i1 [[OMP_FLOOR0_CMP]], label [[OMP_FLOOR0_BODY:%.*]], label [[OMP_FLOOR0_EXIT:%.*]]
+// CHECK:       omp_floor0.body:
+// CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[OMP_FLOOR0_IV]], [[TMP8]]
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp eq i32 [[TMP12]], [[OMP_FLOOR0_TRIPCOUNT]]
+// CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 [[TMP4]], i32 4
+// CHECK-NEXT:    br label [[OMP_TILE0_PREHEADER:%.*]]
+// CHECK:       omp_tile0.preheader:
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER:%.*]]
+// CHECK:       omp_tile0.header:
+// CHECK-NEXT:    [[OMP_TILE0_IV:%.*]] = phi i32 [ 0, [[OMP_TILE0_PREHEADER]] ], [ [[OMP_TILE0_NEXT:%.*]], [[OMP_TILE0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_TILE0_COND:%.*]]
+// CHECK:       omp_tile0.cond:
+// CHECK-NEXT:    [[OMP_TILE0_CMP:%.*]] = icmp ult i32 [[OMP_TILE0_IV]], [[TMP14]]
+// CHECK-NEXT:    br i1 [[OMP_TILE0_CMP]], label [[OMP_TILE0_BODY:%.*]], label [[OMP_TILE0_EXIT:%.*]]
+// CHECK:       omp_tile0.body:
+// CHECK-NEXT:    [[TMP15:%.*]] = mul nuw i32 4, [[TMP12]]
+// CHECK-NEXT:    [[TMP16:%.*]] = add nuw i32 [[TMP15]], [[OMP_TILE0_IV]]
+// CHECK-NEXT:    br label [[OMP_LOOP_BODY:%.*]]
+// CHECK:       omp_loop.body:
+// CHECK-NEXT:    call void @__captured_stmt.1(i32* [[I]], i32 [[TMP16]], %struct.anon.0* [[AGG_CAPTURED1]])
+// CHECK-NEXT:    [[TMP17:%.*]] = load float*, float** [[B_ADDR]], align 8
+// CHECK-NEXT:    [[TMP18:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[TMP18]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds float, float* [[TMP17]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP19:%.*]] = load float, float* [[ARRAYIDX]], align 4
+// CHECK-NEXT:    [[CONV:%.*]] = fpext float [[TMP19]] to double
+// CHECK-NEXT:    [[CALL:%.*]] = call double @sind(double [[CONV]])
+// CHECK-NEXT:    [[TMP20:%.*]] = load float*, float** [[C_ADDR]], align 8
+// CHECK-NEXT:    [[TMP21:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM2:%.*]] = sext i32 [[TMP21]] to i64
+// CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds float, float* [[TMP20]], i64 [[IDXPROM2]]
+// CHECK-NEXT:    [[TMP22:%.*]] = load float, float* [[ARRAYIDX3]], align 4
+// CHECK-NEXT:    [[CONV4:%.*]] = fpext float [[TMP22]] to double
+// CHECK-NEXT:    [[MUL:%.*]] = fmul double [[CALL]], [[CONV4]]
+// CHECK-NEXT:    [[TMP23:%.*]] = load float*, float** [[D_ADDR]], align 8
+// CHECK-NEXT:    [[TMP24:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM5:%.*]] = sext i32 [[TMP24]] to i64
+// CHECK-NEXT:    [[ARRAYIDX6:%.*]] = getelementptr inbounds float, float* [[TMP23]], i64 [[IDXPROM5]]
+// CHECK-NEXT:    [[TMP25:%.*]] = load float, float* [[ARRAYIDX6]], align 4
+// CHECK-NEXT:    [[CONV7:%.*]] = fpext float [[TMP25]] to double
+// CHECK-NEXT:    [[MUL8:%.*]] = fmul double [[MUL]], [[CONV7]]
+// CHECK-NEXT:    [[TMP26:%.*]] = load float*, float** [[E_ADDR]], align 8
+// CHECK-NEXT:    [[TMP27:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM9:%.*]] = sext i32 [[TMP27]] to i64
+// CHECK-NEXT:    [[ARRAYIDX10:%.*]] = getelementptr inbounds float, float* [[TMP26]], i64 [[IDXPROM9]]
+// CHECK-NEXT:    [[TMP28:%.*]] = load float, float* [[ARRAYIDX10]], align 4
+// CHECK-NEXT:    [[CONV11:%.*]] = fpext float [[TMP28]] to double
+// CHECK-NEXT:    [[MUL12:%.*]] = fmul double [[MUL8]], [[CONV11]]
+// CHECK-NEXT:    [[TMP29:%.*]] = load float, float* [[OFFSET_ADDR]], align 4
+// CHECK-NEXT:    [[CONV13:%.*]] = fpext float [[TMP29]] to double
+// CHECK-NEXT:    [[ADD:%.*]] = fadd double [[MUL12]], [[CONV13]]
+// CHECK-NEXT:    [[TMP30:%.*]] = load float*, float** [[A_ADDR]], align 8
+// CHECK-NEXT:    [[TMP31:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM14:%.*]] = sext i32 [[TMP31]] to i64
+// CHECK-NEXT:    [[ARRAYIDX15:%.*]] = getelementptr inbounds float, float* [[TMP30]], i64 [[IDXPROM14]]
+// CHECK-NEXT:    [[TMP32:%.*]] = load float, float* [[ARRAYIDX15]], align 4
+// CHECK-NEXT:    [[CONV16:%.*]] = fpext float [[TMP32]] to double
+// CHECK-NEXT:    [[ADD17:%.*]] = fadd double [[CONV16]], [[ADD]]
+// CHECK-NEXT:    [[CONV18:%.*]] = fptrunc double [[ADD17]] to float
+// CHECK-NEXT:    store float [[CONV18]], float* [[ARRAYIDX15]], align 4
+// CHECK-NEXT:    br label [[OMP_TILE0_INC]]
+// CHECK:       omp_tile0.inc:
+// CHECK-NEXT:    [[OMP_TILE0_NEXT]] = add nuw i32 [[OMP_TILE0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER]], !llvm.loop [[LOOP3:![0-9]+]]
+// CHECK:       omp_tile0.exit:
+// CHECK-NEXT:    br label [[OMP_TILE0_AFTER:%.*]]
+// CHECK:       omp_tile0.after:
+// CHECK-NEXT:    br label [[OMP_FLOOR0_INC]]
+// CHECK:       omp_floor0.inc:
+// CHECK-NEXT:    [[OMP_FLOOR0_NEXT]] = add nuw i32 [[OMP_FLOOR0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER]]
+// CHECK:       omp_floor0.exit:
+// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
+// CHECK-NEXT:    br label [[OMP_FLOOR0_AFTER:%.*]]
+// CHECK:       omp_floor0.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM19:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM19]])
+// CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
+// CHECK:       omp_loop.after:
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK-LABEL: define {{.*}}@__captured_stmt.1(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[LOOPVAR_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[LOGICAL_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon.0*, align 8
-// CHECK-NEXT:    store i32* %[[LOOPVAR:.+]], i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[LOGICAL:.+]], i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    store %struct.anon.0* %[[__CONTEXT:.+]], %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon.0*, %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[TMP1]], align 4
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = mul i32 1, %[[TMP3]]
-// CHECK-NEXT:    %[[ADD:.+]] = add i32 %[[TMP2]], %[[MUL]]
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32*, i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[ADD]], i32* %[[TMP4]], align 4
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[DISTANCE:%.*]], %struct.anon* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[DISTANCE_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon*, align 8
+// CHECK-NEXT:    [[DOTSTART:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTOP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTEP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32* [[DISTANCE]], i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store %struct.anon* [[__CONTEXT]], %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon*, %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON:%.*]], %struct.anon* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32*, i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[TMP2]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    store i32 128, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP5:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP4]], [[TMP5]]
+// CHECK-NEXT:    br i1 [[CMP]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
+// CHECK:       cond.true:
+// CHECK-NEXT:    [[TMP6:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[SUB:%.*]] = sub nsw i32 [[TMP6]], [[TMP7]]
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[DIV:%.*]] = udiv i32 [[SUB]], [[TMP8]]
+// CHECK-NEXT:    br label [[COND_END:%.*]]
+// CHECK:       cond.false:
+// CHECK-NEXT:    br label [[COND_END]]
+// CHECK:       cond.end:
+// CHECK-NEXT:    [[COND:%.*]] = phi i32 [ [[DIV]], [[COND_TRUE]] ], [ 0, [[COND_FALSE]] ]
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32*, i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[COND]], i32* [[TMP9]], align 4
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK: ![[META0:[0-9]+]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[META1:[0-9]+]] = !{i32 7, !"openmp", i32 51}
-// CHECK: ![[META2:[0-9]+]] =
-// CHECK: ![[LOOP3]] = distinct !{![[LOOP3]], ![[LOOPPROP4:[0-9]+]], ![[LOOPPROP5:[0-9]+]]}
-// CHECK: ![[LOOPPROP4]] = !{!"llvm.loop.unroll.enable"}
-// CHECK: ![[LOOPPROP5]] = !{!"llvm.loop.unroll.count", i32 4}
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt.1
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[LOOPVAR:%.*]], i32 [[LOGICAL:%.*]], %struct.anon.0* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[LOOPVAR_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[LOGICAL_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon.0*, align 8
+// CHECK-NEXT:    store i32* [[LOOPVAR]], i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[LOGICAL]], i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    store %struct.anon.0* [[__CONTEXT]], %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon.0*, %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0:%.*]], %struct.anon.0* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[TMP1]], align 4
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = mul i32 1, [[TMP3]]
+// CHECK-NEXT:    [[ADD:%.*]] = add i32 [[TMP2]], [[MUL]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32*, i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[ADD]], i32* [[TMP4]], align 4
+// CHECK-NEXT:    ret void
+//

--- a/clang/test/OpenMP/irbuilder_unroll_partial_heuristic_runtime_for.c
+++ b/clang/test/OpenMP/irbuilder_unroll_partial_heuristic_runtime_for.c
@@ -9,163 +9,6 @@
 
 double sind(double);
 
-// CHECK-LABEL: define {{.*}}@unroll_partial_heuristic_runtime_for(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[N_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[A_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[B_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[C_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[D_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[E_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[OFFSET_ADDR:.+]] = alloca float, align 4
-// CHECK-NEXT:    %[[I:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[AGG_CAPTURED:.+]] = alloca %struct.anon, align 8
-// CHECK-NEXT:    %[[AGG_CAPTURED1:.+]] = alloca %struct.anon.0, align 4
-// CHECK-NEXT:    %[[DOTCOUNT_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LASTITER:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LOWERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_UPPERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_STRIDE:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32 %[[N:.+]], i32* %[[N_ADDR]], align 4
-// CHECK-NEXT:    store float* %[[A:.+]], float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[B:.+]], float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[C:.+]], float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[D:.+]], float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[E:.+]], float** %[[E_ADDR]], align 8
-// CHECK-NEXT:    store float %[[OFFSET:.+]], float* %[[OFFSET_ADDR]], align 4
-// CHECK-NEXT:    store i32 0, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[TMP0:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 0
-// CHECK-NEXT:    store i32* %[[I]], i32** %[[TMP0]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 1
-// CHECK-NEXT:    store i32* %[[N_ADDR]], i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP2:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[AGG_CAPTURED1]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[TMP2]], align 4
-// CHECK-NEXT:    call void @__captured_stmt(i32* %[[DOTCOUNT_ADDR]], %struct.anon* %[[AGG_CAPTURED]])
-// CHECK-NEXT:    %[[DOTCOUNT:.+]] = load i32, i32* %[[DOTCOUNT_ADDR]], align 4
-// CHECK-NEXT:    br label %[[OMP_LOOP_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_PREHEADER]]:
-// CHECK-NEXT:    %[[TMP4:.+]] = udiv i32 %[[DOTCOUNT]], 4
-// CHECK-NEXT:    %[[TMP5:.+]] = urem i32 %[[DOTCOUNT]], 4
-// CHECK-NEXT:    %[[TMP6:.+]] = icmp ne i32 %[[TMP5]], 0
-// CHECK-NEXT:    %[[TMP7:.+]] = zext i1 %[[TMP6]] to i32
-// CHECK-NEXT:    %[[OMP_FLOOR0_TRIPCOUNT:.+]] = add nuw i32 %[[TMP4]], %[[TMP7]]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_PREHEADER]]:
-// CHECK-NEXT:    store i32 0, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP8:.+]] = sub i32 %[[OMP_FLOOR0_TRIPCOUNT]], 1
-// CHECK-NEXT:    store i32 %[[TMP8]], i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[P_STRIDE]], align 4
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* %[[P_LASTITER]], i32* %[[P_LOWERBOUND]], i32* %[[P_UPPERBOUND]], i32* %[[P_STRIDE]], i32 1, i32 1)
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = load i32, i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP11:.+]] = sub i32 %[[TMP10]], %[[TMP9]]
-// CHECK-NEXT:    %[[TMP12:.+]] = add i32 %[[TMP11]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_IV:.+]] = phi i32 [ 0, %[[OMP_FLOOR0_PREHEADER]] ], [ %[[OMP_FLOOR0_NEXT:.+]], %[[OMP_FLOOR0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_COND]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_CMP:.+]] = icmp ult i32 %[[OMP_FLOOR0_IV]], %[[TMP12]]
-// CHECK-NEXT:    br i1 %[[OMP_FLOOR0_CMP]], label %[[OMP_FLOOR0_BODY:.+]], label %[[OMP_FLOOR0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_BODY]]:
-// CHECK-NEXT:    %[[TMP13:.+]] = add i32 %[[OMP_FLOOR0_IV]], %[[TMP9]]
-// CHECK-NEXT:    %[[TMP14:.+]] = icmp eq i32 %[[TMP13]], %[[OMP_FLOOR0_TRIPCOUNT]]
-// CHECK-NEXT:    %[[TMP15:.+]] = select i1 %[[TMP14]], i32 %[[TMP5]], i32 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_PREHEADER]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_TILE0_IV:.+]] = phi i32 [ 0, %[[OMP_TILE0_PREHEADER]] ], [ %[[OMP_TILE0_NEXT:.+]], %[[OMP_TILE0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_TILE0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_COND]]:
-// CHECK-NEXT:    %[[OMP_TILE0_CMP:.+]] = icmp ult i32 %[[OMP_TILE0_IV]], %[[TMP15]]
-// CHECK-NEXT:    br i1 %[[OMP_TILE0_CMP]], label %[[OMP_TILE0_BODY:.+]], label %[[OMP_TILE0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_BODY]]:
-// CHECK-NEXT:    %[[TMP16:.+]] = mul nuw i32 4, %[[TMP13]]
-// CHECK-NEXT:    %[[TMP17:.+]] = add nuw i32 %[[TMP16]], %[[OMP_TILE0_IV]]
-// CHECK-NEXT:    br label %[[OMP_LOOP_BODY:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_BODY]]:
-// CHECK-NEXT:    call void @__captured_stmt.1(i32* %[[I]], i32 %[[TMP17]], %struct.anon.0* %[[AGG_CAPTURED1]])
-// CHECK-NEXT:    %[[TMP18:.+]] = load float*, float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP19:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM:.+]] = sext i32 %[[TMP19]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX:.+]] = getelementptr inbounds float, float* %[[TMP18]], i64 %[[IDXPROM]]
-// CHECK-NEXT:    %[[TMP20:.+]] = load float, float* %[[ARRAYIDX]], align 4
-// CHECK-NEXT:    %[[CONV:.+]] = fpext float %[[TMP20]] to double
-// CHECK-NEXT:    %[[CALL:.+]] = call double @sind(double %[[CONV]])
-// CHECK-NEXT:    %[[TMP21:.+]] = load float*, float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP22:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM2:.+]] = sext i32 %[[TMP22]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX3:.+]] = getelementptr inbounds float, float* %[[TMP21]], i64 %[[IDXPROM2]]
-// CHECK-NEXT:    %[[TMP23:.+]] = load float, float* %[[ARRAYIDX3]], align 4
-// CHECK-NEXT:    %[[CONV4:.+]] = fpext float %[[TMP23]] to double
-// CHECK-NEXT:    %[[MUL:.+]] = fmul double %[[CALL]], %[[CONV4]]
-// CHECK-NEXT:    %[[TMP24:.+]] = load float*, float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP25:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM5:.+]] = sext i32 %[[TMP25]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX6:.+]] = getelementptr inbounds float, float* %[[TMP24]], i64 %[[IDXPROM5]]
-// CHECK-NEXT:    %[[TMP26:.+]] = load float, float* %[[ARRAYIDX6]], align 4
-// CHECK-NEXT:    %[[CONV7:.+]] = fpext float %[[TMP26]] to double
-// CHECK-NEXT:    %[[MUL8:.+]] = fmul double %[[MUL]], %[[CONV7]]
-// CHECK-NEXT:    %[[TMP27:.+]] = load float*, float** %[[E_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP28:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM9:.+]] = sext i32 %[[TMP28]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX10:.+]] = getelementptr inbounds float, float* %[[TMP27]], i64 %[[IDXPROM9]]
-// CHECK-NEXT:    %[[TMP29:.+]] = load float, float* %[[ARRAYIDX10]], align 4
-// CHECK-NEXT:    %[[CONV11:.+]] = fpext float %[[TMP29]] to double
-// CHECK-NEXT:    %[[MUL12:.+]] = fmul double %[[MUL8]], %[[CONV11]]
-// CHECK-NEXT:    %[[TMP30:.+]] = load float, float* %[[OFFSET_ADDR]], align 4
-// CHECK-NEXT:    %[[CONV13:.+]] = fpext float %[[TMP30]] to double
-// CHECK-NEXT:    %[[ADD:.+]] = fadd double %[[MUL12]], %[[CONV13]]
-// CHECK-NEXT:    %[[TMP31:.+]] = load float*, float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP32:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM14:.+]] = sext i32 %[[TMP32]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX15:.+]] = getelementptr inbounds float, float* %[[TMP31]], i64 %[[IDXPROM14]]
-// CHECK-NEXT:    %[[TMP33:.+]] = load float, float* %[[ARRAYIDX15]], align 4
-// CHECK-NEXT:    %[[CONV16:.+]] = fpext float %[[TMP33]] to double
-// CHECK-NEXT:    %[[ADD17:.+]] = fadd double %[[CONV16]], %[[ADD]]
-// CHECK-NEXT:    %[[CONV18:.+]] = fptrunc double %[[ADD17]] to float
-// CHECK-NEXT:    store float %[[CONV18]], float* %[[ARRAYIDX15]], align 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_INC]]:
-// CHECK-NEXT:    %[[OMP_TILE0_NEXT]] = add nuw i32 %[[OMP_TILE0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER]], !llvm.loop ![[LOOP3:[0-9]+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_EXIT]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_INC]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_NEXT]] = add nuw i32 %[[OMP_FLOOR0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_EXIT]]:
-// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM19:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @2, i32 %[[OMP_GLOBAL_THREAD_NUM19]])
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_LOOP_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_AFTER]]:
-// CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
 
 void unroll_partial_heuristic_runtime_for(int n, float *a, float *b, float *c, float *d, float *e, float offset) {
 #pragma omp for
@@ -177,72 +20,208 @@ void unroll_partial_heuristic_runtime_for(int n, float *a, float *b, float *c, f
 
 #endif // HEADER
 
-// CHECK-LABEL: define {{.*}}@__captured_stmt(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[DISTANCE_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon*, align 8
-// CHECK-NEXT:    %[[DOTSTART:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTOP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTEP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32* %[[DISTANCE:.+]], i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store %struct.anon* %[[__CONTEXT:.+]], %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon*, %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32*, i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[TMP2]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP4:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 1
-// CHECK-NEXT:    %[[TMP5:.+]] = load i32*, i32** %[[TMP4]], align 8
-// CHECK-NEXT:    %[[TMP6:.+]] = load i32, i32* %[[TMP5]], align 4
-// CHECK-NEXT:    store i32 %[[TMP6]], i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[CMP:.+]] = icmp slt i32 %[[TMP7]], %[[TMP8]]
-// CHECK-NEXT:    br i1 %[[CMP]], label %[[COND_TRUE:.+]], label %[[COND_FALSE:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_TRUE]]:
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[SUB:.+]] = sub nsw i32 %[[TMP9]], %[[TMP10]]
-// CHECK-NEXT:    %[[TMP11:.+]] = load i32, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[DIV:.+]] = udiv i32 %[[SUB]], %[[TMP11]]
-// CHECK-NEXT:    br label %[[COND_END:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_FALSE]]:
-// CHECK-NEXT:    br label %[[COND_END]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_END]]:
-// CHECK-NEXT:    %[[COND:.+]] = phi i32 [ %[[DIV]], %[[COND_TRUE]] ], [ 0, %[[COND_FALSE]] ]
-// CHECK-NEXT:    %[[TMP12:.+]] = load i32*, i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[COND]], i32* %[[TMP12]], align 4
+
+
+
+
+// CHECK-LABEL: define {{[^@]+}}@unroll_partial_heuristic_runtime_for
+// CHECK-SAME: (i32 [[N:%.*]], float* [[A:%.*]], float* [[B:%.*]], float* [[C:%.*]], float* [[D:%.*]], float* [[E:%.*]], float [[OFFSET:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[N_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[A_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[B_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[C_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[D_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[E_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[OFFSET_ADDR:%.*]] = alloca float, align 4
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[AGG_CAPTURED:%.*]] = alloca [[STRUCT_ANON:%.*]], align 8
+// CHECK-NEXT:    [[AGG_CAPTURED1:%.*]] = alloca [[STRUCT_ANON_0:%.*]], align 4
+// CHECK-NEXT:    [[DOTCOUNT_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LASTITER:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LOWERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_UPPERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_STRIDE:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 [[N]], i32* [[N_ADDR]], align 4
+// CHECK-NEXT:    store float* [[A]], float** [[A_ADDR]], align 8
+// CHECK-NEXT:    store float* [[B]], float** [[B_ADDR]], align 8
+// CHECK-NEXT:    store float* [[C]], float** [[C_ADDR]], align 8
+// CHECK-NEXT:    store float* [[D]], float** [[D_ADDR]], align 8
+// CHECK-NEXT:    store float* [[E]], float** [[E_ADDR]], align 8
+// CHECK-NEXT:    store float [[OFFSET]], float* [[OFFSET_ADDR]], align 4
+// CHECK-NEXT:    store i32 0, i32* [[I]], align 4
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 0
+// CHECK-NEXT:    store i32* [[I]], i32** [[TMP0]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 1
+// CHECK-NEXT:    store i32* [[N_ADDR]], i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds [[STRUCT_ANON_0]], %struct.anon.0* [[AGG_CAPTURED1]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[TMP2]], align 4
+// CHECK-NEXT:    call void @__captured_stmt(i32* [[DOTCOUNT_ADDR]], %struct.anon* [[AGG_CAPTURED]])
+// CHECK-NEXT:    [[DOTCOUNT:%.*]] = load i32, i32* [[DOTCOUNT_ADDR]], align 4
+// CHECK-NEXT:    br label [[OMP_LOOP_PREHEADER:%.*]]
+// CHECK:       omp_loop.preheader:
+// CHECK-NEXT:    [[TMP4:%.*]] = udiv i32 [[DOTCOUNT]], 4
+// CHECK-NEXT:    [[TMP5:%.*]] = urem i32 [[DOTCOUNT]], 4
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp ne i32 [[TMP5]], 0
+// CHECK-NEXT:    [[TMP7:%.*]] = zext i1 [[TMP6]] to i32
+// CHECK-NEXT:    [[OMP_FLOOR0_TRIPCOUNT:%.*]] = add nuw i32 [[TMP4]], [[TMP7]]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_PREHEADER:%.*]]
+// CHECK:       omp_floor0.preheader:
+// CHECK-NEXT:    store i32 0, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP8:%.*]] = sub i32 [[OMP_FLOOR0_TRIPCOUNT]], 1
+// CHECK-NEXT:    store i32 [[TMP8]], i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[P_STRIDE]], align 4
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]])
+// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* [[P_LASTITER]], i32* [[P_LOWERBOUND]], i32* [[P_UPPERBOUND]], i32* [[P_STRIDE]], i32 1, i32 1)
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = load i32, i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    [[TMP11:%.*]] = sub i32 [[TMP10]], [[TMP9]]
+// CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[TMP11]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER:%.*]]
+// CHECK:       omp_floor0.header:
+// CHECK-NEXT:    [[OMP_FLOOR0_IV:%.*]] = phi i32 [ 0, [[OMP_FLOOR0_PREHEADER]] ], [ [[OMP_FLOOR0_NEXT:%.*]], [[OMP_FLOOR0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_COND:%.*]]
+// CHECK:       omp_floor0.cond:
+// CHECK-NEXT:    [[OMP_FLOOR0_CMP:%.*]] = icmp ult i32 [[OMP_FLOOR0_IV]], [[TMP12]]
+// CHECK-NEXT:    br i1 [[OMP_FLOOR0_CMP]], label [[OMP_FLOOR0_BODY:%.*]], label [[OMP_FLOOR0_EXIT:%.*]]
+// CHECK:       omp_floor0.body:
+// CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[OMP_FLOOR0_IV]], [[TMP9]]
+// CHECK-NEXT:    [[TMP14:%.*]] = icmp eq i32 [[TMP13]], [[OMP_FLOOR0_TRIPCOUNT]]
+// CHECK-NEXT:    [[TMP15:%.*]] = select i1 [[TMP14]], i32 [[TMP5]], i32 4
+// CHECK-NEXT:    br label [[OMP_TILE0_PREHEADER:%.*]]
+// CHECK:       omp_tile0.preheader:
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER:%.*]]
+// CHECK:       omp_tile0.header:
+// CHECK-NEXT:    [[OMP_TILE0_IV:%.*]] = phi i32 [ 0, [[OMP_TILE0_PREHEADER]] ], [ [[OMP_TILE0_NEXT:%.*]], [[OMP_TILE0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_TILE0_COND:%.*]]
+// CHECK:       omp_tile0.cond:
+// CHECK-NEXT:    [[OMP_TILE0_CMP:%.*]] = icmp ult i32 [[OMP_TILE0_IV]], [[TMP15]]
+// CHECK-NEXT:    br i1 [[OMP_TILE0_CMP]], label [[OMP_TILE0_BODY:%.*]], label [[OMP_TILE0_EXIT:%.*]]
+// CHECK:       omp_tile0.body:
+// CHECK-NEXT:    [[TMP16:%.*]] = mul nuw i32 4, [[TMP13]]
+// CHECK-NEXT:    [[TMP17:%.*]] = add nuw i32 [[TMP16]], [[OMP_TILE0_IV]]
+// CHECK-NEXT:    br label [[OMP_LOOP_BODY:%.*]]
+// CHECK:       omp_loop.body:
+// CHECK-NEXT:    call void @__captured_stmt.1(i32* [[I]], i32 [[TMP17]], %struct.anon.0* [[AGG_CAPTURED1]])
+// CHECK-NEXT:    [[TMP18:%.*]] = load float*, float** [[B_ADDR]], align 8
+// CHECK-NEXT:    [[TMP19:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[TMP19]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds float, float* [[TMP18]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP20:%.*]] = load float, float* [[ARRAYIDX]], align 4
+// CHECK-NEXT:    [[CONV:%.*]] = fpext float [[TMP20]] to double
+// CHECK-NEXT:    [[CALL:%.*]] = call double @sind(double [[CONV]])
+// CHECK-NEXT:    [[TMP21:%.*]] = load float*, float** [[C_ADDR]], align 8
+// CHECK-NEXT:    [[TMP22:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM2:%.*]] = sext i32 [[TMP22]] to i64
+// CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds float, float* [[TMP21]], i64 [[IDXPROM2]]
+// CHECK-NEXT:    [[TMP23:%.*]] = load float, float* [[ARRAYIDX3]], align 4
+// CHECK-NEXT:    [[CONV4:%.*]] = fpext float [[TMP23]] to double
+// CHECK-NEXT:    [[MUL:%.*]] = fmul double [[CALL]], [[CONV4]]
+// CHECK-NEXT:    [[TMP24:%.*]] = load float*, float** [[D_ADDR]], align 8
+// CHECK-NEXT:    [[TMP25:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM5:%.*]] = sext i32 [[TMP25]] to i64
+// CHECK-NEXT:    [[ARRAYIDX6:%.*]] = getelementptr inbounds float, float* [[TMP24]], i64 [[IDXPROM5]]
+// CHECK-NEXT:    [[TMP26:%.*]] = load float, float* [[ARRAYIDX6]], align 4
+// CHECK-NEXT:    [[CONV7:%.*]] = fpext float [[TMP26]] to double
+// CHECK-NEXT:    [[MUL8:%.*]] = fmul double [[MUL]], [[CONV7]]
+// CHECK-NEXT:    [[TMP27:%.*]] = load float*, float** [[E_ADDR]], align 8
+// CHECK-NEXT:    [[TMP28:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM9:%.*]] = sext i32 [[TMP28]] to i64
+// CHECK-NEXT:    [[ARRAYIDX10:%.*]] = getelementptr inbounds float, float* [[TMP27]], i64 [[IDXPROM9]]
+// CHECK-NEXT:    [[TMP29:%.*]] = load float, float* [[ARRAYIDX10]], align 4
+// CHECK-NEXT:    [[CONV11:%.*]] = fpext float [[TMP29]] to double
+// CHECK-NEXT:    [[MUL12:%.*]] = fmul double [[MUL8]], [[CONV11]]
+// CHECK-NEXT:    [[TMP30:%.*]] = load float, float* [[OFFSET_ADDR]], align 4
+// CHECK-NEXT:    [[CONV13:%.*]] = fpext float [[TMP30]] to double
+// CHECK-NEXT:    [[ADD:%.*]] = fadd double [[MUL12]], [[CONV13]]
+// CHECK-NEXT:    [[TMP31:%.*]] = load float*, float** [[A_ADDR]], align 8
+// CHECK-NEXT:    [[TMP32:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM14:%.*]] = sext i32 [[TMP32]] to i64
+// CHECK-NEXT:    [[ARRAYIDX15:%.*]] = getelementptr inbounds float, float* [[TMP31]], i64 [[IDXPROM14]]
+// CHECK-NEXT:    [[TMP33:%.*]] = load float, float* [[ARRAYIDX15]], align 4
+// CHECK-NEXT:    [[CONV16:%.*]] = fpext float [[TMP33]] to double
+// CHECK-NEXT:    [[ADD17:%.*]] = fadd double [[CONV16]], [[ADD]]
+// CHECK-NEXT:    [[CONV18:%.*]] = fptrunc double [[ADD17]] to float
+// CHECK-NEXT:    store float [[CONV18]], float* [[ARRAYIDX15]], align 4
+// CHECK-NEXT:    br label [[OMP_TILE0_INC]]
+// CHECK:       omp_tile0.inc:
+// CHECK-NEXT:    [[OMP_TILE0_NEXT]] = add nuw i32 [[OMP_TILE0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER]], !llvm.loop [[LOOP3:![0-9]+]]
+// CHECK:       omp_tile0.exit:
+// CHECK-NEXT:    br label [[OMP_TILE0_AFTER:%.*]]
+// CHECK:       omp_tile0.after:
+// CHECK-NEXT:    br label [[OMP_FLOOR0_INC]]
+// CHECK:       omp_floor0.inc:
+// CHECK-NEXT:    [[OMP_FLOOR0_NEXT]] = add nuw i32 [[OMP_FLOOR0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER]]
+// CHECK:       omp_floor0.exit:
+// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
+// CHECK-NEXT:    br label [[OMP_FLOOR0_AFTER:%.*]]
+// CHECK:       omp_floor0.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM19:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM19]])
+// CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
+// CHECK:       omp_loop.after:
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK-LABEL: define {{.*}}@__captured_stmt.1(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[LOOPVAR_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[LOGICAL_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon.0*, align 8
-// CHECK-NEXT:    store i32* %[[LOOPVAR:.+]], i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[LOGICAL:.+]], i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    store %struct.anon.0* %[[__CONTEXT:.+]], %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon.0*, %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[TMP1]], align 4
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = mul i32 1, %[[TMP3]]
-// CHECK-NEXT:    %[[ADD:.+]] = add i32 %[[TMP2]], %[[MUL]]
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32*, i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[ADD]], i32* %[[TMP4]], align 4
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[DISTANCE:%.*]], %struct.anon* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[DISTANCE_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon*, align 8
+// CHECK-NEXT:    [[DOTSTART:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTOP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTEP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32* [[DISTANCE]], i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store %struct.anon* [[__CONTEXT]], %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon*, %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON:%.*]], %struct.anon* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32*, i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[TMP2]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[TMP0]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP5:%.*]] = load i32*, i32** [[TMP4]], align 8
+// CHECK-NEXT:    [[TMP6:%.*]] = load i32, i32* [[TMP5]], align 4
+// CHECK-NEXT:    store i32 [[TMP6]], i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP7]], [[TMP8]]
+// CHECK-NEXT:    br i1 [[CMP]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
+// CHECK:       cond.true:
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[SUB:%.*]] = sub nsw i32 [[TMP9]], [[TMP10]]
+// CHECK-NEXT:    [[TMP11:%.*]] = load i32, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[DIV:%.*]] = udiv i32 [[SUB]], [[TMP11]]
+// CHECK-NEXT:    br label [[COND_END:%.*]]
+// CHECK:       cond.false:
+// CHECK-NEXT:    br label [[COND_END]]
+// CHECK:       cond.end:
+// CHECK-NEXT:    [[COND:%.*]] = phi i32 [ [[DIV]], [[COND_TRUE]] ], [ 0, [[COND_FALSE]] ]
+// CHECK-NEXT:    [[TMP12:%.*]] = load i32*, i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[COND]], i32* [[TMP12]], align 4
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK: ![[META0:[0-9]+]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[META1:[0-9]+]] = !{i32 7, !"openmp", i32 51}
-// CHECK: ![[META2:[0-9]+]] =
-// CHECK: ![[LOOP3]] = distinct !{![[LOOP3]], ![[LOOPPROP4:[0-9]+]], ![[LOOPPROP5:[0-9]+]]}
-// CHECK: ![[LOOPPROP4]] = !{!"llvm.loop.unroll.enable"}
-// CHECK: ![[LOOPPROP5]] = !{!"llvm.loop.unroll.count", i32 4}
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt.1
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[LOOPVAR:%.*]], i32 [[LOGICAL:%.*]], %struct.anon.0* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[LOOPVAR_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[LOGICAL_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon.0*, align 8
+// CHECK-NEXT:    store i32* [[LOOPVAR]], i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[LOGICAL]], i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    store %struct.anon.0* [[__CONTEXT]], %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon.0*, %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0:%.*]], %struct.anon.0* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[TMP1]], align 4
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = mul i32 1, [[TMP3]]
+// CHECK-NEXT:    [[ADD:%.*]] = add i32 [[TMP2]], [[MUL]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32*, i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[ADD]], i32* [[TMP4]], align 4
+// CHECK-NEXT:    ret void
+//

--- a/clang/test/OpenMP/irbuilder_unroll_unroll_partial_factor.c
+++ b/clang/test/OpenMP/irbuilder_unroll_unroll_partial_factor.c
@@ -5,137 +5,6 @@
 #ifndef HEADER
 #define HEADER
 
-// CHECK-LABEL: define {{.*}}@unroll_partial_factor_for(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[A_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[B_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[C_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[D_ADDR:.+]] = alloca float*, align 8
-// CHECK-NEXT:    %[[I:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[AGG_CAPTURED:.+]] = alloca %struct.anon, align 8
-// CHECK-NEXT:    %[[AGG_CAPTURED1:.+]] = alloca %struct.anon.0, align 4
-// CHECK-NEXT:    %[[DOTCOUNT_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LASTITER:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_LOWERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_UPPERBOUND:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[P_STRIDE:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store float* %[[A:.+]], float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[B:.+]], float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[C:.+]], float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    store float* %[[D:.+]], float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    store i32 0, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[TMP0:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[AGG_CAPTURED]], i32 0, i32 0
-// CHECK-NEXT:    store i32* %[[I]], i32** %[[TMP0]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[AGG_CAPTURED1]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    store i32 %[[TMP2]], i32* %[[TMP1]], align 4
-// CHECK-NEXT:    call void @__captured_stmt(i32* %[[DOTCOUNT_ADDR]], %struct.anon* %[[AGG_CAPTURED]])
-// CHECK-NEXT:    %[[DOTCOUNT:.+]] = load i32, i32* %[[DOTCOUNT_ADDR]], align 4
-// CHECK-NEXT:    br label %[[OMP_LOOP_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_PREHEADER]]:
-// CHECK-NEXT:    %[[TMP3:.+]] = udiv i32 %[[DOTCOUNT]], 2
-// CHECK-NEXT:    %[[TMP4:.+]] = urem i32 %[[DOTCOUNT]], 2
-// CHECK-NEXT:    %[[TMP5:.+]] = icmp ne i32 %[[TMP4]], 0
-// CHECK-NEXT:    %[[TMP6:.+]] = zext i1 %[[TMP5]] to i32
-// CHECK-NEXT:    %[[OMP_FLOOR0_TRIPCOUNT:.+]] = add nuw i32 %[[TMP3]], %[[TMP6]]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_PREHEADER]]:
-// CHECK-NEXT:    store i32 0, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = sub i32 %[[OMP_FLOOR0_TRIPCOUNT]], 1
-// CHECK-NEXT:    store i32 %[[TMP7]], i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[P_STRIDE]], align 4
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* %[[P_LASTITER]], i32* %[[P_LOWERBOUND]], i32* %[[P_UPPERBOUND]], i32* %[[P_STRIDE]], i32 1, i32 1)
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[P_LOWERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32, i32* %[[P_UPPERBOUND]], align 4
-// CHECK-NEXT:    %[[TMP10:.+]] = sub i32 %[[TMP9]], %[[TMP8]]
-// CHECK-NEXT:    %[[TMP11:.+]] = add i32 %[[TMP10]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_IV:.+]] = phi i32 [ 0, %[[OMP_FLOOR0_PREHEADER]] ], [ %[[OMP_FLOOR0_NEXT:.+]], %[[OMP_FLOOR0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_COND]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_CMP:.+]] = icmp ult i32 %[[OMP_FLOOR0_IV]], %[[TMP11]]
-// CHECK-NEXT:    br i1 %[[OMP_FLOOR0_CMP]], label %[[OMP_FLOOR0_BODY:.+]], label %[[OMP_FLOOR0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_BODY]]:
-// CHECK-NEXT:    %[[TMP12:.+]] = add i32 %[[OMP_FLOOR0_IV]], %[[TMP8]]
-// CHECK-NEXT:    %[[TMP13:.+]] = icmp eq i32 %[[TMP12]], %[[OMP_FLOOR0_TRIPCOUNT]]
-// CHECK-NEXT:    %[[TMP14:.+]] = select i1 %[[TMP13]], i32 %[[TMP4]], i32 2
-// CHECK-NEXT:    br label %[[OMP_TILE0_PREHEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_PREHEADER]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_HEADER]]:
-// CHECK-NEXT:    %[[OMP_TILE0_IV:.+]] = phi i32 [ 0, %[[OMP_TILE0_PREHEADER]] ], [ %[[OMP_TILE0_NEXT:.+]], %[[OMP_TILE0_INC:.+]] ]
-// CHECK-NEXT:    br label %[[OMP_TILE0_COND:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_COND]]:
-// CHECK-NEXT:    %[[OMP_TILE0_CMP:.+]] = icmp ult i32 %[[OMP_TILE0_IV]], %[[TMP14]]
-// CHECK-NEXT:    br i1 %[[OMP_TILE0_CMP]], label %[[OMP_TILE0_BODY:.+]], label %[[OMP_TILE0_EXIT:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_BODY]]:
-// CHECK-NEXT:    %[[TMP15:.+]] = mul nuw i32 2, %[[TMP12]]
-// CHECK-NEXT:    %[[TMP16:.+]] = add nuw i32 %[[TMP15]], %[[OMP_TILE0_IV]]
-// CHECK-NEXT:    br label %[[OMP_LOOP_BODY:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_BODY]]:
-// CHECK-NEXT:    call void @__captured_stmt.1(i32* %[[I]], i32 %[[TMP16]], %struct.anon.0* %[[AGG_CAPTURED1]])
-// CHECK-NEXT:    %[[TMP17:.+]] = load float*, float** %[[B_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP18:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM:.+]] = sext i32 %[[TMP18]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX:.+]] = getelementptr inbounds float, float* %[[TMP17]], i64 %[[IDXPROM]]
-// CHECK-NEXT:    %[[TMP19:.+]] = load float, float* %[[ARRAYIDX]], align 4
-// CHECK-NEXT:    %[[TMP20:.+]] = load float*, float** %[[C_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP21:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM2:.+]] = sext i32 %[[TMP21]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX3:.+]] = getelementptr inbounds float, float* %[[TMP20]], i64 %[[IDXPROM2]]
-// CHECK-NEXT:    %[[TMP22:.+]] = load float, float* %[[ARRAYIDX3]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = fmul float %[[TMP19]], %[[TMP22]]
-// CHECK-NEXT:    %[[TMP23:.+]] = load float*, float** %[[D_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP24:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM4:.+]] = sext i32 %[[TMP24]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX5:.+]] = getelementptr inbounds float, float* %[[TMP23]], i64 %[[IDXPROM4]]
-// CHECK-NEXT:    %[[TMP25:.+]] = load float, float* %[[ARRAYIDX5]], align 4
-// CHECK-NEXT:    %[[MUL6:.+]] = fmul float %[[MUL]], %[[TMP25]]
-// CHECK-NEXT:    %[[TMP26:.+]] = load float*, float** %[[A_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP27:.+]] = load i32, i32* %[[I]], align 4
-// CHECK-NEXT:    %[[IDXPROM7:.+]] = sext i32 %[[TMP27]] to i64
-// CHECK-NEXT:    %[[ARRAYIDX8:.+]] = getelementptr inbounds float, float* %[[TMP26]], i64 %[[IDXPROM7]]
-// CHECK-NEXT:    store float %[[MUL6]], float* %[[ARRAYIDX8]], align 4
-// CHECK-NEXT:    br label %[[OMP_TILE0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_INC]]:
-// CHECK-NEXT:    %[[OMP_TILE0_NEXT]] = add nuw i32 %[[OMP_TILE0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_TILE0_HEADER]], !llvm.loop ![[LOOP3:[0-9]+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_EXIT]]:
-// CHECK-NEXT:    br label %[[OMP_TILE0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_TILE0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_INC]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_INC]]:
-// CHECK-NEXT:    %[[OMP_FLOOR0_NEXT]] = add nuw i32 %[[OMP_FLOOR0_IV]], 1
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_HEADER]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_EXIT]]:
-// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @1, i32 %[[OMP_GLOBAL_THREAD_NUM]])
-// CHECK-NEXT:    %[[OMP_GLOBAL_THREAD_NUM9:.+]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @1)
-// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @2, i32 %[[OMP_GLOBAL_THREAD_NUM9]])
-// CHECK-NEXT:    br label %[[OMP_FLOOR0_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_FLOOR0_AFTER]]:
-// CHECK-NEXT:    br label %[[OMP_LOOP_AFTER:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[OMP_LOOP_AFTER]]:
-// CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
 
 void unroll_partial_factor_for(float *a, float *b, float *c, float *d) {
 #pragma omp for
@@ -147,69 +16,179 @@ void unroll_partial_factor_for(float *a, float *b, float *c, float *d) {
 
 #endif // HEADER
 
-// CHECK-LABEL: define {{.*}}@__captured_stmt(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[DISTANCE_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon*, align 8
-// CHECK-NEXT:    %[[DOTSTART:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTOP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[DOTSTEP:.+]] = alloca i32, align 4
-// CHECK-NEXT:    store i32* %[[DISTANCE:.+]], i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store %struct.anon* %[[__CONTEXT:.+]], %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon*, %struct.anon** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon, %struct.anon* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32*, i32** %[[TMP1]], align 8
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[TMP2]], align 4
-// CHECK-NEXT:    store i32 %[[TMP3]], i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    store i32 2, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    store i32 1, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[TMP5:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[CMP:.+]] = icmp slt i32 %[[TMP4]], %[[TMP5]]
-// CHECK-NEXT:    br i1 %[[CMP]], label %[[COND_TRUE:.+]], label %[[COND_FALSE:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_TRUE]]:
-// CHECK-NEXT:    %[[TMP6:.+]] = load i32, i32* %[[DOTSTOP]], align 4
-// CHECK-NEXT:    %[[TMP7:.+]] = load i32, i32* %[[DOTSTART]], align 4
-// CHECK-NEXT:    %[[SUB:.+]] = sub nsw i32 %[[TMP6]], %[[TMP7]]
-// CHECK-NEXT:    %[[TMP8:.+]] = load i32, i32* %[[DOTSTEP]], align 4
-// CHECK-NEXT:    %[[DIV:.+]] = udiv i32 %[[SUB]], %[[TMP8]]
-// CHECK-NEXT:    br label %[[COND_END:.+]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_FALSE]]:
-// CHECK-NEXT:    br label %[[COND_END]]
-// CHECK-EMPTY:
-// CHECK-NEXT:  [[COND_END]]:
-// CHECK-NEXT:    %[[COND:.+]] = phi i32 [ %[[DIV]], %[[COND_TRUE]] ], [ 0, %[[COND_FALSE]] ]
-// CHECK-NEXT:    %[[TMP9:.+]] = load i32*, i32** %[[DISTANCE_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[COND]], i32* %[[TMP9]], align 4
+
+
+
+
+// CHECK-LABEL: define {{[^@]+}}@unroll_partial_factor_for
+// CHECK-SAME: (float* [[A:%.*]], float* [[B:%.*]], float* [[C:%.*]], float* [[D:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[A_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[B_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[C_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[D_ADDR:%.*]] = alloca float*, align 8
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[AGG_CAPTURED:%.*]] = alloca [[STRUCT_ANON:%.*]], align 8
+// CHECK-NEXT:    [[AGG_CAPTURED1:%.*]] = alloca [[STRUCT_ANON_0:%.*]], align 4
+// CHECK-NEXT:    [[DOTCOUNT_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LASTITER:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_LOWERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_UPPERBOUND:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[P_STRIDE:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store float* [[A]], float** [[A_ADDR]], align 8
+// CHECK-NEXT:    store float* [[B]], float** [[B_ADDR]], align 8
+// CHECK-NEXT:    store float* [[C]], float** [[C_ADDR]], align 8
+// CHECK-NEXT:    store float* [[D]], float** [[D_ADDR]], align 8
+// CHECK-NEXT:    store i32 0, i32* [[I]], align 4
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds [[STRUCT_ANON]], %struct.anon* [[AGG_CAPTURED]], i32 0, i32 0
+// CHECK-NEXT:    store i32* [[I]], i32** [[TMP0]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0]], %struct.anon.0* [[AGG_CAPTURED1]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    store i32 [[TMP2]], i32* [[TMP1]], align 4
+// CHECK-NEXT:    call void @__captured_stmt(i32* [[DOTCOUNT_ADDR]], %struct.anon* [[AGG_CAPTURED]])
+// CHECK-NEXT:    [[DOTCOUNT:%.*]] = load i32, i32* [[DOTCOUNT_ADDR]], align 4
+// CHECK-NEXT:    br label [[OMP_LOOP_PREHEADER:%.*]]
+// CHECK:       omp_loop.preheader:
+// CHECK-NEXT:    [[TMP3:%.*]] = udiv i32 [[DOTCOUNT]], 2
+// CHECK-NEXT:    [[TMP4:%.*]] = urem i32 [[DOTCOUNT]], 2
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ne i32 [[TMP4]], 0
+// CHECK-NEXT:    [[TMP6:%.*]] = zext i1 [[TMP5]] to i32
+// CHECK-NEXT:    [[OMP_FLOOR0_TRIPCOUNT:%.*]] = add nuw i32 [[TMP3]], [[TMP6]]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_PREHEADER:%.*]]
+// CHECK:       omp_floor0.preheader:
+// CHECK-NEXT:    store i32 0, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = sub i32 [[OMP_FLOOR0_TRIPCOUNT]], 1
+// CHECK-NEXT:    store i32 [[TMP7]], i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[P_STRIDE]], align 4
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]])
+// CHECK-NEXT:    call void @__kmpc_for_static_init_4u(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]], i32 34, i32* [[P_LASTITER]], i32* [[P_LOWERBOUND]], i32* [[P_UPPERBOUND]], i32* [[P_STRIDE]], i32 1, i32 1)
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[P_LOWERBOUND]], align 4
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, i32* [[P_UPPERBOUND]], align 4
+// CHECK-NEXT:    [[TMP10:%.*]] = sub i32 [[TMP9]], [[TMP8]]
+// CHECK-NEXT:    [[TMP11:%.*]] = add i32 [[TMP10]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER:%.*]]
+// CHECK:       omp_floor0.header:
+// CHECK-NEXT:    [[OMP_FLOOR0_IV:%.*]] = phi i32 [ 0, [[OMP_FLOOR0_PREHEADER]] ], [ [[OMP_FLOOR0_NEXT:%.*]], [[OMP_FLOOR0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_FLOOR0_COND:%.*]]
+// CHECK:       omp_floor0.cond:
+// CHECK-NEXT:    [[OMP_FLOOR0_CMP:%.*]] = icmp ult i32 [[OMP_FLOOR0_IV]], [[TMP11]]
+// CHECK-NEXT:    br i1 [[OMP_FLOOR0_CMP]], label [[OMP_FLOOR0_BODY:%.*]], label [[OMP_FLOOR0_EXIT:%.*]]
+// CHECK:       omp_floor0.body:
+// CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[OMP_FLOOR0_IV]], [[TMP8]]
+// CHECK-NEXT:    [[TMP13:%.*]] = icmp eq i32 [[TMP12]], [[OMP_FLOOR0_TRIPCOUNT]]
+// CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 [[TMP4]], i32 2
+// CHECK-NEXT:    br label [[OMP_TILE0_PREHEADER:%.*]]
+// CHECK:       omp_tile0.preheader:
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER:%.*]]
+// CHECK:       omp_tile0.header:
+// CHECK-NEXT:    [[OMP_TILE0_IV:%.*]] = phi i32 [ 0, [[OMP_TILE0_PREHEADER]] ], [ [[OMP_TILE0_NEXT:%.*]], [[OMP_TILE0_INC:%.*]] ]
+// CHECK-NEXT:    br label [[OMP_TILE0_COND:%.*]]
+// CHECK:       omp_tile0.cond:
+// CHECK-NEXT:    [[OMP_TILE0_CMP:%.*]] = icmp ult i32 [[OMP_TILE0_IV]], [[TMP14]]
+// CHECK-NEXT:    br i1 [[OMP_TILE0_CMP]], label [[OMP_TILE0_BODY:%.*]], label [[OMP_TILE0_EXIT:%.*]]
+// CHECK:       omp_tile0.body:
+// CHECK-NEXT:    [[TMP15:%.*]] = mul nuw i32 2, [[TMP12]]
+// CHECK-NEXT:    [[TMP16:%.*]] = add nuw i32 [[TMP15]], [[OMP_TILE0_IV]]
+// CHECK-NEXT:    br label [[OMP_LOOP_BODY:%.*]]
+// CHECK:       omp_loop.body:
+// CHECK-NEXT:    call void @__captured_stmt.1(i32* [[I]], i32 [[TMP16]], %struct.anon.0* [[AGG_CAPTURED1]])
+// CHECK-NEXT:    [[TMP17:%.*]] = load float*, float** [[B_ADDR]], align 8
+// CHECK-NEXT:    [[TMP18:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[TMP18]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds float, float* [[TMP17]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[TMP19:%.*]] = load float, float* [[ARRAYIDX]], align 4
+// CHECK-NEXT:    [[TMP20:%.*]] = load float*, float** [[C_ADDR]], align 8
+// CHECK-NEXT:    [[TMP21:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM2:%.*]] = sext i32 [[TMP21]] to i64
+// CHECK-NEXT:    [[ARRAYIDX3:%.*]] = getelementptr inbounds float, float* [[TMP20]], i64 [[IDXPROM2]]
+// CHECK-NEXT:    [[TMP22:%.*]] = load float, float* [[ARRAYIDX3]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = fmul float [[TMP19]], [[TMP22]]
+// CHECK-NEXT:    [[TMP23:%.*]] = load float*, float** [[D_ADDR]], align 8
+// CHECK-NEXT:    [[TMP24:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM4:%.*]] = sext i32 [[TMP24]] to i64
+// CHECK-NEXT:    [[ARRAYIDX5:%.*]] = getelementptr inbounds float, float* [[TMP23]], i64 [[IDXPROM4]]
+// CHECK-NEXT:    [[TMP25:%.*]] = load float, float* [[ARRAYIDX5]], align 4
+// CHECK-NEXT:    [[MUL6:%.*]] = fmul float [[MUL]], [[TMP25]]
+// CHECK-NEXT:    [[TMP26:%.*]] = load float*, float** [[A_ADDR]], align 8
+// CHECK-NEXT:    [[TMP27:%.*]] = load i32, i32* [[I]], align 4
+// CHECK-NEXT:    [[IDXPROM7:%.*]] = sext i32 [[TMP27]] to i64
+// CHECK-NEXT:    [[ARRAYIDX8:%.*]] = getelementptr inbounds float, float* [[TMP26]], i64 [[IDXPROM7]]
+// CHECK-NEXT:    store float [[MUL6]], float* [[ARRAYIDX8]], align 4
+// CHECK-NEXT:    br label [[OMP_TILE0_INC]]
+// CHECK:       omp_tile0.inc:
+// CHECK-NEXT:    [[OMP_TILE0_NEXT]] = add nuw i32 [[OMP_TILE0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_TILE0_HEADER]], !llvm.loop [[LOOP3:![0-9]+]]
+// CHECK:       omp_tile0.exit:
+// CHECK-NEXT:    br label [[OMP_TILE0_AFTER:%.*]]
+// CHECK:       omp_tile0.after:
+// CHECK-NEXT:    br label [[OMP_FLOOR0_INC]]
+// CHECK:       omp_floor0.inc:
+// CHECK-NEXT:    [[OMP_FLOOR0_NEXT]] = add nuw i32 [[OMP_FLOOR0_IV]], 1
+// CHECK-NEXT:    br label [[OMP_FLOOR0_HEADER]]
+// CHECK:       omp_floor0.exit:
+// CHECK-NEXT:    call void @__kmpc_for_static_fini(%struct.ident_t* @[[GLOB1]], i32 [[OMP_GLOBAL_THREAD_NUM]])
+// CHECK-NEXT:    br label [[OMP_FLOOR0_AFTER:%.*]]
+// CHECK:       omp_floor0.after:
+// CHECK-NEXT:    [[OMP_GLOBAL_THREAD_NUM9:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1]])
+// CHECK-NEXT:    call void @__kmpc_barrier(%struct.ident_t* @[[GLOB2:[0-9]+]], i32 [[OMP_GLOBAL_THREAD_NUM9]])
+// CHECK-NEXT:    br label [[OMP_LOOP_AFTER:%.*]]
+// CHECK:       omp_loop.after:
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK-LABEL: define {{.*}}@__captured_stmt.1(
-// CHECK-NEXT:  [[ENTRY:.*]]:
-// CHECK-NEXT:    %[[LOOPVAR_ADDR:.+]] = alloca i32*, align 8
-// CHECK-NEXT:    %[[LOGICAL_ADDR:.+]] = alloca i32, align 4
-// CHECK-NEXT:    %[[__CONTEXT_ADDR:.+]] = alloca %struct.anon.0*, align 8
-// CHECK-NEXT:    store i32* %[[LOOPVAR:.+]], i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[LOGICAL:.+]], i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    store %struct.anon.0* %[[__CONTEXT:.+]], %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP0:.+]] = load %struct.anon.0*, %struct.anon.0** %[[__CONTEXT_ADDR]], align 8
-// CHECK-NEXT:    %[[TMP1:.+]] = getelementptr inbounds %struct.anon.0, %struct.anon.0* %[[TMP0]], i32 0, i32 0
-// CHECK-NEXT:    %[[TMP2:.+]] = load i32, i32* %[[TMP1]], align 4
-// CHECK-NEXT:    %[[TMP3:.+]] = load i32, i32* %[[LOGICAL_ADDR]], align 4
-// CHECK-NEXT:    %[[MUL:.+]] = mul i32 1, %[[TMP3]]
-// CHECK-NEXT:    %[[ADD:.+]] = add i32 %[[TMP2]], %[[MUL]]
-// CHECK-NEXT:    %[[TMP4:.+]] = load i32*, i32** %[[LOOPVAR_ADDR]], align 8
-// CHECK-NEXT:    store i32 %[[ADD]], i32* %[[TMP4]], align 4
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[DISTANCE:%.*]], %struct.anon* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[DISTANCE_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon*, align 8
+// CHECK-NEXT:    [[DOTSTART:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTOP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[DOTSTEP:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32* [[DISTANCE]], i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store %struct.anon* [[__CONTEXT]], %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon*, %struct.anon** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON:%.*]], %struct.anon* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32*, i32** [[TMP1]], align 8
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[TMP2]], align 4
+// CHECK-NEXT:    store i32 [[TMP3]], i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    store i32 2, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    store i32 1, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[TMP5:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP4]], [[TMP5]]
+// CHECK-NEXT:    br i1 [[CMP]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
+// CHECK:       cond.true:
+// CHECK-NEXT:    [[TMP6:%.*]] = load i32, i32* [[DOTSTOP]], align 4
+// CHECK-NEXT:    [[TMP7:%.*]] = load i32, i32* [[DOTSTART]], align 4
+// CHECK-NEXT:    [[SUB:%.*]] = sub nsw i32 [[TMP6]], [[TMP7]]
+// CHECK-NEXT:    [[TMP8:%.*]] = load i32, i32* [[DOTSTEP]], align 4
+// CHECK-NEXT:    [[DIV:%.*]] = udiv i32 [[SUB]], [[TMP8]]
+// CHECK-NEXT:    br label [[COND_END:%.*]]
+// CHECK:       cond.false:
+// CHECK-NEXT:    br label [[COND_END]]
+// CHECK:       cond.end:
+// CHECK-NEXT:    [[COND:%.*]] = phi i32 [ [[DIV]], [[COND_TRUE]] ], [ 0, [[COND_FALSE]] ]
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32*, i32** [[DISTANCE_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[COND]], i32* [[TMP9]], align 4
 // CHECK-NEXT:    ret void
-// CHECK-NEXT:  }
-
-
-// CHECK: ![[META0:[0-9]+]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[META1:[0-9]+]] = !{i32 7, !"openmp", i32 51}
-// CHECK: ![[META2:[0-9]+]] =
-// CHECK: ![[LOOP3]] = distinct !{![[LOOP3]], ![[LOOPPROP4:[0-9]+]], ![[LOOPPROP5:[0-9]+]]}
-// CHECK: ![[LOOPPROP4]] = !{!"llvm.loop.unroll.enable"}
-// CHECK: ![[LOOPPROP5]] = !{!"llvm.loop.unroll.count", i32 2}
+//
+//
+// CHECK-LABEL: define {{[^@]+}}@__captured_stmt.1
+// CHECK-SAME: (i32* nonnull align 4 dereferenceable(4) [[LOOPVAR:%.*]], i32 [[LOGICAL:%.*]], %struct.anon.0* noalias [[__CONTEXT:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[LOOPVAR_ADDR:%.*]] = alloca i32*, align 8
+// CHECK-NEXT:    [[LOGICAL_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[__CONTEXT_ADDR:%.*]] = alloca %struct.anon.0*, align 8
+// CHECK-NEXT:    store i32* [[LOOPVAR]], i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[LOGICAL]], i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    store %struct.anon.0* [[__CONTEXT]], %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load %struct.anon.0*, %struct.anon.0** [[__CONTEXT_ADDR]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds [[STRUCT_ANON_0:%.*]], %struct.anon.0* [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, i32* [[TMP1]], align 4
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, i32* [[LOGICAL_ADDR]], align 4
+// CHECK-NEXT:    [[MUL:%.*]] = mul i32 1, [[TMP3]]
+// CHECK-NEXT:    [[ADD:%.*]] = add i32 [[TMP2]], [[MUL]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32*, i32** [[LOOPVAR_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[ADD]], i32* [[TMP4]], align 4
+// CHECK-NEXT:    ret void
+//

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -633,10 +633,14 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
     } else if (const auto &orderedClause =
                    std::get_if<Fortran::parser::OmpClause::Ordered>(
                        &clause.u)) {
-      const auto *expr = Fortran::semantics::GetExpr(orderedClause->v);
-      const std::optional<std::int64_t> orderedValue =
-          Fortran::evaluate::ToInt64(*expr);
-      wsLoopOp.ordered_valAttr(firOpBuilder.getI64IntegerAttr(*orderedValue));
+      if (orderedClause->v.has_value()) {
+        const auto *expr = Fortran::semantics::GetExpr(orderedClause->v);
+        const std::optional<std::int64_t> orderedValue =
+            Fortran::evaluate::ToInt64(*expr);
+        wsLoopOp.ordered_valAttr(firOpBuilder.getI64IntegerAttr(*orderedValue));
+      } else {
+        wsLoopOp.ordered_valAttr(firOpBuilder.getI64IntegerAttr(0));
+      }
     } else if (const auto &scheduleClause =
                    std::get_if<Fortran::parser::OmpClause::Schedule>(
                        &clause.u)) {

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -514,7 +514,7 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
   mlir::Location currentLocation = converter.getCurrentLocation();
   SmallVector<Value, 4> lowerBound, upperBound, step, privateClauseOperands,
       firstPrivateClauseOperands, lastPrivateClauseOperands, linearVars,
-      linearStepVars, reductionVars;
+      linearStepVars, reductionVars, doacrossVars;
   mlir::Value scheduleChunkClauseOperand;
   mlir::Attribute scheduleClauseOperand, collapseClauseOperand,
       noWaitClauseOperand, orderedClauseOperand, orderClauseOperand;
@@ -618,7 +618,7 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
       scheduleChunkClauseOperand,
       collapseClauseOperand.dyn_cast_or_null<IntegerAttr>(),
       noWaitClauseOperand.dyn_cast_or_null<UnitAttr>(),
-      orderedClauseOperand.dyn_cast_or_null<IntegerAttr>(),
+      orderedClauseOperand.dyn_cast_or_null<IntegerAttr>(), doacrossVars,
       orderClauseOperand.dyn_cast_or_null<StringAttr>(),
       firOpBuilder.getUnitAttr() /* Inclusive stop */, false /* buildBody */);
 

--- a/flang/test/Lower/OpenMP/omp-wsloop-collapse.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-collapse.f90
@@ -153,10 +153,10 @@ program wsloop_collapse
 ! LLVMIR:         br i1 %[[VAL_68]], label %[[VAL_69:.*]], label %[[VAL_70:.*]], !dbg !26
 ! LLVMIR:       omp_collapsed.exit:                               ; preds = %[[VAL_67]]
 ! LLVMIR:         call void @__kmpc_for_static_fini(%[[VAL_58]]* @3, i32 %[[VAL_57]]), !dbg !26
-! LLVMIR:         %[[VAL_71:.*]] = call i32 @__kmpc_global_thread_num(%[[VAL_58]]* @3), !dbg !26
-! LLVMIR:         call void @__kmpc_barrier(%[[VAL_58]]* @4, i32 %[[VAL_71]]), !dbg !26
 ! LLVMIR:         br label %[[VAL_72:.*]], !dbg !26
 ! LLVMIR:       omp_collapsed.after:                              ; preds = %[[VAL_70]]
+! LLVMIR:         %[[VAL_71:.*]] = call i32 @__kmpc_global_thread_num(%[[VAL_58]]* @3), !dbg !26
+! LLVMIR:         call void @__kmpc_barrier(%[[VAL_58]]* @4, i32 %[[VAL_71]]), !dbg !26
 ! LLVMIR:         br label %[[VAL_73:.*]], !dbg !26
 ! LLVMIR:       omp_loop.after:                                   ; preds = %[[VAL_72]]
 ! LLVMIR:       omp.par.pre_finalize:                             ; preds = %[[VAL_73]]

--- a/flang/test/Lower/OpenMP/omp-wsloop-dynamic.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-dynamic.f90
@@ -42,7 +42,7 @@ program wsloop_dynamic
 !LLVMIR:    br label %omp_loop.preheader
 !LLVMIR:  omp_loop.preheader:                               ; preds = %omp.par.region1
 !LLVMIR:    @__kmpc_global_thread_num
-!LLVMIR:    @__kmpc_dispatch_init_4u(%struct.ident_t* @{{.*}}, i32 %omp_global_thread_num{{.*}}, i32 35, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
+!LLVMIR:    @__kmpc_dispatch_init_4u(%struct.ident_t* @{{.*}}, i32 %omp_global_thread_num{{.*}}, i32 1073741859, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
 !LLVMIR:    br label %omp_loop.preheader.outer.cond
 !LLVMIR:  omp_loop.preheader.outer.cond:
 !LLVMIR:    @__kmpc_dispatch_next_4u

--- a/flang/test/Lower/OpenMP/omp-wsloop-ordered.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-ordered.f90
@@ -35,3 +35,49 @@ subroutine wsloop_ordered_no_para()
   !$omp end do
 
 end
+
+! This checks lowering ordered clause specified with a parameter
+subroutine wsloop_ordered_with_para()
+  integer :: a(10), i
+
+! FIRDialect: func @_QPwsloop_ordered_with_para() {
+! FIRDialect:    [[ARG3:%.*]] = arith.constant 1 : i64
+! FIRDialect-DAG:    [[ARG1:%.*]] = fir.convert %{{.*}} : (i32) -> i64
+! FIRDialect-DAG:    [[ARG2:%.*]] = fir.convert %{{.*}} : (i32) -> i64
+! FIRDialect:  omp.wsloop (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) ordered(1) doacross([[ARG1]] : i64, [[ARG2]] : i64, [[ARG3]] : i64)  {
+! FIRDialect:    omp.yield
+! FIRDialect:  }
+
+! LLVMIRDialect:  llvm.func @_QPwsloop_ordered_with_para() {
+! LLVMIRDialect:    [[ARG3:%.*]] = llvm.mlir.constant(1 : i64) : i64
+! LLVMIRDialect-DAG:    [[ARG1:%.*]] = llvm.sext %{{.*}} : i32 to i64
+! LLVMIRDialect-DAG:    [[ARG2:%.*]] = llvm.sext %{{.*}} : i32 to i64
+! LLVMIRDialect:    omp.wsloop (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) ordered(1) doacross([[ARG1]] : i64, [[ARG2]] : i64, [[ARG3]] : i64)  {
+! LLVMIRDialect:      omp.yield
+! LLVMIRDialect:    }
+
+! LLVMIR: define void @_QPwsloop_ordered_with_para
+! LLVMIR: omp_loop.preheader:
+! LLVMIR:   [[ADDR:%.*]] = getelementptr inbounds [1 x %kmp_dim], [1 x %kmp_dim]* [[DIMS:%.*]], i64 0, i64 0
+! LLVMIR:   [[ST1:%.*]] = getelementptr inbounds %kmp_dim, %kmp_dim* [[ADDR]], i32 0, i32 0
+! LLVMIR:   store i64 2, i64* [[ST1]], align 8
+! LLVMIR:   [[ST2:%.*]] = getelementptr inbounds %kmp_dim, %kmp_dim* [[ADDR]], i32 0, i32 1
+! LLVMIR:   store i64 10, i64* [[ST2]], align 8
+! LLVMIR:   [[ST3:%.*]] = getelementptr inbounds %kmp_dim, %kmp_dim* [[ADDR]], i32 0, i32 2
+! LLVMIR:   store i64 1, i64* [[ST3]], align 8
+! LLVMIR:   [[BASE:%.*]] = getelementptr inbounds [1 x %kmp_dim], [1 x %kmp_dim]* [[DIMS]], i64 0, i64 0
+! LLVMIR:   [[INIT_ARG:%.*]] = bitcast %kmp_dim* [[BASE]] to i8*
+! LLVMIR:   [[TMP1:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB1:[0-9]+]])
+! LLVMIR:   call void @__kmpc_doacross_init(%struct.ident_t* @[[GLOB1]], i32 [[TMP1]], i32 1, i8* [[INIT_ARG]])
+! LLVMIR: omp_loop.exit:
+! LLVMIR:   call void @__kmpc_doacross_fini(%struct.ident_t* @[[GLOB1]], i32 [[TMP1]])
+
+  !$omp do ordered(1)
+  do i = 2, 10
+    !!$omp ordered depend(sink: i-1)
+    a(i) = a(i-1) + 1
+    !!$omp ordered depend(source)
+  end do
+  !$omp end do
+
+end

--- a/flang/test/Lower/OpenMP/omp-wsloop-ordered.f90
+++ b/flang/test/Lower/OpenMP/omp-wsloop-ordered.f90
@@ -1,0 +1,37 @@
+! This test checks lowering of worksharing-loop construct with ordered clause.
+
+! RUN: bbc -fopenmp -emit-fir %s -o - | FileCheck %s --check-prefix=FIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | \
+! RUN:   tco --disable-llvm --print-ir-after=fir-to-llvm-ir 2>&1 | \
+! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
+! RUN: bbc -fopenmp -emit-fir %s -o - | tco | FileCheck %s --check-prefix=LLVMIR
+
+! This checks lowering ordered clause specified without parameter
+subroutine wsloop_ordered_no_para()
+  integer :: a(10), i
+
+! FIRDialect:  omp.wsloop (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) ordered(0)  {
+! FIRDialect:    omp.yield
+! FIRDialect:  }
+
+! LLVMIRDialect:    omp.wsloop (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) ordered(0)  {
+! LLVMIRDialect:      omp.yield
+! LLVMIRDialect:    }
+
+! LLVMIR: omp_loop.preheader:
+! LLVMIR: [[TMP0:%.*]] = call i32 @__kmpc_global_thread_num(%struct.ident_t* @[[GLOB0:[0-9]+]])
+! LLVMIR-NEXT: call void @__kmpc_dispatch_init_4u(%struct.ident_t* @[[GLOB0]], i32 [[TMP0]],
+! LLVMIR: omp_loop.inc:
+! LLVMIR: call void @__kmpc_dispatch_fini_4u(%struct.ident_t* @[[GLOB0]], i32 [[TMP0]])
+! LLVMIR: omp_loop.preheader.outer.cond:
+! LLVMIR: {{.*}} = call i32 @__kmpc_dispatch_next_4u(%struct.ident_t* @[[GLOB0]], i32 [[TMP0]],
+
+  !$omp do ordered
+  do i = 2, 10
+    !$omp ordered
+    a(i) = a(i-1) + 1
+    !$omp end ordered
+  end do
+  !$omp end do
+
+end

--- a/llvm/include/llvm/Frontend/OpenMP/OMPConstants.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPConstants.h
@@ -113,8 +113,6 @@ inline std::string getAllAssumeClauseOptions() {
 enum class OMPScheduleType {
   StaticChunked = 33,
   Static = 34, // static unspecialized
-  DistributeChunked = 91,
-  Distribute = 92,
   DynamicChunked = 35,
   GuidedChunked = 36, // guided unspecialized
   Runtime = 37,
@@ -123,6 +121,16 @@ enum class OMPScheduleType {
   StaticBalancedChunked = 45, // static with chunk adjustment (e.g., simd)
   GuidedSimd = 46,            // guided with chunk adjustment
   RuntimeSimd = 47,           // runtime with chunk adjustment
+
+  OrderedStaticChunked = 65,
+  OrderedStatic = 66, // ordered static unspecialized
+  OrderedDynamicChunked = 67,
+  OrderedGuidedChunked = 68,
+  OrderedRuntime = 69,
+  OrderedAuto = 70, // ordered auto
+
+  DistributeChunked = 91, // distribute static chunked
+  Distribute = 92,        // distribute static unspecialized
 
   ModifierMonotonic =
       (1 << 29), // Set if the monotonic schedule modifier was present

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -399,13 +399,16 @@ public:
   ///                     the loop.
   /// \param Chunk    The size of loop chunk considered as a unit when
   ///                 scheduling. If \p nullptr, defaults to 1.
+  /// \param Ordered  Indicates whether the ordered clause is specified without
+  ///                 parameter.
   ///
   /// \returns Point where to insert code after the workshare construct.
   InsertPointTy applyDynamicWorkshareLoop(DebugLoc DL, CanonicalLoopInfo *CLI,
                                           InsertPointTy AllocaIP,
                                           omp::OMPScheduleType SchedType,
                                           bool NeedsBarrier,
-                                          Value *Chunk = nullptr);
+                                          Value *Chunk = nullptr,
+                                          bool Ordered = false);
 
   /// Modifies the canonical loop to be a workshare loop.
   ///

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -410,6 +410,25 @@ public:
                                           Value *Chunk = nullptr,
                                           bool Ordered = false);
 
+  /// Insert doacross loop info in a workshare loop.
+  ///
+  /// In \p AllocaIP, allocate space for the loop bounds info. In the front of
+  /// \p PreHeaderBB, store \p DoacrossVars in the loop bounds info and call
+  /// doacross loop init runtime function. Call the fini doacross loop runtime
+  /// function in \p ExitBB.
+  ///
+  /// \param DL           Debug location for instructions.
+  /// \param AllocaIP     An insertion point for Alloca instructions.
+  /// \param PreHeaderBB  The preheader basic block of the loop.
+  /// \param ExitBB       The exit basic block of the loop.
+  /// \param OrderedVal   The ordered parameter (n) specified in ordered clause.
+  /// \param DoacrossVars The lower bounds, upper bounds, and steps of n outer
+  ///                     loops.
+  void applyDoacrossLoop(DebugLoc DL, InsertPointTy AllocaIP,
+                         BasicBlock *PreHeaderBB, BasicBlock *ExitBB,
+                         std::int64_t OrderedVal,
+                         ArrayRef<llvm::Value *> DoacrossVars);
+
   /// Modifies the canonical loop to be a workshare loop.
   ///
   /// This takes a \p LoopInfo representing a canonical loop, such as the one

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -1601,9 +1601,24 @@ getKmpcForDynamicNextForType(Type *Ty, Module &M, OpenMPIRBuilder &OMPBuilder) {
   llvm_unreachable("unknown OpenMP loop iterator bitwidth");
 }
 
+/// Returns an LLVM function to call for finalizing the dynamic loop using
+/// depending on `type`. Only i32 and i64 are supported by the runtime. Always
+/// interpret integers as unsigned similarly to CanonicalLoopInfo.
+static FunctionCallee
+getKmpcForDynamicFiniForType(Type *Ty, Module &M, OpenMPIRBuilder &OMPBuilder) {
+  unsigned Bitwidth = Ty->getIntegerBitWidth();
+  if (Bitwidth == 32)
+    return OMPBuilder.getOrCreateRuntimeFunction(
+        M, omp::RuntimeFunction::OMPRTL___kmpc_dispatch_fini_4u);
+  if (Bitwidth == 64)
+    return OMPBuilder.getOrCreateRuntimeFunction(
+        M, omp::RuntimeFunction::OMPRTL___kmpc_dispatch_fini_8u);
+  llvm_unreachable("unknown OpenMP loop iterator bitwidth");
+}
+
 OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyDynamicWorkshareLoop(
     DebugLoc DL, CanonicalLoopInfo *CLI, InsertPointTy AllocaIP,
-    OMPScheduleType SchedType, bool NeedsBarrier, Value *Chunk) {
+    OMPScheduleType SchedType, bool NeedsBarrier, Value *Chunk, bool Ordered) {
   assert(CLI->isValid() && "Requires a valid canonical loop");
 
   // Set up the source location value for OpenMP runtime.
@@ -1641,6 +1656,7 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyDynamicWorkshareLoop(
   BasicBlock *Header = CLI->getHeader();
   BasicBlock *Exit = CLI->getExit();
   BasicBlock *Cond = CLI->getCond();
+  BasicBlock *Latch = CLI->getLatch();
   InsertPointTy AfterIP = CLI->getAfterIP();
 
   // The CLI will be "broken" in the code below, as the loop is no longer
@@ -1699,6 +1715,13 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::applyDynamicWorkshareLoop(
   auto *BI = cast<BranchInst>(Branch);
   assert(BI->getSuccessor(1) == Exit);
   BI->setSuccessor(1, OuterCond);
+
+  // Call the "fini" function if "ordered" is present in wsloop directive.
+  if (Ordered) {
+    Builder.SetInsertPoint(&Latch->back());
+    FunctionCallee DynamicFini = getKmpcForDynamicFiniForType(IVTy, M, *this);
+    Builder.CreateCall(DynamicFini, {SrcLoc, ThreadNum});
+  }
 
   // Add the barrier if requested.
   if (NeedsBarrier) {

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -218,9 +218,9 @@ def SectionsOp : OpenMP_Op<"sections", [AttrSizedOperandSegments]> {
 
 def WsLoopOp : OpenMP_Op<"wsloop", [AttrSizedOperandSegments,
                          AllTypesMatch<["lowerBound", "upperBound", "step"]>]> {
-  let summary = "workshare loop construct";
+  let summary = "worksharing-loop construct";
   let description = [{
-    The workshare loop construct specifies that the iterations of the loop(s)
+    The worksharing-loop construct specifies that the iterations of the loop(s)
     will be executed in parallel by threads in the current context. These
     iterations are spread across threads that already exist in the enclosing
     parallel region. The lower and upper bounds specify a half-open range: the
@@ -271,7 +271,8 @@ def WsLoopOp : OpenMP_Op<"wsloop", [AttrSizedOperandSegments,
     implicit barrier at the end of the loop.
 
     The optional `ordered_val` attribute specifies how many loops are associated
-    with the do loop construct.
+    with the worksharing-loop construct. The value of zero refers to the ordered
+    clause specified without parameter.
 
     The optional `order` attribute specifies which order the iterations of the
     associate loops are executed in. Currently the only option for this

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -274,6 +274,10 @@ def WsLoopOp : OpenMP_Op<"wsloop", [AttrSizedOperandSegments,
     with the worksharing-loop construct. The value of zero refers to the ordered
     clause specified without parameter.
 
+    The `doacross_vars` are arguments of doacross loop nest, which is formed by
+    "n" outer loops when the parameter "n" is in ordered clause. The arguments
+    store the loop bounds info, which is required in doacorss init runtime call.
+
     The optional `order` attribute specifies which order the iterations of the
     associate loops are executed in. Currently the only option for this
     attribute is "concurrent".
@@ -296,6 +300,7 @@ def WsLoopOp : OpenMP_Op<"wsloop", [AttrSizedOperandSegments,
              Confined<OptionalAttr<I64Attr>, [IntMinValue<0>]>:$collapse_val,
              UnitAttr:$nowait,
              Confined<OptionalAttr<I64Attr>, [IntMinValue<0>]>:$ordered_val,
+             Variadic<IntLikeType>:$doacross_vars,
              OptionalAttr<OrderKind>:$order_val,
              UnitAttr:$inclusive);
 
@@ -312,8 +317,9 @@ def WsLoopOp : OpenMP_Op<"wsloop", [AttrSizedOperandSegments,
                "ValueRange":$linear_step_vars, "ValueRange":$reduction_vars,
                "StringAttr":$schedule_val, "Value":$schedule_chunk_var,
                "IntegerAttr":$collapse_val, "UnitAttr":$nowait,
-               "IntegerAttr":$ordered_val, "StringAttr":$order_val,
-               "UnitAttr":$inclusive, CArg<"bool", "true">:$buildBody)>,
+               "IntegerAttr":$ordered_val, "ValueRange":$doacross_vars,
+               "StringAttr":$order_val, "UnitAttr":$inclusive,
+               CArg<"bool", "true">:$buildBody)>,
     OpBuilder<(ins "TypeRange":$resultTypes, "ValueRange":$operands,
                CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
   ];

--- a/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
+++ b/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
@@ -53,7 +53,7 @@ func @wsloop(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: inde
       // CHECK: "test.payload"(%[[ARG6]], %[[ARG7]]) : (i64, i64) -> ()
       "test.payload"(%arg6, %arg7) : (index, index) -> ()
       omp.yield
-    }) {operand_segment_sizes = dense<[2, 2, 2, 0, 0, 0, 0, 0, 0, 0]> : vector<10xi32>} : (index, index, index, index, index, index) -> ()
+    }) {operand_segment_sizes = dense<[2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0]> : vector<11xi32>} : (index, index, index, index, index, index) -> ()
     omp.terminator
   }
   return

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -120,7 +120,7 @@ func @order_not_allowed() {
 
 func @ordered_not_allowed() {
   // expected-error@+1 {{ordered is not a valid clause for the omp.parallel operation}}
-  omp.parallel ordered(2) {}
+  omp.parallel ordered(0) {}
 }
 
 // -----
@@ -448,8 +448,8 @@ omp.critical.declare @mutex hint(invalid_hint)
 
 // -----
 
-func @omp_ordered1(%arg1 : i32, %arg2 : i32, %arg3 : i32) -> () {
-  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) {
+func @omp_ordered1(%arg1 : i32, %arg2 : i32, %arg3 : i32, %doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64) -> () {
+  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) doacross(%doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64) {
     // expected-error @below {{ordered region must be closely nested inside a worksharing-loop region with an ordered clause without parameter present}}
     omp.ordered_region {
       omp.terminator
@@ -493,8 +493,8 @@ func @omp_ordered4(%arg1 : i32, %arg2 : i32, %arg3 : i32, %vec0 : i64) -> () {
 }
 // -----
 
-func @omp_ordered5(%arg1 : i32, %arg2 : i32, %arg3 : i32, %vec0 : i64, %vec1 : i64) -> () {
-  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) {
+func @omp_ordered5(%arg1 : i32, %arg2 : i32, %arg3 : i32, %vec0 : i64, %vec1 : i64, %doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64) -> () {
+  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) doacross(%doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64) {
     // expected-error @below {{number of variables in depend clause does not match number of iteration variables in the doacross loop}}
     omp.ordered depend_type("dependsource") depend_vec(%vec0, %vec1 : i64, i64) {num_loops_val = 2 : i64}
 
@@ -753,7 +753,7 @@ func @omp_sections() {
 
 func @omp_sections() {
   // expected-error @below {{ordered is not a valid clause for the omp.sections operation}}
-  omp.sections ordered(2) {
+  omp.sections ordered(0) {
     omp.terminator
   }
   return

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -147,52 +147,51 @@ func @omp_parallel_pretty(%data_var : memref<i32>, %if_cond : i1, %num_threads :
 }
 
 // CHECK-LABEL: omp_wsloop
-func @omp_wsloop(%lb : index, %ub : index, %step : index, %data_var : memref<i32>, %linear_var : i32, %chunk_var : i32) -> () {
+func @omp_wsloop(%lb : index, %ub : index, %step : index, %data_var : memref<i32>, %linear_var : i32, %chunk_var : i32, %doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64, %doacross_var4 : i64, %doacross_var5 : i64, %doacross_var6 : i64) -> () {
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>, %{{.*}} : memref<i32>) collapse(2) ordered(1)
-  "omp.wsloop" (%lb, %ub, %step, %data_var, %data_var) ({
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>, %{{.*}} : memref<i32>) collapse(2) ordered(1) doacross(%{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64)
+  "omp.wsloop" (%lb, %ub, %step, %data_var, %data_var, %doacross_var1, %doacross_var2, %doacross_var3) ({
     ^bb0(%iv: index):
       omp.yield
-  }) {operand_segment_sizes = dense<[1,1,1,2,0,0,0,0,0,0]> : vector<10xi32>, collapse_val = 2, ordered_val = 1} :
-    (index, index, index, memref<i32>, memref<i32>) -> ()
+  }) {operand_segment_sizes = dense<[1,1,1,2,0,0,0,0,0,0,3]> : vector<11xi32>, collapse_val = 2, ordered_val = 1} :
+    (index, index, index, memref<i32>, memref<i32>, i64, i64, i64) -> ()
 
   // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(static)
   "omp.wsloop" (%lb, %ub, %step, %data_var, %linear_var) ({
     ^bb0(%iv: index):
       omp.yield
-  }) {operand_segment_sizes = dense<[1,1,1,0,0,0,1,1,0,0]> : vector<10xi32>, schedule_val = "Static"} :
+  }) {operand_segment_sizes = dense<[1,1,1,0,0,0,1,1,0,0,0]> : vector<11xi32>, schedule_val = "Static"} :
     (index, index, index, memref<i32>, i32) -> ()
 
   // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) linear(%{{.*}} = %{{.*}} : memref<i32>, %{{.*}} = %{{.*}} : memref<i32>) schedule(static)
   "omp.wsloop" (%lb, %ub, %step, %data_var, %data_var, %linear_var, %linear_var) ({
     ^bb0(%iv: index):
       omp.yield
-  }) {operand_segment_sizes = dense<[1,1,1,0,0,0,2,2,0,0]> : vector<10xi32>, schedule_val = "Static"} :
+  }) {operand_segment_sizes = dense<[1,1,1,0,0,0,2,2,0,0,0]> : vector<11xi32>, schedule_val = "Static"} :
     (index, index, index, memref<i32>, memref<i32>, i32, i32) -> ()
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}) collapse(3) ordered(2)
-  "omp.wsloop" (%lb, %ub, %step, %data_var, %data_var, %data_var, %data_var, %linear_var, %chunk_var) ({
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}) collapse(3) ordered(2) doacross(%{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64)
+  "omp.wsloop" (%lb, %ub, %step, %data_var, %data_var, %data_var, %data_var, %linear_var, %chunk_var, %doacross_var1, %doacross_var2, %doacross_var3, %doacross_var4, %doacross_var5, %doacross_var6) ({
     ^bb0(%iv: index):
       omp.yield
-  }) {operand_segment_sizes = dense<[1,1,1,1,1,1,1,1,0,1]> : vector<10xi32>, schedule_val = "Dynamic", collapse_val = 3, ordered_val = 2} :
-    (index, index, index, memref<i32>, memref<i32>, memref<i32>, memref<i32>, i32, i32) -> ()
+  }) {operand_segment_sizes = dense<[1,1,1,1,1,1,1,1,0,1,6]> : vector<11xi32>, schedule_val = "Dynamic", collapse_val = 3, ordered_val = 2} :
+    (index, index, index, memref<i32>, memref<i32>, memref<i32>, memref<i32>, i32, i32, i64, i64, i64, i64, i64, i64) -> ()
 
   // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) schedule(auto) nowait
   "omp.wsloop" (%lb, %ub, %step, %data_var) ({
     ^bb0(%iv: index):
       omp.yield
-  }) {operand_segment_sizes = dense<[1,1,1,1,0,0,0,0,0,0]> : vector<10xi32>, nowait, schedule_val = "Auto"} :
+  }) {operand_segment_sizes = dense<[1,1,1,1,0,0,0,0,0,0,0]> : vector<11xi32>, nowait, schedule_val = "Auto"} :
     (index, index, index, memref<i32>) -> ()
 
   return
 }
 
 // CHECK-LABEL: omp_wsloop_pretty
-func @omp_wsloop_pretty(%lb : index, %ub : index, %step : index,
-                 %data_var : memref<i32>, %linear_var : i32, %chunk_var : i32) -> () {
+func @omp_wsloop_pretty(%lb : index, %ub : index, %step : index, %data_var : memref<i32>, %linear_var : i32, %chunk_var : i32, %doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64, %doacross_var4 : i64, %doacross_var5 : i64, %doacross_var6 : i64) -> () {
 
   // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>) collapse(2) ordered(2) {
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>) collapse(2) {
     omp.yield
   }
 
@@ -201,36 +200,36 @@ func @omp_wsloop_pretty(%lb : index, %ub : index, %step : index,
     omp.yield
   }
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(static = %{{.*}}) collapse(3) ordered(2)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) private(%data_var : memref<i32>)
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(static = %{{.*}}) collapse(3) ordered(2) doacross(%{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64)
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) doacross(%doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64, %doacross_var4 : i64, %doacross_var5 : i64, %doacross_var6 : i64) private(%data_var : memref<i32>)
      firstprivate(%data_var : memref<i32>) lastprivate(%data_var : memref<i32>) linear(%data_var = %linear_var : memref<i32>)
      schedule(static = %chunk_var) collapse(3) {
     omp.yield
   }
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, nonmonotonic) collapse(3) ordered(2)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) private(%data_var : memref<i32>)
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, nonmonotonic) collapse(3)
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>)
      firstprivate(%data_var : memref<i32>) lastprivate(%data_var : memref<i32>) linear(%data_var = %linear_var : memref<i32>)
      schedule(dynamic = %chunk_var, nonmonotonic) collapse(3) {
     omp.yield
   }
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, monotonic) collapse(3) ordered(2)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) private(%data_var : memref<i32>)
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, monotonic) collapse(3)
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>)
      firstprivate(%data_var : memref<i32>) lastprivate(%data_var : memref<i32>) linear(%data_var = %linear_var : memref<i32>)
      schedule(dynamic = %chunk_var, monotonic) collapse(3) {
     omp.yield
   }
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, nonmonotonic) collapse(3) ordered(2)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) private(%data_var : memref<i32>)
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, nonmonotonic) collapse(3)
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>)
      firstprivate(%data_var : memref<i32>) lastprivate(%data_var : memref<i32>) linear(%data_var = %linear_var : memref<i32>)
      schedule(dynamic = %chunk_var, nonmonotonic) collapse(3) {
     omp.yield
   }
 
-  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, monotonic) collapse(3) ordered(2)
-  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) ordered(2) private(%data_var : memref<i32>)
+  // CHECK: omp.wsloop (%{{.*}}) : index = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) private(%{{.*}} : memref<i32>) firstprivate(%{{.*}} : memref<i32>) lastprivate(%{{.*}} : memref<i32>) linear(%{{.*}} = %{{.*}} : memref<i32>) schedule(dynamic = %{{.*}}, monotonic) collapse(3)
+  omp.wsloop (%iv) : index = (%lb) to (%ub) step (%step) private(%data_var : memref<i32>)
      firstprivate(%data_var : memref<i32>) lastprivate(%data_var : memref<i32>) linear(%data_var = %linear_var : memref<i32>)
      schedule(dynamic = %chunk_var, monotonic) collapse(3) {
     omp.yield
@@ -464,8 +463,7 @@ func @omp_critical() -> () {
   return
 }
 
-func @omp_ordered(%arg1 : i32, %arg2 : i32, %arg3 : i32,
-    %vec0 : i64, %vec1 : i64, %vec2 : i64, %vec3 : i64) -> () {
+func @omp_ordered(%arg1 : i32, %arg2 : i32, %arg3 : i32, %vec0 : i64, %vec1 : i64, %vec2 : i64, %vec3 : i64, %doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64, %doacross_var4 : i64, %doacross_var5 : i64, %doacross_var6 : i64) -> () {
   // CHECK: omp.ordered_region
   omp.ordered_region {
     // CHECK: omp.terminator
@@ -479,7 +477,7 @@ func @omp_ordered(%arg1 : i32, %arg2 : i32, %arg3 : i32,
     omp.yield
   }
 
-  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) {
+  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(1) doacross(%doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64) {
     // Only one DEPEND(SINK: vec) clause
     // CHECK: omp.ordered depend_type("dependsink") depend_vec(%{{.*}} : i64) {num_loops_val = 1 : i64}
     omp.ordered depend_type("dependsink") depend_vec(%vec0 : i64) {num_loops_val = 1 : i64}
@@ -490,7 +488,7 @@ func @omp_ordered(%arg1 : i32, %arg2 : i32, %arg3 : i32,
     omp.yield
   }
 
-  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(2) {
+  omp.wsloop (%0) : i32 = (%arg1) to (%arg2) step (%arg3) ordered(2) doacross(%doacross_var1 : i64, %doacross_var2 : i64, %doacross_var3 : i64, %doacross_var4 : i64, %doacross_var5 : i64, %doacross_var6 : i64) {
     // Multiple DEPEND(SINK: vec) clauses
     // CHECK: omp.ordered depend_type("dependsink") depend_vec(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i64, i64, i64, i64) {num_loops_val = 2 : i64}
     omp.ordered depend_type("dependsink") depend_vec(%vec0, %vec1, %vec2, %vec3 : i64, i64, i64, i64) {num_loops_val = 2 : i64}

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -421,7 +421,7 @@ llvm.func @body(i64)
 
 llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, none) {
-  // CHECK: call void @__kmpc_dispatch_init_8u
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741859, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
@@ -433,7 +433,7 @@ llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
 
 llvm.func @test_omp_wsloop_auto(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(auto, none) {
-  // CHECK: call void @__kmpc_dispatch_init_8u
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741862, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
@@ -445,7 +445,7 @@ llvm.func @test_omp_wsloop_auto(%lb : i64, %ub : i64, %step : i64) -> () {
 
 llvm.func @test_omp_wsloop_runtime(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(runtime, none) {
-  // CHECK: call void @__kmpc_dispatch_init_8u
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741861, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
@@ -457,7 +457,7 @@ llvm.func @test_omp_wsloop_runtime(%lb : i64, %ub : i64, %step : i64) -> () {
 
 llvm.func @test_omp_wsloop_guided(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(guided, none) {
-  // CHECK: call void @__kmpc_dispatch_init_8u
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741860, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
@@ -469,7 +469,7 @@ llvm.func @test_omp_wsloop_guided(%lb : i64, %ub : i64, %step : i64) -> () {
 
 llvm.func @test_omp_wsloop_dynamic_nonmonotonic(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, nonmonotonic) {
-  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741859
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741859, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
@@ -481,7 +481,144 @@ llvm.func @test_omp_wsloop_dynamic_nonmonotonic(%lb : i64, %ub : i64, %step : i6
 
 llvm.func @test_omp_wsloop_dynamic_monotonic(%lb : i64, %ub : i64, %step : i64) -> () {
  omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, monotonic) {
-  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 536870947
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 536870947, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(static) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 66, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i32)
+
+llvm.func @test_omp_wsloop_dynamic(%lb : i32, %ub : i32, %step : i32) -> () {
+ %static_chunk_size = llvm.mlir.constant(1 : i32) : i32
+ omp.wsloop (%iv) : i32 = (%lb) to (%ub) step (%step) schedule(static = %static_chunk_size) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_4u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 65, i32 1, i32 %{{.*}}, i32 1, i32 1)
+  // CHECK: call void @__kmpc_dispatch_fini_4u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_4u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i32) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741891, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_auto(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(auto) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741894, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_runtime(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(runtime) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741893, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_guided(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(guided) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741892, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_dynamic_nonmonotonic(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, nonmonotonic) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741891, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
+  // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
+  // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
+  // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}
+   llvm.call @body(%iv) : (i64) -> ()
+   omp.yield
+ }
+ llvm.return
+}
+
+// -----
+
+llvm.func @body(i64)
+
+llvm.func @test_omp_wsloop_dynamic_monotonic(%lb : i64, %ub : i64, %step : i64) -> () {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, monotonic) ordered(0) {
+  // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 536870979, i64 1, i64 %{{.*}}, i64 1, i64 1)
+  // CHECK: call void @__kmpc_dispatch_fini_8u
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
   // CHECK  br i1 %[[cond]], label %omp_loop.header{{.*}}, label %omp_loop.exit{{.*}}

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -420,7 +420,7 @@ llvm.func @wsloop_inclusive_2(%arg0: !llvm.ptr<f32>) {
 llvm.func @body(i64)
 
 llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
- omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic, none) {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(dynamic) {
   // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741859, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
@@ -432,7 +432,7 @@ llvm.func @test_omp_wsloop_dynamic(%lb : i64, %ub : i64, %step : i64) -> () {
 }
 
 llvm.func @test_omp_wsloop_auto(%lb : i64, %ub : i64, %step : i64) -> () {
- omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(auto, none) {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(auto) {
   // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741862, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
@@ -444,7 +444,7 @@ llvm.func @test_omp_wsloop_auto(%lb : i64, %ub : i64, %step : i64) -> () {
 }
 
 llvm.func @test_omp_wsloop_runtime(%lb : i64, %ub : i64, %step : i64) -> () {
- omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(runtime, none) {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(runtime) {
   // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741861, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0
@@ -456,7 +456,7 @@ llvm.func @test_omp_wsloop_runtime(%lb : i64, %ub : i64, %step : i64) -> () {
 }
 
 llvm.func @test_omp_wsloop_guided(%lb : i64, %ub : i64, %step : i64) -> () {
- omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(guided, none) {
+ omp.wsloop (%iv) : i64 = (%lb) to (%ub) step (%step) schedule(guided) {
   // CHECK: call void @__kmpc_dispatch_init_8u(%struct.ident_t* @{{.*}}, i32 %{{.*}}, i32 1073741860, i64 1, i64 %{{.*}}, i64 1, i64 1)
   // CHECK: %[[continue:.*]] = call i32 @__kmpc_dispatch_next_8u
   // CHECK: %[[cond:.*]] = icmp ne i32 %[[continue]], 0


### PR DESCRIPTION
This supports lowering ordered clause in worksharing-loop directive. Since ordered clause and ordered construct must cooperate to make the code region executing in order, this is used to show the whole design of lowering for the doacross loop nest. https://reviews.llvm.org/D116292 and https://reviews.llvm.org/D114940 are prerequisite of this patch and they are under review.

The target of this PR with the cooperation of https://reviews.llvm.org/D116292, https://reviews.llvm.org/D114940, and https://github.com/flang-compiler/f18-llvm-project/pull/1368 is to make the following code work.
```
program main
  integer :: a(10), i

  do i = 1, 10
    a(i) = 1
  enddo

  !$omp parallel num_threads(9)
  !$omp do ordered(1)
  do i = 2, 10
    !$omp ordered depend(sink: i-1)
    a(i) = a(i-1) + 1
    !$omp ordered depend(source)
  end do
  !$omp end do
  !$omp end parallel

  print *, a
end
```
```
program main
!  use omp_lib
  integer :: a(10), i

  do i = 1, 10
    a(i) = 1
  enddo

  !$omp parallel num_threads(9)
  !$omp do ordered
  do i = 2, 10
    !$omp ordered
    a(i) = a(i-1) + 1
    !$omp end ordered
  end do
  !$omp end do
  !$omp end parallel

  print *, a
end
```
Expected result: `1 2 3 4 5 6 7 8 9 10`