### PR TITLE
[flang] Implement checking for DIM arguments for LBOUND and SIZE

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Inquiry.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Inquiry.h
@@ -1,0 +1,40 @@
+//===-- Inquiry.h - generate inquiry runtime API calls ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_BUILDER_RUNTIME_INQUIRY_H
+#define FORTRAN_OPTIMIZER_BUILDER_RUNTIME_INQUIRY_H
+
+namespace mlir {
+class Value;
+class Location;
+} // namespace mlir
+
+namespace fir {
+class FirOpBuilder;
+}
+
+namespace fir::runtime {
+
+/// Generate call to general `LboundDim` runtime routine.  Calls to LBOUND
+/// without a DIM argument get transformed into descriptor inquiries so they're
+/// not handled in the runtime.
+mlir::Value genLboundDim(fir::FirOpBuilder &builder, mlir::Location loc,
+                         mlir::Value array, mlir::Value dim);
+
+/// Generate call to `Size` runtime routine. This routine is a specialized
+/// version when the DIM argument is not specified by the user.
+mlir::Value genSize(fir::FirOpBuilder &builder, mlir::Location loc,
+                    mlir::Value array);
+
+/// Generate call to general `SizeDim` runtime routine.  This version is for
+/// when the user specifies a DIM argument.
+mlir::Value genSizeDim(fir::FirOpBuilder &builder, mlir::Location loc,
+                       mlir::Value array, mlir::Value dim);
+
+} // namespace fir::runtime
+#endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_INQUIRY_H

