### PR TITLE
Support calling assumed length dummy procedure

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -107,7 +107,10 @@ public:
     Value,
     /// ValueAttribute means dummy has the the Fortran VALUE attribute.
     BaseAddressValueAttribute,
-    CharBoxValueAttribute // BoxChar with VALUE
+    CharBoxValueAttribute, // BoxChar with VALUE
+    // Passing a character procedure as a <procedure address, result length>
+    // tuple.
+    CharProcTuple
   };
   /// Different properties of an entity that can be passed/returned.
   /// One-to-One mapping with PassEntityBy but for
@@ -117,6 +120,7 @@ public:
     BoxChar,
     CharAddress,
     CharLength,
+    CharProcTuple,
     Box,
     MutableBox,
     Value
@@ -394,6 +398,13 @@ getOrDeclareFunction(llvm::StringRef name,
 /// Return the type of an argument that is a dummy procedure.
 mlir::Type getDummyProcedureType(const Fortran::semantics::Symbol &dummyProc,
                                  Fortran::lower::AbstractConverter &);
+
+/// Is it required to pass \p proc as a tuple<function address, result length> ?
+// This is required to convey  the length of character functions passed as dummy
+// procedures.
+bool mustPassLengthWithDummyProcedure(
+    const Fortran::evaluate::ProcedureDesignator &proc,
+    Fortran::lower::AbstractConverter &);
 
 } // namespace Fortran::lower
 

--- a/flang/include/flang/Optimizer/Builder/Character.h
+++ b/flang/include/flang/Optimizer/Builder/Character.h
@@ -208,6 +208,39 @@ mlir::FuncOp getLlvmStackSave(FirOpBuilder &builder);
 /// Get the `llvm.stackrestore` intrinsic.
 mlir::FuncOp getLlvmStackRestore(FirOpBuilder &builder);
 
+//===----------------------------------------------------------------------===//
+// Tools to work with Character dummy procedures
+//===----------------------------------------------------------------------===//
+
+/// Create a tuple<function type, length type> type to pass character functions
+/// as arguments along their length. The function type set in the tuple is the
+/// one provided by \p funcPointerType.
+mlir::Type getCharacterProcedureTupleType(mlir::Type funcPointerType);
+
+/// Is this tuple type holding a character function and its result length ?
+bool isCharacterProcedureTuple(mlir::Type type);
+
+/// Is \p tuple a value holding a character function address and its result
+/// length ?
+inline bool isCharacterProcedureTuple(mlir::Value tuple) {
+  return isCharacterProcedureTuple(tuple.getType());
+}
+
+/// Create a tuple<addr, len> given \p addr and \p len as well as the tuple
+/// type \p argTy. \p addr must be any function address, and \p len must be
+/// any integer. Converts will be inserted if needed if \addr and \p len
+/// types are not the same as the one inside the tuple type \p tupleType.
+mlir::Value createCharacterProcedureTuple(fir::FirOpBuilder &builder,
+                                          mlir::Location loc,
+                                          mlir::Type tupleType,
+                                          mlir::Value addr, mlir::Value len);
+
+/// Given a tuple containing a character function address and its result length,
+/// extract the tuple into a pair of value <function address, result length>.
+std::pair<mlir::Value, mlir::Value>
+extractCharacterProcedureTuple(fir::FirOpBuilder &builder, mlir::Location loc,
+                               mlir::Value tuple);
+
 } // namespace fir::factory
 
 #endif // FORTRAN_OPTIMIZER_BUILDER_CHARACTER_H

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -77,6 +77,12 @@ static constexpr llvm::StringRef getHostAssocAttrName() {
   return "fir.host_assoc";
 }
 
+/// Attribute to mark that a function argument is a character dummy procedure.
+/// Character dummy procedure have special ABI constraints.
+static constexpr llvm::StringRef getCharacterProcedureDummyAttrName() {
+  return "fir.char_proc";
+}
+
 /// Does the function, \p func, have a host-associations tuple argument?
 /// Some internal procedures may have access to host procedure variables.
 bool hasHostAssociationArgument(mlir::FuncOp func);

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -749,3 +749,51 @@ mlir::Value fir::factory::CharacterExprHelper::getLength(mlir::Value memref) {
   // Length cannot be deduced from memref.
   return {};
 }
