### PR TITLE
Support array internal procedure depending on host associated symbols

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1804,9 +1804,38 @@ void Fortran::lower::mapCallInterfaceSymbols(
       instantiateVariable(converter, var, symMap, storeMap);
     } else {
       const Fortran::semantics::Symbol &sym = var.getSymbol();
-      // Get the argument for the dummy argument symbols of the current call.
-      if (Fortran::semantics::IsDummy(sym) && sym.owner() == result.owner())
+      const auto *hostDetails =
+          sym.detailsIf<Fortran::semantics::HostAssocDetails>();
+      if (hostDetails && !var.isModuleVariable()) {
+        // The callee is an internal procedure `A` whose result properties
+        // depend on host variables. There caller may be the host, or another
+        // internal procedure `B` contained in the same host.  In the first
+        // case, the host symbol is obviously mapped, in the second case, it
+        // must also be mapped because
+        // HostAssociations::internalProcedureBindings that was called when
+        // lowering `B` did map all host symbols of captured variables to the
+        // variable from the tuple argument, whether the host symbol is actually
+        // referred to in `B`. Hence it is possible to simply lookup for the
+        // variable associated to the host symbol without having to go back to
+        // the tuple argument.
+        Fortran::lower::SymbolBox hostValue =
+            symMap.lookupSymbol(hostDetails->symbol());
+        assert(hostValue && "callee host symbol must be mapped on caller side");
+        symMap.addSymbol(sym, hostValue.toExtendedValue());
+        // The SymbolBox associated to the host symbols is complete, skip
+        // instantiateVariable that would try to allocate a new storage.
+        continue;
+      }
+      if (Fortran::semantics::IsDummy(sym) && sym.owner() == result.owner()) {
+        // Get the argument for the dummy argument symbols of the current call.
         symMap.addSymbol(sym, caller.getArgumentValue(sym));
+        // All the properties of the dummy variable may not come from the actual
+        // argument, let instantiateVariable handle this.
+      }
+      // If this is neither a host associated or dummy symbol, it must be a
+      // module or common block variable to satisfy specification expression
+      // requirements in  10.1.11, instantiateVariable will get its address and
+      // properties.
       instantiateVariable(converter, var, symMap, storeMap);
     }
   }

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1808,16 +1808,16 @@ void Fortran::lower::mapCallInterfaceSymbols(
           sym.detailsIf<Fortran::semantics::HostAssocDetails>();
       if (hostDetails && !var.isModuleVariable()) {
         // The callee is an internal procedure `A` whose result properties
-        // depend on host variables. There caller may be the host, or another
+        // depend on host variables. The caller may be the host, or another
         // internal procedure `B` contained in the same host.  In the first
         // case, the host symbol is obviously mapped, in the second case, it
         // must also be mapped because
         // HostAssociations::internalProcedureBindings that was called when
-        // lowering `B` did map all host symbols of captured variables to the
-        // variable from the tuple argument, whether the host symbol is actually
-        // referred to in `B`. Hence it is possible to simply lookup for the
-        // variable associated to the host symbol without having to go back to
-        // the tuple argument.
+        // lowering `B` will have mapped all host symbols of captured variables
+        // to the tuple argument containing the composite of all host associated
+        // variables, whether or not the host symbol is actually referred to in
+        // `B`. Hence it is possible to simply lookup the variable associated to
+        // the host symbol without having to go back to the tuple argument.
         Fortran::lower::SymbolBox hostValue =
             symMap.lookupSymbol(hostDetails->symbol());
         assert(hostValue && "callee host symbol must be mapped on caller side");
@@ -1834,7 +1834,7 @@ void Fortran::lower::mapCallInterfaceSymbols(
       }
       // If this is neither a host associated or dummy symbol, it must be a
       // module or common block variable to satisfy specification expression
-      // requirements in  10.1.11, instantiateVariable will get its address and
+      // requirements in 10.1.11, instantiateVariable will get its address and
       // properties.
       instantiateVariable(converter, var, symMap, storeMap);
     }

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -3032,13 +3032,13 @@ IntrinsicLibrary::genSize(mlir::Type resultType,
   // Handle the ARRAY argument
   mlir::Value array = builder.createBox(loc, args[0]);
 
-  // Handle the DIM argument.  Note that the lowering code never sees a call
-  // to SIZE that doesn't have a DIM argument.  If the Fortran source has such
-  // a call, the front end changes it to an expression that consists of the
-  // product of a set of calls to SIZE(ARRAY, DIM) where DIM goes from 1 to N
-  // where N is the rank of an array.  For N == 2, for example, a call to
-  // "SIZE(ARRAY)" gets changed to "SIZE(ARRAY, 1) * SIZE(ARRAY, 2)".
+  // The front-end rewrites SIZE without the DIM argument to
+  // an array of SIZE with DIM in most cases, but it may not be
+  // possible in some cases like when in SIZE(function_call()).
+  if (isAbsent(args, 1))
+    TODO(loc, "lowering of size intrinsic without 'dim' argument");
 
+  // Handle the DIM argument.
   // Convert the Fortran 1-based index to the FIR 0-based index
   mlir::IndexType indexType = builder.getIndexType();
   mlir::Value oneBasedDim =

--- a/flang/test/Lower/explicit-interface-results-2.f90
+++ b/flang/test/Lower/explicit-interface-results-2.f90
@@ -1,0 +1,216 @@
+! Test lowering of internal procedures returning arrays or characters.
+! This test allocation on the caller side of the results that may depend on
+! host associated symbols.
+! RUN: bbc %s -o - | FileCheck %s
+
+module some_module
+ integer :: n_module
+end module
+
+! Test host calling array internal procedure.
+! Result depends on host variable.
+! CHECK-LABEL: func @_QPhost1
+subroutine host1()
+  implicit none
+  integer :: n
+! CHECK:  %[[VAL_1:.*]] = fir.alloca i32
+  call takes_array(return_array())
+! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:  %[[VAL_6:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_5]] {bindc_name = ".result"}
+contains
+  function return_array()
+    real :: return_array(n)
+  end function
+end subroutine
+
+! Test host calling array internal procedure.
+! Result depends on module variable with the use statement inside the host.
+! CHECK-LABEL: func @_QPhost2
+subroutine host2()
+  use :: some_module
+  call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QMsome_moduleEn_module) : !fir.ref<i32>
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (i32) -> index
+! CHECK:  %[[VAL_3:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_2]] {bindc_name = ".result"}
+contains
+  function return_array()
+    real :: return_array(n_module)
+  end function
+end subroutine
+
+! Test host calling array internal procedure.
+! Result depends on module variable with the use statement inside the internal procedure.
+! CHECK-LABEL: func @_QPhost3
+subroutine host3()
+  call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QMsome_moduleEn_module) : !fir.ref<i32>
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (i32) -> index
+! CHECK:  %[[VAL_3:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_2]] {bindc_name = ".result"}
+contains
+  function return_array()
+    use :: some_module
+    real :: return_array(n_module)
+  end function
+end subroutine
+
+! Test internal procedure A calling array internal procedure B.
+! Result depends on host variable not directly used in A.
+subroutine host4()
+  implicit none
+  integer :: n
+  call internal_proc_a()
+contains
+! CHECK-LABEL: func @_QFhost4Pinternal_proc_a
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
+  subroutine internal_proc_a()
+    call takes_array(return_array())
+! CHECK:  %[[VAL_1:.*]] = arith.constant 0 : i32
+! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_2]] : !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:  %[[VAL_6:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_5]] {bindc_name = ".result"}
+  end subroutine
+  function return_array()
+    real :: return_array(n)
+  end function
+end subroutine
+
+! Test internal procedure A calling array internal procedure B.
+! Result depends on module variable with use statement in the host.
+subroutine host5()
+  use :: some_module
+  implicit none
+  call internal_proc_a()
+contains
+! CHECK-LABEL: func @_QFhost5Pinternal_proc_a() {
+  subroutine internal_proc_a()
+    call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QMsome_moduleEn_module) : !fir.ref<i32>
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (i32) -> index
+! CHECK:  %[[VAL_3:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_2]] {bindc_name = ".result"}
+  end subroutine
+  function return_array()
+    real :: return_array(n_module)
+  end function
+end subroutine
+
+! Test internal procedure A calling array internal procedure B.
+! Result depends on module variable with use statement in B.
+subroutine host6()
+  implicit none
+  call internal_proc_a()
+contains
+! CHECK-LABEL: func @_QFhost6Pinternal_proc_a
+  subroutine internal_proc_a()
+    call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QMsome_moduleEn_module) : !fir.ref<i32>
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (i32) -> index
+! CHECK:  %[[VAL_3:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_2]] {bindc_name = ".result"}
+  end subroutine
+  function return_array()
+    use :: some_module
+    real :: return_array(n_module)
+  end function
+end subroutine
+
+! Test host calling array internal procedure.
+! Result depends on a common block variable declared in the host.
+! CHECK-LABEL: func @_QPhost7
+subroutine host7()
+  implicit none
+  integer :: n_common
+  common /mycom/ n_common
+  call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = arith.constant 0 : index
+! CHECK:  %[[VAL_2:.*]] = fir.address_of(@_QBmycom) : !fir.ref<!fir.array<4xi8>>
+! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<?xi8>>
+! CHECK:  %[[VAL_4:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_0]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:  %[[VAL_8:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i32) -> index
+! CHECK:  %[[VAL_10:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_9]] {bindc_name = ".result"}
+contains
+  function return_array()
+    real :: return_array(n_common)
+  end function
+end subroutine
+
+! Test host calling array internal procedure.
+! Result depends on a common block variable declared in the internal procedure.
+! CHECK-LABEL: func @_QPhost8
+subroutine host8()
+  implicit none
+  call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = arith.constant 0 : index
+! CHECK:  %[[VAL_1:.*]] = fir.address_of(@_QBmycom) : !fir.ref<!fir.array<4xi8>>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<?xi8>>
+! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_0]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_6]] {bindc_name = ".result"}
+contains
+  function return_array()
+    integer :: n_common
+    common /mycom/ n_common
+    real :: return_array(n_common)
+  end function
+end subroutine
+
+! Test internal procedure A calling array internal procedure B.
+! Result depends on a common block variable declared in the host.
+! Note that the current implementation captures the common block variable
+! address, even though it could recompute it in the internal procedure.
+subroutine host9()
+  implicit none
+  integer :: n_common
+  common /mycom/ n_common
+  call internal_proc_a()
+contains
+! CHECK-LABEL: func @_QFhost9Pinternal_proc_a
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
+  subroutine internal_proc_a()
+! CHECK:  %[[VAL_1:.*]] = arith.constant 0 : i32
+! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_2]] : !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
+! CHECK:  %[[VAL_6:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_5]] {bindc_name = ".result"}
+    call takes_array(return_array())
+  end subroutine
+  function return_array()
+    use :: some_module
+    real :: return_array(n_common)
+  end function
+end subroutine
+
+! Test internal procedure A calling array internal procedure B.
+! Result depends on a common block variable declared in B.
+subroutine host10()
+  implicit none
+  call internal_proc_a()
+contains
+! CHECK-LABEL: func @_QFhost10Pinternal_proc_a
+  subroutine internal_proc_a()
+    call takes_array(return_array())
+! CHECK:  %[[VAL_0:.*]] = arith.constant 0 : index
+! CHECK:  %[[VAL_1:.*]] = fir.address_of(@_QBmycom) : !fir.ref<!fir.array<4xi8>>
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<4xi8>>) -> !fir.ref<!fir.array<?xi8>>
+! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_0]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> index
+! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_6]] {bindc_name = ".result"}
+  end subroutine
+  function return_array()
+    integer :: n_common
+    common /mycom/ n_common
+    real :: return_array(n_common)
+  end function
+end subroutine


### PR DESCRIPTION
Array function results are allocated on the caller side. This requires
mapping the symbols appearing in the result specification expression on
the callee side. The current code did not account properly for the cases
where those symbols are captured symbols from the host. This lead to
"symbol is not a dummy in this call" compiler internal errors.

Handle this case and add related tests.

Also add a small TODO around SIZE intrinsic lowering for a related array function issue (it won't fire yet due to a front-end expression rewrite issue, but we will have to deal with it soon).