### PR TITLE
Support calling character functions with only the result is being explicit

### DIFF
--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -240,23 +240,27 @@ void Fortran::lower::CallerInterface::walkResultExtents(
   // descriptor inquiries to it that would fail to lower on the caller side).
   const Fortran::semantics::Symbol *interfaceSymbol =
       procRef.proc().GetInterfaceSymbol();
-  assert(interfaceSymbol &&
-         "can only walk result extent of user procedure with interface");
-  const Fortran::semantics::Symbol &result =
-      interfaceSymbol->get<Fortran::semantics::SubprogramDetails>().result();
-  if (const auto *objectDetails =
-          result.detailsIf<Fortran::semantics::ObjectEntityDetails>())
-    if (objectDetails->shape().IsExplicitShape())
-      for (const Fortran::semantics::ShapeSpec &shapeSpec :
-           objectDetails->shape())
-        visitor(Fortran::evaluate::AsGenericExpr(getExtentExpr(shapeSpec)));
+  if (interfaceSymbol) {
+    const Fortran::semantics::Symbol &result =
+        interfaceSymbol->get<Fortran::semantics::SubprogramDetails>().result();
+    if (const auto *objectDetails =
+            result.detailsIf<Fortran::semantics::ObjectEntityDetails>())
+      if (objectDetails->shape().IsExplicitShape())
+        for (const Fortran::semantics::ShapeSpec &shapeSpec :
+             objectDetails->shape())
+          visitor(Fortran::evaluate::AsGenericExpr(getExtentExpr(shapeSpec)));
+  } else {
+    assert(procRef.Rank() == 0 &&
+           "only scalar functions may not have an interface symbol");
+  }
 }
 
 bool Fortran::lower::CallerInterface::mustMapInterfaceSymbols() const {
   assert(characteristic && "characteristic was not computed");
   const std::optional<Fortran::evaluate::characteristics::FunctionResult>
       &result = characteristic->functionResult;
-  if (!result || result->CanBeReturnedViaImplicitInterface())
+  if (!result || result->CanBeReturnedViaImplicitInterface() ||
+      !procRef.proc().GetInterfaceSymbol())
     return false;
   bool allResultSpecExprConstant = true;
   auto visitor = [&](const Fortran::lower::SomeExpr &e) {

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -250,8 +250,10 @@ void Fortran::lower::CallerInterface::walkResultExtents(
              objectDetails->shape())
           visitor(Fortran::evaluate::AsGenericExpr(getExtentExpr(shapeSpec)));
   } else {
-    assert(procRef.Rank() == 0 &&
-           "only scalar functions may not have an interface symbol");
+    if (procRef.Rank() != 0)
+      fir::emitFatalError(
+          converter.getCurrentLocation(),
+          "only scalar functions may not have an interface symbol");
   }
 }
 

--- a/flang/test/Lower/explicit-interface-results.f90
+++ b/flang/test/Lower/explicit-interface-results.f90
@@ -387,3 +387,16 @@ function test_recursion(n) result(res)
     print *, n
   end if
 end function
+
+! Test call to character function for which only the result type is explicit
+!CHECK-LABEL:func @_QPtest_not_entirely_explicit_interface(
+!CHECK-SAME: %[[n_arg:.*]]: !fir.ref<i64>) {
+subroutine test_not_entirely_explicit_interface(n)
+  integer(8) :: n
+  character(n) :: return_dyn_char_2
+  print *, return_dyn_char_2(10)
+  !CHECK: %[[n:.*]] = fir.load %[[n_arg]] : !fir.ref<i64>
+  !CHECK: %[[len:.*]] = fir.convert %[[n]] : (i64) -> index
+  !CHECK: %[[result:.*]] = fir.alloca !fir.char<1,?>(%[[len]] : index) {bindc_name = ".result"}
+  !CHECK: fir.call @_QPreturn_dyn_char_2(%[[result]], %[[len]], %{{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+end subroutine


### PR DESCRIPTION
When calling a character function, the result is allocated on the caller
side. The current code was assuming that there would be an interface
when calling these kinds of function. This is not entirely correct, for
scalar character function, the result type may be explicitly defined
while the rest of the function interface is still implicit.
Support this case by relaxing an assert and avoid requiring result
symbol mapping if there is no interface (and hence no mapping to do
with a result symbol belonging to an interface).