### PR TITLE
Fixed erring semantic errors arising from D108904

### DIFF
--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -66,8 +66,14 @@ public:
       switch ((llvm::omp::Directive)currentDirective_) {
       // exclude directives which do not need a check for unlabelled CYCLES
       case llvm::omp::Directive::OMPD_do:
-        return;
       case llvm::omp::Directive::OMPD_simd:
+      case llvm::omp::Directive::OMPD_parallel_do:
+      case llvm::omp::Directive::OMPD_parallel_do_simd:
+      case llvm::omp::Directive::OMPD_distribute_parallel_do:
+      case llvm::omp::Directive::OMPD_distribute_parallel_do_simd:
+      case llvm::omp::Directive::OMPD_distribute_parallel_for:
+      case llvm::omp::Directive::OMPD_distribute_simd:
+      case llvm::omp::Directive::OMPD_distribute_parallel_for_simd:
         return;
       default:
         break;

--- a/flang/test/Semantics/omp-do05.f90
+++ b/flang/test/Semantics/omp-do05.f90
@@ -9,6 +9,9 @@ program omp_do
   integer i,j,k
   !$omp do
   do i=1,10
+    if( i == 5 ) then
+        cycle
+    end if
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single
     do j=1,10
@@ -20,6 +23,8 @@ program omp_do
 
   !$omp parallel do
   do i=1,10
+    if( i == 9 ) then
+    end if
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single
     do j=1,10
@@ -31,6 +36,9 @@ program omp_do
 
   !$omp parallel do simd
   do i=1,10
+    if( i == 5 ) then
+        cycle
+    end if
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single
@@ -44,6 +52,9 @@ program omp_do
   !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
   !$omp distribute parallel do
   do i=1,10
+    if( i == 3 ) then
+        cycle
+    end if
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single
     do j=1,10
@@ -56,6 +67,9 @@ program omp_do
   !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.
   !$omp distribute parallel do simd
   do i=1,10
+    if( i == 3 ) then
+        cycle
+    end if
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single


### PR DESCRIPTION
Cherry-picking an upstream OpenMP patch. This enables writing some tests for https://github.com/flang-compiler/f18-llvm-project/pull/1394. Creating this as a separate PR as per @vdonaldson's suggestion in https://github.com/flang-compiler/f18-llvm-project/pull/1394.

commit [9faed88](https://github.com/flang-compiler/f18-llvm-project/commit/9faed889cfebf5d77faf1fab1ef8f0a2f0255e5c)
Author: Nimish Mishra neelam.nimish@gmail.com
Date: Sat Oct 30 03:39:09 2021 +0530
Fixed erring semantic errors arising from D108904