### PR TITLE
Add lowering of GET_ENVIRONMENT_VARIABLE intrinsic

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Command.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Command.h
@@ -32,5 +32,14 @@ void genGetCommandArgument(fir::FirOpBuilder &, mlir::Location,
                            mlir::Value length, mlir::Value status,
                            mlir::Value errmsg);
 
+/// Generate call to GET_ENVIRONMENT_VARIABLE intrinsic runtime routine.
+/// Note that GET_ENVIRONMENT_ARGUMENT intrinsic is split between 2 functions in
+/// implementation; EnvVariableValue and EnvVariableLength. So we handle each
+/// seperately.
+void genGetEnvironmentVariable(fir::FirOpBuilder &, mlir::Location,
+                               mlir::Value number, mlir::Value value,
+                               mlir::Value length, mlir::Value status,
+                               mlir::Value trimName, mlir::Value errmsg);
+
 } // namespace fir::runtime
 #endif // FORTRAN_OPTIMIZER_BUILDER_RUNTIME_COMMAND_H

--- a/flang/lib/Optimizer/Builder/Runtime/Command.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Command.cpp
@@ -13,6 +13,18 @@
 
 using namespace Fortran::runtime;
 
+// Certain runtime intrinsics should only be run when select parameters of the
+// intrisic are supplied. In certain cases one of these parameters may not be
+// given, however the intrinsic needs to be run due to another required
+// parameter being supplied. In this case the missing parameter is assigned to
+// have an "absent" value. This typically happens in IntrinsicCall.cpp. For this
+// reason the extra indirection with `isAbsent` is needed for testing whether a
+// given parameter is actually present (so that parameters with "value" absent
+// are not considered as present).
+inline bool isAbsent(mlir::Value val) {
+  return mlir::isa_and_nonnull<fir::AbsentOp>(val.getDefiningOp());
+}
+
 mlir::Value fir::runtime::genCommandArgumentCount(fir::FirOpBuilder &builder,
                                                   mlir::Location loc) {
   auto argumentCountFunc =
@@ -30,26 +42,17 @@ void fir::runtime::genGetCommandArgument(fir::FirOpBuilder &builder,
   auto argumentLengthFunc =
       fir::runtime::getRuntimeFunc<mkRTKey(ArgumentLength)>(loc, builder);
 
-  auto isPresent = [&](mlir::Value val) -> bool {
-    return !mlir::isa_and_nonnull<fir::AbsentOp>(val.getDefiningOp());
-  };
-
   mlir::Value valueResult;
-  // Run `ArgumentValue` intrisc only if we have either "value", "status" or
-  // "errmsg" `ArgumentValue` "requires" existing values for its arguments
-  // "value" and "errmsg". So in the case they aren't given, but the user has
-  // requested "status", we have to assign "absent" values to them before
-  // calling `ArgumentValue`. This happens in IntrinsicCall.cpp. For this reason
-  // we need extra indirection with `isPresent` for testing whether "value" or
-  // "errmsg" is present.
-  if (isPresent(value) || status || isPresent(errmsg)) {
+  // Run `ArgumentValue` intrinsic only if we have a "value" in either "VALUE",
+  // "STATUS" or "ERRMSG" parameters.
+  if (!isAbsent(value) || status || !isAbsent(errmsg)) {
     llvm::SmallVector<mlir::Value> args = fir::runtime::createArguments(
         builder, loc, argumentValueFunc.getType(), number, value, errmsg);
     valueResult =
         builder.create<fir::CallOp>(loc, argumentValueFunc, args).getResult(0);
   }
 
-  // Only save result of ArgumentValue if "status" parameter has been given
+  // Only save result of `ArgumentValue` if "STATUS" parameter has been given
   if (status) {
     const mlir::Value statusLoaded = builder.create<fir::LoadOp>(loc, status);
     mlir::Value resultCast =
@@ -57,6 +60,7 @@ void fir::runtime::genGetCommandArgument(fir::FirOpBuilder &builder,
     builder.create<fir::StoreOp>(loc, resultCast, status);
   }
 
+  // Only run `ArgumentLength` intrinsic if "LENGTH" parameter provided
   if (length) {
     llvm::SmallVector<mlir::Value> args = fir::runtime::createArguments(
         builder, loc, argumentLengthFunc.getType(), number);
@@ -65,6 +69,58 @@ void fir::runtime::genGetCommandArgument(fir::FirOpBuilder &builder,
     const mlir::Value valueLoaded = builder.create<fir::LoadOp>(loc, length);
     mlir::Value resultCast =
         builder.createConvert(loc, valueLoaded.getType(), result);
+    builder.create<fir::StoreOp>(loc, resultCast, length);
+  }
+}
+
+void fir::runtime::genGetEnvironmentVariable(
+    fir::FirOpBuilder &builder, mlir::Location loc, mlir::Value name,
+    mlir::Value value, mlir::Value length, mlir::Value status,
+    mlir::Value trimName, mlir::Value errmsg) {
+  auto valueFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(EnvVariableValue)>(loc, builder);
+  auto lengthFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(EnvVariableLength)>(loc, builder);
+
+  mlir::Value sourceFile;
+  mlir::Value sourceLine;
+  // We only need `sourceFile` and `sourceLine` variables when calling either
+  // `EnvVariableValue` or `EnvVariableLength` below.
+  if (!isAbsent(value) || status || !isAbsent(errmsg) || length) {
+    sourceFile = fir::factory::locationToFilename(builder, loc);
+    sourceLine = fir::factory::locationToLineNo(
+        builder, loc, valueFunc.getType().getInput(5));
+  }
+
+  mlir::Value valueResult;
+  // Run `EnvVariableValue` intrinsic only if we have a "value" in either
+  // "VALUE", "STATUS" or "ERRMSG" parameters.
+  if (!isAbsent(value) || status || !isAbsent(errmsg)) {
+    llvm::SmallVector<mlir::Value> args = fir::runtime::createArguments(
+        builder, loc, valueFunc.getType(), name, value, trimName, errmsg,
+        sourceFile, sourceLine);
+    valueResult =
+        builder.create<fir::CallOp>(loc, valueFunc, args).getResult(0);
+  }
+
+  // Only save result of `EnvVariableValue` if "STATUS" parameter provided
+  if (status) {
+    const mlir::Value statusLoaded = builder.create<fir::LoadOp>(loc, status);
+    mlir::Value resultCast =
+        builder.createConvert(loc, statusLoaded.getType(), valueResult);
+    builder.create<fir::StoreOp>(loc, resultCast, status);
+  }
+
+  // Only run `EnvVariableLength` intrinsic if "LENGTH" parameter provided
+  if (length) {
+    llvm::SmallVector<mlir::Value> args =
+        fir::runtime::createArguments(builder, loc, lengthFunc.getType(), name,
+                                      trimName, sourceFile, sourceLine);
+    mlir::Value result =
+        builder.create<fir::CallOp>(loc, lengthFunc, args).getResult(0);
+    const mlir::Value lengthLoaded = builder.create<fir::LoadOp>(loc, length);
+    mlir::Value resultCast =
+        builder.createConvert(loc, lengthLoaded.getType(), result);
     builder.create<fir::StoreOp>(loc, resultCast, length);
   }
 }

--- a/flang/test/Lower/intrinsic-procedures/get_environment_variable.f90
+++ b/flang/test/Lower/intrinsic-procedures/get_environment_variable.f90
@@ -1,0 +1,160 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-32 -DDEFAULT_INTEGER_SIZE=32 %s
+! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
+
+! CHECK-LABEL: func @_QPnumber_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"}) {
+subroutine number_only(name)
+    character(len=32) :: name
+    call get_environment_variable(name)
+! CHECK-NOT: fir.call @_FortranAEnvVariableValue
+! CHECK-NOT: fir.call @_FortranAEnvVariableLength
+! CHECK-NEXT: return
+end subroutine number_only
+
+! CHECK-LABEL: func @_QPname_and_value_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[valueArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "value"}) {
+subroutine name_and_value_only(name, value)
+    character(len=32) :: name, value
+    call get_environment_variable(name, value)
+! CHECK: %[[nameUnbox:.*]]:2 = fir.unboxchar %[[nameArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[nameLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[valueUnbox:.*]]:2 = fir.unboxchar %[[valueArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[valueLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameBox:.*]] = fir.embox %[[nameUnbox]]#0 typeparams %[[nameLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[valueBox:.*]] = fir.embox %[[valueUnbox]]#0 typeparams %[[valueLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %true = arith.constant true
+! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 10]] : i32
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[value:.*]] = fir.convert %[[valueBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
+! CHECK-NEXT: %{{[0-9]+}} = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %true, %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-NEXT: return
+end subroutine name_and_value_only
+
+! CHECK-LABEL: func @_QPname_and_length_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[lengthArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]> {fir.bindc_name = "length"}) {
+subroutine name_and_length_only(name, length)
+    character(len=32) :: name
+    integer :: length
+    call get_environment_variable(name, LENGTH=length)
+! CHECK-NOT: fir.call @_FortranAEnvVariableValue
+! CHECK: %[[nameUnbox:.*]]:2 = fir.unboxchar %[[nameArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[nameLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameBox:.*]] = fir.embox %0#0 typeparams %[[nameLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %true = arith.constant true
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 7]] : i32
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
+! CHECK-32-NEXT: %[[length64:.*]] = fir.call @_FortranAEnvVariableLength(%[[name]], %true, %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, i1, !fir.ref<i8>, i32) -> i64
+! CHECK-64-NEXT: %[[length:.*]] = fir.call @_FortranAEnvVariableLength(%[[name]], %true, %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, i1, !fir.ref<i8>, i32) -> i64
+! CHECK-32-NEXT: %[[length:.*]] = fir.convert %[[length64]] : (i64) -> i32
+! CHECK-NEXT: fir.store %[[length]] to %[[lengthArg]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: return
+end subroutine name_and_length_only
+
+! CHECK-LABEL: func @_QPname_and_status_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]> {fir.bindc_name = "status"}) {
+subroutine name_and_status_only(name, status)
+    character(len=32) :: name
+    integer :: status
+    call get_environment_variable(name, STATUS=status)
+! CHECK: %[[nameUnbox:.*]]:2 = fir.unboxchar %[[nameArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[nameLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameBox:.*]] = fir.embox %[[nameUnbox]]#0 typeparams %[[nameLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %true = arith.constant true
+! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 8]] : i32
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
+! CHECK-32-NEXT: %[[status:.*]] = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %true, %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-64-NEXT: %[[status32:.*]] = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %true, %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-64-NEXT: %[[status:.*]] = fir.convert %[[status32]] : (i32) -> i64
+! CHECK-NEXT: fir.store %[[status]] to %[[statusArg]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: return
+end subroutine name_and_status_only
+
+! CHECK-LABEL: func @_QPname_and_trim_name_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[trimNameArg:.*]]: !fir.ref<!fir.logical<4>> {fir.bindc_name = "trim_name"}) {
+subroutine name_and_trim_name_only(name, trim_name)
+    character(len=32) :: name
+    logical :: trim_name
+    call get_environment_variable(name, TRIM_NAME=trim_name)
+    ! CHECK-NOT: fir.call @_FortranAEnvVariableValue
+    ! CHECK-NOT: fir.call @_FortranAEnvVariableLength
+    ! CHECK-NEXT: return
+end subroutine name_and_trim_name_only
+
+! CHECK-LABEL: func @_QPname_and_errmsg_only(
+! CHECK-SAME: %[[nameArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[errmsgArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "errmsg"}) {
+subroutine name_and_errmsg_only(name, errmsg)
+    character(len=32) :: name, errmsg
+    call get_environment_variable(name, ERRMSG=errmsg)
+! CHECK: %[[errmsgUnbox:.*]]:2 = fir.unboxchar %[[errmsgArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[errmsgLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameUnbox:.*]]:2 = fir.unboxchar %[[nameArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[nameLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameBox:.*]] = fir.embox %[[nameUnbox]]#0 typeparams %[[nameLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
+! CHECK-NEXT: %true = arith.constant true
+! CHECK-NEXT: %[[errmsgBox:.*]] = fir.embox %[[errmsgUnbox]]#0 typeparams %c32 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 10]] : i32
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBox]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
+! CHECK-NEXT: %{{[0-9]+}} = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %true, %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-NEXT: return
+end subroutine name_and_errmsg_only
+
+! CHECK-LABEL: func @_QPall_arguments(
+! CHECK-SAME: %[[nameArg:[^:]*]]: !fir.boxchar<1> {fir.bindc_name = "name"},
+! CHECK-SAME: %[[valueArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "value"},
+! CHECK-SAME: %[[lengthArg:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]> {fir.bindc_name = "length"},
+! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]> {fir.bindc_name = "status"},
+! CHECK-SAME: %[[trimNameArg:.*]]: !fir.ref<!fir.logical<4>> {fir.bindc_name = "trim_name"},
+! CHECK-SAME: %[[errmsgArg:.*]]: !fir.boxchar<1> {fir.bindc_name = "errmsg"}) {
+subroutine all_arguments(name, value, length, status, trim_name, errmsg)
+    character(len=32) :: name, value, errmsg
+    integer :: length, status
+    logical :: trim_name
+    call get_environment_variable(name, value, length, status, trim_name, errmsg)
+! CHECK: %[[errmsgUnbox:.*]]:2 = fir.unboxchar %[[errmsgArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[errmsgLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[nameUnbox:.*]]:2 = fir.unboxchar %[[nameArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[nameLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[valueUnbox:.*]]:2 = fir.unboxchar %[[valueArg]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK-NEXT: %[[valueLength:.*]] = arith.constant 32 : index
+! CHECK-NEXT: %[[trimNameLoaded:.*]] = fir.load %[[trimNameArg]] : !fir.ref<!fir.logical<4>>
+! CHECK-NEXT: %[[nameBoxed:.*]] = fir.embox %[[nameUnbox]]#0 typeparams %[[nameLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[valueBoxed:.*]] = fir.embox %[[valueUnbox]]#0 typeparams %[[valueLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[errmsgBoxed:.*]] = fir.embox %[[errmsgUnbox]]#0 typeparams %[[errmsgLength]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.[[fileString:.*]]) : !fir.ref<!fir.char<1,[[fileStringLength:.*]]>>
+! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 12]] : i32
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[value:.*]] = fir.convert %[[valueBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[trimName:.*]] = fir.convert %[[trimNameLoaded]] : (!fir.logical<4>) -> i1
+! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[fileStringLength]]>>) -> !fir.ref<i8>
+! CHECK-32-NEXT: %[[status:.*]] = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %[[trimName]], %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-64-NEXT: %[[status32:.*]] = fir.call @_FortranAEnvVariableValue(%[[name]], %[[value]], %[[trimName]], %[[errmsg]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, !fir.box<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK-64-NEXT: %[[status:.*]] = fir.convert %[[status32]] : (i32) -> i64
+! CHECK-NEXT: fir.store %[[status]] to %[[statusArg]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBoxed]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>
+! CHECK-NEXT: %[[trimName:.*]] = fir.convert %[[trimNameLoaded]] : (!fir.logical<4>) -> i1
+! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[fileStringLength]]>>) -> !fir.ref<i8>
+! CHECK-32-NEXT: %[[result64:.*]] = fir.call @_FortranAEnvVariableLength(%[[name]], %[[trimName]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, i1, !fir.ref<i8>, i32) -> i64
+! CHECK-64-NEXT: %[[result:.*]] = fir.call @_FortranAEnvVariableLength(%[[name]], %[[trimName]], %[[sourceFile]], %[[sourceLine]]) : (!fir.box<none>, i1, !fir.ref<i8>, i32) -> i64
+! CHECK-32-NEXT: %[[result:.*]] = fir.convert %[[result64]] : (i64) -> i32
+! CHECK-NEXT: fir.store %[[result]] to %[[lengthArg]] : !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>
+! CHECK-NEXT: return
+end subroutine all_arguments


### PR DESCRIPTION
This patch adds the lowering of the "GET_ENVIRONMENT_VARIABLE" intrinsic
to the backend runtime hook implemented in patches D111394 and D112698.
It also renames the `isPresent` lambda to `isAbsent` and moves it out to
its own function in `Command.cpp`. Corresponding comment fixes for this
are also modified.