### PR TITLE
REAL and COMPLEX KIND=16 IO

### DIFF
--- a/flang/include/flang/ISO_Fortran_binding.h
+++ b/flang/include/flang/ISO_Fortran_binding.h
@@ -43,7 +43,8 @@ typedef unsigned char CFI_attribute_t;
 typedef signed char CFI_type_t;
 /* These codes are required to be macros (i.e., #ifdef will work).
  * They are not required to be distinct, but neither are they required
- * to have had their synonyms combined.
+ * to have had their synonyms combined.  Codes marked as extensions may be
+ * place holders for as yet unimplemented types.
  */
 #define CFI_type_signed_char 1
 #define CFI_type_short 2
@@ -60,27 +61,35 @@ typedef signed char CFI_type_t;
 #define CFI_type_int_least16_t 13
 #define CFI_type_int_least32_t 14
 #define CFI_type_int_least64_t 15
-#define CFI_type_int_least128_t 16
+#define CFI_type_int_least128_t 16 /* extension */
 #define CFI_type_int_fast8_t 17
 #define CFI_type_int_fast16_t 18
 #define CFI_type_int_fast32_t 19
 #define CFI_type_int_fast64_t 20
-#define CFI_type_int_fast128_t 21
+#define CFI_type_int_fast128_t 21 /* extension */
 #define CFI_type_intmax_t 22
 #define CFI_type_intptr_t 23
 #define CFI_type_ptrdiff_t 24
-#define CFI_type_float 25
-#define CFI_type_double 26
-#define CFI_type_long_double 27
-#define CFI_type_float_Complex 28
-#define CFI_type_double_Complex 29
-#define CFI_type_long_double_Complex 30
-#define CFI_type_Bool 31
-#define CFI_type_char 32
-#define CFI_type_cptr 33
-#define CFI_type_struct 34
-#define CFI_type_char16_t 35 /* extension: char16_t */
-#define CFI_type_char32_t 36 /* extension: char32_t */
+#define CFI_type_half_float 25 /* extension: kind=2 */
+#define CFI_type_bfloat 26 /* extension: kind=3 */
+#define CFI_type_float 27
+#define CFI_type_double 28
+#define CFI_type_extended_double 29 /* extension: kind=10 */
+#define CFI_type_long_double 30
+#define CFI_type_float128 31 /* extension: kind=16 */
+#define CFI_type_half_float_Complex 32 /* extension: kind=2 */
+#define CFI_type_bfloat_Complex 33 /* extension: kind=3 */
+#define CFI_type_float_Complex 34
+#define CFI_type_double_Complex 35
+#define CFI_type_extended_double_Complex 36 /* extension: kind=10 */
+#define CFI_type_long_double_Complex 37
+#define CFI_type_float128_Complex 38 /* extension: kind=16 */
+#define CFI_type_Bool 39
+#define CFI_type_char 40
+#define CFI_type_cptr 41
+#define CFI_type_struct 42
+#define CFI_type_char16_t 43 /* extension */
+#define CFI_type_char32_t 44 /* extension */
 #define CFI_TYPE_LAST CFI_type_char32_t
 #define CFI_type_other (-1) // must be negative
 