+
+std::pair<mlir::Value, mlir::Value>
+fir::factory::extractCharacterProcedureTuple(fir::FirOpBuilder &builder,
+                                             mlir::Location loc,
+                                             mlir::Value tuple) {
+  mlir::TupleType tupleType = tuple.getType().cast<mlir::TupleType>();
+  mlir::Value addr = builder.create<fir::ExtractValueOp>(
+      loc, tupleType.getType(0), tuple,
+      builder.getArrayAttr(
+          {builder.getIntegerAttr(builder.getIndexType(), 0)}));
+  mlir::Value len = builder.create<fir::ExtractValueOp>(
+      loc, tupleType.getType(1), tuple,
+      builder.getArrayAttr(
+          {builder.getIntegerAttr(builder.getIndexType(), 1)}));
+  return {addr, len};
+}
+
+mlir::Value fir::factory::createCharacterProcedureTuple(
+    fir::FirOpBuilder &builder, mlir::Location loc, mlir::Type argTy,
+    mlir::Value addr, mlir::Value len) {
+  mlir::TupleType tupleType = argTy.cast<mlir::TupleType>();
+  addr = builder.createConvert(loc, tupleType.getType(0), addr);
+  len = builder.createConvert(loc, tupleType.getType(1), len);
+  mlir::Value tuple = builder.create<fir::UndefOp>(loc, tupleType);
+  tuple = builder.create<fir::InsertValueOp>(
+      loc, tupleType, tuple, addr,
+      builder.getArrayAttr(
+          {builder.getIntegerAttr(builder.getIndexType(), 0)}));
+  tuple = builder.create<fir::InsertValueOp>(
+      loc, tupleType, tuple, len,
+      builder.getArrayAttr(
+          {builder.getIntegerAttr(builder.getIndexType(), 1)}));
+  return tuple;
+}
+
+bool fir::factory::isCharacterProcedureTuple(mlir::Type ty) {
+  mlir::TupleType tuple = ty.dyn_cast<mlir::TupleType>();
+  return tuple && tuple.size() == 2 &&
+         tuple.getType(0).isa<mlir::FunctionType>() &&
+         fir::isa_integer(tuple.getType(1));
+}
+
+mlir::Type
+fir::factory::getCharacterProcedureTupleType(mlir::Type funcPointerType) {
+  mlir::MLIRContext *context = funcPointerType.getContext();
+  mlir::Type lenType = mlir::IntegerType::get(context, 64);
+  return mlir::TupleType::get(context, {funcPointerType, lenType});
+}

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -7,12 +7,14 @@ add_flang_library(FIRCodeGen
   TargetRewrite.cpp
 
   DEPENDS
+  FIRBuilder
   FIRDialect
   FIRSupport
   FIROptCodeGenPassIncGen
   CGOpsIncGen
 
   LINK_LIBS
+  FIRBuilder
   FIRDialect
   FIRSupport
   MLIROpenMPToLLVM

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -17,9 +17,11 @@
 #include "PassDetail.h"
 #include "Target.h"
 #include "flang/Lower/Todo.h"
+#include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/FIRContext.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -42,7 +44,8 @@ struct FixupTy {
     ReturnAsStore,
     ReturnType,
     Split,
-    Trailing
+    Trailing,
+    TrailingCharProc
   };
 
   FixupTy(Codes code, std::size_t index, std::size_t second = 0)
@@ -174,7 +177,8 @@ public:
         auto ty = std::get<mlir::Type>(tup);
         auto index = e.index();
         auto idx = rewriter->getIntegerAttr(iTy, index);
