### PR TITLE
In a forall context, a pass is made to isolate all the base arrays in

### DIFF
--- a/flang/include/flang/Lower/ComponentPath.h
+++ b/flang/include/flang/Lower/ComponentPath.h
@@ -61,6 +61,8 @@ private:
   void setPC(bool isImplicit);
 };
 
+/// Examine each subscript expression of \p x and return true if and only if any
+/// of the subscripts is a vector or has a rank greater than 0.
 bool isRankedArrayAccess(const Fortran::evaluate::ArrayRef &x);
 
 } // namespace Fortran::lower

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -3993,33 +3993,25 @@ private:
   // Expression traversal and lowering.
   //===--------------------------------------------------------------------===//
 
-  // Lower the expression in a scalar context.
+  /// Lower the expression, \p x, in a scalar context.
   template <typename A>
   ExtValue asScalar(const A &x) {
     return ScalarExprLowering{getLoc(), converter, symMap, stmtCtx}.genval(x);
   }
+
+  /// Lower the expression, \p x, in a scalar context. If this is an explicit
+  /// space, the expression may be scalar and refer to an array. We want to
+  /// raise the array access to array operations in FIR to analyze potential
+  /// conflicts even when the result is a scalar element.
   template <typename A>
   ExtValue asScalarArray(const A &x) {
-    assert(explicitSpace);
-    return genarr(x)(IterationSpace{});
+    return explicitSpaceIsActive() ? genarr(x)(IterationSpace{}) : asScalar(x);
   }
 
   /// Lower the expression in a scalar context to a memory reference.
   template <typename A>
   ExtValue asScalarRef(const A &x) {
     return ScalarExprLowering{getLoc(), converter, symMap, stmtCtx}.gen(x);
-  }
-  template <typename A>
-  ExtValue asScalarArrayRef(const A &x) {
-    assert(explicitSpace);
-    PushSemantics(ConstituentSemantics::RefOpaque);
-    return genarr(x)(IterationSpace{});
-  }
-  template <typename A>
-  ExtValue asScalarArrayRef(const A &x, ComponentPath &components) {
-    assert(explicitSpace);
-    PushSemantics(ConstituentSemantics::RefOpaque);
-    return genarr(x, components)(IterationSpace{});
   }
 
   // An expression with non-zero rank is an array expression.
@@ -5844,7 +5836,7 @@ private:
                               // Lower scalar index expression, append it to
                               // subs.
                               mlir::Value subscriptVal =
-                                  fir::getBase(asScalar(e));
+                                  fir::getBase(asScalarArray(e));
                               // arrayExv is the base array. It needs to reflect
                               // the current array component instead.
                               // FIXME: must use lower bound of this component,

