### PR TITLE
Fixes stack allocation growth issue. When in a loop, allocating on the

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Character.h
+++ b/flang/include/flang/Optimizer/Builder/Character.h
@@ -190,11 +190,23 @@ private:
   mlir::Location loc;
 };
 
-// FIXME: Move these to Optimizer
+/// Get the LLVM intrinsic for `memcpy`. Use the 64 bit version.
 mlir::FuncOp getLlvmMemcpy(FirOpBuilder &builder);
+
+/// Get the LLVM intrinsic for `memmove`. Use the 64 bit version.
 mlir::FuncOp getLlvmMemmove(FirOpBuilder &builder);
+
+/// Get the LLVM intrinsic for `memset`. Use the 64 bit version.
 mlir::FuncOp getLlvmMemset(FirOpBuilder &builder);
+
+/// Get the C standard library `realloc` function.
 mlir::FuncOp getRealloc(FirOpBuilder &builder);
+
+/// Get the `llvm.stacksave` intrinsic.
+mlir::FuncOp getLlvmStackSave(FirOpBuilder &builder);
+
+/// Get the `llvm.stackrestore` intrinsic.
+mlir::FuncOp getLlvmStackRestore(FirOpBuilder &builder);
 
 } // namespace fir::factory
 

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -59,12 +59,12 @@ public:
   /// Get a reference to the kind map.
   const fir::KindMapping &getKindMap() { return kindMap; }
 
-  /// The LHS and RHS are not always in agreement in terms of
-  /// type. In some cases, the disagreement is between COMPLEX and other scalar
-  /// types. In that case, the conversion must insert/extract out of a COMPLEX
-  /// value to have the proper semantics and be strongly typed. For e.g for
-  /// converting an integer/real to a complex, the real part is filled using
-  /// the integer/real after type conversion and the imaginary part is zero.
+  /// The LHS and RHS are not always in agreement in terms of type. In some
+  /// cases, the disagreement is between COMPLEX and other scalar types. In that
+  /// case, the conversion must insert (extract) out of a COMPLEX value to have
+  /// the proper semantics and be strongly typed. E.g., converting an integer
+  /// (real) to a complex, the real part is filled using the integer (real)
+  /// after type conversion and the imaginary part is zero.
   mlir::Value convertWithSemantics(mlir::Location loc, mlir::Type toTy,
                                    mlir::Value val,
                                    bool allowConversionsWithCharacters = false);
@@ -94,11 +94,12 @@ public:
     return getI64Type();
   }
 
+  /// Wrap `str` to a SymbolRefAttr.
   mlir::SymbolRefAttr getSymbolRefAttr(llvm::StringRef str) {
     return mlir::SymbolRefAttr::get(getContext(), str);
   }
 
-  /// Get the mlir real type that implements fortran REAL(kind).
+  /// Get the mlir float type that implements Fortran REAL(kind).
   mlir::Type getRealType(int kind);
 
   /// Create a null constant memory reference of type \p ptrType.

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1996,7 +1996,7 @@ public:
         lengths.emplace_back(lowerSpecExpr(e));
       });
 
-      // Result lengths parameters should not be provided to box storage
+      // Result length parameters should not be provided to box storage
       // allocation and save_results, but they are still useful information to
       // keep in the ExtendedValue if non-deferred.
       if (!type.isa<fir::BoxType>())

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1995,11 +1995,29 @@ public:
       caller.walkResultLengths([&](const Fortran::lower::SomeExpr &e) {
         lengths.emplace_back(lowerSpecExpr(e));
       });
-      /// Result lengths parameters should not be provided to box storage
-      /// allocation and save_results, but they are still useful information to
-      /// keep in the ExtendedValue if non-deferred.
+
+      // Result lengths parameters should not be provided to box storage
+      // allocation and save_results, but they are still useful information to
+      // keep in the ExtendedValue if non-deferred.
       if (!type.isa<fir::BoxType>())
         resultLengths = lengths;
+
+      if (!extents.empty() || !lengths.empty()) {
+        auto *bldr = &converter.getFirOpBuilder();
+        auto stackSaveFn = fir::factory::getLlvmStackSave(builder);
+        auto stackSaveSymbol = bldr->getSymbolRefAttr(stackSaveFn.getName());
+        mlir::Value sp =
+            bldr->create<fir::CallOp>(loc, stackSaveFn.getType().getResults(),
+                                      stackSaveSymbol, mlir::ValueRange{})
+                .getResult(0);
+        stmtCtx.attachCleanup([bldr, loc, sp]() {
+          auto stackRestoreFn = fir::factory::getLlvmStackRestore(*bldr);
+          auto stackRestoreSymbol =
+              bldr->getSymbolRefAttr(stackRestoreFn.getName());
+          bldr->create<fir::CallOp>(loc, stackRestoreFn.getType().getResults(),
+                                    stackRestoreSymbol, mlir::ValueRange{sp});
+        });
+      }
       mlir::Value temp =
           builder.createTemporary(loc, type, ".result", extents, resultLengths);
       return toExtendedValue(loc, temp, extents, lengths);
@@ -2251,7 +2269,7 @@ public:
   /// Generate a contiguous temp to pass \p actualArg as argument \p arg. The
   /// creation of the temp and copy-in can be made conditional at runtime by
   /// providing a runtime boolean flag \p restrictCopyAtRuntime (in which case