--- a/flang/include/flang/Optimizer/Support/TypeCode.h
+++ b/flang/include/flang/Optimizer/Support/TypeCode.h
@@ -37,10 +37,11 @@ inline int characterBitsToTypeCode(unsigned bits) {
 inline int complexBitsToTypeCode(unsigned bits) {
   // clang-format off
   switch (bits) {
+  case 16:  return CFI_type_half_float_Complex; // CFI_type_bfloat_Complex ?
   case 32:  return CFI_type_float_Complex;
   case 64:  return CFI_type_double_Complex;
-  case 80:
-  case 128: return CFI_type_long_double_Complex;
+  case 80:  return CFI_type_extended_double_Complex;
+  case 128: return CFI_type_float128_Complex;
   default:  llvm_unreachable("unsupported complex size");
   }
   // clang-format on
@@ -74,10 +75,11 @@ inline int logicalBitsToTypeCode(unsigned bits) {
 inline int realBitsToTypeCode(unsigned bits) {
   // clang-format off
   switch (bits) {
+  case 16:  return CFI_type_half_float; // CFI_type_bfloat ?
   case 32:  return CFI_type_float;
   case 64:  return CFI_type_double;
-  case 80:
-  case 128: return CFI_type_long_double;
+  case 80:  return CFI_type_extended_double;
+  case 128: return CFI_type_float128;
   default:  llvm_unreachable("unsupported real size");
   }
   // clang-format on

--- a/flang/include/flang/Runtime/type-code.h
+++ b/flang/include/flang/Runtime/type-code.h
@@ -33,11 +33,11 @@ public:
     return raw_ >= CFI_type_signed_char && raw_ <= CFI_type_ptrdiff_t;
   }
   constexpr bool IsReal() const {
-    return raw_ >= CFI_type_float && raw_ <= CFI_type_long_double;
+    return raw_ >= CFI_type_half_float && raw_ <= CFI_type_float128;
   }
   constexpr bool IsComplex() const {
-    return raw_ >= CFI_type_float_Complex &&
-        raw_ <= CFI_type_long_double_Complex;
+    return raw_ >= CFI_type_half_float_Complex &&
+        raw_ <= CFI_type_float128_Complex;
   }
   constexpr bool IsCharacter() const {
     return raw_ == CFI_type_char || raw_ == CFI_type_char16_t ||

--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -178,14 +178,32 @@ static constexpr std::size_t MinElemLen(CFI_type_t type) {
   case CFI_type_ptrdiff_t:
     minElemLen = sizeof(std::ptrdiff_t);
     break;
+  case CFI_type_half_float:
+    minElemLen = 2;
+    break;
+  case CFI_type_bfloat:
+    minElemLen = 2;
+    break;
   case CFI_type_float:
     minElemLen = sizeof(float);
     break;
   case CFI_type_double:
     minElemLen = sizeof(double);
     break;
+  case CFI_type_extended_double:
+    minElemLen = 10;
+    break;
   case CFI_type_long_double:
     minElemLen = sizeof(long double);
+    break;
+  case CFI_type_float128:
+    minElemLen = 16;
+    break;
+  case CFI_type_half_float_Complex:
+    minElemLen = 2 * MinElemLen(CFI_type_half_float);
+    break;
+  case CFI_type_bfloat_Complex:
+    minElemLen = 2 * MinElemLen(CFI_type_bfloat);
     break;
   case CFI_type_float_Complex:
     minElemLen = 2 * sizeof(float);
@@ -193,8 +211,14 @@ static constexpr std::size_t MinElemLen(CFI_type_t type) {
   case CFI_type_double_Complex:
     minElemLen = 2 * sizeof(double);
     break;
+  case CFI_type_extended_double_Complex:
+    minElemLen = 2 * MinElemLen(CFI_type_extended_double);
+    break;
   case CFI_type_long_double_Complex:
     minElemLen = 2 * sizeof(long double);
+    break;
+  case CFI_type_float128_Complex:
+    minElemLen = 2 * MinElemLen(CFI_type_float128);
     break;
   case CFI_type_Bool:
     minElemLen = 1;

--- a/flang/runtime/type-code.cpp
+++ b/flang/runtime/type-code.cpp
@@ -33,6 +33,12 @@ TypeCode::TypeCode(TypeCategory f, int kind) {
     break;
   case TypeCategory::Real:
     switch (kind) {
+    case 2:
+      raw_ = CFI_type_half_float;
+      break;
+    case 3:
+      raw_ = CFI_type_bfloat;
+      break;
     case 4:
       raw_ = CFI_type_float;
       break;
@@ -40,8 +46,10 @@ TypeCode::TypeCode(TypeCategory f, int kind) {
       raw_ = CFI_type_double;
       break;
     case 10:
+      raw_ = CFI_type_extended_double;
+      break;
     case 16:
-      raw_ = CFI_type_long_double;
+      raw_ = CFI_type_float128;
       break;
     }
     break;
@@ -107,26 +115,42 @@ TypeCode::GetCategoryAndKind() const {
     return std::make_pair(TypeCategory::Integer, 8);
   case CFI_type_int128_t:
     return std::make_pair(TypeCategory::Integer, 16);
+  case CFI_type_half_float:
+    return std::make_pair(TypeCategory::Real, 2);
+  case CFI_type_bfloat:
+    return std::make_pair(TypeCategory::Real, 3);
   case CFI_type_float:
     return std::make_pair(TypeCategory::Real, 4);
   case CFI_type_double:
     return std::make_pair(TypeCategory::Real, 8);
+  case CFI_type_extended_double:
+    return std::make_pair(TypeCategory::Real, 10);
   case CFI_type_long_double:
 #if __x86_64__
     return std::make_pair(TypeCategory::Real, 10);
 #else
     return std::make_pair(TypeCategory::Real, 16);
 #endif
+  case CFI_type_float128:
+    return std::make_pair(TypeCategory::Real, 16);
+  case CFI_type_half_float_Complex:
+    return std::make_pair(TypeCategory::Complex, 2);
+  case CFI_type_bfloat_Complex:
+    return std::make_pair(TypeCategory::Complex, 3);
   case CFI_type_float_Complex:
     return std::make_pair(TypeCategory::Complex, 4);
   case CFI_type_double_Complex:
     return std::make_pair(TypeCategory::Complex, 8);
+  case CFI_type_extended_double_Complex:
+    return std::make_pair(TypeCategory::Complex, 10);
   case CFI_type_long_double_Complex:
 #if __x86_64__
     return std::make_pair(TypeCategory::Complex, 10);
 #else
     return std::make_pair(TypeCategory::Complex, 16);
 #endif
+  case CFI_type_float128_Complex:
+    return std::make_pair(TypeCategory::Complex, 16);
   case CFI_type_char:
     return std::make_pair(TypeCategory::Character, 1);
   case CFI_type_char16_t:

--- a/flang/test/Fir/box.fir
+++ b/flang/test/Fir/box.fir
@@ -9,7 +9,7 @@ fir.global internal @globalx : !fir.box<!fir.heap<i32>> {
   fir.has_value %1 : !fir.box<!fir.heap<i32>>
 }
 
-// CHECK-LABEL: @globaly = internal global { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* null, i64 4, i32 20180515, i8 1, i8 25, i8 2, i8 0,{{.*}}[3 x i64] [i64 1, i64 0, i64 4]
+// CHECK-LABEL: @globaly = internal global { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* null, i64 4, i32 20180515, i8 1, i8 27, i8 2, i8 0,{{.*}}[3 x i64] [i64 1, i64 0, i64 4]
 fir.global internal @globaly : !fir.box<!fir.heap<!fir.array<?xf32>>> {
   %c0 = arith.constant 0 : index
   %0 = fir.convert %c0 : (index) -> !fir.heap<!fir.array<?xf32>>
@@ -27,7 +27,7 @@ func private @ga(%b : !fir.box<!fir.array<?xf32>>)
 // CHECK: (float* %[[ARG:.*]])
 func @f(%a : !fir.ref<f32>) {
   // CHECK: %[[DESC:.*]] = alloca { float*, i64, i32, i8, i8, i8, i8 }
-  // CHECK: %[[INS0:.*]] = insertvalue {{.*}} { float* undef, i64 4, i32 20180515, i8 0, i8 25, i8 0, i8 0 }, float* %[[ARG]], 0
+  // CHECK: %[[INS0:.*]] = insertvalue {{.*}} { float* undef, i64 4, i32 20180515, i8 0, i8 27, i8 0, i8 0 }, float* %[[ARG]], 0
   // CHECK: store {{.*}} %[[INS0]], {{.*}}* %[[DESC]]
   %b = fir.embox %a : (!fir.ref<f32>) -> !fir.box<f32>
 
@@ -45,7 +45,7 @@ func @fa(%a : !fir.ref<!fir.array<100xf32>>) {
   %c100 = arith.constant 100 : index
   %d = fir.shape %c100 : (index) -> !fir.shape<1>
   // CHECK: %[[bitcast:.*]] = bitcast [100 x float]* %
-  // CHECK: %[[INS70:.*]] = insertvalue {{.*}} { float* undef, i64 4, i32 20180515, i8 1, i8 25, i8 0, i8 0, {{.*}} }, float* %[[bitcast]], 0
+  // CHECK: %[[INS70:.*]] = insertvalue {{.*}} { float* undef, i64 4, i32 20180515, i8 1, i8 27, i8 0, i8 0, {{.*}} }, float* %[[bitcast]], 0
   %b = fir.embox %c(%d) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
   // CHECK: call void @ga(
   fir.call @ga(%b) : (!fir.box<!fir.array<?xf32>>) -> ()
@@ -71,7 +71,7 @@ func @b1(%arg0 : !fir.ref<!fir.char<1,?>>, %arg1 : index) -> !fir.box<!fir.char<
 // CHECK-SAME: [5 x i8]* %[[arg0:.*]], i64 %[[arg1:.*]])
 func @b2(%arg0 : !fir.ref<!fir.array<?x!fir.char<1,5>>>, %arg1 : index) -> !fir.box<!fir.array<?x!fir.char<1,5>>> {
   %1 = fir.shape %arg1 : (index) -> !fir.shape<1>
-  // CHECK: insertvalue {{.*}} { [5 x i8]* undef, i64 5, i32 20180515, i8 1, i8 32, i8 0, i8 0, {{.*}} }, i64 %[[arg1]], 7, 0, 1
+  // CHECK: insertvalue {{.*}} { [5 x i8]* undef, i64 5, i32 20180515, i8 1, i8 40, i8 0, i8 0, {{.*}} }, i64 %[[arg1]], 7, 0, 1
   // CHECK: insertvalue {{.*}} %{{.*}}, i64 5, 7, 0, 2
   // CHECK: insertvalue {{.*}} [5 x i8]* %[[arg0]], 0
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<?x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<?x!fir.char<1,5>>>
@@ -145,7 +145,7 @@ func @box6(%0 : !fir.ref<!fir.array<?x?x?x?xf32>>, %1 : index, %2 : index) -> i3
   // CHECK: %[[sdp2:.*]] = sdiv i64 %[[dp2]], 2
   // CHECK: %[[cmp:.*]] = icmp sgt i64 %[[sdp2]], 0
   // CHECK: %[[extent:.*]] = select i1 %[[cmp]], i64 %[[sdp2]], i64 0
-  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 25, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 1, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[extent]], 7, 0, 1
+  // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } { float* undef, i64 4, i32 20180515, i8 2, i8 27, i8 0, i8 0, [2 x [3 x i64]] [{{\[}}3 x i64] [i64 1, i64 undef, i64 undef], [3 x i64] undef] }, i64 %[[extent]], 7, 0, 1
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 800, 7, 0, 2
   // CHECK: %[[op25:.*]] = add i64 25000, %[[i100p40]]
   // CHECK: insertvalue { float*, i64, i32, i8, i8, i8, i8, [2 x [3 x i64]] } %{{.*}}, i64 1, 7, 1, 0

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -1096,7 +1096,7 @@ func private @_QPxb(!fir.box<!fir.array<?x?xf64>>)
 // CHECK:         %[[ARR:.*]] = llvm.alloca %[[ARR_SIZE]] x f64 {bindc_name = "arr", in_type = !fir.array<?x?xf64>, operand_segment_sizes = dense<[0, 2]> : vector<2xi32>, uniq_name = "_QFsbEarr"} : (i64) -> !llvm.ptr<f64>
 // CHECK:         %[[BOX0:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<f64>, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, array<2 x array<3 x i64>>)>
 // CHECK:         %[[ELEM_LEN:.*]] = llvm.mlir.constant(8 : i32) : i32
-// CHECK:         %[[TYPE_CODE:.*]] = llvm.mlir.constant(26 : i32) : i32
+// CHECK:         %[[TYPE_CODE:.*]] = llvm.mlir.constant(28 : i32) : i32
 // CHECK:         %[[ELEM_LEN_I64:.*]] = llvm.sext %[[ELEM_LEN]] : i32 to i64
 // CHECK:         %[[BOX1:.*]] = llvm.insertvalue %[[ELEM_LEN_I64]], %[[BOX0]][1 : i32] : !llvm.struct<(ptr<f64>, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, array<2 x array<3 x i64>>)>
 // CHECK:         %[[VERSION:.*]] = llvm.mlir.constant(20180515 : i32) : i32
@@ -1537,7 +1537,7 @@ func @test_rebox_1(%arg0: !fir.box<!fir.array<?x?xf32>>) {
 //CHECK:    %[[EIGHTY:.*]] = llvm.mlir.constant(80 : index) : i64
 //CHECK:    %[[RBOX:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>)>
 //CHECK:    %[[ELEM_SIZE:.*]] = llvm.mlir.constant(4 : i32) : i32
-//CHECK:    %[[FLOAT_TYPE:.*]] = llvm.mlir.constant(25 : i32) : i32
+//CHECK:    %[[FLOAT_TYPE:.*]] = llvm.mlir.constant(27 : i32) : i32
 //CHECK:    %[[ELEM_SIZE_I64:.*]] = llvm.sext %[[ELEM_SIZE]] : i32 to i64
 //CHECK:    %[[RBOX_TMP1:.*]] = llvm.insertvalue %[[ELEM_SIZE_I64]], %[[RBOX]][1 : i32] : !llvm.struct<(ptr<f32>, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>)>
 //CHECK:    %[[CFI_VERSION:.*]] = llvm.mlir.constant(20180515 : i32) : i32
@@ -1618,7 +1618,7 @@ func @foo(%arg0: !fir.box<!fir.array<?x!fir.type<t{i:i32,c:!fir.char<1,10>}>>>) 
 //CHECK:   %[[COMPONENT_OFFSET_1:.*]] = llvm.mlir.constant(1 : i64) : i64
 //CHECK:   %[[ELEM_SIZE:.*]] = llvm.mlir.constant(7 : i64) : i64
 //CHECK:   %[[COMPONENT_OFFSET_2:.*]] = llvm.mlir.constant(1 : i32) : i32
-//CHECK:   %[[TYPE_CHAR:.*]] = llvm.mlir.constant(32 : i32) : i32
+//CHECK:   %[[TYPE_CHAR:.*]] = llvm.mlir.constant(40 : i32) : i32
 //CHECK:   %[[RBOX_TMP1:.*]] = llvm.insertvalue %[[ELEM_SIZE]], %{{.*}}[1 : i32] : !llvm.struct<(ptr<i8>, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>)>
 //CHECK:   %[[RBOX_TMP2:.*]] = llvm.insertvalue %{{.*}}, %[[RBOX_TMP1]][2 : i32] : !llvm.struct<(ptr<i8>, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>)>
 //CHECK:   %[[RANK:.*]] = llvm.mlir.constant(1 : i32) : i32

--- a/flang/test/Fir/embox.fir
+++ b/flang/test/Fir/embox.fir
@@ -74,7 +74,7 @@ func @emboxSubstring(%arg0: !fir.ref<!fir.array<2x3x!fir.char<1,4>>>) {
 
   // CHECK: %[[addr:.*]] = getelementptr [3 x [2 x [4 x i8]]], [3 x [2 x [4 x i8]]]* %[[arg0]], i64 0, i64 0, i64 0
   // CHECK: %[[substringAddr:.*]] = getelementptr [4 x i8], [4 x i8]* %[[addr]], i64 0, i64 1
-  // CHECK: insertvalue {[[descriptorType:.*]]} { i8* undef, i64 2, i32 20180515, i8 2, i8 32, i8 0, i8 0,
+  // CHECK: insertvalue {[[descriptorType:.*]]} { i8* undef, i64 2, i32 20180515, i8 2, i8 40, i8 0, i8 0,
   // CHECK-SAME: [2 x [3 x i64]] [{{\[}}3 x i64] [i64 1, i64 2, i64 4], [3 x i64] [i64 1, i64 3, i64 8]] },
   // CHECK-SAME: i8* %[[substringAddr]], 0
 

--- a/flang/test/Fir/rebox.fir
+++ b/flang/test/Fir/rebox.fir
@@ -33,7 +33,7 @@ func @test_rebox_1(%arg0: !fir.box<!fir.array<?x?xf32>>) {
   // CHECK: %[[OFFSET_1:.*]] = mul i64 2, %[[INSTRIDE_1]]
   // CHECK: %[[VOIDBASE1:.*]] = getelementptr i8, i8* %[[VOIDBASE0]], i64 %[[OFFSET_1]]
   // CHECK: %[[OUTSTRIDE0:.*]] = mul i64 3, %[[INSTRIDE_1]]
-  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 1, i8 25, i8 0, i8 0, [1 x [3 x i64]] [{{.*}} [i64 1, i64 25, i64 undef]] }, i64 %[[OUTSTRIDE0]], 7, 0, 2
+  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 1, i8 27, i8 0, i8 0, [1 x [3 x i64]] [{{.*}} [i64 1, i64 25, i64 undef]] }, i64 %[[OUTSTRIDE0]], 7, 0, 2
   // CHECK: %[[OUTBASE:.*]] = bitcast i8* %[[VOIDBASE1]] to float*
   // CHECK: %[[OUTBOX1:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } %[[OUTBOX0]], float* %[[OUTBASE]], 0
   // CHECK: store { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] } %[[OUTBOX1]], { float*, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }* %[[OUTBOX_ALLOC]], align 8
@@ -93,7 +93,7 @@ func @test_rebox_3(%arg0: !fir.box<!fir.array<?xf32>>) {
   // CHECK: %[[VOIDBASE:.*]] = bitcast float* %[[INBASE]] to i8*
   // CHECK: %[[OUTSTRIDE1:.*]] = mul i64 3, %[[INSTRIDE]]
   // CHECK: %[[OUTSTRIDE2:.*]] = mul i64 4, %[[OUTSTRIDE1]]
-  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 3, i8 25, i8 0, i8 0, [3 x [3 x i64]] [{{.*}} [i64 2, i64 3, i64 undef], [3 x i64] undef, [3 x i64] undef] }, i64 %[[INSTRIDE]], 7, 0, 2
+  // CHECK: %[[OUTBOX0:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } { float* undef, i64 4, i32 {{.*}}, i8 3, i8 27, i8 0, i8 0, [3 x [3 x i64]] [{{.*}} [i64 2, i64 3, i64 undef], [3 x i64] undef, [3 x i64] undef] }, i64 %[[INSTRIDE]], 7, 0, 2
   // CHECK: %[[OUTBOX1:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX0]], i64 3, 7, 1, 0
   // CHECK: %[[OUTBOX2:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX1]], i64 4, 7, 1, 1
   // CHECK: %[[OUTBOX3:.*]] = insertvalue { float*, i64, i32, i8, i8, i8, i8, [3 x [3 x i64]] } %[[OUTBOX2]], i64 %[[OUTSTRIDE1]], 7, 1, 2

--- a/flang/test/Fir/type-descriptor.fir
+++ b/flang/test/Fir/type-descriptor.fir
@@ -9,7 +9,7 @@ fir.global internal @_QFfooEx2 : !fir.box<!fir.heap<!type_defined_elsewhere>> {
 // CHECK: @_QMsome_moduleE.dt.type_defined_elsewhere = extern_weak global i8
 // CHECK: @_QFfooEx2 = internal global { %_QMsome_moduleTtype_defined_elsewhere*, i64, i32, i8, i8, i8, i8, i8*, [1 x i64] }
 // CHECK-SAME: { %_QMsome_moduleTtype_defined_elsewhere* null, i64 ptrtoint (%_QMsome_moduleTtype_defined_elsewhere* getelementptr (%_QMsome_moduleTtype_defined_elsewhere, %_QMsome_moduleTtype_defined_elsewhere* null, i32 1) to i64),
-// CHECK-SAME: i32 20180515, i8 0, i8 34, i8 2, i8 1, i8* @_QMsome_moduleE.dt.type_defined_elsewhere, [1 x i64] undef }
+// CHECK-SAME: i32 20180515, i8 0, i8 42, i8 2, i8 1, i8* @_QMsome_moduleE.dt.type_defined_elsewhere, [1 x i64] undef }
 
 !sometype = type !fir.type<_QFfooTsometype{num:i32,values:!fir.box<!fir.ptr<!fir.array<?x?xf32>>>}>
 fir.global internal @_QFfooE.dt.sometype : i8
@@ -20,4 +20,4 @@ fir.global internal @_QFfooEx : !fir.box<!fir.heap<!sometype>> {
 }
 // CHECK: @_QFfooEx = internal global { %_QFfooTsometype*, i64, i32, i8, i8, i8, i8, i8*, [1 x i64] }
 // CHECK-SAME: { %_QFfooTsometype* null, i64 ptrtoint (%_QFfooTsometype* getelementptr (%_QFfooTsometype, %_QFfooTsometype* null, i32 1) to i64),
-// CHECK-SAME: i32 20180515, i8 0, i8 34, i8 2, i8 1, i8* @_QFfooE.dt.sometype, [1 x i64] undef }
+// CHECK-SAME: i32 20180515, i8 0, i8 42, i8 2, i8 1, i8* @_QFfooE.dt.sometype, [1 x i64] undef }

--- a/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
@@ -198,12 +198,12 @@ end subroutine
 !FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputReal32(%[[LIST_IO]], %[[ARG3_PVT_VAL]]) : (!fir.ref<i8>, f32) -> i1
 !FIRDialect-DAG:     %[[ARG4_PVT_VAL:.*]] = fir.load %[[ARG4_PVT]] : !fir.ref<f64>
 !FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputReal64(%[[LIST_IO]], %[[ARG4_PVT_VAL]]) : (!fir.ref<i8>, f64) -> i1
-!FIRDialect-DAG:     %[[ARG5_PVT_VAL:.*]] = fir.load %[[ARG5_PVT]] : !fir.ref<f80>
-!FIRDialect-DAG:     %[[ARG5_PVT_CVT:.*]] = fir.convert %[[ARG5_PVT_VAL]] : (f80) -> f64
-!FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputReal64(%[[LIST_IO]], %[[ARG5_PVT_CVT]]) : (!fir.ref<i8>, f64) -> i1
-!FIRDialect-DAG:     %[[ARG6_PVT_VAL:.*]] = fir.load %[[ARG6_PVT]] : !fir.ref<f128>
-!FIRDialect-DAG:     %[[ARG6_PVT_CVT:.*]] = fir.convert %[[ARG6_PVT_VAL]] : (f128) -> f64
-!FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputReal64(%[[LIST_IO]], %[[ARG6_PVT_CVT]]) : (!fir.ref<i8>, f64) -> i1
+!FIRDialect-DAG:     %[[ARG5_PVT_VAL:.*]] = fir.embox %[[ARG5_PVT]] : (!fir.ref<f80>) -> !fir.box<f80>
+!FIRDialect-DAG:     %[[ARG5_PVT_CVT:.*]] = fir.convert %[[ARG5_PVT_VAL]] : (!fir.box<f80>) -> !fir.box<none>
+!FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputDescriptor(%[[LIST_IO]], %[[ARG5_PVT_CVT]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+!FIRDialect-DAG:     %[[ARG6_PVT_VAL:.*]] = fir.embox %[[ARG6_PVT]] : (!fir.ref<f128>) -> !fir.box<f128>
+!FIRDialect-DAG:     %[[ARG6_PVT_CVT:.*]] = fir.convert %[[ARG6_PVT_VAL]] : (!fir.box<f128>) -> !fir.box<none>
+!FIRDialect-DAG:     %{{.*}} = fir.call @_FortranAioOutputDescriptor(%[[LIST_IO]], %[[ARG6_PVT_CVT]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
 !FIRDialect-DAG:     omp.terminator
 !FIRDialect-DAG:   }
 


### PR DESCRIPTION
Update file `ISO_Fortran_binding.h` with "CFI" types for Fortran REAL and
COMPLEX kinds 2, 3, 10, 16, and modify KIND=16 IO to use descriptors.

File `ISO_Fortran_binding.h` and runtime file changes are copied from llvm.
The changes to `IO.cpp` ,`Optimizer/Support/TypeCode.h`, and test files are new.