-        auto val = rewriter->create<ExtractValueOp>(loc, ty, oper, rewriter->getArrayAttr(idx));
+        auto val = rewriter->create<ExtractValueOp>(
+            loc, ty, oper, rewriter->getArrayAttr(idx));
         newInTys.push_back(ty);
         newOpers.push_back(val);
       }
@@ -265,6 +269,41 @@ public:
           })
           .template Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
             rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
+          })
+          .template Case<mlir::TupleType>([&](mlir::TupleType tuple) {
+            if (factory::isCharacterProcedureTuple(tuple)) {
+              mlir::ModuleOp module = getModule();
+              if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
+                if (callOp.callee()) {
+                  llvm::StringRef charProcAttr =
+                      fir::getCharacterProcedureDummyAttrName();
+                  // The charProcAttr attribute is only used as a safety to
+                  // confirm that this is a dummy procedure and should be split.
+                  // It cannot be used to match because attributes are not
+                  // available in case of indirect calls.
+                  auto funcOp =
+                      module.lookupSymbol<mlir::FuncOp>(*callOp.callee());
+                  if (funcOp &&
+                      !funcOp.template getArgAttrOfType<mlir::UnitAttr>(
+                          index, charProcAttr))
+                    mlir::emitError(loc, "tuple argument will be split even "
+                                         "though it does not have the `" +
+                                             charProcAttr + "` attribute");
+                }
+              }
+              mlir::Type funcPointerType = tuple.getType(0);
+              mlir::Type lenType = tuple.getType(1);
+              FirOpBuilder builder(*rewriter, getKindMapping(module));
+              auto [funcPointer, len] =
+                  factory::extractCharacterProcedureTuple(builder, loc, oper);
+              newInTys.push_back(funcPointerType);
+              newOpers.push_back(funcPointer);
+              trailingInTys.push_back(lenType);
+              trailingOpers.push_back(len);
+            } else {
+              newInTys.push_back(tuple);
+              newOpers.push_back(oper);
+            }
           })
           .Default([&](mlir::Type ty) {
             newInTys.push_back(ty);
@@ -359,6 +398,14 @@ public:
           .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
             lowerComplexSignatureArg(ty, newInTys);
           })
+          .Case<mlir::TupleType>([&](mlir::TupleType tuple) {
+            if (factory::isCharacterProcedureTuple(tuple)) {
+              newInTys.push_back(tuple.getType(0));
+              trailingInTys.push_back(tuple.getType(1));
+            } else {
+              newInTys.push_back(ty);
+            }
+          })
           .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
     }
     // append trailing input types
@@ -395,7 +442,8 @@ public:
         return false;
       }
     for (auto ty : func.getInputs())
-      if ((ty.isa<BoxCharType>() && !noCharacterConversion) ||
+      if (((ty.isa<BoxCharType>() || factory::isCharacterProcedureTuple(ty)) &&
+           !noCharacterConversion) ||
           (isa_complex(ty) && !noComplexConversion)) {
         LLVM_DEBUG(llvm::dbgs() << "rewrite " << signature << " for target\n");
         return false;
@@ -476,6 +524,16 @@ public:
               newInTys.push_back(cmplx);
             else
               doComplexArg(func, cmplx, newInTys, fixups);
+          })
+          .Case<mlir::TupleType>([&](mlir::TupleType tuple) {
+            if (factory::isCharacterProcedureTuple(tuple)) {
+              fixups.emplace_back(FixupTy::Codes::TrailingCharProc,
+                                  newInTys.size(), trailingTys.size());
+              newInTys.push_back(tuple.getType(0));
+              trailingTys.push_back(tuple.getType(1));
+            } else {
+              newInTys.push_back(ty);
+            }
           })
           .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
     }
@@ -577,14 +635,14 @@ public:
             rewriter->setInsertionPointToStart(&func.front());
             auto cplxTy = oldArgTys[fixup.index - offset - fixup.second];
             auto undef = rewriter->create<UndefOp>(loc, cplxTy);
