### PR TITLE
Fixes bugs relating to array expressions on CHARACTER elements. Fixes a

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -4738,7 +4738,7 @@ private:
   /// (loop-invarianet) scalar expressions. This returns the base entity, the
   /// resulting type, and a continuation to adjust the default iteration space.
   void genSliceIndices(ComponentPath &cmptData, const ExtValue &arrayExv,
-                       const Fortran::evaluate::ArrayRef &x) {
+                       const Fortran::evaluate::ArrayRef &x, bool atBase) {
     mlir::Location loc = getLoc();
     mlir::IndexType idxTy = builder.getIndexType();
     mlir::Value one = builder.createIntegerConstant(loc, idxTy, 1);
@@ -4789,8 +4789,8 @@ private:
                     IterationSpace newIters = currentPC(iters);
                     mlir::Value impliedIter = newIters.iterValue(subsIndex);
                     // FIXME: must use the lower bound of this component.
-                    // auto arrLowerBound = getLBound(arrayExv, subsIndex, one);
-                    auto arrLowerBound = one;
+                    auto arrLowerBound =
+                        atBase ? getLBound(arrayExv, subsIndex, one) : one;
                     auto initial = builder.create<mlir::arith::SubIOp>(
                         loc, lowerBound, arrLowerBound);
                     auto prod = builder.create<mlir::arith::MulIOp>(
@@ -5825,7 +5825,7 @@ private:
               },
               [&](const Fortran::evaluate::ArrayRef *x) {
                 if (Fortran::lower::isRankedArrayAccess(*x)) {
-                  genSliceIndices(components, arrayExv, *x);
+                  genSliceIndices(components, arrayExv, *x, atBase);
                 } else {
                   // Array access where the expressions are scalar and cannot
                   // depend upon the implied iteration space.

--- a/flang/test/Lower/forall/character-1.f90
+++ b/flang/test/Lower/forall/character-1.f90
@@ -1,0 +1,30 @@
+! RUN: bbc %s -o - | tco | FileCheck %s
+! Test from Fortran source through to LLVM IR.
+
+! Assumed size array of assumed length character.
+program test
+  character :: x(3) = (/ '1','2','3' /)
+  call sub(x)
+contains
+  subroutine sub(x)
+    character(*) x(:)
+    forall (i=1:2)
+       x(i:i)(1:1) = x(i+1:i+1)(1:1)
+    end forall
+    print *,x
+  end subroutine sub
+end program test
+
+! CHECK-LABEL: define void @_QFPsub({
+! CHECK-SAME: , [1 x [3 x i64]] }* %[[arg:.*]])
+! CHECK: %[[extent:.*]] = getelementptr { {{.*}}, [1 x [3 x i64]] }, { {{.*}}, [1 x [3 x i64]] }* %[[arg]], i32 0, i32 7, i64 0, i32 1
+! CHECK: %[[extval:.*]] = load i64, i64* %[[extent]]
+! CHECK: %[[elesize:.*]] = getelementptr { {{.*}}, [1 x [3 x i64]] }, { {{.*}}, [1 x [3 x i64]] }* %[[arg]], i32 0, i32 1
+! CHECK: %[[esval:.*]] = load i64, i64* %[[elesize]]
+! CHECK: %[[mul:.*]] = mul i64 1, %[[esval]]
+! CHECK: %[[mul2:.*]] = mul i64 %[[mul]], %[[extval]], !dbg !18
+! CHECK: %[[buff:.*]] = call i8* @malloc(i64 %[[mul2]])
+! CHECK: %[[to:.*]] = getelementptr i8, i8* %[[buff]], i64 %
+! CHECK: call void @llvm.memmove.p0i8.p0i8.i64(i8* %[[to]], i8* %{{.*}}, i64 %{{.*}}, i1 false)
+! CHECK: call void @free(i8* %[[buff]])
+! CHECK: call i8* @_FortranAioBeginExternalListOutput


### PR DESCRIPTION
segmentation failt, an overallocation issue, using the wrong lower
bounds, and assumed shape arrays of assumed length character.

Add regression test end to end.
