### PR TITLE
Traversal of an expression can cause subexpressions to be copied onto

### DIFF
--- a/flang/include/flang/Evaluate/variable.h
+++ b/flang/include/flang/Evaluate/variable.h
@@ -160,10 +160,17 @@ public:
       std::optional<Expr<SubscriptInteger>> &&);
 
   std::optional<Expr<SubscriptInteger>> lower() const;
+  const Expr<SubscriptInteger> *GetLower() const {
+    return lower_.has_value() ? &lower_->value() : nullptr;
+  }
   Triplet &set_lower(Expr<SubscriptInteger> &&);
   std::optional<Expr<SubscriptInteger>> upper() const;
+  const Expr<SubscriptInteger> *GetUpper() const {
+    return upper_.has_value() ? &upper_->value() : nullptr;
+  }
   Triplet &set_upper(Expr<SubscriptInteger> &&);
   Expr<SubscriptInteger> stride() const; // N.B. result is not optional<>
+  const Expr<SubscriptInteger> &GetStride() const { return stride_.value(); }
   Triplet &set_stride(Expr<SubscriptInteger> &&);
 
   bool operator==(const Triplet &) const;

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -6526,7 +6526,7 @@ void Fortran::lower::createArrayLoads(
     esp.resetInnerArgs();
     esp.bindLoad(base, load);
   }
-  for (auto &base : esp.rhsBases[counter])
+  for (const auto &base : esp.rhsBases[counter])
     esp.bindLoad(base, std::visit(genLoad, base));
 }
 

--- a/flang/lib/Lower/IterationSpace.cpp
+++ b/flang/lib/Lower/IterationSpace.cpp
@@ -648,11 +648,11 @@ private:
     return found;
   }
   RT find(const Fortran::evaluate::Triplet &x) {
-    if (x.lower().has_value())
-      (void)find(*x.lower());
-    if (x.upper().has_value())
-      (void)find(*x.upper());
-    return find(x.stride());
+    if (const auto *lower = x.GetLower())
+      (void)find(*lower);
+    if (const auto *upper = x.GetUpper())
+      (void)find(*upper);
+    return find(x.GetStride());
   }
   RT find(const Fortran::evaluate::IndirectSubscriptIntegerExpr &x) {
     return find(x.value());


### PR DESCRIPTION
the stack unexpectedly. This breaks assumptions about constant iterators
over Expr trees. Add methods that skip making copies and use references
to the data in memory.