-	    auto iTy = rewriter->getIntegerType(32);
+            auto iTy = rewriter->getIntegerType(32);
             auto zero = rewriter->getIntegerAttr(iTy, 0);
             auto one = rewriter->getIntegerAttr(iTy, 1);
             auto cplx1 = rewriter->create<InsertValueOp>(
                 loc, cplxTy, undef, func.front().getArgument(fixup.index - 1),
                 rewriter->getArrayAttr(zero));
-            auto cplx = rewriter->create<InsertValueOp>(loc, cplxTy, cplx1,
-                                                        newArg, rewriter->getArrayAttr(one));
+            auto cplx = rewriter->create<InsertValueOp>(
+                loc, cplxTy, cplx1, newArg, rewriter->getArrayAttr(one));
             func.getArgument(fixup.index + 1).replaceAllUsesWith(cplx);
             func.front().eraseArgument(fixup.index + 1);
             offset++;
@@ -603,6 +661,22 @@ public:
           auto box =
               rewriter->create<EmboxCharOp>(loc, boxTy, newBufArg, newLenArg);
           func.getArgument(fixup.index + 1).replaceAllUsesWith(box);
+          func.front().eraseArgument(fixup.index + 1);
+        } break;
+        case FixupTy::Codes::TrailingCharProc: {
+          // The FIR character procedure argument tuple has been split into a
+          // pair of distinct arguments. The first part of the pair appears in
+          // the original argument position. The second part of the pair is
+          // appended after all the original arguments.
+          auto newProcPointerArg =
+              func.front().insertArgument(fixup.index, newInTys[fixup.index]);
+          auto newLenArg = func.front().addArgument(trailingTys[fixup.second]);
+          auto tupleType = oldArgTys[fixup.index - offset];
+          rewriter->setInsertionPointToStart(&func.front());
+          FirOpBuilder builder(*rewriter, getKindMapping(getModule()));
+          auto tuple = factory::createCharacterProcedureTuple(
+              builder, loc, tupleType, newProcPointerArg, newLenArg);
+          func.getArgument(fixup.index + 1).replaceAllUsesWith(tuple);
           func.front().eraseArgument(fixup.index + 1);
         } break;
         }

