### PR TITLE
[flang] Add lowering of GET_COMMAND_ARGUMENT intrinsic

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Command.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Command.h
@@ -16,13 +16,7 @@ class Location;
 
 namespace fir {
 class FirOpBuilder;
-class CharBoxValue;
 } // namespace fir
-
-namespace llvm {
-template <typename T>
-class Optional;
-}
 
 namespace fir::runtime {
 

--- a/flang/include/flang/Optimizer/Builder/Runtime/Command.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Command.h
@@ -16,12 +16,23 @@ class Location;
 
 namespace fir {
 class FirOpBuilder;
+class CharBoxValue;
+}
+
+namespace llvm {
+    template<typename T>
+    class Optional;
 }
 
 namespace fir::runtime {
 
 /// Generate call to COMMAND_ARGUMENT_COUNT intrinsic runtime routine.
 mlir::Value genCommandArgumentCount(fir::FirOpBuilder &, mlir::Location);
+
+/// Generate call to GET_COMMAND_ARGUMENT intrinsic runtime routine.
+void genGetCommandArgument(fir::FirOpBuilder &, mlir::Location, mlir::Value number,
+                           llvm::Optional<fir::CharBoxValue> valueBox, mlir::Value length,
+                           mlir::Value status, llvm::Optional<fir::CharBoxValue> errmsgBox);
 
 } // namespace fir::runtime
 #endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_COMMAND_H

--- a/flang/include/flang/Optimizer/Builder/Runtime/Command.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Command.h
@@ -17,11 +17,11 @@ class Location;
 namespace fir {
 class FirOpBuilder;
 class CharBoxValue;
-}
+} // namespace fir
 
 namespace llvm {
-    template<typename T>
-    class Optional;
+template <typename T>
+class Optional;
 }
 
 namespace fir::runtime {
@@ -30,9 +30,13 @@ namespace fir::runtime {
 mlir::Value genCommandArgumentCount(fir::FirOpBuilder &, mlir::Location);
 
 /// Generate call to GET_COMMAND_ARGUMENT intrinsic runtime routine.
-void genGetCommandArgument(fir::FirOpBuilder &, mlir::Location, mlir::Value number,
-                           llvm::Optional<fir::CharBoxValue> valueBox, mlir::Value length,
-                           mlir::Value status, llvm::Optional<fir::CharBoxValue> errmsgBox);
+/// Note that GET_COMMAND_ARGUMENT intrinsic is split between 2 functions in
+/// implementation; ArgumentValue and ArgumentLength. So we handle each
+/// seperately.
+void genGetCommandArgument(fir::FirOpBuilder &, mlir::Location,
+                           mlir::Value number, mlir::Value value,
+                           mlir::Value length, mlir::Value status,
+                           mlir::Value errmsg);
 
 } // namespace fir::runtime
 #endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_COMMAND_H

--- a/flang/lib/Optimizer/Builder/Runtime/Command.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Command.cpp
@@ -7,11 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Command.h"
-#include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
 #include "flang/Runtime/command.h"
-#include "llvm/ADT/Optional.h"
+
 using namespace Fortran::runtime;
 
 mlir::Value fir::runtime::genCommandArgumentCount(fir::FirOpBuilder &builder,
@@ -32,24 +31,30 @@ void fir::runtime::genGetCommandArgument(fir::FirOpBuilder &builder,
       fir::runtime::getRuntimeFunc<mkRTKey(ArgumentLength)>(loc, builder);
 
   auto isPresent = [&](mlir::Value val) -> bool {
-    auto definingOp = val.getDefiningOp();
-    if (auto cst = mlir::dyn_cast<fir::AbsentOp>(definingOp))
-      return false;
-    return true;
+    return !mlir::isa_and_nonnull<fir::AbsentOp>(val.getDefiningOp());
   };
 
+  mlir::Value valueResult;
+  // Run `ArgumentValue` intrisc only if we have either "value", "status" or
+  // "errmsg" `ArgumentValue` "requires" existing values for its arguments
+  // "value" and "errmsg". So in the case they aren't given, but the user has
+  // requested "status", we have to assign "absent" values to them before
+  // calling `ArgumentValue`. This happens in IntrinsicCall.cpp. For this reason
+  // we need extra indirection with `isPresent` for testing whether "value" or
+  // "errmsg" is present.
   if (isPresent(value) || status || isPresent(errmsg)) {
     llvm::SmallVector<mlir::Value> args = fir::runtime::createArguments(
         builder, loc, argumentValueFunc.getType(), number, value, errmsg);
-    mlir::Value result =
+    valueResult =
         builder.create<fir::CallOp>(loc, argumentValueFunc, args).getResult(0);
+  }
 
-    if (status) {
-      const mlir::Value statusLoaded = builder.create<fir::LoadOp>(loc, status);
-      mlir::Value resultCast =
-          builder.createConvert(loc, statusLoaded.getType(), result);
-      builder.create<fir::StoreOp>(loc, resultCast, status);
-    }
+  // Only save result of ArgumentValue if "status" parameter has been given
+  if (status) {
+    const mlir::Value statusLoaded = builder.create<fir::LoadOp>(loc, status);
+    mlir::Value resultCast =
+        builder.createConvert(loc, statusLoaded.getType(), valueResult);
+    builder.create<fir::StoreOp>(loc, resultCast, status);
   }
 
   if (length) {

--- a/flang/lib/Optimizer/Builder/Runtime/Command.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Command.cpp
@@ -9,8 +9,9 @@
 #include "flang/Optimizer/Builder/Runtime/Command.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Runtime/command.h"
-
+#include "llvm/ADT/Optional.h"
 using namespace Fortran::runtime;
 
 mlir::Value fir::runtime::genCommandArgumentCount(fir::FirOpBuilder &builder,
@@ -18,4 +19,49 @@ mlir::Value fir::runtime::genCommandArgumentCount(fir::FirOpBuilder &builder,
   auto argumentCountFunc =
       fir::runtime::getRuntimeFunc<mkRTKey(ArgumentCount)>(loc, builder);
   return builder.create<fir::CallOp>(loc, argumentCountFunc).getResult(0);
+}
+
+// GET_COMMAND_ARGUMENT intrinsic is split between 2 functions in implementation; ArgumentValue and ArgumentLength.
+// So we handle each seperately.
+void fir::runtime::genGetCommandArgument(fir::FirOpBuilder & builder, mlir::Location loc, mlir::Value number,
+                           llvm::Optional<fir::CharBoxValue> valueBox, mlir::Value length,
+                           mlir::Value status, llvm::Optional<fir::CharBoxValue> errmsgBox)
+{
+    auto argumentValueFunc = fir::runtime::getRuntimeFunc<mkRTKey(ArgumentValue)>(loc, builder);
+    auto argumentLengthFunc = fir::runtime::getRuntimeFunc<mkRTKey(ArgumentLength)>(loc, builder);
+
+    auto processCharBox = [&](llvm::Optional<fir::CharBoxValue> arg, mlir::Value &value) {
+        if (arg.hasValue()) {
+            value = builder.createBox(loc, *arg);
+        } else {
+            value = builder.create<fir::AbsentOp>(loc, fir::BoxType::get(builder.getNoneType()));
+        }
+    };
+
+    mlir::Value value;
+    processCharBox(valueBox, value);
+
+    mlir::Value errmsg;
+    processCharBox(errmsgBox, errmsg);
+
+    llvm::SmallVector<mlir::Value> args = fir::runtime::createArguments(
+        builder, loc, argumentValueFunc.getType(), number, value, errmsg
+    );
+    mlir::Value result = builder.create<fir::CallOp>(loc, argumentValueFunc, args).getResult(0);
+
+    if(status) {
+        const mlir::Value statusLoaded = builder.create<fir::LoadOp>(loc, status);
+        mlir::Value resultCast = builder.createConvert(loc, statusLoaded.getType(), result);
+        builder.create<fir::StoreOp>(loc, resultCast, status);
+    }
+
+    if(length) {
+        args = fir::runtime::createArguments(
+            builder, loc, argumentLengthFunc.getType(), number
+        );
+        result = builder.create<fir::CallOp>(loc, argumentLengthFunc, args).getResult(0);
+        const mlir::Value valueLoaded = builder.create<fir::LoadOp>(loc, length);
+        mlir::Value resultCast = builder.createConvert(loc, valueLoaded.getType(), result);
+        builder.create<fir::StoreOp>(loc, resultCast, length);
+    }
 }

--- a/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
+++ b/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
@@ -1,71 +1,70 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
 ! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
 
-! CHECK-LABEL: func @_QPget_command_argument_test1(
-! CHECK-32-SAME: %[[num:.*]]: !fir.ref<i32>) {
-! CHECK-64-SAME: %[[num:.*]]: !fir.ref<i64>) {
-subroutine get_command_argument_test1(num)
+! CHECK-LABEL: func @_QPnumber_only(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+subroutine number_only(num)
     integer :: num
     call get_command_argument(num)
 ! CHECK-NOT: fir.call @_FortranAArgumentValue
 ! CHECK-NOT: fir.call @_FortranAArgumentLength
 ! CHECK-NEXT: return
-end subroutine get_command_argument_test1
+end subroutine number_only
 
-! CHECK-LABEL: func @_QPget_command_argument_test2(
+! CHECK-LABEL: func @_QPnumber_and_value_only(
 ! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>) {
-subroutine get_command_argument_test2(num, arg)
+! CHECK-SAME: %[[value:.*]]: !fir.boxchar<1>) {
+subroutine number_and_value_only(num, value)
 integer :: num
-character(len=32) :: arg
-call get_command_argument(num, arg)
-! CHECK: %[[argUnboxed:.*]]:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-NEXT: %[[argLength:.*]] = arith.constant 32 : index
+character(len=32) :: value
+call get_command_argument(num, value)
+! CHECK: %[[valueUnboxed:.*]]:2 = fir.unboxchar %[[value]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[valueLength:.*]] = arith.constant 32 : index
 ! CHECK-NEXT: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
-! CHECK-NEXT: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[valueBoxed:.*]] = fir.embox %[[valueUnboxed]]#0 typeparams %[[valueLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
 ! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnbox]] : (i64) -> i32
-! CHECK-NEXT: %[[argCast:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[argCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[argCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-NEXT: %[[valueCast:.*]] = fir.convert %[[valueBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[valueCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[valueCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
 ! CHECK-NOT: fir.call @_FortranAArgumentLength
-end subroutine get_command_argument_test2
+end subroutine number_and_value_only
 
-! CHECK-LABEL: func @_QPget_command_argument_test3(
+! CHECK-LABEL: func @_QPall_arguments(
 ! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>,
+! CHECK-SAME: %[[value:.*]]: !fir.boxchar<1>,
 ! CHECK-SAME: %[[length:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
-subroutine get_command_argument_test3(num, arg, length, status, errmsg)
+subroutine all_arguments(num, value, length, status, errmsg)
     integer :: num, length, status
-    character(len=32) :: arg, errmsg
-    call get_command_argument(num, arg, length, status, errmsg)
-! CHECK: %[[argUnboxed:.*]]:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-NEXT: %[[argLen:.*]] = arith.constant 32 : index
-! CHECK-NEXT: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+    character(len=32) :: value, errmsg
+    call get_command_argument(num, value, length, status, errmsg)
+! CHECK: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK-NEXT: %[[errmsgLen:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[valueUnboxed:.*]]:2 = fir.unboxchar %[[value]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[valueLen:.*]] = arith.constant 32 : index
 ! CHECK-NEXT: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
-! CHECK-NEXT: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[valueBoxed:.*]] = fir.embox %[[valueUnboxed]]#0 typeparams %[[valueLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-NEXT: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
-! CHECK-NEXT: %[[argBuffer:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[valueBuffer:.*]] = fir.convert %[[valueBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[errmsgBuffer:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-32-NEXT: %[[valueResult:.*]] = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK-64-NEXT: %[[valueResult32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK-64-NEXT: %[[valueResult:.*]] = fir.convert %[[valueResult32]] : (i32) -> i64
-! CHECK-NEXT: fir.store %[[valueResult]] to %[[status]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-32-NEXT: %[[statusResult:.*]] = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[valueBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[statusResult32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[valueBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[statusResult:.*]] = fir.convert %[[statusResult32]] : (i32) -> i64
+! CHECK-NEXT: fir.store %[[statusResult]] to %[[status]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
 ! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
 ! CHECK-32-NEXT: %[[lengthResult64:.*]] = fir.call @_FortranAArgumentLength(%[[numUnboxed]]) : (i32) -> i64
 ! CHECK-64-NEXT: %[[lengthResult:.*]] = fir.call @_FortranAArgumentLength(%[[numCast]]) : (i32) -> i64
 ! CHECK-32-NEXT: %[[lengthResult:.*]] = fir.convert %[[lengthResult64]] : (i64) -> i32
 ! CHECK-NEXT: fir.store %[[lengthResult]] to %[[length]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
-end subroutine get_command_argument_test3
+end subroutine all_arguments
 
-! CHECK-LABEL: func @_QPget_command_argument_test4(
+! CHECK-LABEL: func @_QPnumber_and_length_only(
 ! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[length:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
-subroutine get_command_argument_test4(num, length)
+subroutine number_and_length_only(num, length)
     integer :: num, length
     call get_command_argument(num, LENGTH=length)
 ! CHECK-NOT: fir.call @_FortranAArgumentValue
@@ -76,40 +75,40 @@ subroutine get_command_argument_test4(num, length)
 ! CHECK-32-NEXT: %[[result:.*]] = fir.convert %[[result64]] : (i64) -> i32
 ! CHECK-NEXT: fir.store %[[result]] to %[[length]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
 ! CHECK-NEXT: return
-end subroutine get_command_argument_test4
+end subroutine number_and_length_only
 
-! CHECK-LABEL: func @_QPget_command_argument_test5(
+! CHECK-LABEL: func @_QPnumber_and_status_only(
 ! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
-subroutine get_command_argument_test5(num, status)
+subroutine number_and_status_only(num, status)
     integer :: num, status
     call get_command_argument(num, STATUS=status)
 ! CHECK: %[[numLoaded:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
-! CHECK-NEXT: %[[arg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
 ! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numLoaded]] : (i64) -> i32
-! CHECK-32-NEXT: %[[result:.*]] = fir.call @_FortranAArgumentValue(%[[numLoaded]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK-64-NEXT: %[[result32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-32-NEXT: %[[result:.*]] = fir.call @_FortranAArgumentValue(%[[numLoaded]], %[[value]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[result32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[value]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
 ! CHECK-64-NEXT: %[[result:.*]] = fir.convert %[[result32]] : (i32) -> i64
 ! CHECK-32-NEXT: fir.store %[[result]] to %[[status]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
 ! CHECK-NOT: fir.call @_FortranAArgumentLength
-end subroutine get_command_argument_test5
+end subroutine number_and_status_only
 
-! CHECK-LABEL: func @_QPget_command_argument_test6(
+! CHECK-LABEL: func @_QPnumber_and_errmsg_only(
 ! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
-subroutine get_command_argument_test6(num, errmsg)
+subroutine number_and_errmsg_only(num, errmsg)
     integer :: num
     character(len=32) :: errmsg
     call get_command_argument(num, ERRMSG=errmsg)
 ! CHECK: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK-NEXT: %[[errmsgLength:.*]] = arith.constant 32 : index
 ! CHECK-NEXT: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
-! CHECK-NEXT: %[[arg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
 ! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[value]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[value]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
 ! CHECK-NOT: fir.call @_FortranAArgumentLength
-end subroutine get_command_argument_test6
+end subroutine number_and_errmsg_only

--- a/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
+++ b/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
@@ -1,63 +1,115 @@
-! RUN: flang-new -fc1 -emit-fir %s -o - | FileCheck %s
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
+! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
 
 ! CHECK-LABEL: func @_QPget_command_argument_test1(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i32>) {
+! CHECK-32-SAME: %[[num:.*]]: !fir.ref<i32>) {
+! CHECK-64-SAME: %[[num:.*]]: !fir.ref<i64>) {
 subroutine get_command_argument_test1(num)
     integer :: num
     call get_command_argument(num)
-! CHECK: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i32>
-! CHECK: %[[arg:.*]] = fir.absent !fir.box<none>
-! CHECK: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-NOT: fir.call @_FortranAArgumentValue
+! CHECK-NOT: fir.call @_FortranAArgumentLength
+! CHECK-NEXT: return
 end subroutine get_command_argument_test1
 
 ! CHECK-LABEL: func @_QPget_command_argument_test2(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>) {
 subroutine get_command_argument_test2(num, arg)
 integer :: num
 character(len=32) :: arg
 call get_command_argument(num, arg)
-! CHECK: %0:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %c32 = arith.constant 32 : index
-! CHECK: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i32>
-! CHECK: %2 = fir.embox %0#0 typeparams %c32 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK: %[[argUnbox:.*]] = fir.convert %2 : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK: %5 = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[argUnbox]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK: %[[argUnboxed:.*]]:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[argLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnbox]] : (i64) -> i32
+! CHECK-NEXT: %[[argCast:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[argCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[argCast]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-NOT: fir.call @_FortranAArgumentLength
 end subroutine get_command_argument_test2
 
 ! CHECK-LABEL: func @_QPget_command_argument_test3(
-! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[length:[^:]*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[status:.*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[length:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
+! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
 ! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
 subroutine get_command_argument_test3(num, arg, length, status, errmsg)
     integer :: num, length, status
     character(len=32) :: arg, errmsg
     call get_command_argument(num, arg, length, status, errmsg)
 ! CHECK: %[[argUnboxed:.*]]:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[argLen:.*]] = arith.constant 32 : index
-! CHECK: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[errmsgLen:.*]] = arith.constant 32 : index
-! CHECK: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i32>
-! CHECK: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK: %[[argBuffer:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK: %[[errmsgBuffer:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
-! CHECK: %[[valueResult:.*]] = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
-! CHECK: fir.store %[[valueResult]] to %[[status]] : !fir.ref<i32>
-! CHECK: %[[lengthResult:.*]] = fir.call @_FortranAArgumentLength(%[[numUnboxed]]) : (i32) -> i64
-! CHECK: %[[lengthCast:.*]] = fir.convert %[[lengthResult]] : (i64) -> i32
-! CHECK: fir.store %[[lengthCast]] to %[[length]] : !fir.ref<i32>
+! CHECK-NEXT: %[[argLen:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[errmsgLen:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
+! CHECK-NEXT: %[[argBuffer:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[errmsgBuffer:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-32-NEXT: %[[valueResult:.*]] = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[valueResult32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[valueResult:.*]] = fir.convert %[[valueResult32]] : (i32) -> i64
+! CHECK-NEXT: fir.store %[[valueResult]] to %[[status]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
+! CHECK-32-NEXT: %[[lengthResult64:.*]] = fir.call @_FortranAArgumentLength(%[[numUnboxed]]) : (i32) -> i64
+! CHECK-64-NEXT: %[[lengthResult:.*]] = fir.call @_FortranAArgumentLength(%[[numCast]]) : (i32) -> i64
+! CHECK-32-NEXT: %[[lengthResult:.*]] = fir.convert %[[lengthResult64]] : (i64) -> i32
+! CHECK-NEXT: fir.store %[[lengthResult]] to %[[length]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
 end subroutine get_command_argument_test3
 
+! CHECK-LABEL: func @_QPget_command_argument_test4(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
+! CHECK-SAME: %[[length:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+subroutine get_command_argument_test4(num, length)
+    integer :: num, length
+    call get_command_argument(num, LENGTH=length)
+! CHECK-NOT: fir.call @_FortranAArgumentValue
+! CHECK: %[[numLoaded:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numLoaded]] : (i64) -> i32
+! CHECK-32-NEXT: %[[result64:.*]] = fir.call @_FortranAArgumentLength(%[[numLoaded]]) : (i32) -> i64
+! CHECK-64-NEXT: %[[result:.*]] = fir.call @_FortranAArgumentLength(%[[numCast]]) : (i32) -> i64
+! CHECK-32-NEXT: %[[result:.*]] = fir.convert %[[result64]] : (i64) -> i32
+! CHECK-NEXT: fir.store %[[result]] to %[[length]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: return
+end subroutine get_command_argument_test4
 
+! CHECK-LABEL: func @_QPget_command_argument_test5(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
+! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+subroutine get_command_argument_test5(num, status)
+    integer :: num, status
+    call get_command_argument(num, STATUS=status)
+! CHECK: %[[numLoaded:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: %[[arg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numLoaded]] : (i64) -> i32
+! CHECK-32-NEXT: %[[result:.*]] = fir.call @_FortranAArgumentValue(%[[numLoaded]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[result32:.*]] = fir.call @_FortranAArgumentValue(%[[numCast]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %[[result:.*]] = fir.convert %[[result32]] : (i32) -> i64
+! CHECK-32-NEXT: fir.store %[[result]] to %[[status]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NOT: fir.call @_FortranAArgumentLength
+end subroutine get_command_argument_test5
 
-
-
-
-
-
+! CHECK-LABEL: func @_QPget_command_argument_test6(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
+! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
+subroutine get_command_argument_test6(num, errmsg)
+    integer :: num
+    character(len=32) :: errmsg
+    call get_command_argument(num, ERRMSG=errmsg)
+! CHECK: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[errmsgLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: %[[arg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-64-NEXT: %[[numCast:.*]] = fir.convert %[[numUnboxed]] : (i64) -> i32
+! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-32-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-64-NEXT: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numCast]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK-NOT: fir.call @_FortranAArgumentLength
+end subroutine get_command_argument_test6

--- a/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
+++ b/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
@@ -1,0 +1,63 @@
+! RUN: flang-new -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPget_command_argument_test1(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i32>) {
+subroutine get_command_argument_test1(num)
+    integer :: num
+    call get_command_argument(num)
+! CHECK: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i32>
+! CHECK: %[[arg:.*]] = fir.absent !fir.box<none>
+! CHECK: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK: %{{[0-9]+}} = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[arg]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+end subroutine get_command_argument_test1
+
+! CHECK-LABEL: func @_QPget_command_argument_test2(
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>) {
+subroutine get_command_argument_test2(num, arg)
+integer :: num
+character(len=32) :: arg
+call get_command_argument(num, arg)
+! CHECK: %0:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK: %c32 = arith.constant 32 : index
+! CHECK: %[[numUnbox:.*]] = fir.load %[[num]] : !fir.ref<i32>
+! CHECK: %2 = fir.embox %0#0 typeparams %c32 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK: %[[argUnbox:.*]] = fir.convert %2 : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK: %5 = fir.call @_FortranAArgumentValue(%[[numUnbox]], %[[argUnbox]], %[[errmsg]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+end subroutine get_command_argument_test2
+
+! CHECK-LABEL: func @_QPget_command_argument_test3(
+! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[arg:.*]]: !fir.boxchar<1>,
+! CHECK-SAME: %[[length:[^:]*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[status:.*]]: !fir.ref<i32>,
+! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
+subroutine get_command_argument_test3(num, arg, length, status, errmsg)
+    integer :: num, length, status
+    character(len=32) :: arg, errmsg
+    call get_command_argument(num, arg, length, status, errmsg)
+! CHECK: %[[argUnboxed:.*]]:2 = fir.unboxchar %[[arg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK: %[[argLen:.*]] = arith.constant 32 : index
+! CHECK: %[[errmsgUnboxed:.*]]:2 = fir.unboxchar %[[errmsg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK: %[[errmsgLen:.*]] = arith.constant 32 : index
+! CHECK: %[[numUnboxed:.*]] = fir.load %[[num]] : !fir.ref<i32>
+! CHECK: %[[argBoxed:.*]] = fir.embox %[[argUnboxed]]#0 typeparams %[[argLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnboxed]]#0 typeparams %[[errmsgLen]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK: %[[argBuffer:.*]] = fir.convert %[[argBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK: %[[errmsgBuffer:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK: %[[valueResult:.*]] = fir.call @_FortranAArgumentValue(%[[numUnboxed]], %[[argBuffer]], %[[errmsgBuffer]]) : (i32, !fir.box<none>, !fir.box<none>) -> i32
+! CHECK: fir.store %[[valueResult]] to %[[status]] : !fir.ref<i32>
+! CHECK: %[[lengthResult:.*]] = fir.call @_FortranAArgumentLength(%[[numUnboxed]]) : (i32) -> i64
+! CHECK: %[[lengthCast:.*]] = fir.convert %[[lengthResult]] : (i64) -> i32
+! CHECK: fir.store %[[lengthCast]] to %[[length]] : !fir.ref<i32>
+end subroutine get_command_argument_test3
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This patch adds the lowering of the "GET_COMMAND_ARGUMENT" intrinsic to
the backend runtime hook implemented in patches D109227, D109813,
D109814.

This pull request relies on #1347 for Command.h/Command.cpp file created, and associated commits will be removed from pull request when #1347 gets merged.