--- a/flang/include/flang/Runtime/inquiry.h
+++ b/flang/include/flang/Runtime/inquiry.h
@@ -1,0 +1,33 @@
+//===-- include/flang/Runtime/inquiry.h ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Defines the API for the inquiry intrinsic functions
+// that inquire about shape information in arrays: LBOUND and SIZE.
+
+#ifndef FORTRAN_RUNTIME_INQUIRY_H_
+#define FORTRAN_RUNTIME_INQUIRY_H_
+
+#include "flang/Runtime/entry-names.h"
+#include <cinttypes>
+
+namespace Fortran::runtime {
+
+class Descriptor;
+
+extern "C" {
+
+std::int64_t RTNAME(LboundDim)(const Descriptor &array, int dim,
+    const char *sourceFile = nullptr, int line = 0);
+std::int64_t RTNAME(Size)(
+    const Descriptor &array, const char *sourceFile = nullptr, int line = 0);
+std::int64_t RTNAME(SizeDim)(const Descriptor &array, int dim,
+    const char *sourceFile = nullptr, int line = 0);
+
+} // extern "C"
+} // namespace Fortran::runtime
+#endif // FORTRAN_RUNTIME_INQUIRY_H_

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -11,6 +11,7 @@ add_flang_library(FIRBuilder
   Runtime/Character.cpp
   Runtime/Command.cpp
   Runtime/Derived.cpp
+  Runtime/Inquiry.cpp
   Runtime/Numeric.cpp
   Runtime/Ragged.cpp
   Runtime/Reduction.cpp

--- a/flang/lib/Optimizer/Builder/Runtime/Inquiry.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Inquiry.cpp
@@ -1,0 +1,60 @@
+//===-- Inquiry.h - generate inquiry runtime API calls ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/Runtime/Inquiry.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
+#include "flang/Runtime/inquiry.h"
+
+using namespace Fortran::runtime;
+
+/// Generate call to `Lbound` runtime routine when the DIM argument is present.
+mlir::Value fir::runtime::genLboundDim(fir::FirOpBuilder &builder,
+                                       mlir::Location loc, mlir::Value array,
+                                       mlir::Value dim) {
+  mlir::FuncOp lboundFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(LboundDim)>(loc, builder);
+  auto fTy = lboundFunc.getType();
+  auto sourceFile = fir::factory::locationToFilename(builder, loc);
+  auto sourceLine =
+      fir::factory::locationToLineNo(builder, loc, fTy.getInput(3));
+  auto args = fir::runtime::createArguments(builder, loc, fTy, array, dim,
+                                            sourceFile, sourceLine);
+  return builder.create<fir::CallOp>(loc, lboundFunc, args).getResult(0);
+}
+
+/// Generate call to `Size` runtime routine. This routine is a version when
+/// the DIM argument is present.
+mlir::Value fir::runtime::genSizeDim(fir::FirOpBuilder &builder,
+                                     mlir::Location loc, mlir::Value array,
+                                     mlir::Value dim) {
+  mlir::FuncOp sizeFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(SizeDim)>(loc, builder);
+  auto fTy = sizeFunc.getType();
+  auto sourceFile = fir::factory::locationToFilename(builder, loc);
+  auto sourceLine =
+      fir::factory::locationToLineNo(builder, loc, fTy.getInput(3));
+  auto args = fir::runtime::createArguments(builder, loc, fTy, array, dim,
+                                            sourceFile, sourceLine);
+  return builder.create<fir::CallOp>(loc, sizeFunc, args).getResult(0);
+}
+
+/// Generate call to `Size` runtime routine. This routine is a version when
+/// the DIM argument is absent.
+mlir::Value fir::runtime::genSize(fir::FirOpBuilder &builder,
+                                  mlir::Location loc, mlir::Value array) {
+  mlir::FuncOp sizeFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(Size)>(loc, builder);
+  auto fTy = sizeFunc.getType();
+  auto sourceFile = fir::factory::locationToFilename(builder, loc);
+  auto sourceLine =
+      fir::factory::locationToLineNo(builder, loc, fTy.getInput(2));
+  auto args = fir::runtime::createArguments(builder, loc, fTy, array,
+                                            sourceFile, sourceLine);
+  return builder.create<fir::CallOp>(loc, sizeFunc, args).getResult(0);
+}

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ add_flang_library(FortranRuntime PARTIAL_SOURCES_INTENDED
   file.cpp
   findloc.cpp
   format.cpp
+  inquiry.cpp
   internal-unit.cpp
   iostat.cpp
   io-api.cpp

--- a/flang/runtime/inquiry.cpp
+++ b/flang/runtime/inquiry.cpp
@@ -1,0 +1,54 @@
+//===-- runtime/inquiry.cpp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Implements the inquiry intrinsic functions of Fortran 2018 that
+// inquire about shape information of arrays -- LBOUND and SIZE.
+
+#include "flang/Runtime/inquiry.h"
+#include "copy.h"
+#include "terminator.h"
+#include "tools.h"
+#include "flang/Runtime/descriptor.h"
+#include <algorithm>
+#include <stdio.h>
+
+namespace Fortran::runtime {
+
+extern "C" {
+std::int64_t RTNAME(LboundDim)(
+    const Descriptor &array, int dim, const char *sourceFile, int line) {
+  if (dim < 1 || dim > array.rank()) {
+    Terminator terminator{sourceFile, line};
+    terminator.Crash("SIZE: bad DIM=%d", dim);
+  }
+  const Dimension &dimension{array.GetDimension(dim - 1)};
+  return static_cast<std::int64_t>(dimension.LowerBound());
+}
+
+std::int64_t RTNAME(Size)(
+    const Descriptor &array, const char *sourceFile, int line) {
+  SubscriptValue result{1};
+  for (int i = 0; i < array.rank(); ++i) {
+    const Dimension &dimension{array.GetDimension(i)};
+    result *= dimension.Extent();
+  }
+  return result;
+}
+
+std::int64_t RTNAME(SizeDim)(
+    const Descriptor &array, int dim, const char *sourceFile, int line) {
+  if (dim < 1 || dim > array.rank()) {
+    Terminator terminator{sourceFile, line};
+    terminator.Crash("SIZE: bad DIM=%d", dim);
+  }
+  const Dimension &dimension{array.GetDimension(dim - 1)};
+  return static_cast<std::int64_t>(dimension.Extent());
+}
+
+} // extern "C"
+} // namespace Fortran::runtime

--- a/flang/test/Lower/intrinsic-procedures/lbound.f90
+++ b/flang/test/Lower/intrinsic-procedures/lbound.f90
@@ -2,63 +2,52 @@
 
 
 ! CHECK-LABEL: func @_QPlbound_test(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
+! CHECK:  %[[VAL_0:.*]] = fir.load %arg1 : !fir.ref<i64>
+! CHECK:  %[[VAL_1:.*]] = fir.rebox %arg0 : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>>
 subroutine lbound_test(a, dim, res)
   real, dimension(:, :) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i64
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:         %[[VAL_2:.*]] = fir.address_of(
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_0]] : (i64) -> i32
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_2]]
+! CHECK:         %[[VAL_6:.*]] = fir.call @_FortranALboundDim(%[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         fir.store %[[VAL_6]] to %arg2 : !fir.ref<i64>
   res = lbound(a, dim, 8)
 end subroutine
 
 ! CHECK-LABEL: func @_QPlbound_test_2(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
+! CHECK:  %[[VAL_c1_i64:.*]] = arith.constant 1 : i64
+! CHECK:  %[[VAL_0:.*]] = fir.convert %[[VAL_c1_i64]] : (i64) -> index
+! CHECK:  %[[VAL_c2_i64:.*]] = arith.constant 2 : i64
+! CHECK:  %[[VAL_1:.*]] = fir.convert %[[VAL_c2_i64]] : (i64) -> index
+! CHECK:  %[[VAL_2:.*]] = fir.load %arg1 : !fir.ref<i64>
 subroutine lbound_test_2(a, dim, res)
   real, dimension(:, 2:) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
-! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
-! CHECK:         %[[VAL_6:.*]] = arith.constant 2 : i64
-! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
-! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
-! CHECK:         %[[VAL_9:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_10:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_9]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_11]] to %[[VAL_10]] : !fir.ref<i64>
-! CHECK:         %[[VAL_12:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_12]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_7]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_14]] to %[[VAL_13]] : !fir.ref<i64>
-! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_16:.*]] = arith.subi %[[VAL_8]], %[[VAL_15]] : i64
-! CHECK:         %[[VAL_17:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_16]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
-! CHECK:         %[[VAL_18:.*]] = fir.load %[[VAL_17]] : !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_18]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:  %[[VAL_3:.*]] = fir.shift %[[VAL_0]], %[[VAL_1]] : (index, index) -> !fir.shift<2>
+! CHECK:  %[[VAL_4:.*]] = fir.rebox %arg0(%[[VAL_3]]) : (!fir.box<!fir.array<?x?xf32>>, !fir.shift<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:  %[[VAL_5:.*]] = fir.address_of(
+! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_2]] : (i64) -> i32
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_5]]
+! CHECK:  %[[VAL_9:.*]] = fir.call @_FortranALboundDim(%[[VAL_6]], %[[VAL_7]], %[[VAL_8]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         fir.store %[[VAL_9]] to %arg2 : !fir.ref<i64>
   res = lbound(a, dim, 8)
 end subroutine
 
-! CHECK-LABEL: func @_QPlbound_test_3(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<9x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
+! CHECK:  %[[VAL_0:.*]] = fir.undefined index
 subroutine lbound_test_3(a, dim, res)
   real, dimension(2:10, 3:*) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
-! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : index
-! CHECK:         %[[VAL_5:.*]] = arith.constant 3 : index
-! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
-! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_8:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_7]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_4]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_9]] to %[[VAL_8]] : !fir.ref<i64>
-! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_11:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_10]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_12]] to %[[VAL_11]] : !fir.ref<i64>
-! CHECK:         %[[VAL_13:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_14:.*]] = arith.subi %[[VAL_6]], %[[VAL_13]] : i64
-! CHECK:         %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_14]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
-! CHECK:         %[[VAL_16:.*]] = fir.load %[[VAL_15]] : !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_16]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:  %[[VAL_1:.*]] = fir.load %arg1 : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = fir.shape_shift %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_0]] : (index, index, index, index) -> !fir.shapeshift<2>
+! CHECK:         %[[VAL_3:.*]] = fir.embox %arg0(%[[VAL_2]]) : (!fir.ref<!fir.array<9x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.array<9x?xf32>>
+! CHECK:         %[[VAL_4:.*]] = fir.address_of(
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.array<9x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_1]] : (i64) -> i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_4]]
+! CHECK:         %[[VAL_8:.*]] = fir.call @_FortranALboundDim(%[[VAL_5]], %[[VAL_6]], %[[VAL_7]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         fir.store %[[VAL_8]] to %arg2 : !fir.ref<i64>
   res = lbound(a, dim, 8)
 end subroutine

--- a/flang/test/Lower/intrinsic-procedures/size.f90
+++ b/flang/test/Lower/intrinsic-procedures/size.f90
@@ -5,35 +5,35 @@ subroutine size_test()
   real, dimension(1:10, -10:10) :: a
   integer :: dim = 1
   integer :: iSize
-! CHECK:         %[[VAL_0:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_2:.*]] = arith.constant -10 : index
-! CHECK:         %[[VAL_3:.*]] = arith.constant 21 : index
-! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.array<10x21xf32> {bindc_name = "a", uniq_name = "_QFsize_testEa"}
-! CHECK:         %[[VAL_5:.*]] = fir.address_of(@_QFsize_testEdim) : !fir.ref<i32>
-! CHECK:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "isize", uniq_name = "_QFsize_testEisize"}
-! CHECK:         %[[VAL_7:.*]] = arith.constant 2 : i64
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
-! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i64) -> index
-! CHECK:         %[[VAL_11:.*]] = arith.constant 5 : i64
-! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
-! CHECK:         %[[VAL_13:.*]] = arith.constant -1 : i64
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i64) -> index
-! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i64) -> index
-! CHECK:         %[[VAL_17:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (i64) -> index
-! CHECK:         %[[VAL_19:.*]] = fir.shape_shift %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index) -> !fir.shapeshift<2>
-! CHECK:         %[[VAL_20:.*]] = fir.slice %[[VAL_8]], %[[VAL_12]], %[[VAL_10]], %[[VAL_14]], %[[VAL_18]], %[[VAL_16]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:         %[[VAL_21:.*]] = fir.embox %[[VAL_4]](%[[VAL_19]]) {{\[}}%[[VAL_20]]] : (!fir.ref<!fir.array<10x21xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
-! CHECK:         %[[VAL_22:.*]] = fir.load %[[VAL_5]] : !fir.ref<i32>
-! CHECK:         %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i32) -> index
-! CHECK:         %[[VAL_24:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_25:.*]] = arith.subi %[[VAL_23]], %[[VAL_24]] : index
-! CHECK:         %[[VAL_26:.*]]:3 = fir.box_dims %[[VAL_21]], %[[VAL_25]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_26]]#1 : (index) -> i64
-! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i64) -> i32
-! CHECK:         fir.store %[[VAL_28]] to %[[VAL_6]] : !fir.ref<i32>
+! CHECK:         %[[VAL_c1:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_c10:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_cneg10:.*]] = arith.constant -10 : index
+! CHECK:         %[[VAL_c21:.*]] = arith.constant 21 : index
+! CHECK:         %[[VAL_0:.*]] = fir.alloca !fir.array<10x21xf32> {bindc_name = "a", uniq_name = "_QFsize_testEa"}
+! CHECK:         %[[VAL_1:.*]] = fir.address_of(@_QFsize_testEdim) : !fir.ref<i32>
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "isize", uniq_name = "_QFsize_testEisize"}
+! CHECK:         %[[VAL_c2_i64:.*]] = arith.constant 2 : i64
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_c2_i64]] : (i64) -> index
+! CHECK:         %[[VAL_c1_i64:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_c1_i64]] : (i64) -> index
+! CHECK:         %[[VAL_c5_i64:.*]] = arith.constant 5 : i64
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_c5_i64]] : (i64) -> index
+! CHECK:         %[[VAL_neg1_i64:.*]] = arith.constant -1 : i64
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_neg1_i64]] : (i64) -> index
+! CHECK:         %[[VAL_c1_i64_0:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_c1_i64_0]] : (i64) -> index
+! CHECK:         %[[VAL_c1_i64_1:.*]] = arith.constant 1 : i64
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_c1_i64_1]] : (i64) -> index
+! CHECK:         %[[VAL_9:.*]] = fir.shape_shift %[[VAL_c1]], %[[VAL_c10]], %[[VAL_cneg10]], %[[VAL_c21]] : (index, index, index, index) -> !fir.shapeshift<2>
+! CHECK:         %[[VAL_10:.*]] = fir.slice %[[VAL_3]], %[[VAL_5]], %[[VAL_4]], %[[VAL_6]], %[[VAL_8]], %[[VAL_7]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_11:.*]] = fir.embox %[[VAL_0]](%[[VAL_9]]) [%[[VAL_10]]] : (!fir.ref<!fir.array<10x21xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:         %[[VAL_13:.*]] = fir.address_of({{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:         %[[VAL_c38_i32:.*]] = arith.constant 38 : i32
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_16:.*]] = fir.call @_FortranASizeDim(%[[VAL_14]], %[[VAL_12]], %[[VAL_15]], %[[VAL_c38_i32]]) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i64) -> i32
+! CHECK:         fir.store %[[VAL_17]] to %[[VAL_2]] : !fir.ref<i32>
   iSize = size(a(2:5, -1:1), dim, 8)
 end subroutine size_test

--- a/flang/test/Lower/intrinsic-procedures/ubound.f90
+++ b/flang/test/Lower/intrinsic-procedures/ubound.f90
@@ -1,81 +1,70 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-
 ! CHECK-LABEL: func @_QPubound_test(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test(a, dim, res)
   real, dimension(:, :) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
-! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
-! CHECK:         %[[VAL_5:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_6:.*]] = arith.subi %[[VAL_4]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_7:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_6]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]]#1 : (index) -> i64
-! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : i64
-! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_8]] : i64
-! CHECK:         fir.store %[[VAL_12]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:         %[[VAL_0:.*]] = fir.load
+! CHECK:         %[[VAL_1:.*]] = fir.address_of(
+! CHECK:         %[[VAL_2:.*]] = fir.convert
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_0]] : (i64) -> i32
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_1]]
+! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranASizeDim(%[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_6:.*]] = fir.address_of(
+! CHECK:         %[[VAL_7:.*]] = fir.convert %{{.*}} : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_0]] : (i64) -> i32
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_6]]
+! CHECK:         %[[VAL_10:.*]] = fir.call @_FortranALboundDim(%[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_10]], %c1_i64 : i64
+! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_5]] : i64
+
+! CHECK:         fir.store %[[VAL_12]] to %{{.*}} : !fir.ref<i64>
   res = ubound(a, dim, 8)
 end subroutine
 
 ! CHECK-LABEL: func @_QPubound_test_2(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test_2(a, dim, res)
   real, dimension(2:, 3:) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.array<2xi64>
-! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : i64
-! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
-! CHECK:         %[[VAL_6:.*]] = arith.constant 3 : i64
-! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
-! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
-! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
-! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
-! CHECK:         %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]]#1 : (index) -> i64
-! CHECK:         %[[VAL_14:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_14]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_5]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_16]] to %[[VAL_15]] : !fir.ref<i64>
-! CHECK:         %[[VAL_17:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_17]] : (!fir.ref<!fir.array<2xi64>>, index) -> !fir.ref<i64>
-! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_7]] : (index) -> i64
-! CHECK:         fir.store %[[VAL_19]] to %[[VAL_18]] : !fir.ref<i64>
-! CHECK:         %[[VAL_20:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_21:.*]] = arith.subi %[[VAL_8]], %[[VAL_20]] : i64
-! CHECK:         %[[VAL_22:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_21]] : (!fir.ref<!fir.array<2xi64>>, i64) -> !fir.ref<i64>
-! CHECK:         %[[VAL_23:.*]] = fir.load %[[VAL_22]] : !fir.ref<i64>
-! CHECK:         %[[VAL_24:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_25:.*]] = arith.subi %[[VAL_23]], %[[VAL_24]] : i64
-! CHECK:         %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_13]] : i64
-! CHECK:         fir.store %[[VAL_26]] to %[[VAL_2]] : !fir.ref<i64>
+! CHECK:         %[[VAL_0:.*]] = fir.load %{{.*}} : !fir.ref<i64>
+! CHECK:         %[[VAL_1:.*]] = fir.address_of(
+! CHECK:         %[[VAL_2:.*]] = fir.convert %{{.*}} : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_0]] : (i64) -> i32
+! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_1]]
+! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranASizeDim(%[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_6:.*]] = fir.address_of(
+! CHECK:         %[[VAL_7:.*]] = fir.convert %{{.*}} : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_0]] : (i64) -> i32
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_6]]
+! CHECK:         %[[VAL_10:.*]] = fir.call @_FortranALboundDim(%[[VAL_7]], %[[VAL_8]], %[[VAL_9]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_10]], %{{.*}} : i64
+! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_5]] : i64
+! CHECK:         fir.store %[[VAL_12]] to %{{.*}} : !fir.ref<i64>
   res = ubound(a, dim, 8)
 end subroutine
 
 ! CHECK-LABEL: func @_QPubound_test_3(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x20x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test_3(a, dim, res)
   real, dimension(10, 20, *) :: a
   integer(8):: dim, res
-! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_4:.*]] = arith.constant 20 : index
-! CHECK:         %[[VAL_5:.*]] = fir.undefined index
-! CHECK:         %[[VAL_6:.*]] = fir.shape %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : (index, index, index) -> !fir.shape<3>
-! CHECK:         %[[VAL_7:.*]] = fir.embox %[[VAL_0]](%[[VAL_6]]) : (!fir.ref<!fir.array<10x20x?xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<10x20x?xf32>>
-! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
-! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
-! CHECK:         %[[VAL_10:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_9]], %[[VAL_10]] : index
-! CHECK:         %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_7]], %[[VAL_11]] : (!fir.box<!fir.array<10x20x?xf32>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]]#1 : (index) -> i64
-! CHECK:         %[[VAL_14:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_15:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_16:.*]] = arith.subi %[[VAL_14]], %[[VAL_15]] : i64
-! CHECK:         %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : i64
-! CHECK:         fir.store %[[VAL_17]] to %[[VAL_2]] : !fir.ref<i64>
-! CHECK:         return
+! CHECK:         %[[VAL_0:.*]] = fir.undefined index
+! CHECK:         %[[VAL_1:.*]] = fir.shape %{{.*}}, %{{.*}}, %[[VAL_0]] : (index, index, index) -> !fir.shape<3>
+! CHECK:         %[[VAL_2:.*]] = fir.embox %{{.*}}(%[[VAL_1]]) : (!fir.ref<!fir.array<10x20x?xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<10x20x?xf32>>
+! CHECK:         %[[VAL_3:.*]] = fir.load %{{.*}} : !fir.ref<i64>
+! CHECK:         %[[VAL_4:.*]] = fir.address_of(
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_2]] : (!fir.box<!fir.array<10x20x?xf32>>) -> !fir.box<none>
+
+! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (i64) -> i32
+! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_4]]
+! CHECK:         %[[VAL_8:.*]] = fir.call @_FortranASizeDim(%[[VAL_5]], %[[VAL_6]], %[[VAL_7]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_9:.*]] = fir.rebox %[[VAL_2]] : (!fir.box<!fir.array<10x20x?xf32>>) -> !fir.box<!fir.array<10x20x?xf32>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(
+! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.array<10x20x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_3]]
+! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_10]]
+! CHECK:         %[[VAL_14:.*]] = fir.call @_FortranALboundDim(%[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:         %[[VAL_15:.*]] = arith.subi %[[VAL_14]], %{{.*}} : i64
+! CHECK:         %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_8]] : i64
+! CHECK:         fir.store %[[VAL_16]] to %{{.*}} : !fir.ref<i64>
   res = ubound(a, dim, 8)
 end subroutine