--- a/flang/test/Fir/target-rewrite-char-proc.fir
+++ b/flang/test/Fir/target-rewrite-char-proc.fir
@@ -1,0 +1,69 @@
+// Test rewrite of character procedure pointer tuple argument to two different
+// arguments: one for the function address, and one for the length. The length
+// argument is added after other characters.
+// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+
+// CHECK:  func private @takes_char_proc(() -> () {fir.char_proc}, i64)
+func private @takes_char_proc(tuple<() -> (), i64> {fir.char_proc})
+
+func private @takes_char(!fir.boxchar<1>)
+func private @char_proc(!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
+
+func @_QPcst_len() {
+  %0 = fir.address_of(@char_proc) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
+  %c7_i64 = arith.constant 7 : i64
+  %1 = fir.convert %0 : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
+  %2 = fir.undefined tuple<() -> (), i64>
+  %3 = fir.insert_value %2, %1, [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+  %4 = fir.insert_value %3, %c7_i64, [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+
+  // CHECK:  %[[PROC_ADDR:.*]] = fir.extract_value %{{.*}}, [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+  // CHECK:  %[[LEN:.*]] = fir.extract_value %{{.*}}, [1 : index] : (tuple<() -> (), i64>) -> i64
+  // CHECK:  fir.call @takes_char_proc(%[[PROC_ADDR]], %[[LEN]]) : (() -> (), i64) -> ()
+  fir.call @takes_char_proc(%4) : (tuple<() -> (), i64>) -> ()
+  return
+}
+
+// CHECK:  func @test_dummy_proc_that_takes_dummy_char_proc(
+// CHECK-SAME: %[[ARG0:.*]]: () -> ()) {
+func @test_dummy_proc_that_takes_dummy_char_proc(%arg0: () -> ()) {
+  %0 = fir.address_of(@char_proc) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
+  %c7_i64 = arith.constant 7 : i64
+  %1 = fir.convert %0 : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
+  %2 = fir.undefined tuple<() -> (), i64>
+  %3 = fir.insert_value %2, %1, [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+  %4 = fir.insert_value %3, %c7_i64, [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+  %5 = fir.convert %arg0 : (() -> ()) -> ((tuple<() -> (), i64>) -> ())
+
+  // CHECK:  %[[ARG_CAST:.*]] = fir.convert %[[ARG0]] : (() -> ()) -> ((() -> (), i64) -> ())
+  // CHECK:  %[[PROC_ADDR:.*]] = fir.extract_value %4, [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+  // CHECK:  %[[PROC_LEN:.*]] = fir.extract_value %4, [1 : index] : (tuple<() -> (), i64>) -> i64
+  // CHECK: fir.call %[[ARG_CAST]](%[[PROC_ADDR]], %[[PROC_LEN]]) : (() -> (), i64) -> ()
+  fir.call %5(%4) : (tuple<() -> (), i64>) -> ()
+  return
+}
+
+// CHECK:  func @takes_dummy_char_proc_impl(
+// CHECK-SAME: %[[PROC_ADDR:.*]]: () -> () {fir.char_proc},
+// CHECK-SAME: %[[C_ADDR:.*]]: !fir.ref<!fir.char<1,?>>,
+// CHECK-SAME: %[[PROC_LEN:.*]]: i64,
+// CHECK-SAME: %[[C_LEN:.*]]: i64) {
+func @takes_dummy_char_proc_impl(%arg0: tuple<() -> (), i64> {fir.char_proc}, %arg1: !fir.boxchar<1>) {
+  // CHECK:    %[[UNDEF:.*]] = fir.undefined tuple<() -> (), i64>
+  // CHECK:    %[[TUPLE0:.*]] = fir.insert_value %[[UNDEF]], %[[PROC_ADDR]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+  // CHECK:    %[[TUPLE1:.*]] = fir.insert_value %[[TUPLE0]], %[[PROC_LEN]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+  %0 = fir.alloca !fir.char<1,7> {bindc_name = ".result"}
+  %1:2 = fir.unboxchar %arg1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  %c5 = arith.constant 5 : index
+  %2 = fir.emboxchar %1#0, %c5 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  %3 = fir.extract_value %arg0, [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+  %c7_i64 = arith.constant 7 : i64
+  %4 = fir.convert %c7_i64 : (i64) -> index
+  %6 = fir.convert %3 : (() -> ()) -> ((!fir.ref<!fir.char<1,7>>, index, !fir.boxchar<1>) -> !fir.boxchar<1>)
+  %7 = fir.call %6(%0, %4, %2) : (!fir.ref<!fir.char<1,7>>, index, !fir.boxchar<1>) -> !fir.boxchar<1>
+  %8 = fir.convert %0 : (!fir.ref<!fir.char<1,7>>) -> !fir.ref<!fir.char<1,?>>
+  %9 = fir.emboxchar %8, %4 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  fir.call @takes_char(%9) : (!fir.boxchar<1>) -> ()
+  return
+}
+

--- a/flang/test/Lower/dummy-procedure-character.f90
+++ b/flang/test/Lower/dummy-procedure-character.f90
@@ -1,0 +1,190 @@
+! Test lowering of character function dummy procedure. The length must be
+! passed along the function address.
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! -----------------------------------------------------------------------------
+!     Test passing a character function as dummy procedure
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPcst_len
+subroutine cst_len()
+  interface
+    character(7) function bar1()
+    end function
+  end interface
+  call foo1(bar1)
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar1) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
+! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo1(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_len_array
+subroutine cst_len_array()
+  interface
+    function bar1_array()
+      character(7) :: bar1_array(10)
+    end function
+  end interface
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar1_array) : () -> !fir.array<10x!fir.char<1,7>>
+! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : (() -> !fir.array<10x!fir.char<1,7>>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo1b(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+  call foo1b(bar1_array)
+end subroutine
+
+! CHECK-LABEL: func @_QPcst_len_2
+subroutine cst_len_2()
+  character(7) :: bar2
+  external :: bar2
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar2) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
+! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo2(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+  call foo2(bar2)
+end subroutine
+
+! CHECK-LABEL: func @_QPdyn_len
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32>) {
+subroutine dyn_len(n)
+  integer :: n
+  character(n) :: bar3
+  external :: bar3
+! CHECK:  %[[VAL_1:.*]] = fir.address_of(@_QPbar3) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:  %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (i32) -> i64
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_5:.*]] = arith.cmpi sgt, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:  %[[VAL_6:.*]] = select %[[VAL_5]], %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_1]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_8:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_9:.*]] = fir.insert_value %[[VAL_8]], %[[VAL_7]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_6]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo3(%[[VAL_10]]) : (tuple<() -> (), i64>) -> ()
+  call foo3(bar3)
+end subroutine
+
+! CHECK-LABEL: func @_QPcannot_compute_len_yet
+subroutine cannot_compute_len_yet()
+  interface
+    function bar4(n)
+      integer :: n
+      character(n) :: bar4
+    end function
+  end interface
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar4) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK:  %[[VAL_1:.*]] = arith.constant -1 : index
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (index) -> i64
+! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo4(%[[VAL_6]]) : (tuple<() -> (), i64>) -> ()
+  call foo4(bar4)
+end subroutine
+
+! CHECK-LABEL: func @_QPcannot_compute_len_yet_2
+subroutine cannot_compute_len_yet_2()
+  character(*) :: bar5
+  external :: bar5
+! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar5) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:  %[[VAL_1:.*]] = arith.constant -1 : index
+! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (index) -> i64
+! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo5(%[[VAL_6]]) : (tuple<() -> (), i64>) -> ()
+  call foo5(bar5)
+end subroutine
+
+! CHECK-LABEL: func @_QPforward_incoming_length
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+subroutine forward_incoming_length(bar6)
+  character(*) :: bar6
+  external :: bar6
+! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_2:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<() -> (), i64>) -> i64
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_1]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo6(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+  call foo6(bar6)
+end subroutine
+
+! CHECK-LABEL: func @_QPoverride_incoming_length
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+subroutine override_incoming_length(bar7)
+  character(7) :: bar7
+  external :: bar7
+! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_2:.*]] = arith.constant 7 : i64
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_1]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
+! CHECK:  fir.call @_QPfoo7(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+  call foo7(bar7)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test calling character dummy function
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPcall_assumed_length
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+subroutine call_assumed_length(bar8)
+  character(*) :: bar8
+  external :: bar8
+! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<() -> (), i64>) -> i64
+! CHECK:  %[[VAL_6:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_4]] : i64) {bindc_name = ".result"}
+! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_3]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:  fir.call %[[VAL_7]](%[[VAL_6]], %[[VAL_8]], %{{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+  call test(bar8(42))
+end subroutine
+
+! CHECK-LABEL: func @_QPcall_explicit_length
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+subroutine call_explicit_length(bar9)
+  character(7) :: bar9
+  external :: bar9
+! CHECK:  %[[VAL_1:.*]] = fir.alloca !fir.char<1,7> {bindc_name = ".result"}
+! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_5:.*]] = arith.constant 7 : i64
+! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i64) -> index
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_4]] : (() -> ()) -> ((!fir.ref<!fir.char<1,7>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
+! CHECK:  fir.call %[[VAL_8]](%[[VAL_1]], %[[VAL_6]], %{{.*}}) : (!fir.ref<!fir.char<1,7>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+  call test(bar9(42))
+end subroutine
+
+! CHECK-LABEL: func @_QPcall_explicit_length_with_iface
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+subroutine call_explicit_length_with_iface(bar10)
+  interface
+    function bar10(n)
+      integer(8) :: n
+      character(n) :: bar10
+    end function
+  end interface
+! CHECK:  %[[VAL_1:.*]] = fir.alloca i64
+! CHECK:  %[[VAL_2:.*]] = arith.constant 42 : i64
+! CHECK:  fir.store %[[VAL_2]] to %[[VAL_1]] : !fir.ref<i64>
+! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:  %[[VAL_6:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_5]] : index) {bindc_name = ".result"}
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_3]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i64>) -> !fir.boxchar<1>)
+! CHECK:  fir.call %[[VAL_8]](%[[VAL_7]], %[[VAL_5]], %[[VAL_1]]) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i64>) -> !fir.boxchar<1>
+  call test(bar10(42_8))
+end subroutine

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -80,12 +80,12 @@ entry rr(n2)
   rr = rr + n2
 end
 
