### PR TITLE
Cherry pick from main

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -29,7 +29,7 @@ using namespace fir;
 namespace {
 
 template <typename TYPE>
-TYPE parseIntSingleton(mlir::DialectAsmParser &parser) {
+TYPE parseIntSingleton(mlir::AsmParser &parser) {
   int kind = 0;
   if (parser.parseLess() || parser.parseInteger(kind) || parser.parseGreater())
     return {};
@@ -37,17 +37,17 @@ TYPE parseIntSingleton(mlir::DialectAsmParser &parser) {
 }
 
 template <typename TYPE>
-TYPE parseKindSingleton(mlir::DialectAsmParser &parser) {
+TYPE parseKindSingleton(mlir::AsmParser &parser) {
   return parseIntSingleton<TYPE>(parser);
 }
 
 template <typename TYPE>
-TYPE parseRankSingleton(mlir::DialectAsmParser &parser) {
+TYPE parseRankSingleton(mlir::AsmParser &parser) {
   return parseIntSingleton<TYPE>(parser);
 }
 
 template <typename TYPE>
-TYPE parseTypeSingleton(mlir::DialectAsmParser &parser) {
+TYPE parseTypeSingleton(mlir::AsmParser &parser) {
   mlir::Type ty;
   if (parser.parseLess() || parser.parseType(ty) || parser.parseGreater())
     return {};
@@ -74,7 +74,7 @@ bool verifySameLists(llvm::ArrayRef<RecordType::TypePair> a1,
   return a1 == a2;
 }
 
-RecordType verifyDerived(mlir::DialectAsmParser &parser, RecordType derivedTy,
+RecordType verifyDerived(mlir::AsmParser &parser, RecordType derivedTy,
                          llvm::ArrayRef<RecordType::TypePair> lenPList,
                          llvm::ArrayRef<RecordType::TypePair> typeList) {
   auto loc = parser.getNameLoc();
@@ -323,14 +323,14 @@ bool fir::isa_unknown_size_box(mlir::Type t) {
 //===----------------------------------------------------------------------===//
 
 // `boxproc` `<` return-type `>`
-mlir::Type BoxProcType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type BoxProcType::parse(mlir::AsmParser &parser) {
   mlir::Type ty;
   if (parser.parseLess() || parser.parseType(ty) || parser.parseGreater())
     return {};
   return get(parser.getContext(), ty);
 }
 
-void fir::BoxProcType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::BoxProcType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getEleTy() << '>';
 }
 
@@ -356,7 +356,7 @@ static bool cannotBePointerOrHeapElementType(mlir::Type eleTy) {
 //===----------------------------------------------------------------------===//
 
 // `box` `<` type (',' affine-map)? `>`
-mlir::Type fir::BoxType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::BoxType::parse(mlir::AsmParser &parser) {
   mlir::Type ofTy;
   if (parser.parseLess() || parser.parseType(ofTy))
     return {};
@@ -373,7 +373,7 @@ mlir::Type fir::BoxType::parse(mlir::DialectAsmParser &parser) {
   return get(ofTy, map);
 }
 
-void fir::BoxType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::BoxType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getEleTy();
   if (auto map = getLayoutMap()) {
     printer << ", " << map;
@@ -392,11 +392,11 @@ fir::BoxType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 // BoxCharType
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::BoxCharType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::BoxCharType::parse(mlir::AsmParser &parser) {
   return parseKindSingleton<fir::BoxCharType>(parser);
 }
 
-void fir::BoxCharType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::BoxCharType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getKind() << ">";
 }
 
@@ -414,7 +414,7 @@ CharacterType fir::BoxCharType::getEleTy() const {
 //===----------------------------------------------------------------------===//
 
 // `char` `<` kind [`,` `len`] `>`
-mlir::Type fir::CharacterType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::CharacterType::parse(mlir::AsmParser &parser) {
   int kind = 0;
   if (parser.parseLess() || parser.parseInteger(kind))
     return {};
@@ -431,7 +431,7 @@ mlir::Type fir::CharacterType::parse(mlir::DialectAsmParser &parser) {
   return get(parser.getContext(), kind, len);
 }
 
-void fir::CharacterType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::CharacterType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getFKind();
   auto len = getLen();
   if (len != fir::CharacterType::singleton()) {
@@ -448,11 +448,11 @@ void fir::CharacterType::print(mlir::DialectAsmPrinter &printer) const {
 // ComplexType
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::ComplexType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::ComplexType::parse(mlir::AsmParser &parser) {
   return parseKindSingleton<fir::ComplexType>(parser);
 }
 
-void fir::ComplexType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::ComplexType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getFKind() << '>';
 }
 
@@ -465,11 +465,11 @@ mlir::Type fir::ComplexType::getElementType() const {
 //===----------------------------------------------------------------------===//
 
 // `heap` `<` type `>`
-mlir::Type fir::HeapType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::HeapType::parse(mlir::AsmParser &parser) {
   return parseTypeSingleton<HeapType>(parser);
 }
 
-void fir::HeapType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::HeapType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getEleTy() << '>';
 }
 
@@ -487,11 +487,11 @@ fir::HeapType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 //===----------------------------------------------------------------------===//
 
 // `int` `<` kind `>`
-mlir::Type fir::IntegerType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::IntegerType::parse(mlir::AsmParser &parser) {
   return parseKindSingleton<fir::IntegerType>(parser);
 }
 
-void fir::IntegerType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::IntegerType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getFKind() << '>';
 }
 
@@ -500,11 +500,11 @@ void fir::IntegerType::print(mlir::DialectAsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 // `logical` `<` kind `>`
-mlir::Type fir::LogicalType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::LogicalType::parse(mlir::AsmParser &parser) {
   return parseKindSingleton<fir::LogicalType>(parser);
 }
 
-void fir::LogicalType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::LogicalType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getFKind() << '>';
 }
 
@@ -513,11 +513,11 @@ void fir::LogicalType::print(mlir::DialectAsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 // `ptr` `<` type `>`
-mlir::Type fir::PointerType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::PointerType::parse(mlir::AsmParser &parser) {
   return parseTypeSingleton<fir::PointerType>(parser);
 }
 
-void fir::PointerType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::PointerType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getEleTy() << '>';
 }
 
@@ -534,11 +534,11 @@ mlir::LogicalResult fir::PointerType::verify(
 //===----------------------------------------------------------------------===//
 
 // `real` `<` kind `>`
-mlir::Type fir::RealType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::RealType::parse(mlir::AsmParser &parser) {
   return parseKindSingleton<fir::RealType>(parser);
 }
 
-void fir::RealType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::RealType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getFKind() << '>';
 }
 
@@ -557,7 +557,7 @@ fir::RealType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 // `type` `<` name
 //           (`(` id `:` type (`,` id `:` type)* `)`)?
 //           (`{` id `:` type (`,` id `:` type)* `}`)? '>'
-mlir::Type fir::RecordType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::RecordType::parse(mlir::AsmParser &parser) {
   llvm::StringRef name;
   if (parser.parseLess() || parser.parseKeyword(&name))
     return {};
@@ -609,7 +609,7 @@ mlir::Type fir::RecordType::parse(mlir::DialectAsmParser &parser) {
   return verifyDerived(parser, result, lenParamList, typeList);
 }
 
-void fir::RecordType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::RecordType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getName();
   if (!recordTypeVisited.count(uniqueKey())) {
     recordTypeVisited.insert(uniqueKey());
@@ -684,11 +684,11 @@ unsigned fir::RecordType::getFieldIndex(llvm::StringRef ident) {
 //===----------------------------------------------------------------------===//
 
 // `ref` `<` type `>`
-mlir::Type fir::ReferenceType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::ReferenceType::parse(mlir::AsmParser &parser) {
   return parseTypeSingleton<fir::ReferenceType>(parser);
 }
 
-void fir::ReferenceType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::ReferenceType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getEleTy() << '>';
 }
 
@@ -707,7 +707,7 @@ mlir::LogicalResult fir::ReferenceType::verify(
 
 // `array` `<` `*` | bounds (`x` bounds)* `:` type (',' affine-map)? `>`
 // bounds ::= `?` | int-lit
-mlir::Type fir::SequenceType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::SequenceType::parse(mlir::AsmParser &parser) {
   if (parser.parseLess())
     return {};
   SequenceType::Shape shape;
@@ -729,7 +729,7 @@ mlir::Type fir::SequenceType::parse(mlir::DialectAsmParser &parser) {
   return SequenceType::get(parser.getContext(), shape, eleTy, map);
 }
 
-void fir::SequenceType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::SequenceType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic();
   auto shape = getShape();
   if (shape.size()) {
@@ -810,11 +810,11 @@ mlir::LogicalResult fir::SequenceType::verify(
 // ShapeType
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::ShapeType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::ShapeType::parse(mlir::AsmParser &parser) {
   return parseRankSingleton<fir::ShapeType>(parser);
 }
 
-void fir::ShapeType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::ShapeType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getImpl()->rank << ">";
 }
 
@@ -822,11 +822,11 @@ void fir::ShapeType::print(mlir::DialectAsmPrinter &printer) const {
 // ShapeShiftType
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::ShapeShiftType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::ShapeShiftType::parse(mlir::AsmParser &parser) {
   return parseRankSingleton<fir::ShapeShiftType>(parser);
 }
 
-void fir::ShapeShiftType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::ShapeShiftType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getRank() << ">";
 }
 
@@ -834,11 +834,11 @@ void fir::ShapeShiftType::print(mlir::DialectAsmPrinter &printer) const {
 // ShiftType
 //===----------------------------------------------------------------------===//
 
-mlir::Type fir::ShiftType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::ShiftType::parse(mlir::AsmParser &parser) {
   return parseRankSingleton<fir::ShiftType>(parser);
 }
 
-void fir::ShiftType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::ShiftType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getRank() << ">";
 }
 
@@ -847,11 +847,11 @@ void fir::ShiftType::print(mlir::DialectAsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 // `slice` `<` rank `>`
-mlir::Type fir::SliceType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::SliceType::parse(mlir::AsmParser &parser) {
   return parseRankSingleton<fir::SliceType>(parser);
 }
 
-void fir::SliceType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::SliceType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getRank() << '>';
 }
 
@@ -860,11 +860,11 @@ void fir::SliceType::print(mlir::DialectAsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 // `tdesc` `<` type `>`
-mlir::Type fir::TypeDescType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::TypeDescType::parse(mlir::AsmParser &parser) {
   return parseTypeSingleton<fir::TypeDescType>(parser);
 }
 
-void fir::TypeDescType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::TypeDescType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getOfTy() << '>';
 }
 
@@ -884,7 +884,7 @@ mlir::LogicalResult fir::TypeDescType::verify(
 //===----------------------------------------------------------------------===//
 
 // `vector` `<` len `:` type `>`
-mlir::Type fir::VectorType::parse(mlir::DialectAsmParser &parser) {
+mlir::Type fir::VectorType::parse(mlir::AsmParser &parser) {
   int64_t len = 0;
   mlir::Type eleTy;
   if (parser.parseLess() || parser.parseInteger(len) || parser.parseColon() ||
@@ -893,7 +893,7 @@ mlir::Type fir::VectorType::parse(mlir::DialectAsmParser &parser) {
   return fir::VectorType::get(len, eleTy);
 }
 
-void fir::VectorType::print(mlir::DialectAsmPrinter &printer) const {
+void fir::VectorType::print(mlir::AsmPrinter &printer) const {
   printer << getMnemonic() << "<" << getLen() << ':' << getEleTy() << '>';
 }
 

--- a/mlir/include/mlir/Dialect/DLTI/DLTI.h
+++ b/mlir/include/mlir/Dialect/DLTI/DLTI.h
@@ -51,10 +51,10 @@ public:
   Attribute getValue() const;
 
   /// Parses an instance of this attribute.
-  static DataLayoutEntryAttr parse(DialectAsmParser &parser);
+  static DataLayoutEntryAttr parse(AsmParser &parser);
 
   /// Prints this attribute.
-  void print(DialectAsmPrinter &os) const;
+  void print(AsmPrinter &os) const;
 };
 
 //===----------------------------------------------------------------------===//
@@ -99,10 +99,10 @@ public:
   DataLayoutEntryListRef getEntries() const;
 
   /// Parses an instance of this attribute.
-  static DataLayoutSpecAttr parse(DialectAsmParser &parser);
+  static DataLayoutSpecAttr parse(AsmParser &parser);
 
   /// Prints this attribute.
-  void print(DialectAsmPrinter &os) const;
+  void print(AsmPrinter &os) const;
 };
 
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h
@@ -24,8 +24,8 @@ class TypeSize;
 
 namespace mlir {
 
-class DialectAsmParser;
-class DialectAsmPrinter;
+class AsmParser;
+class AsmPrinter;
 
 namespace LLVM {
 class LLVMDialect;
@@ -419,7 +419,7 @@ namespace detail {
 Type parseType(DialectAsmParser &parser);
 
 /// Prints an LLVM Dialect type.
-void printType(Type type, DialectAsmPrinter &printer);
+void printType(Type type, AsmPrinter &printer);
 } // namespace detail
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/Vector/VectorOps.h
+++ b/mlir/include/mlir/Dialect/Vector/VectorOps.h
@@ -132,8 +132,8 @@ public:
 
   CombiningKind getKind() const;
 
-  void print(DialectAsmPrinter &p) const;
-  static Attribute parse(DialectAsmParser &parser);
+  void print(AsmPrinter &p) const;
+  static Attribute parse(AsmParser &parser, Type type);
 };
 
 /// Enum to control the lowering of `vector.contract` operations.

--- a/mlir/include/mlir/IR/DialectImplementation.h
+++ b/mlir/include/mlir/IR/DialectImplementation.h
@@ -62,7 +62,7 @@ template <typename AttributeT>
 struct FieldParser<
     AttributeT, std::enable_if_t<std::is_base_of<Attribute, AttributeT>::value,
                                  AttributeT>> {
-  static FailureOr<AttributeT> parse(DialectAsmParser &parser) {
+  static FailureOr<AttributeT> parse(AsmParser &parser) {
     AttributeT value;
     if (parser.parseAttribute(value))
       return failure();
@@ -86,7 +86,7 @@ struct FieldParser<
 template <typename IntT>
 struct FieldParser<IntT,
                    std::enable_if_t<std::is_integral<IntT>::value, IntT>> {
-  static FailureOr<IntT> parse(DialectAsmParser &parser) {
+  static FailureOr<IntT> parse(AsmParser &parser) {
     IntT value;
     if (parser.parseInteger(value))
       return failure();
@@ -97,7 +97,7 @@ struct FieldParser<IntT,
 /// Parse a string.
 template <>
 struct FieldParser<std::string> {
-  static FailureOr<std::string> parse(DialectAsmParser &parser) {
+  static FailureOr<std::string> parse(AsmParser &parser) {
     std::string value;
     if (parser.parseString(&value))
       return failure();
@@ -112,7 +112,7 @@ struct FieldParser<
                                      decltype(&ContainerT::push_back)>::value,
                                  ContainerT>> {
   using ElementT = typename ContainerT::value_type;
-  static FailureOr<ContainerT> parse(DialectAsmParser &parser) {
+  static FailureOr<ContainerT> parse(AsmParser &parser) {
     ContainerT elements;
     auto elementParser = [&]() {
       auto element = FieldParser<ElementT>::parse(parser);

--- a/mlir/lib/Dialect/Async/IR/Async.cpp
+++ b/mlir/lib/Dialect/Async/IR/Async.cpp
@@ -338,14 +338,14 @@ static LogicalResult verify(AwaitOp op) {
 #define GET_TYPEDEF_CLASSES
 #include "mlir/Dialect/Async/IR/AsyncOpsTypes.cpp.inc"
 
-void ValueType::print(DialectAsmPrinter &printer) const {
+void ValueType::print(AsmPrinter &printer) const {
   printer << getMnemonic();
   printer << "<";
   printer.printType(getValueType());
   printer << '>';
 }
 
-Type ValueType::parse(mlir::DialectAsmParser &parser) {
+Type ValueType::parse(mlir::AsmParser &parser) {
   Type ty;
   if (parser.parseLess() || parser.parseType(ty) || parser.parseGreater()) {
     parser.emitError(parser.getNameLoc(), "failed to parse async value type");

--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -65,7 +65,7 @@ Attribute DataLayoutEntryAttr::getValue() const { return getImpl()->value; }
 
 /// Parses an attribute with syntax:
 ///   attr ::= `#target.` `dl_entry` `<` (type | quoted-string) `,` attr `>`
-DataLayoutEntryAttr DataLayoutEntryAttr::parse(DialectAsmParser &parser) {
+DataLayoutEntryAttr DataLayoutEntryAttr::parse(AsmParser &parser) {
   if (failed(parser.parseLess()))
     return {};
 
@@ -92,7 +92,7 @@ DataLayoutEntryAttr DataLayoutEntryAttr::parse(DialectAsmParser &parser) {
               : get(parser.getBuilder().getIdentifier(identifier), value);
 }
 
-void DataLayoutEntryAttr::print(DialectAsmPrinter &os) const {
+void DataLayoutEntryAttr::print(AsmPrinter &os) const {
   os << DataLayoutEntryAttr::kAttrKeyword << "<";
   if (auto type = getKey().dyn_cast<Type>())
     os << type;
@@ -277,7 +277,7 @@ DataLayoutEntryListRef DataLayoutSpecAttr::getEntries() const {
 ///   attr ::= `#target.` `dl_spec` `<` attr-list? `>`
 ///   attr-list ::= attr
 ///               | attr `,` attr-list
-DataLayoutSpecAttr DataLayoutSpecAttr::parse(DialectAsmParser &parser) {
+DataLayoutSpecAttr DataLayoutSpecAttr::parse(AsmParser &parser) {
   if (failed(parser.parseLess()))
     return {};
 
@@ -298,7 +298,7 @@ DataLayoutSpecAttr DataLayoutSpecAttr::parse(DialectAsmParser &parser) {
                     parser.getContext(), entries);
 }
 
-void DataLayoutSpecAttr::print(DialectAsmPrinter &os) const {
+void DataLayoutSpecAttr::print(AsmPrinter &os) const {
   os << DataLayoutSpecAttr::kAttrKeyword << "<";
   llvm::interleaveComma(getEntries(), os);
   os << ">";

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -166,7 +166,7 @@ static ParseResult parseIncludeOp(OpAsmParser &parser, OperationState &result) {
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/EmitC/IR/EmitCAttributes.cpp.inc"
 
-Attribute emitc::OpaqueAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute emitc::OpaqueAttr::parse(AsmParser &parser, Type type) {
   if (parser.parseLess())
     return Attribute();
   std::string value;
@@ -200,7 +200,7 @@ void EmitCDialect::printAttribute(Attribute attr, DialectAsmPrinter &os) const {
     llvm_unreachable("unexpected 'EmitC' attribute kind");
 }
 
-void emitc::OpaqueAttr::print(DialectAsmPrinter &printer) const {
+void emitc::OpaqueAttr::print(AsmPrinter &printer) const {
   printer << "opaque<\"";
   llvm::printEscapedString(getValue(), printer.getStream());
   printer << "\">";
@@ -213,7 +213,7 @@ void emitc::OpaqueAttr::print(DialectAsmPrinter &printer) const {
 #define GET_TYPEDEF_CLASSES
 #include "mlir/Dialect/EmitC/IR/EmitCTypes.cpp.inc"
 
-Type emitc::OpaqueType::parse(DialectAsmParser &parser) {
+Type emitc::OpaqueType::parse(AsmParser &parser) {
   if (parser.parseLess())
     return Type();
   std::string value;
@@ -227,7 +227,7 @@ Type emitc::OpaqueType::parse(DialectAsmParser &parser) {
   return get(parser.getContext(), value);
 }
 
-Type EmitCDialect::parseType(DialectAsmParser &parser) const {
+Type EmitCDialect::parseType(AsmParser &parser) const {
   llvm::SMLoc typeLoc = parser.getCurrentLocation();
   StringRef mnemonic;
   if (parser.parseKeyword(&mnemonic))
@@ -241,12 +241,12 @@ Type EmitCDialect::parseType(DialectAsmParser &parser) const {
   return Type();
 }
 
-void EmitCDialect::printType(Type type, DialectAsmPrinter &os) const {
+void EmitCDialect::printType(Type type, AsmPrinter &os) const {
   if (failed(generatedTypePrinter(type, os)))
     llvm_unreachable("unexpected 'EmitC' type kind");
 }
 
-void emitc::OpaqueType::print(DialectAsmPrinter &printer) const {
+void emitc::OpaqueType::print(AsmPrinter &printer) const {
   printer << "opaque<\"";
   llvm::printEscapedString(getValue(), printer.getStream());
   printer << "\">";

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -227,6 +227,25 @@ Type emitc::OpaqueType::parse(AsmParser &parser) {
   return get(parser.getContext(), value);
 }
 
+Type EmitCDialect::parseType(DialectAsmParser &parser) const {
+  llvm::SMLoc typeLoc = parser.getCurrentLocation();
+  StringRef mnemonic;
+  if (parser.parseKeyword(&mnemonic))
+    return Type();
+  Type genType;
+  OptionalParseResult parseResult =
+      generatedTypeParser(parser, mnemonic, genType);
+  if (parseResult.hasValue())
+    return genType;
+  parser.emitError(typeLoc, "unknown type in EmitC dialect");
+  return Type();
+}
+
+void EmitCDialect::printType(Type type, DialectAsmPrinter &os) const {
+  if (failed(generatedTypePrinter(type, os)))
+    llvm_unreachable("unexpected 'EmitC' type kind");
+}
+
 void emitc::OpaqueType::print(AsmPrinter &printer) const {
   printer << "opaque<\"";
   llvm::printEscapedString(getValue(), printer.getStream());

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -227,25 +227,6 @@ Type emitc::OpaqueType::parse(AsmParser &parser) {
   return get(parser.getContext(), value);
 }
 
-Type EmitCDialect::parseType(AsmParser &parser) const {
-  llvm::SMLoc typeLoc = parser.getCurrentLocation();
-  StringRef mnemonic;
-  if (parser.parseKeyword(&mnemonic))
-    return Type();
-  Type genType;
-  OptionalParseResult parseResult =
-      generatedTypeParser(parser, mnemonic, genType);
-  if (parseResult.hasValue())
-    return genType;
-  parser.emitError(typeLoc, "unknown type in EmitC dialect");
-  return Type();
-}
-
-void EmitCDialect::printType(Type type, AsmPrinter &os) const {
-  if (failed(generatedTypePrinter(type, os)))
-    llvm_unreachable("unexpected 'EmitC' type kind");
-}
-
 void emitc::OpaqueType::print(AsmPrinter &printer) const {
   printer << "opaque<\"";
   llvm::printEscapedString(getValue(), printer.getStream());

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -2364,7 +2364,7 @@ static constexpr const FastmathFlags FastmathFlagsList[] = {
     // clang-format on
 };
 
-void FMFAttr::print(DialectAsmPrinter &printer) const {
+void FMFAttr::print(AsmPrinter &printer) const {
   printer << "fastmath<";
   auto flags = llvm::make_filter_range(FastmathFlagsList, [&](auto flag) {
     return bitEnumContains(this->getFlags(), flag);
@@ -2374,7 +2374,7 @@ void FMFAttr::print(DialectAsmPrinter &printer) const {
   printer << ">";
 }
 
-Attribute FMFAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute FMFAttr::parse(AsmParser &parser, Type type) {
   if (failed(parser.parseLess()))
     return {};
 
@@ -2402,7 +2402,7 @@ Attribute FMFAttr::parse(DialectAsmParser &parser, Type type) {
   return FMFAttr::get(parser.getContext(), flags);
 }
 
-void LinkageAttr::print(DialectAsmPrinter &printer) const {
+void LinkageAttr::print(AsmPrinter &printer) const {
   printer << "linkage<";
   if (static_cast<uint64_t>(getLinkage()) <= getMaxEnumValForLinkage())
     printer << stringifyEnum(getLinkage());
@@ -2411,7 +2411,7 @@ void LinkageAttr::print(DialectAsmPrinter &printer) const {
   printer << ">";
 }
 
-Attribute LinkageAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute LinkageAttr::parse(AsmParser &parser, Type type) {
   StringRef elemName;
   if (parser.parseLess() || parser.parseKeyword(&elemName) ||
       parser.parseGreater())
@@ -2518,7 +2518,7 @@ LoopOptionsAttr LoopOptionsAttr::get(MLIRContext *context,
   return Base::get(context, optionBuilders.options);
 }
 
-void LoopOptionsAttr::print(DialectAsmPrinter &printer) const {
+void LoopOptionsAttr::print(AsmPrinter &printer) const {
   printer << getMnemonic() << "<";
   llvm::interleaveComma(getOptions(), printer, [&](auto option) {
     printer << stringifyEnum(option.first) << " = ";
@@ -2537,7 +2537,7 @@ void LoopOptionsAttr::print(DialectAsmPrinter &printer) const {
   printer << ">";
 }
 
-Attribute LoopOptionsAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute LoopOptionsAttr::parse(AsmParser &parser, Type type) {
   if (failed(parser.parseLess()))
     return {};
 

--- a/mlir/lib/Dialect/PDL/IR/PDLTypes.cpp
+++ b/mlir/lib/Dialect/PDL/IR/PDLTypes.cpp
@@ -33,7 +33,7 @@ void PDLDialect::registerTypes() {
       >();
 }
 
-static Type parsePDLType(DialectAsmParser &parser) {
+static Type parsePDLType(AsmParser &parser) {
   StringRef typeTag;
   if (parser.parseKeyword(&typeTag))
     return Type();
@@ -74,7 +74,7 @@ bool PDLType::classof(Type type) {
 // RangeType
 //===----------------------------------------------------------------------===//
 
-Type RangeType::parse(DialectAsmParser &parser) {
+Type RangeType::parse(AsmParser &parser) {
   if (parser.parseLess())
     return Type();
 
@@ -92,7 +92,7 @@ Type RangeType::parse(DialectAsmParser &parser) {
   return RangeType::get(elementType);
 }
 
-void RangeType::print(DialectAsmPrinter &printer) const {
+void RangeType::print(AsmPrinter &printer) const {
   printer << "range<";
   (void)generatedTypePrinter(getElementType(), printer);
   printer << ">";

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -39,7 +39,7 @@ static bool acceptBitWidth(unsigned bitWidth) {
   }
 }
 
-Attribute SparseTensorEncodingAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute SparseTensorEncodingAttr::parse(AsmParser &parser, Type type) {
   if (failed(parser.parseLess()))
     return {};
   // Parse the data as a dictionary.
@@ -117,7 +117,7 @@ Attribute SparseTensorEncodingAttr::parse(DialectAsmParser &parser, Type type) {
                                                      map, ptr, ind);
 }
 
-void SparseTensorEncodingAttr::print(DialectAsmPrinter &printer) const {
+void SparseTensorEncodingAttr::print(AsmPrinter &printer) const {
   // Print the struct-like storage in dictionary fashion.
   printer << "encoding<{ dimLevelType = [ ";
   for (unsigned i = 0, e = getDimLevelType().size(); i < e; i++) {

--- a/mlir/lib/Dialect/Vector/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/VectorOps.cpp
@@ -169,7 +169,7 @@ static constexpr const CombiningKind combiningKindsList[] = {
     // clang-format on
 };
 
-void CombiningKindAttr::print(DialectAsmPrinter &printer) const {
+void CombiningKindAttr::print(AsmPrinter &printer) const {
   printer << "kind<";
   auto kinds = llvm::make_filter_range(combiningKindsList, [&](auto kind) {
     return bitEnumContains(this->getKind(), kind);
@@ -179,7 +179,7 @@ void CombiningKindAttr::print(DialectAsmPrinter &printer) const {
   printer << ">";
 }
 
-Attribute CombiningKindAttr::parse(DialectAsmParser &parser) {
+Attribute CombiningKindAttr::parse(AsmParser &parser, Type type) {
   if (failed(parser.parseLess()))
     return {};
 
@@ -207,7 +207,7 @@ Attribute VectorDialect::parseAttribute(DialectAsmParser &parser,
     return {};
 
   if (attrKind == "kind")
-    return CombiningKindAttr::parse(parser);
+    return CombiningKindAttr::parse(parser, {});
 
   parser.emitError(parser.getNameLoc(), "Unknown attribute type: ") << attrKind;
   return {};

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -29,15 +29,14 @@ using namespace test;
 // AttrWithSelfTypeParamAttr
 //===----------------------------------------------------------------------===//
 
-Attribute AttrWithSelfTypeParamAttr::parse(DialectAsmParser &parser,
-                                           Type type) {
+Attribute AttrWithSelfTypeParamAttr::parse(AsmParser &parser, Type type) {
   Type selfType;
   if (parser.parseType(selfType))
     return Attribute();
   return get(parser.getContext(), selfType);
 }
 
-void AttrWithSelfTypeParamAttr::print(DialectAsmPrinter &printer) const {
+void AttrWithSelfTypeParamAttr::print(AsmPrinter &printer) const {
   printer << "attr_with_self_type_param " << getType();
 }
 
@@ -45,22 +44,27 @@ void AttrWithSelfTypeParamAttr::print(DialectAsmPrinter &printer) const {
 // AttrWithTypeBuilderAttr
 //===----------------------------------------------------------------------===//
 
-Attribute AttrWithTypeBuilderAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute AttrWithTypeBuilderAttr::parse(AsmParser &parser, Type type) {
   IntegerAttr element;
   if (parser.parseAttribute(element))
     return Attribute();
   return get(parser.getContext(), element);
 }
 
+<<<<<<< HEAD
 void AttrWithTypeBuilderAttr::print(DialectAsmPrinter &printer) const {
   printer << "attr_with_type_builder " << getAttr();
+=======
+void AttrWithTypeBuilderAttr::print(AsmPrinter &printer) const {
+  printer << " " << getAttr();
+>>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
 }
 
 //===----------------------------------------------------------------------===//
 // CompoundAAttr
 //===----------------------------------------------------------------------===//
 
-Attribute CompoundAAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute CompoundAAttr::parse(AsmParser &parser, Type type) {
   int widthOfSomething;
   Type oneType;
   SmallVector<int, 4> arrayOfInts;
@@ -81,9 +85,14 @@ Attribute CompoundAAttr::parse(DialectAsmParser &parser, Type type) {
   return get(parser.getContext(), widthOfSomething, oneType, arrayOfInts);
 }
 
+<<<<<<< HEAD
 void CompoundAAttr::print(DialectAsmPrinter &printer) const {
   printer << "cmpnd_a<" << getWidthOfSomething() << ", " << getOneType()
           << ", [";
+=======
+void CompoundAAttr::print(AsmPrinter &printer) const {
+  printer << "<" << getWidthOfSomething() << ", " << getOneType() << ", [";
+>>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
   llvm::interleaveComma(getArrayOfInts(), printer);
   printer << "]>";
 }
@@ -92,7 +101,7 @@ void CompoundAAttr::print(DialectAsmPrinter &printer) const {
 // CompoundAAttr
 //===----------------------------------------------------------------------===//
 
-Attribute TestI64ElementsAttr::parse(DialectAsmParser &parser, Type type) {
+Attribute TestI64ElementsAttr::parse(AsmParser &parser, Type type) {
   SmallVector<uint64_t> elements;
   if (parser.parseLess() || parser.parseLSquare())
     return Attribute();
@@ -109,8 +118,13 @@ Attribute TestI64ElementsAttr::parse(DialectAsmParser &parser, Type type) {
       parser.getContext(), type.cast<ShapedType>(), elements);
 }
 
+<<<<<<< HEAD
 void TestI64ElementsAttr::print(DialectAsmPrinter &printer) const {
   printer << "i64_elements<[";
+=======
+void TestI64ElementsAttr::print(AsmPrinter &printer) const {
+  printer << "<[";
+>>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
   llvm::interleaveComma(getElements(), printer);
   printer << "] : " << getType() << ">";
 }
@@ -142,7 +156,7 @@ TestAttrWithFormatAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 // Utility Functions for Generated Attributes
 //===----------------------------------------------------------------------===//
 
-static FailureOr<SmallVector<int>> parseIntArray(DialectAsmParser &parser) {
+static FailureOr<SmallVector<int>> parseIntArray(AsmParser &parser) {
   SmallVector<int> ints;
   if (parser.parseLSquare() || parser.parseCommaSeparatedList([&]() {
         ints.push_back(0);
@@ -153,13 +167,66 @@ static FailureOr<SmallVector<int>> parseIntArray(DialectAsmParser &parser) {
   return ints;
 }
 
-static void printIntArray(DialectAsmPrinter &printer, ArrayRef<int> ints) {
+static void printIntArray(AsmPrinter &printer, ArrayRef<int> ints) {
   printer << '[';
   llvm::interleaveComma(ints, printer);
   printer << ']';
 }
 
 //===----------------------------------------------------------------------===//
+<<<<<<< HEAD
+=======
+// TestSubElementsAccessAttr
+//===----------------------------------------------------------------------===//
+
+Attribute TestSubElementsAccessAttr::parse(::mlir::AsmParser &parser,
+                                           ::mlir::Type type) {
+  Attribute first, second, third;
+  if (parser.parseLess() || parser.parseAttribute(first) ||
+      parser.parseComma() || parser.parseAttribute(second) ||
+      parser.parseComma() || parser.parseAttribute(third) ||
+      parser.parseGreater()) {
+    return {};
+  }
+  return get(parser.getContext(), first, second, third);
+}
+
+void TestSubElementsAccessAttr::print(::mlir::AsmPrinter &printer) const {
+  printer << "<" << getFirst() << ", " << getSecond() << ", " << getThird()
+          << ">";
+}
+
+void TestSubElementsAccessAttr::walkImmediateSubElements(
+    llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+    llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
+  walkAttrsFn(getFirst());
+  walkAttrsFn(getSecond());
+  walkAttrsFn(getThird());
+}
+
+SubElementAttrInterface TestSubElementsAccessAttr::replaceImmediateSubAttribute(
+    ArrayRef<std::pair<size_t, Attribute>> replacements) const {
+  Attribute first = getFirst();
+  Attribute second = getSecond();
+  Attribute third = getThird();
+  for (auto &it : replacements) {
+    switch (it.first) {
+    case 0:
+      first = it.second;
+      break;
+    case 1:
+      second = it.second;
+      break;
+    case 2:
+      third = it.second;
+      break;
+    }
+  }
+  return get(getContext(), first, second, third);
+}
+
+//===----------------------------------------------------------------------===//
+>>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
 // Tablegen Generated Definitions
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -51,13 +51,8 @@ Attribute AttrWithTypeBuilderAttr::parse(AsmParser &parser, Type type) {
   return get(parser.getContext(), element);
 }
 
-<<<<<<< HEAD
-void AttrWithTypeBuilderAttr::print(DialectAsmPrinter &printer) const {
-  printer << "attr_with_type_builder " << getAttr();
-=======
 void AttrWithTypeBuilderAttr::print(AsmPrinter &printer) const {
-  printer << " " << getAttr();
->>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
+  printer << "attr_with_type_builder " << getAttr();
 }
 
 //===----------------------------------------------------------------------===//
@@ -85,14 +80,8 @@ Attribute CompoundAAttr::parse(AsmParser &parser, Type type) {
   return get(parser.getContext(), widthOfSomething, oneType, arrayOfInts);
 }
 
-<<<<<<< HEAD
-void CompoundAAttr::print(DialectAsmPrinter &printer) const {
-  printer << "cmpnd_a<" << getWidthOfSomething() << ", " << getOneType()
-          << ", [";
-=======
 void CompoundAAttr::print(AsmPrinter &printer) const {
-  printer << "<" << getWidthOfSomething() << ", " << getOneType() << ", [";
->>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
+  printer << "cmpnd_a<" << getWidthOfSomething() << ", " << getOneType() << ", [";
   llvm::interleaveComma(getArrayOfInts(), printer);
   printer << "]>";
 }
@@ -118,13 +107,8 @@ Attribute TestI64ElementsAttr::parse(AsmParser &parser, Type type) {
       parser.getContext(), type.cast<ShapedType>(), elements);
 }
 
-<<<<<<< HEAD
-void TestI64ElementsAttr::print(DialectAsmPrinter &printer) const {
-  printer << "i64_elements<[";
-=======
 void TestI64ElementsAttr::print(AsmPrinter &printer) const {
-  printer << "<[";
->>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
+  printer << "i64_elements<[";
   llvm::interleaveComma(getElements(), printer);
   printer << "] : " << getType() << ">";
 }
@@ -174,59 +158,6 @@ static void printIntArray(AsmPrinter &printer, ArrayRef<int> ints) {
 }
 
 //===----------------------------------------------------------------------===//
-<<<<<<< HEAD
-=======
-// TestSubElementsAccessAttr
-//===----------------------------------------------------------------------===//
-
-Attribute TestSubElementsAccessAttr::parse(::mlir::AsmParser &parser,
-                                           ::mlir::Type type) {
-  Attribute first, second, third;
-  if (parser.parseLess() || parser.parseAttribute(first) ||
-      parser.parseComma() || parser.parseAttribute(second) ||
-      parser.parseComma() || parser.parseAttribute(third) ||
-      parser.parseGreater()) {
-    return {};
-  }
-  return get(parser.getContext(), first, second, third);
-}
-
-void TestSubElementsAccessAttr::print(::mlir::AsmPrinter &printer) const {
-  printer << "<" << getFirst() << ", " << getSecond() << ", " << getThird()
-          << ">";
-}
-
-void TestSubElementsAccessAttr::walkImmediateSubElements(
-    llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
-    llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
-  walkAttrsFn(getFirst());
-  walkAttrsFn(getSecond());
-  walkAttrsFn(getThird());
-}
-
-SubElementAttrInterface TestSubElementsAccessAttr::replaceImmediateSubAttribute(
-    ArrayRef<std::pair<size_t, Attribute>> replacements) const {
-  Attribute first = getFirst();
-  Attribute second = getSecond();
-  Attribute third = getThird();
-  for (auto &it : replacements) {
-    switch (it.first) {
-    case 0:
-      first = it.second;
-      break;
-    case 1:
-      second = it.second;
-      break;
-    case 2:
-      third = it.second;
-      break;
-    }
-  }
-  return get(getContext(), first, second, third);
-}
-
-//===----------------------------------------------------------------------===//
->>>>>>> f97e72aaca4a... Use base class AsmParser/AsmPrinter in Types and Attribute print/parse method (NFC)
 // Tablegen Generated Definitions
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -26,7 +26,7 @@ using namespace test;
 
 // Custom parser for SignednessSemantics.
 static ParseResult
-parseSignedness(DialectAsmParser &parser,
+parseSignedness(AsmParser &parser,
                 TestIntegerType::SignednessSemantics &result) {
   StringRef signStr;
   auto loc = parser.getCurrentLocation();
@@ -46,7 +46,7 @@ parseSignedness(DialectAsmParser &parser,
 }
 
 // Custom printer for SignednessSemantics.
-static void printSignedness(DialectAsmPrinter &printer,
+static void printSignedness(AsmPrinter &printer,
                             const TestIntegerType::SignednessSemantics &ss) {
   switch (ss) {
   case TestIntegerType::SignednessSemantics::Unsigned:
@@ -87,7 +87,7 @@ static llvm::hash_code test::hash_value(const FieldInfo &fi) { // NOLINT
 // CompoundAType
 //===----------------------------------------------------------------------===//
 
-Type CompoundAType::parse(DialectAsmParser &parser) {
+Type CompoundAType::parse(AsmParser &parser) {
   int widthOfSomething;
   Type oneType;
   SmallVector<int, 4> arrayOfInts;
@@ -108,7 +108,7 @@ Type CompoundAType::parse(DialectAsmParser &parser) {
 
   return get(parser.getContext(), widthOfSomething, oneType, arrayOfInts);
 }
-void CompoundAType::print(DialectAsmPrinter &printer) const {
+void CompoundAType::print(AsmPrinter &printer) const {
   printer << "cmpnd_a<" << getWidthOfSomething() << ", " << getOneType()
           << ", [";
   auto intArray = getArrayOfInts();
@@ -142,14 +142,14 @@ void TestType::printTypeC(Location loc) const {
 // TestTypeWithLayout
 //===----------------------------------------------------------------------===//
 
-Type TestTypeWithLayoutType::parse(DialectAsmParser &parser) {
+Type TestTypeWithLayoutType::parse(AsmParser &parser) {
   unsigned val;
   if (parser.parseLess() || parser.parseInteger(val) || parser.parseGreater())
     return Type();
   return TestTypeWithLayoutType::get(parser.getContext(), val);
 }
 
-void TestTypeWithLayoutType::print(DialectAsmPrinter &printer) const {
+void TestTypeWithLayoutType::print(AsmPrinter &printer) const {
   printer << "test_type_with_layout<" << getKey() << ">";
 }
 
@@ -235,7 +235,7 @@ void TestDialect::registerTypes() {
   SimpleAType::attachInterface<PtrElementModel>(*getContext());
 }
 
-static Type parseTestType(DialectAsmParser &parser, SetVector<Type> &stack) {
+static Type parseTestType(AsmParser &parser, SetVector<Type> &stack) {
   StringRef typeTag;
   if (failed(parser.parseKeyword(&typeTag)))
     return Type();
@@ -282,7 +282,7 @@ Type TestDialect::parseType(DialectAsmParser &parser) const {
   return parseTestType(parser, stack);
 }
 
-static void printTestType(Type type, DialectAsmPrinter &printer,
+static void printTestType(Type type, AsmPrinter &printer,
                           SetVector<Type> &stack) {
   if (succeeded(generatedTypePrinter(type, printer)))
     return;

--- a/mlir/test/lib/Dialect/Test/TestTypes.h
+++ b/mlir/test/lib/Dialect/Test/TestTypes.h
@@ -56,7 +56,7 @@ inline llvm::hash_code hash_value(const test::CustomParam &param) {
 namespace mlir {
 template <>
 struct FieldParser<test::CustomParam> {
-  static FailureOr<test::CustomParam> parse(DialectAsmParser &parser) {
+  static FailureOr<test::CustomParam> parse(AsmParser &parser) {
     auto value = FieldParser<int>::parse(parser);
     if (failed(value))
       return failure();
@@ -65,8 +65,8 @@ struct FieldParser<test::CustomParam> {
 };
 } // end namespace mlir
 
-inline mlir::DialectAsmPrinter &operator<<(mlir::DialectAsmPrinter &printer,
-                                           const test::CustomParam &param) {
+inline mlir::AsmPrinter &operator<<(mlir::AsmPrinter &printer,
+                                    const test::CustomParam &param) {
   return printer << param.value;
 }
 

--- a/mlir/test/mlir-tblgen/attr-or-type-format.td
+++ b/mlir/test/mlir-tblgen/attr-or-type-format.td
@@ -34,7 +34,7 @@ def TypeParamB : TypeParameter<"TestParamD", "a type param D"> {
 
 /// Check simple attribute parser and printer are generated correctly.
 
-// ATTR: ::mlir::Attribute TestAAttr::parse(::mlir::DialectAsmParser &parser,
+// ATTR: ::mlir::Attribute TestAAttr::parse(::mlir::AsmParser &parser,
 // ATTR:                                    ::mlir::Type attrType) {
 // ATTR:   FailureOr<IntegerAttr> _result_value;
 // ATTR:   FailureOr<TestParamA> _result_complex;
@@ -57,7 +57,7 @@ def TypeParamB : TypeParameter<"TestParamD", "a type param D"> {
 // ATTR:                         _result_complex.getValue());
 // ATTR: }
 
-// ATTR: void TestAAttr::print(::mlir::DialectAsmPrinter &printer) const {
+// ATTR: void TestAAttr::print(::mlir::AsmPrinter &printer) const {
 // ATTR:   printer << "attr_a";
 // ATTR:   printer << ' ' << "hello";
 // ATTR:   printer << ' ' << "=";
@@ -81,7 +81,7 @@ def AttrA : TestAttr<"TestA"> {
 
 /// Test simple struct parser and printer are generated correctly.
 
-// ATTR: ::mlir::Attribute TestBAttr::parse(::mlir::DialectAsmParser &parser,
+// ATTR: ::mlir::Attribute TestBAttr::parse(::mlir::AsmParser &parser,
 // ATTR:                                    ::mlir::Type attrType) {
 // ATTR:   bool _seen_v0 = false;
 // ATTR:   bool _seen_v1 = false;
@@ -112,7 +112,7 @@ def AttrA : TestAttr<"TestA"> {
 // ATTR:                         _result_v1.getValue());
 // ATTR: }
 
-// ATTR: void TestBAttr::print(::mlir::DialectAsmPrinter &printer) const {
+// ATTR: void TestBAttr::print(::mlir::AsmPrinter &printer) const {
 // ATTR:   printer << "v0";
 // ATTR:   printer << ' ' << "=";
 // ATTR:   printer << ' ';
@@ -136,7 +136,7 @@ def AttrB : TestAttr<"TestB"> {
 
 /// Test attribute with capture-all params has correct parser and printer.
 
-// ATTR: ::mlir::Attribute TestFAttr::parse(::mlir::DialectAsmParser &parser,
+// ATTR: ::mlir::Attribute TestFAttr::parse(::mlir::AsmParser &parser,
 // ATTR:                                    ::mlir::Type attrType) {
 // ATTR:   ::mlir::FailureOr<int> _result_v0;
 // ATTR:   ::mlir::FailureOr<int> _result_v1;
@@ -153,7 +153,7 @@ def AttrB : TestAttr<"TestB"> {
 // ATTR:     _result_v1.getValue());
 // ATTR: }
 
-// ATTR: void TestFAttr::print(::mlir::DialectAsmPrinter &printer) const {
+// ATTR: void TestFAttr::print(::mlir::AsmPrinter &printer) const {
 // ATTR:   printer << "attr_c";
 // ATTR:   printer << ' ';
 // ATTR:   printer << getV0();
@@ -172,7 +172,7 @@ def AttrC : TestAttr<"TestF"> {
 /// Test type parser and printer that mix variables and struct are generated
 /// correctly.
 
-// TYPE: ::mlir::Type TestCType::parse(::mlir::DialectAsmParser &parser) {
+// TYPE: ::mlir::Type TestCType::parse(::mlir::AsmParser &parser) {
 // TYPE:  FailureOr<IntegerAttr> _result_value;
 // TYPE:  FailureOr<TestParamC> _result_complex;
 // TYPE:  if (parser.parseKeyword("foo"))
@@ -208,7 +208,7 @@ def AttrC : TestAttr<"TestF"> {
 // TYPE:    return {};
 // TYPE:  }
 
-// TYPE: void TestCType::print(::mlir::DialectAsmPrinter &printer) const {
+// TYPE: void TestCType::print(::mlir::AsmPrinter &printer) const {
 // TYPE:   printer << "type_c";
 // TYPE:   printer << ' ' << "foo";
 // TYPE:   printer << ",";
@@ -237,7 +237,7 @@ def TypeA : TestType<"TestC"> {
 /// Test type parser and printer with mix of variables and struct are generated
 /// correctly.
 
-// TYPE: ::mlir::Type TestDType::parse(::mlir::DialectAsmParser &parser) {
+// TYPE: ::mlir::Type TestDType::parse(::mlir::AsmParser &parser) {
 // TYPE:   _result_v0 = ::parseTypeParamC(parser);
 // TYPE:   if (failed(_result_v0))
 // TYPE:     return {};
@@ -275,7 +275,7 @@ def TypeA : TestType<"TestC"> {
 // TYPE:                         _result_v3.getValue());
 // TYPE: }
 
-// TYPE: void TestDType::print(::mlir::DialectAsmPrinter &printer) const {
+// TYPE: void TestDType::print(::mlir::AsmPrinter &printer) const {
 // TYPE:   printer << getV0();
 // TYPE:   myPrinter(getV1());
 // TYPE:   printer << ' ' << "v2";
@@ -300,7 +300,7 @@ def TypeB : TestType<"TestD"> {
 /// Type test with two struct directives has correctly generated parser and
 /// printer.
 
-// TYPE: ::mlir::Type TestEType::parse(::mlir::DialectAsmParser &parser) {
+// TYPE: ::mlir::Type TestEType::parse(::mlir::AsmParser &parser) {
 // TYPE:   FailureOr<IntegerAttr> _result_v0;
 // TYPE:   FailureOr<IntegerAttr> _result_v1;
 // TYPE:   FailureOr<IntegerAttr> _result_v2;
@@ -360,7 +360,7 @@ def TypeB : TestType<"TestD"> {
 // TYPE:     _result_v3.getValue());
 // TYPE: }
 
-// TYPE: void TestEType::print(::mlir::DialectAsmPrinter &printer) const {
+// TYPE: void TestEType::print(::mlir::AsmPrinter &printer) const {
 // TYPE:   printer << "v0";
 // TYPE:   printer << ' ' << "=";
 // TYPE:   printer << ' ';

--- a/mlir/test/mlir-tblgen/attrdefs.td
+++ b/mlir/test/mlir-tblgen/attrdefs.td
@@ -19,7 +19,7 @@ include "mlir/IR/OpBase.td"
 // DEF: ::test::SingleParameterAttr
 
 // DEF-LABEL: ::mlir::OptionalParseResult generatedAttributeParser(
-// DEF-NEXT: ::mlir::DialectAsmParser &parser,
+// DEF-NEXT: ::mlir::AsmParser &parser,
 // DEF-NEXT: ::llvm::StringRef mnemonic, ::mlir::Type type,
 // DEF-NEXT: ::mlir::Attribute &value) {
 // DEF: if (mnemonic == ::test::CompoundAAttr::getMnemonic()) {
@@ -67,8 +67,8 @@ def B_CompoundAttrA : TestAttr<"CompoundA"> {
 // DECL:   return ::llvm::StringLiteral("cmpnd_a");
 // DECL: }
 // DECL: static ::mlir::Attribute parse(
-// DECL-SAME: ::mlir::DialectAsmParser &parser, ::mlir::Type type);
-// DECL: void print(::mlir::DialectAsmPrinter &printer) const;
+// DECL-SAME: ::mlir::AsmParser &parser, ::mlir::Type type);
+// DECL: void print(::mlir::AsmPrinter &printer) const;
 // DECL: int getWidthOfSomething() const;
 // DECL: ::test::SimpleTypeA getExampleTdType() const;
 // DECL: ::llvm::APFloat getApFloat() const;
@@ -111,8 +111,8 @@ def C_IndexAttr : TestAttr<"Index"> {
 // DECL:   return ::llvm::StringLiteral("index");
 // DECL: }
 // DECL: static ::mlir::Attribute parse(
-// DECL-SAME: ::mlir::DialectAsmParser &parser, ::mlir::Type type);
-// DECL: void print(::mlir::DialectAsmPrinter &printer) const;
+// DECL-SAME: ::mlir::AsmParser &parser, ::mlir::Type type);
+// DECL: void print(::mlir::AsmPrinter &printer) const;
 }
 
 def D_SingleParameterAttr : TestAttr<"SingleParameter"> {

--- a/mlir/test/mlir-tblgen/typedefs.td
+++ b/mlir/test/mlir-tblgen/typedefs.td
@@ -7,8 +7,8 @@ include "mlir/IR/OpBase.td"
 // DECL: #undef GET_TYPEDEF_CLASSES
 
 // DECL: namespace mlir {
-// DECL: class DialectAsmParser;
-// DECL: class DialectAsmPrinter;
+// DECL: class AsmParser;
+// DECL: class AsmPrinter;
 // DECL: } // namespace mlir
 
 // DEF: #ifdef GET_TYPEDEF_LIST
@@ -20,7 +20,7 @@ include "mlir/IR/OpBase.td"
 // DEF: ::test::IntegerType
 
 // DEF-LABEL: ::mlir::OptionalParseResult generatedTypeParser(
-// DEF-NEXT: ::mlir::DialectAsmParser &parser,
+// DEF-NEXT: ::mlir::AsmParser &parser,
 // DEF-NEXT: ::llvm::StringRef mnemonic,
 // DEF-NEXT: ::mlir::Type &value) {
 // DEF: if (mnemonic == ::test::CompoundAType::getMnemonic()) {
@@ -71,8 +71,8 @@ def B_CompoundTypeA : TestType<"CompoundA"> {
 // DECL: static constexpr ::llvm::StringLiteral getMnemonic() {
 // DECL:   return ::llvm::StringLiteral("cmpnd_a");
 // DECL: }
-// DECL: static ::mlir::Type parse(::mlir::DialectAsmParser &parser);
-// DECL: void print(::mlir::DialectAsmPrinter &printer) const;
+// DECL: static ::mlir::Type parse(::mlir::AsmParser &parser);
+// DECL: void print(::mlir::AsmPrinter &printer) const;
 // DECL: int getWidthOfSomething() const;
 // DECL: ::test::SimpleTypeA getExampleTdType() const;
 // DECL: SomeCppStruct getExampleCppType() const;
@@ -90,8 +90,8 @@ def C_IndexType : TestType<"Index"> {
 // DECL: static constexpr ::llvm::StringLiteral getMnemonic() {
 // DECL:   return ::llvm::StringLiteral("index");
 // DECL: }
-// DECL: static ::mlir::Type parse(::mlir::DialectAsmParser &parser);
-// DECL: void print(::mlir::DialectAsmPrinter &printer) const;
+// DECL: static ::mlir::Type parse(::mlir::AsmParser &parser);
+// DECL: void print(::mlir::AsmPrinter &printer) const;
 }
 
 def D_SingleParameterType : TestType<"SingleParameter"> {

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -210,7 +210,9 @@ struct TypeDefGenerator : public DefGenerator {
 /// later on.
 static const char *const typeDefDeclHeader = R"(
 namespace mlir {
+class AsmParser;
 class DialectAsmParser;
+class AsmPrinter;
 class DialectAsmPrinter;
 } // namespace mlir
 )";
@@ -256,8 +258,8 @@ static const char *const defDeclParametricBeginStr = R"(
 /// {0}: The name of the base value type, e.g. Attribute or Type.
 /// {1}: Extra parser parameters.
 static const char *const defDeclParsePrintStr = R"(
-    static ::mlir::{0} parse(::mlir::DialectAsmParser &parser{1});
-    void print(::mlir::DialectAsmPrinter &printer) const;
+    static ::mlir::{0} parse(::mlir::AsmParser &parser{1});
+    void print(::mlir::AsmPrinter &printer) const;
 )";
 
 /// The code block for the verify method declaration.
@@ -495,7 +497,7 @@ void DefGenerator::emitTypeDefList(ArrayRef<AttrOrTypeDef> defs) {
 /// {1}: Additional parser parameters.
 static const char *const defParserDispatchStartStr = R"(
 static ::mlir::OptionalParseResult generated{0}Parser(
-                                      ::mlir::DialectAsmParser &parser,
+                                      ::mlir::AsmParser &parser,
                                       ::llvm::StringRef mnemonic{1},
                                       ::mlir::{0} &value) {{
 )";
@@ -505,7 +507,7 @@ static ::mlir::OptionalParseResult generated{0}Parser(
 /// {0}: The name of the base value type, e.g. Attribute or Type.
 static const char *const defPrinterDispatchStartStr = R"(
 static ::mlir::LogicalResult generated{0}Printer(
-                         ::mlir::{0} def, ::mlir::DialectAsmPrinter &printer) {{
+                         ::mlir::{0} def, ::mlir::AsmPrinter &printer) {{
   return ::llvm::TypeSwitch<::mlir::{0}, ::mlir::LogicalResult>(def)
 )";
 
@@ -740,7 +742,7 @@ void DefGenerator::emitParsePrint(const AttrOrTypeDef &def) {
     // Both the mnenomic and printerCode must be defined (for parity with
     // parserCode).
     os << "void " << def.getCppClassName()
-       << "::print(::mlir::DialectAsmPrinter &printer) const {\n";
+       << "::print(::mlir::AsmPrinter &printer) const {\n";
     if (printerCode->empty()) {
       // If no code specified, emit error.
       PrintFatalError(def.getLoc(),
@@ -759,7 +761,7 @@ void DefGenerator::emitParsePrint(const AttrOrTypeDef &def) {
 
     // The mnenomic must be defined so the dispatcher knows how to dispatch.
     os << llvm::formatv("::mlir::{0} {1}::parse("
-                        "::mlir::DialectAsmParser &parser",
+                        "::mlir::AsmParser &parser",
                         valueType, def.getCppClassName());
     if (isAttrGenerator) {
       // Attributes also accept a type parameter instead of a context.

--- a/mlir/tools/mlir-tblgen/AttrOrTypeFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeFormatGen.cpp
@@ -162,7 +162,7 @@ public:
 ///
 /// $0: The attribute C++ class name.
 static const char *const attrParserDefn = R"(
-::mlir::Attribute $0::parse(::mlir::DialectAsmParser &$_parser,
+::mlir::Attribute $0::parse(::mlir::AsmParser &$_parser,
                              ::mlir::Type $_type) {
 )";
 
@@ -170,7 +170,7 @@ static const char *const attrParserDefn = R"(
 ///
 /// $0: The type C++ class name.
 static const char *const typeParserDefn = R"(
-::mlir::Type $0::parse(::mlir::DialectAsmParser &$_parser) {
+::mlir::Type $0::parse(::mlir::AsmParser &$_parser) {
 )";
 
 /// Default parser for attribute or type parameters.
@@ -191,7 +191,7 @@ static const char *const parseErrorStr =
 /// $0: The attribute or type C++ class name.
 /// $1: The attribute or type mnemonic.
 static const char *const attrOrTypePrinterDefn = R"(
-void $0::print(::mlir::DialectAsmPrinter &$_printer) const {
+void $0::print(::mlir::AsmPrinter &$_printer) const {
   $_printer << "$1";
 )";
 


### PR DESCRIPTION
Cherry pick f97e72aaca4a7534341f67a8f93fa3246882622a from main in order to decrease the diff between `fir-dev` and `main` for `FIRType.cpp`.