--- a/flang/test/Lower/forall/array-subscripts.f90
+++ b/flang/test/Lower/forall/array-subscripts.f90
@@ -1,0 +1,21 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+  ! Make sure we use array values for subscripts that are arrays on the lhs so
+  ! that copy-in/copy-out works correctly.
+  integer :: a(4,4)
+  forall(i=1:4,j=1:4)
+    a(a(i,j),a(j,i)) = j - i*100
+  end forall
+end
+
+! CHECK-LABEL: func @_QQmain
+! CHECK: %[[a:.*]] = fir.address_of(@_QFEa) : !fir.ref<!fir.array<4x4xi32>>
+! CHECK: %[[a1:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<4x4xi32>>, !fir.shape<2>) -> !fir.array<4x4xi32>
+! CHECK: %[[a2:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<4x4xi32>>, !fir.shape<2>) -> !fir.array<4x4xi32>
+! CHECK: %[[a3:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<4x4xi32>>, !fir.shape<2>) -> !fir.array<4x4xi32>
+! CHECK: %[[av:.*]] = fir.do_loop
+! CHECK: fir.do_loop
+! CHECK: = fir.array_fetch %[[a2]], %{{.*}}, %{{.*}} : (!fir.array<4x4xi32>, index, index) -> i32
+! CHECK: = fir.array_fetch %[[a3]], %{{.*}}, %{{.*}} : (!fir.array<4x4xi32>, index, index) -> i32
+! CHECK: = fir.array_update %{{.*}}, %{{.*}}, %{{.*}} : (!fir.array<4x4xi32>, i32, index, index) -> !fir.array<4x4xi32>
+! CHECK : fir.array_merge_store %[[a1]], %[[av]] to %[[a]] : !fir.array<4x4xi32>, !fir.array<4x4xi32>, !fir.ref<!fir.array<4x4xi32>>

--- a/flang/test/Lower/forall/forall-array.f90
+++ b/flang/test/Lower/forall/forall-array.f90
@@ -44,8 +44,8 @@ end subroutine test_forall_with_array_assignment
 ! CHECK:           %[[VAL_25:.*]] = arith.constant 64 : i64
 ! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i64) -> index
 ! CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-! CHECK:           %[[VAL_29:.*]] = arith.constant 1 : i32
+! CHECK-DAG:       %[[VAL_28:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK-DAG:       %[[VAL_29:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_28]], %[[VAL_29]] : i32
 ! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (i32) -> i64
 ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_31]] : (i64) -> index

--- a/flang/test/Lower/forall/forall-construct-2.f90
+++ b/flang/test/Lower/forall/forall-construct-2.f90
@@ -54,8 +54,8 @@ end subroutine test2_forall_construct
 ! CHECK:             %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (i64) -> index
 ! CHECK:             %[[VAL_42:.*]] = arith.subi %[[VAL_41]], %[[VAL_34]] : index
 ! CHECK:             %[[VAL_43:.*]] = arith.constant 1 : index
-! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-! CHECK:             %[[VAL_45:.*]] = arith.constant 1 : i32
+! CHECK-DAG:         %[[VAL_44:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
+! CHECK-DAG:         %[[VAL_45:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_46:.*]] = arith.addi %[[VAL_44]], %[[VAL_45]] : i32
 ! CHECK:             %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i32) -> i64
 ! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i64) -> index

--- a/flang/test/Lower/forall/forall-construct-3.f90
+++ b/flang/test/Lower/forall/forall-construct-3.f90
@@ -68,8 +68,8 @@ end subroutine test3_forall_construct
 ! CHECK:               %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (i64) -> index
 ! CHECK:               %[[VAL_55:.*]] = arith.subi %[[VAL_54]], %[[VAL_47]] : index
 ! CHECK:               %[[VAL_56:.*]] = arith.constant 1 : index
-! CHECK:               %[[VAL_57:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
-! CHECK:               %[[VAL_58:.*]] = arith.constant 1 : i32
+! CHECK-DAG:           %[[VAL_57:.*]] = fir.load %[[VAL_6]] : !fir.ref<i32>
+! CHECK-DAG:           %[[VAL_58:.*]] = arith.constant 1 : i32
 ! CHECK:               %[[VAL_59:.*]] = arith.addi %[[VAL_57]], %[[VAL_58]] : i32
 ! CHECK:               %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (i32) -> i64
 ! CHECK:               %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (i64) -> index

--- a/flang/test/Lower/forall/forall-ranked.f90
+++ b/flang/test/Lower/forall/forall-ranked.f90
@@ -34,8 +34,8 @@
 ! CHECK:           %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_26]] : index
 ! CHECK:           %[[VAL_31:.*]] = select %[[VAL_30]], %[[VAL_29]], %[[VAL_26]] : index
 ! CHECK:           %[[VAL_32:.*]] = fir.field_index arr, !fir.type<_QFtest_forall_with_ranked_dimensionTt{arr:!fir.array<11xi32>}>
-! CHECK:           %[[VAL_33:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:           %[[VAL_34:.*]] = arith.constant 4 : i32
+! CHECK-DAG:       %[[VAL_33:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK-DAG:       %[[VAL_34:.*]] = arith.constant 4 : i32
 ! CHECK:           %[[VAL_35:.*]] = arith.addi %[[VAL_33]], %[[VAL_34]] : i32
 ! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_35]] : (i32) -> i64
 ! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i64) -> index

--- a/flang/test/Lower/forall/test9.f90
+++ b/flang/test/Lower/forall/test9.f90
@@ -54,8 +54,8 @@ end subroutine test9
 ! CHECK:           %[[VAL_38:.*]] = fir.array_fetch %[[VAL_22]], %[[VAL_36]] : (!fir.array<?xf32>, index) -> f32
 ! CHECK:           %[[VAL_39:.*]] = arith.addf %[[VAL_37]], %[[VAL_38]] : f32
 ! CHECK:           %[[VAL_40:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_41:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
-! CHECK:           %[[VAL_42:.*]] = arith.constant 1 : i32
+! CHECK-DAG:       %[[VAL_41:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK-DAG:       %[[VAL_42:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_43:.*]] = arith.addi %[[VAL_41]], %[[VAL_42]] : i32
 ! CHECK:           %[[VAL_44:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
 ! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i64) -> index


### PR DESCRIPTION
the assignment expression. This pass was skipping arrays that appeared
in array indexing expression positions. Normally, this omission was not
consequential, but in some cases it meant that array copies might be
missed when needed. This patch adds the scanning of array index
expressions to the pass.

Add a regression test.