-! CHECK-LABEL: func @_QPhh(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPhh(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
 function hh(c1)
   character(10) c1, hh, qq
   hh = c1
   return
-! CHECK-LABEL: func @_QPqq(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPqq(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
 entry qq(c1)
   qq = c1
 end

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
 function char_return_callee(i)
   character(10) :: char_return_callee
   integer :: i
@@ -9,7 +9,7 @@ end function
 ! CHECK-LABEL: @_QPtest_char_return_caller()
 subroutine test_char_return_caller
   character(10) :: char_return_caller
-  ! CHECK: fir.call @_QPchar_return_caller({{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+  ! CHECK: fir.call @_QPchar_return_caller({{.*}}) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   print *, char_return_caller(5)
 end subroutine
 

--- a/flang/test/Lower/intrinsic-procedures/maxval.f90
+++ b/flang/test/Lower/intrinsic-procedures/maxval.f90
@@ -14,7 +14,7 @@ integer function maxval_test(a)
 end function
 
 ! CHECK-LABEL: maxval_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1,?>>,
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>,
 ! CHECK-SAME: %[[arg1:.*]]: index,
 ! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.boxchar<1>
 character function maxval_test2(a)

--- a/flang/test/Lower/intrinsic-procedures/merge.f90
+++ b/flang/test/Lower/intrinsic-procedures/merge.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: merge_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1,?>>, 
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>, 
 ! CHECK-SAME: %[[arg1:.*]]: index, 
 ! CHECK-SAME: %[[arg2:[^:]+]]: !fir.boxchar<1>, 
 ! CHECK-SAME: %[[arg3:[^:]+]]: !fir.boxchar<1>, 

--- a/flang/test/Lower/intrinsic-procedures/minval.f90
+++ b/flang/test/Lower/intrinsic-procedures/minval.f90
@@ -14,7 +14,7 @@ integer function minval_test(a)
 end function
 
 ! CHECK-LABEL: minval_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1,?>>,
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>,
 ! CHECK-SAME: %[[arg1:.*]]: index,
 ! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.boxchar<1>
 character function minval_test2(a)


### PR DESCRIPTION
Lowering was not able to compile the following kind of program:

```
subroutine foo(bar)
 character*(*) :: bar
 print *, bar()
end subroutine

character(10) function bar()
  bar = "abcdefghijkl"
end function

program test
  character(10) :: bar
  external :: bar
  call foo(bar)
end
```

This resulted in error `missing length for character`.

To support this kind of program, pass the result character dummy procedure as
character dummy objects: with its length. This matches nvfortran, ifort,
nag and xlf behavior (but not gfortran that does not support the above
code).

This is done by using fir.boxchar. The rational for using it instead of
manually mangling the length argument is that in call like
`foo(c1, bar, c2)` with `c1` and `c2` F77 like characters, the result
length of `bar` must be placed between the one of `c1` and `c2` after
all other arguments. fir.boxchar guarantees exactly that.

Three places are impacted:
- The function interface lowering (mustPassDummyProcedureAsBoxChar is
the central place that can completly disable this feature On and Off).
- When placing a call to a dummy procedure, use the fir.boxchar length
as a last resort if present in the interface.
- When passing a procedure designator, forward the length for character
function based on mustPassDummyProcedureAsBoxChar.