### PR TITLE
[flang] Add lowering of EXIT intrinsic

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Stop.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Stop.h
@@ -1,0 +1,27 @@
+//===-- Stop.h - generate stop runtime API calls ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_BUILDER_RUNTIME_STOP_H
+#define FORTRAN_OPTIMIZER_BUILDER_RUNTIME_STOP_H
+
+namespace mlir {
+class Value;
+class Location;
+} // namespace mlir
+
+namespace fir {
+class FirOpBuilder;
+}
+
+namespace fir::runtime {
+
+/// Generate call to EXIT intrinsic runtime routine.
+void genExit(fir::FirOpBuilder &, mlir::Location, mlir::Value status);
+
+} // namespace fir::runtime
+#endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_STOP_H

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -14,6 +14,7 @@ add_flang_library(FIRBuilder
   Runtime/Numeric.cpp
   Runtime/Ragged.cpp
   Runtime/Reduction.cpp
+  Runtime/Stop.cpp
   Runtime/Transformational.cpp
 
   DEPENDS

--- a/flang/lib/Optimizer/Builder/Runtime/Stop.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Stop.cpp
@@ -1,0 +1,22 @@
+//===-- Stop.h - generate stop runtime API calls ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/Runtime/Stop.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/stop.h"
+
+using namespace Fortran::runtime;
+
+void fir::runtime::genExit(fir::FirOpBuilder &builder, mlir::Location loc,
+                           mlir::Value status) {
+  auto exitFunc = fir::runtime::getRuntimeFunc<mkRTKey(Exit)>(loc, builder);
+  llvm::SmallVector<mlir::Value> args =
+      fir::runtime::createArguments(builder, loc, exitFunc.getType(), status);
+  builder.create<fir::CallOp>(loc, exitFunc, args);
+}

--- a/flang/test/Lower/intrinsic-procedures/exit.f90
+++ b/flang/test/Lower/intrinsic-procedures/exit.f90
@@ -1,0 +1,23 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
+! bbc doesn't have a way to set the default kinds so we use flang-new driver
+! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
+
+! CHECK-LABEL: func @_QPexit_test1() {
+subroutine exit_test1
+  call exit()
+! CHECK: %[[status:.*]] = arith.constant 0 : i[[DEFAULT_INTEGER_SIZE]]
+! CHECK-64: %[[statusConvert:.*]] = fir.convert %[[status]] : (i64) -> i32
+! CHECK-32: %{{[0-9]+}} = fir.call @_FortranAExit(%[[status]]) : (i32) -> none
+! CHECK-64: %{{[0-9]+}} = fir.call @_FortranAExit(%[[statusConvert]]) : (i32) -> none
+end subroutine exit_test1
+
+! CHECK-LABEL: func @_QPexit_test2(
+! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+subroutine exit_test2(status)
+  integer :: status
+  call exit(status)
+! CHECK: %[[status:.*]] = fir.load %[[statusArg]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-64: %[[statusConv:.*]] = fir.convert %[[status]] : (i64) -> i32
+! CHECK-32: %{{[0-9]+}} = fir.call @_FortranAExit(%[[status]]) : (i32) -> none
+! CHECK-64: %{{[0-9]+}} = fir.call @_FortranAExit(%[[statusConv]]) : (i32) -> none
+end subroutine exit_test2


### PR DESCRIPTION
This patch adds the lowering of the "EXIT" intrinsic to the backend runtime hook implemented in patch D110741.