--- a/flang/unittests/Runtime/CMakeLists.txt
+++ b/flang/unittests/Runtime/CMakeLists.txt
@@ -5,6 +5,7 @@ add_flang_unittest(FlangRuntimeTests
   CrashHandlerFixture.cpp
   ExternalIOTest.cpp
   Format.cpp
+  Inquiry.cpp
   ListInputTest.cpp
   Matmul.cpp
   MiscIntrinsic.cpp

--- a/flang/unittests/Runtime/Inquiry.cpp
+++ b/flang/unittests/Runtime/Inquiry.cpp
@@ -1,0 +1,42 @@
+//===-- flang/unittests/RuntimeGTest/Inquiry.cpp -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Runtime/inquiry.h"
+#include "gtest/gtest.h"
+#include "tools.h"
+#include "flang/Runtime/type-code.h"
+
+using namespace Fortran::runtime;
+using Fortran::common::TypeCategory;
+
+TEST(Inquiry, Lbound) {
+  // ARRAY  1 3 5
+  //        2 4 6
+  auto array{MakeArray<TypeCategory::Integer, 4>(
+      std::vector<int>{2, 3}, std::vector<std::int32_t>{1, 2, 3, 4, 5, 6})};
+  array->GetDimension(0).SetLowerBound(0);
+  array->GetDimension(1).SetLowerBound(-1);
+  StaticDescriptor<2, true> statDesc;
+
+  EXPECT_EQ(RTNAME(LboundDim)(*array, 1, __FILE__, __LINE__), std::int64_t{0});
+  EXPECT_EQ(RTNAME(LboundDim)(*array, 2, __FILE__, __LINE__), std::int64_t{-1});
+}
+
+TEST(Inquiry, Size) {
+  // ARRAY  1 3 5
+  //        2 4 6
+  auto array{MakeArray<TypeCategory::Integer, 4>(
+      std::vector<int>{2, 3}, std::vector<std::int32_t>{1, 2, 3, 4, 5, 6})};
+  array->GetDimension(0).SetLowerBound(0); // shouldn't matter
+  array->GetDimension(1).SetLowerBound(-1);
+  StaticDescriptor<2, true> statDesc;
+
+  EXPECT_EQ(RTNAME(SizeDim)(*array, 1, __FILE__, __LINE__), std::int64_t{2});
+  EXPECT_EQ(RTNAME(SizeDim)(*array, 2, __FILE__, __LINE__), std::int64_t{3});
+  EXPECT_EQ(RTNAME(Size)(*array, __FILE__, __LINE__), std::int64_t{6});
+}


### PR DESCRIPTION
Calls to the LBOUND and SIZE intrinsics with invalid DIM arguments were not
producing runtime errors.  Also, we were not correctly handling array arguments
for these intrinsics when the actual argument was a function call that returned
an array.

I fixed these problems by creating runtime routines for them that check the DIM
argument for validity.  I also added tests for the new runtime routines.  Also,
the changes to lowering affected the lowering code for LBOUND, UBOUND, and
SIZE.  This required updating the associated test results.