### PR TITLE
Fix derived type scalar function call issue

### DIFF
--- a/flang/test/Lower/call.f90
+++ b/flang/test/Lower/call.f90
@@ -1,0 +1,19 @@
+! Test various aspects around call lowering. More detailed tests around core
+! requirements are done in call-xxx.f90 and dummy-argument-xxx.f90 files.
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPtest_nested_calls
+subroutine test_nested_calls()
+  interface
+    subroutine foo(i)
+      integer :: i
+    end subroutine
+    integer function bar()
+    end function
+  end interface
+  ! CHECK: %[[result:.*]] = fir.call @_QPbar() : () -> i32
+  ! CHECK: %[[result_storage:.*]] = fir.alloca i32
+  ! CHECK: fir.store %[[result]] to %[[result_storage]] : !fir.ref<i32>
+  ! CHECK: fir.call @_QPfoo(%[[result_storage]]) : (!fir.ref<i32>) -> ()
+  call foo(bar())
+end subroutine

--- a/flang/test/Lower/intrinsic-procedures/merge.f90
+++ b/flang/test/Lower/intrinsic-procedures/merge.f90
@@ -33,3 +33,19 @@ merge_test2 = merge(o1, o2, mask)
 ! CHECK:  %{{.*}} = select %[[a4]], %[[a1]], %[[a2]] : i32
 end
 
+! CHECK-LABEL: merge_test3
+! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<!fir.array<10x!fir.type<_QFmerge_test3Tt{i:i32}>>>, 
+! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>, 
+! CHECK-SAME: %[[arg2:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>, 
+! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.logical<4>>) {
+subroutine merge_test3(result, o1, o2, mask)
+type t
+  integer :: i
+end type
+type(t) :: result(10), o1, o2
+logical :: mask
+result = merge(o1, o2, mask)
+! CHECK:  %[[mask:.*]] = fir.load %[[arg3]] : !fir.ref<!fir.logical<4>>
+! CHECK:  %[[mask_cast:.*]] = fir.convert %[[mask]] : (!fir.logical<4>) -> i1
+! CHECK:  = select %[[mask_cast]], %[[arg1]], %[[arg2]] : !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>
+end


### PR DESCRIPTION
The `genval` template overload for function reference was specialized for intrinsic
type, causing the ProcedureRef path to be used, and the result type to
be lost which in a few contexts like merge intrinsic lowering is problematic.

Make `genval` less specialized so that it will catch all FunctionRef<T>.