-  /// the temp and copy will only be made if the value is true at runtmime).
+  /// the temp and copy will only be made if the value is true at runtime).
   ExtValue genCopyIn(const ExtValue &actualArg,
                      const Fortran::lower::CallerInterface::PassedEntity &arg,
                      CopyOutPairs &copyOutPairs,
@@ -3250,6 +3268,7 @@ public:
     llvm::SmallVector<mlir::Value> shape = genIterationShape();
     auto [iterSpace, insPt] = genImplicitLoops(shape, /*innerArg=*/{});
     f(iterSpace);
+    finalizeElementCtx();
     builder.restoreInsertionPoint(insPt);
   }
 
@@ -4006,9 +4025,11 @@ private:
   /// array expression evaluation. Collect the cleanups here so the resources
   /// can be freed before the next loop iteration, avoiding memory leaks. etc.
   Fortran::lower::StatementContext &getElementCtx() {
-    if (!elementCtx)
-      elementCtx = new Fortran::lower::StatementContext;
-    return *elementCtx;
+    if (!elementCtx) {
+      stmtCtx.pushScope();
+      elementCtx = true;
+    }
+    return stmtCtx;
   }
 
   /// If there were temporaries created for this element evaluation, finalize
@@ -4016,8 +4037,8 @@ private:
   /// fir::ResultOp at the end of the innermost loop.
   void finalizeElementCtx() {
     if (elementCtx) {
-      elementCtx->finalize();
-      elementCtx = nullptr;
+      stmtCtx.finalize(/*popScope=*/true);
+      elementCtx = false;
     }
   }
 
@@ -4083,7 +4104,7 @@ private:
     };
   }
 
-  // A procedure reference to a user-defined elemental procedure.
+  /// Lower a procedure reference to a user-defined elemental procedure.
   CC genElementalUserDefinedProcRef(
       const Fortran::evaluate::ProcedureRef &procRef,
       llvm::Optional<mlir::Type> retTy) {
@@ -4202,7 +4223,7 @@ private:
                 [&](const auto &) { return fir::getBase(exv); });
             caller.placeInput(argIface, arg);
           }
-          return ScalarExprLowering{loc, converter, symMap, stmtCtx}
+          return ScalarExprLowering{loc, converter, symMap, getElementCtx()}
               .genCallOpAndResult(caller, callSiteType, retTy);
         };
   }
@@ -6183,7 +6204,7 @@ private:
   Fortran::lower::AbstractConverter &converter;
   fir::FirOpBuilder &builder;
   Fortran::lower::StatementContext &stmtCtx;
-  Fortran::lower::StatementContext *elementCtx = nullptr;
+  bool elementCtx = false;
   Fortran::lower::SymMap &symMap;
   /// The continuation to generate code to update the destination.
   llvm::Optional<CC> ccStoreToDest;

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -318,7 +318,6 @@ mlir::Value fir::factory::CharacterExprHelper::getCharBoxBuffer(
   return buff;
 }
 
-/// Get the LLVM intrinsic for `memcpy`. Use the 64 bit version.
 mlir::FuncOp fir::factory::getLlvmMemcpy(fir::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
@@ -329,7 +328,6 @@ mlir::FuncOp fir::factory::getLlvmMemcpy(fir::FirOpBuilder &builder) {
                                   "llvm.memcpy.p0i8.p0i8.i64", memcpyTy);
 }
 
-/// Get the LLVM intrinsic for `memmove`. Use the 64 bit version.
 mlir::FuncOp fir::factory::getLlvmMemmove(fir::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
@@ -340,7 +338,6 @@ mlir::FuncOp fir::factory::getLlvmMemmove(fir::FirOpBuilder &builder) {
                                   "llvm.memmove.p0i8.p0i8.i64", memmoveTy);
 }
 
-/// Get the LLVM intrinsic for `memset`. Use the 64 bit version.
 mlir::FuncOp fir::factory::getLlvmMemset(fir::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
@@ -351,13 +348,28 @@ mlir::FuncOp fir::factory::getLlvmMemset(fir::FirOpBuilder &builder) {
                                   "llvm.memset.p0i8.p0i8.i64", memsetTy);
 }
 
-/// Get the standard `realloc` function.
 mlir::FuncOp fir::factory::getRealloc(fir::FirOpBuilder &builder) {
   auto ptrTy = builder.getRefType(builder.getIntegerType(8));
   llvm::SmallVector<mlir::Type> args = {ptrTy, builder.getI64Type()};
   auto reallocTy = mlir::FunctionType::get(builder.getContext(), args, {ptrTy});
   return builder.addNamedFunction(builder.getUnknownLoc(), "realloc",
                                   reallocTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmStackSave(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy =
+      mlir::FunctionType::get(builder.getContext(), llvm::None, {ptrTy});
+  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stacksave",
+                                  funcTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmStackRestore(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy =
+      mlir::FunctionType::get(builder.getContext(), {ptrTy}, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stackrestore",
+                                  funcTy);
 }
 
 /// Create a loop to copy `count` characters from `src` to `dest`. Note that the


### PR DESCRIPTION
stack grows linearly with the iteration space of the loop (nest). Add
the llvm primitives to make each iteration reuse the same stack space
rather than continue to grow the stack. Also fixes pre-existing bugs.
Use the newly coined stack of statement contexts instead of a seconday
StatementContext for the loop nest body for the elemental computation.

