### PR TITLE
Add annotations to function arguments to track the original name in the

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -494,8 +494,9 @@ private:
     return {};
   }
 
-  /// Add the symbol to the local map. If the symbol is already in the map, it
-  /// is not updated. Instead the value `false` is returned.
+  /// Add the symbol to the local map and return `true`. If the symbol is
+  /// already in the map and \p forced is `false`, the map is not updated.
+  /// Instead the value `false` is returned.
   bool addSymbol(const Fortran::semantics::SymbolRef sym, mlir::Value val,
                  bool forced = false) {
     if (!forced && lookupSymbol(sym))
@@ -2406,12 +2407,12 @@ private:
   /// result is also mapped. The symbol map is used to hold this mapping.
   void mapDummiesAndResults(Fortran::lower::pft::FunctionLikeUnit &funit,
                             const Fortran::lower::CalleeInterface &callee) {
-    assert(builder && "need a builder at this point");
+    assert(builder && "require a builder object at this point");
     using PassBy = Fortran::lower::CalleeInterface::PassEntityBy;
     auto mapPassedEntity = [&](const auto arg) -> void {
       if (arg.passBy == PassBy::AddressAndLength) {
         // TODO: now that fir call has some attributes regarding character
-        // return, this should PassBy::AddressAndLength should be retired.
+        // return, PassBy::AddressAndLength should be retired.
         mlir::Location loc = toLocation();
         fir::factory::CharacterExprHelper charHelp{*builder, loc};
         mlir::Value box =

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -686,10 +686,9 @@ private:
     addFirResult(boxCharTy, resultPosition, Property::BoxChar);
   }
 
-  /// Return an ArrayRef with an attribute with the name of the argument if this
+  /// Return a vector with an attribute with the name of the argument if this
   /// is a callee interface and the name is available. Otherwise, just return
-  /// llvm::None. The storage for the ArrayRef is provided by the caller and
-  /// passed as \p vector.
+  /// an empty vector.
   llvm::SmallVector<mlir::NamedAttribute>
   dummyNameAttr(const FortranEntity &entity) {
     if constexpr (std::is_same_v<FortranEntity,

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -686,6 +686,28 @@ private:
     addFirResult(boxCharTy, resultPosition, Property::BoxChar);
   }
 
+  /// Return an ArrayRef with an attribute with the name of the argument if this
+  /// is a callee interface and the name is available. Otherwise, just return
+  /// llvm::None. The storage for the ArrayRef is provided by the caller and
+  /// passed as \p vector.
+  llvm::SmallVector<mlir::NamedAttribute>
+  dummyNameAttr(const FortranEntity &entity) {
+    if constexpr (std::is_same_v<FortranEntity,
+                                 std::optional<Fortran::common::Reference<
+                                     const Fortran::semantics::Symbol>>>) {
+      if (entity.has_value()) {
+        const Fortran::semantics::Symbol *argument = &*entity.value();
+        // "fir.bindc_name" is used for arguments for the sake of consistency
+        // with other attributes carrying surface syntax names in FIR.
+        return {mlir::NamedAttribute(
+            mlir::Identifier::get("fir.bindc_name", &mlirContext),
+            mlir::StringAttr::get(&mlirContext,
+                                  toStringRef(argument->name())))};
+      }
+    }
+    return {};
+  }
+
   void handleImplicitDummy(
       const DummyCharacteristics *characteristics,
       const Fortran::evaluate::characteristics::DummyDataObject &obj,
@@ -694,7 +716,8 @@ private:
     if (dynamicType.category() == Fortran::common::TypeCategory::Character) {
       mlir::Type boxCharTy =
           fir::BoxCharType::get(&mlirContext, dynamicType.kind());
-      addFirOperand(boxCharTy, nextPassedArgPosition(), Property::BoxChar);
+      addFirOperand(boxCharTy, nextPassedArgPosition(), Property::BoxChar,
+                    dummyNameAttr(entity));
       addPassedArg(PassEntityBy::BoxChar, entity, characteristics);
     } else {
       // non-PDT derived type allowed in implicit interface.
@@ -703,7 +726,8 @@ private:
       if (!bounds.empty())
         type = fir::SequenceType::get(bounds, type);
       mlir::Type refType = fir::ReferenceType::get(type);
-      addFirOperand(refType, nextPassedArgPosition(), Property::BaseAddress);
+      addFirOperand(refType, nextPassedArgPosition(), Property::BaseAddress,
+                    dummyNameAttr(entity));
       addPassedArg(PassEntityBy::BaseAddress, entity, characteristics);
     }
   }
@@ -757,10 +781,10 @@ private:
     bool isValueAttr = false;
     [[maybe_unused]] mlir::Location loc =
         interface.converter.getCurrentLocation();
-    llvm::SmallVector<mlir::NamedAttribute> attrs;
+    llvm::SmallVector<mlir::NamedAttribute> attrs = dummyNameAttr(entity);
     auto addMLIRAttr = [&](llvm::StringRef attr) {
       attrs.emplace_back(mlir::Identifier::get(attr, &mlirContext),
-                         UnitAttr::get(&mlirContext));
+                         mlir::UnitAttr::get(&mlirContext));
     };
     if (obj.attrs.test(Attrs::Optional))
       addMLIRAttr(fir::getOptionalAttrName());

--- a/flang/test/Lower/OpenMP/omp-check-privatise-params.f90
+++ b/flang/test/Lower/OpenMP/omp-check-privatise-params.f90
@@ -3,7 +3,7 @@
 ! RUN: bbc -fopenmp -emit-fir %s -o - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 
-!FIRDialect: func @_QParray(%{{.*}}: !fir.ref<!fir.array<?xi32>>, %[[ARG1:.*]]: !fir.ref<i32>) {
+!FIRDialect: func @_QParray(%{{.*}}: !fir.ref<!fir.array<?xi32>>{{.*}}, %[[ARG1:.*]]: !fir.ref<i32>{{.*}}) {
 !FIRDialect-DAG:  %[[N:.*]] = fir.load %[[ARG1]] : !fir.ref<i32>
 !FIRDialect-DAG:  %[[N_CVT1:.*]] = fir.convert %[[N]] : (i32) -> i64
 !FIRDialect-DAG:  %[[N_CVT2:.*]] = fir.convert %[[N_CVT1]] : (i64) -> index

--- a/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-arrays.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-arrays.f90
@@ -3,7 +3,7 @@
 ! RUN: bbc -fopenmp -emit-fir %s -o - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 
-!FIRDialect: func @_QPfirstprivate_arrays(%[[ARG1:.*]]: !fir.boxchar<1>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
+!FIRDialect: func @_QPfirstprivate_arrays(%[[ARG1:.*]]: !fir.boxchar<1>{{.*}}, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 !FIRDialect-DAG: %[[ARG1_UNBOX:.*]]:2 = fir.unboxchar %[[ARG1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 !FIRDialect-DAG: %[[FIVE:.*]] = arith.constant 5 : index
 !FIRDialect-DAG: omp.parallel {

--- a/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-firstprivate-clause-scalar.f90
@@ -2,7 +2,7 @@
 
 ! RUN: bbc -fopenmp -emit-fir %s -o - | FileCheck %s --check-prefix=FIRDialect
 
-!FIRDialect: func @_QPfirstprivate_character(%[[ARG1:.*]]: !fir.boxchar<1>) {
+!FIRDialect: func @_QPfirstprivate_character(%[[ARG1:.*]]: !fir.boxchar<1>{{.*}}) {
 !FIRDialect-DAG: %[[ARG1_UNBOX:.*]]:2 = fir.unboxchar %[[ARG1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 !FIRDialect-DAG: %[[FIVE:.*]] = arith.constant 5 : index
 !FIRDialect-DAG: omp.parallel {
@@ -39,7 +39,7 @@ subroutine firstprivate_character(arg1)
 
 end subroutine
 
-!FIRDialect: func @_QPfirstprivate_complex(%[[ARG1:.*]]: !fir.ref<!fir.complex<4>>, %[[ARG2:.*]]: !fir.ref<!fir.complex<8>>) {
+!FIRDialect: func @_QPfirstprivate_complex(%[[ARG1:.*]]: !fir.ref<!fir.complex<4>>{{.*}}, %[[ARG2:.*]]: !fir.ref<!fir.complex<8>>{{.*}}) {
 !FIRDialect-DAG:   omp.parallel {
 !FIRDialect-DAG:     %[[ARG1_PVT:.*]] = fir.alloca !fir.complex<4> {bindc_name = "arg1", pinned, uniq_name = "_QFfirstprivate_complexEarg1"}
 !FIRDialect-DAG:     %[[ARG1_VAL:.*]] = fir.load %arg0 : !fir.ref<!fir.complex<4>>
@@ -69,7 +69,7 @@ subroutine firstprivate_complex(arg1, arg2)
 
 end subroutine
 
-!FIRDialect: func @_QPfirstprivate_integer(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<i8>, %[[ARG3:.*]]: !fir.ref<i16>, %[[ARG4:.*]]: !fir.ref<i32>, %[[ARG5:.*]]: !fir.ref<i64>, %[[ARG6:.*]]: !fir.ref<i128>) {
+!FIRDialect: func @_QPfirstprivate_integer(%[[ARG1:.*]]: !fir.ref<i32>{{.*}}, %[[ARG2:.*]]: !fir.ref<i8>{{.*}}, %[[ARG3:.*]]: !fir.ref<i16>{{.*}}, %[[ARG4:.*]]: !fir.ref<i32>{{.*}}, %[[ARG5:.*]]: !fir.ref<i64>{{.*}}, %[[ARG6:.*]]: !fir.ref<i128>{{.*}}) {
 !FIRDialect-DAG:  omp.parallel {
 !FIRDialect-DAG:    %[[ARG1_PVT:.*]] = fir.alloca i32 {bindc_name = "arg1", pinned, uniq_name = "_QFfirstprivate_integerEarg1"}
 !FIRDialect-DAG:    %[[ARG1_VAL:.*]] = fir.load %[[ARG1]] : !fir.ref<i32>
@@ -119,7 +119,7 @@ subroutine firstprivate_integer(arg1, arg2, arg3, arg4, arg5, arg6)
 
 end subroutine
 
-!FIRDialect: func @_QPfirstprivate_logical(%[[ARG1:.*]]: !fir.ref<!fir.logical<4>>, %[[ARG2:.*]]: !fir.ref<!fir.logical<1>>, %[[ARG3:.*]]: !fir.ref<!fir.logical<2>>, %[[ARG4:.*]]: !fir.ref<!fir.logical<4>>, %[[ARG5:.*]]: !fir.ref<!fir.logical<8>>) {
+!FIRDialect: func @_QPfirstprivate_logical(%[[ARG1:.*]]: !fir.ref<!fir.logical<4>>{{.*}}, %[[ARG2:.*]]: !fir.ref<!fir.logical<1>>{{.*}}, %[[ARG3:.*]]: !fir.ref<!fir.logical<2>>{{.*}}, %[[ARG4:.*]]: !fir.ref<!fir.logical<4>>{{.*}}, %[[ARG5:.*]]: !fir.ref<!fir.logical<8>>{{.*}}) {
 !FIRDialect-DAG:   omp.parallel {
 !FIRDialect-DAG:     %[[ARG1_PVT:.*]] = fir.alloca !fir.logical<4> {bindc_name = "arg1", pinned, uniq_name = "_QFfirstprivate_logicalEarg1"}
 !FIRDialect-DAG:     %[[ARG1_VAL:.*]] = fir.load %[[ARG1]] : !fir.ref<!fir.logical<4>>
@@ -168,7 +168,7 @@ subroutine firstprivate_logical(arg1, arg2, arg3, arg4, arg5)
 
 end subroutine
 
-!FIRDialect-DAG: func @_QPfirstprivate_real(%[[ARG1:.*]]: !fir.ref<f32>, %[[ARG2:.*]]: !fir.ref<f16>, %[[ARG3:.*]]: !fir.ref<f32>, %[[ARG4:.*]]: !fir.ref<f64>, %[[ARG5:.*]]: !fir.ref<f80>, %[[ARG6:.*]]: !fir.ref<f128>) {
+!FIRDialect-DAG: func @_QPfirstprivate_real(%[[ARG1:.*]]: !fir.ref<f32>{{.*}}, %[[ARG2:.*]]: !fir.ref<f16>{{.*}}, %[[ARG3:.*]]: !fir.ref<f32>{{.*}}, %[[ARG4:.*]]: !fir.ref<f64>{{.*}}, %[[ARG5:.*]]: !fir.ref<f80>{{.*}}, %[[ARG6:.*]]: !fir.ref<f128>{{.*}}) {
 !FIRDialect-DAG:   omp.parallel {
 !FIRDialect-DAG:     %[[ARG1_PVT:.*]] = fir.alloca f32 {bindc_name = "arg1", pinned, uniq_name = "_QFfirstprivate_realEarg1"}
 !FIRDialect-DAG:     %[[ARG1_VAL:.*]] = fir.load %[[ARG1]] : !fir.ref<f32>

--- a/flang/test/Lower/OpenMP/omp-parallel-private-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-private-clause.f90
@@ -4,7 +4,7 @@
 ! RUN: bbc -fopenmp -emit-fir %s -o - | \
 ! RUN:   FileCheck %s --check-prefix=FIRDialect
 
-!FIRDialect: func @_QPprivate_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>, %[[ARG3:.*]]: !fir.boxchar<1>, %[[ARG4:.*]]: !fir.boxchar<1>) {
+!FIRDialect: func @_QPprivate_clause(%[[ARG1:.*]]: !fir.ref<i32>{{.*}}, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[ARG3:.*]]: !fir.boxchar<1>{{.*}}, %[[ARG4:.*]]: !fir.boxchar<1>{{.*}}) {
 !FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"}
 !FIRDialect-DAG: %[[ALPHA_ARRAY:.*]] = fir.alloca !fir.array<10xi32> {{{.*}}, uniq_name = "{{.*}}Ealpha_array"}
 !FIRDialect-DAG: %[[BETA:.*]] = fir.alloca !fir.char<1,5> {{{.*}}, uniq_name = "{{.*}}Ebeta"}

--- a/flang/test/Lower/OpenMP/omp-parallel-shared-clause.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-shared-clause.f90
@@ -7,7 +7,7 @@
 ! RUN:   tco --disable-llvm --print-ir-after=fir-to-llvm-ir 2>&1 | \
 ! RUN:   FileCheck %s --check-prefix=LLVMIRDialect
 
-!FIRDialect: func @_QPshared_clause(%[[ARG1:.*]]: !fir.ref<i32>, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>) {
+!FIRDialect: func @_QPshared_clause(%[[ARG1:.*]]: !fir.ref<i32>{{.*}}, %[[ARG2:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 !FIRDialect-DAG: %[[ALPHA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ealpha"}
 !FIRDialect-DAG: %[[BETA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ebeta"}
 !FIRDialect-DAG: %[[GAMA:.*]] = fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Egama"}
@@ -17,7 +17,7 @@
 !FIRDialect:    omp.terminator
 !FIRDialect:  }
 
-!LLVMDialect: llvm.func @_QPshared_clause(%[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>) {
+!LLVMDialect: llvm.func @_QPshared_clause(%[[ARG1:.*]]: !llvm.ptr<i32>{{.*}}, %[[ARG2:.*]]: !llvm.ptr<array<10 x i32>>{{.*}}) {
 !LLVMIRDialect-DAG:  %[[ALPHA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ealpha"} : (i64) -> !llvm.ptr<i32>
 !LLVMIRDialect-DAG:  %[[BETA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Ebeta"} : (i64) -> !llvm.ptr<i32>
 !LLVMIRDialect-DAG:  %[[GAMA:.*]] = llvm.alloca %{{.*}} x i32 {{{.*}}, uniq_name = "{{.*}}Egama"} : (i64) -> !llvm.ptr<i32>

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -12,7 +12,7 @@ contains
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_simple_scalar(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>{{.*}}) {
 subroutine test_simple_scalar(x)
   real, allocatable  :: x
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 4.200000e+01 : f32
@@ -86,7 +86,7 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_deferred_char_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>{{.*}}) {
 subroutine test_deferred_char_scalar(x)
   character(:), allocatable  :: x
 ! CHECK:  %[[VAL_1:.*]] = fir.address_of(@_QQ{{.*}}) : !fir.ref<!fir.char<1,12>>
@@ -130,7 +130,7 @@ subroutine test_deferred_char_scalar(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_cst_char_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>{{.*}}) {
 subroutine test_cst_char_scalar(x)
   character(10), allocatable  :: x
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 10 : index
@@ -172,8 +172,8 @@ subroutine test_cst_char_scalar(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_dyn_char_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine test_dyn_char_scalar(x, n)
   integer :: n
   character(n), allocatable  :: x
@@ -219,8 +219,8 @@ subroutine test_dyn_char_scalar(x, n)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_derived_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.type<_QMalloc_assignTt{i:i32}>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.type<_QMalloc_assignTt{i:i32}>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.type<_QMalloc_assignTt{i:i32}>>{{.*}}) {
 subroutine test_derived_scalar(x, s)
   type(t), allocatable  :: x
   type(t) :: s
@@ -263,8 +263,8 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_from_cst_shape_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.array<2x3xf32>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.array<2x3xf32>>{{.*}}) {
 subroutine test_from_cst_shape_array(x, y)
   real, allocatable  :: x(:, :)
   real :: y(2, 3)
@@ -315,8 +315,8 @@ subroutine test_from_cst_shape_array(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_from_dyn_shape_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}) {
 subroutine test_from_dyn_shape_array(x, y)
   real, allocatable  :: x(:, :)
   real :: y(:, :)
@@ -369,8 +369,8 @@ subroutine test_from_dyn_shape_array(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_with_lbounds(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}) {
 subroutine test_with_lbounds(x, y)
   real, allocatable  :: x(:, :)
   real :: y(10:, 20:)
@@ -427,7 +427,7 @@ subroutine test_with_lbounds(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_runtime_shape(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>{{.*}}) {
 subroutine test_runtime_shape(x)
   real, allocatable  :: x(:, :)
   interface
@@ -561,8 +561,8 @@ end subroutine
 !end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_cst_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>{{.*}},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine test_cst_char(x, c)
   character(10), allocatable  :: x(:)
   character(12) :: c(20)
@@ -609,9 +609,7 @@ subroutine test_cst_char(x, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMalloc_assignPtest_dyn_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_2:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine test_dyn_char(x, n, c)
   integer :: n
   character(n), allocatable  :: x(:)

--- a/flang/test/Lower/allocatable-callee.f90
+++ b/flang/test/Lower/allocatable-callee.f90
@@ -3,7 +3,7 @@
 ! Test allocatable dummy argument on callee side
 
 ! CHECK-LABEL: func @_QPtest_scalar(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>{{.*}})
 subroutine test_scalar(x)
   real, allocatable :: x
 
@@ -14,7 +14,7 @@ subroutine test_scalar(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>{{.*}})
 subroutine test_array(x)
   integer, allocatable :: x(:,:)
 
@@ -26,7 +26,7 @@ subroutine test_array(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_deferred(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>{{.*}})
 subroutine test_char_scalar_deferred(c)
   character(:), allocatable :: c
   external foo1
@@ -40,7 +40,7 @@ subroutine test_char_scalar_deferred(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_explicit_cst(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>{{.*}})
 subroutine test_char_scalar_explicit_cst(c)
   character(10), allocatable :: c
   external foo1
@@ -53,7 +53,7 @@ subroutine test_char_scalar_explicit_cst(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_explicit_dynamic(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>, %[[arg1:.*]]: !fir.ref<i32>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>{{.*}})
 subroutine test_char_scalar_explicit_dynamic(c, n)
   integer :: n
   character(n), allocatable :: c
@@ -72,7 +72,7 @@ subroutine test_char_scalar_explicit_dynamic(c, n)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_array_deferred(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>{{.*}})
 subroutine test_char_array_deferred(c)
   character(:), allocatable :: c(:)
   external foo1
@@ -87,7 +87,7 @@ subroutine test_char_array_deferred(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_array_explicit_cst(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>{{.*}})
 subroutine test_char_array_explicit_cst(c)
   character(10), allocatable :: c(:)
   external foo1
@@ -100,7 +100,7 @@ subroutine test_char_array_explicit_cst(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_array_explicit_dynamic(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>, %[[arg1:.*]]: !fir.ref<i32>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>{{.*}})
 subroutine test_char_array_explicit_dynamic(c, n)
   integer :: n
   character(n), allocatable :: c(:)
@@ -123,7 +123,7 @@ end subroutine
 ! into account when the kind is not 1.
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_deferred_k2(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>{{.*}})
 subroutine test_char_scalar_deferred_k2(c)
   character(kind=2, len=:), allocatable :: c
   external foo2

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPissue(
-! CHECK-SAME:                 %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME:                 %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine issue(c1, c2)
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant false
   ! CHECK-DAG: %[[VAL_3:.*]] = arith.constant 32 : i8

--- a/flang/test/Lower/array-constructor-2.f90
+++ b/flang/test/Lower/array-constructor-2.f90
@@ -20,8 +20,7 @@ end subroutine test1
 
 !  Dynamic array ctor with constant extent.
 ! CHECK-LABEL: func @_QPtest2(
-! CHECK-SAME: %[[a:[^:]*]]: !fir.ref<!fir.array<5xf32>>,
-! CHECK-SAME: %[[b:[^:]*]]: !fir.ref<f32>)
+! CHECK-SAME: %[[a:[^:]*]]: !fir.ref<!fir.array<5xf32>>{{.*}}, %[[b:[^:]*]]: !fir.ref<f32>{{.*}})
 subroutine test2(a, b)
   real :: a(5), b
   real, external :: f
@@ -55,7 +54,7 @@ end subroutine test2
 
 !  Dynamic array ctor with dynamic extent.
 ! CHECK-LABEL: func @_QPtest3(
-! CHECK-SAME: %[[a:.*]]: !fir.box<!fir.array<?xf32>>)
+! CHECK-SAME: %[[a:.*]]: !fir.box<!fir.array<?xf32>>{{.*}})
 subroutine test3(a)
   real :: a(:)
   real, allocatable :: b(:), c(:)
@@ -120,8 +119,7 @@ subroutine test4(a, b, n1, m1)
 end subroutine test4
 
 ! CHECK-LABEL: func @_QPtest5(
-! CHECK-SAME: %[[a:[^:]*]]: !fir.box<!fir.array<?xf32>>,
-! CHECK-SAME: %[[array2:[^:]*]]: !fir.ref<!fir.array<2xf32>>)
+! CHECK-SAME: %[[a:[^:]*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[array2:[^:]*]]: !fir.ref<!fir.array<2xf32>>{{.*}})
 subroutine test5(a, array2)
   real :: a(:)
   real, parameter :: const_array1(2) = [ 1.0, 2.0 ]

--- a/flang/test/Lower/array-copy.f90
+++ b/flang/test/Lower/array-copy.f90
@@ -123,7 +123,7 @@ end subroutine test8
 
 ! Do make a copy. Assume vector subscripts cause dependences.
 ! CHECK-LABEL: func @_QPtest9(
-! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<?x?xf32>>,
+! CHECK-SAME: %[[a:[^:]+]]: !fir.ref<!fir.array<?x?xf32>>
 ! CHECK: %[[und:.*]] = fir.undefined index
 ! CHECK: %[[slice:.*]] = fir.slice %[[und]], %[[und]], %[[und]],
 ! CHECK: %[[heap:.*]] = fir.allocmem !fir.array<?x?xf32>, %{{.*}}, %{{.*}}

--- a/flang/test/Lower/array-derived-assignments.f90
+++ b/flang/test/Lower/array-derived-assignments.f90
@@ -15,8 +15,7 @@ contains
 
 ! Simple copies are implemented inline component by component.
 ! CHECK-LABEL: func @_QMarray_derived_assignPtest_simple_copy(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTsimple_copy{i:i32,c:!fir.array<20x!fir.char<1,10>>,p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>{{.*}}) {
 subroutine test_simple_copy(t1, t2)
   type(simple_copy) :: t1(10), t2(10)
   ! CHECK-DAG:         %[[VAL_2:.*]] = arith.constant 20 : index
@@ -71,8 +70,7 @@ end subroutine
 
 ! Types require more complex assignments are passed to the runtime
 ! CHECK-LABEL: func @_QMarray_derived_assignPtest_deep_copy(
-! CHECK-SAME:                                               %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>,
-! CHECK-SAME:                                               %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}) {
 subroutine test_deep_copy(t1, t2)
   ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 10 : index
   ! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 0 : index

--- a/flang/test/Lower/array-derived.f90
+++ b/flang/test/Lower/array-derived.f90
@@ -17,8 +17,7 @@ module cs
 contains
 
   ! CHECK: func @_QMcsPc1(
-  ! CHECK-SAME: %[[arg0:[^:]+]]: !fir.box<!fir.array<?x!fir.type<_QMcsTr{n:i32,d:i32}>>>,
-  ! CHECK-SAME: %[[arg1:[^:]+]]: !fir.box<!fir.array<?x!fir.type<_QMcsTr{n:i32,d:i32}>>>)
+  ! CHECK-SAME:   %[[arg0:[^:]+]]: !fir.box<!fir.array<?x!fir.type<_QMcsTr{n:i32,d:i32}>>>{{.*}}, %[[arg1:[^:]+]]: !fir.box<!fir.array<?x!fir.type<_QMcsTr{n:i32,d:i32}>>>{{.*}})
   function c1(e, c)
     type(r), intent(in) :: e(:), c(:)
     ! CHECK-DAG: fir.alloca !fir.logical<1> {bindc_name = "c1", uniq_name = "_QMcsFc1Ec1"}
@@ -35,8 +34,7 @@ contains
   end function c1
 
 ! CHECK-LABEL: func @_QMcsPtest2(
-! CHECK-SAME:                    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>,
-! CHECK-SAME:                    %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>{{.*}}) {
 ! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 2 : index
 ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 4 : index
 ! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 0 : index
@@ -79,8 +77,7 @@ contains
   end subroutine test2
 
 ! CHECK-LABEL: func @_QMcsPtest3(
-! CHECK-SAME:                    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>,
-! CHECK-SAME:                    %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>{{.*}}) {
 ! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 2 : index
 ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 3 : index
 ! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 4 : i32

--- a/flang/test/Lower/array-elemental-calls-char-byval.f90
+++ b/flang/test/Lower/array-elemental-calls-char-byval.f90
@@ -14,9 +14,7 @@ end interface
 
 contains
 ! CHECK-LABEL: func @_QMchar_elem_byvalPfoo1(
-! CHECK-SAME: %[[VAL_22:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_19:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_5:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_22:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_19:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_5:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo1(i, j, c)
   integer :: i(10), j(10)
   character(*) :: c(10)
@@ -52,9 +50,7 @@ subroutine foo1(i, j, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elem_byvalPfoo2(
-! CHECK-SAME: %[[VAL_44:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_41:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_29:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_44:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_41:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_29:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo2(i, j, c)
   integer :: i(10), j(10)
   character(*) :: c
@@ -88,8 +84,7 @@ subroutine foo2(i, j, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elem_byvalPfoo3(
-! CHECK-SAME: %[[VAL_65:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_55:[^:]+]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[VAL_65:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_55:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine foo3(i, j)
   integer :: i(10), j(10)
 ! CHECK-DAG:   %[[VAL_46:.*]] = arith.constant 10 : index
@@ -122,8 +117,7 @@ subroutine foo3(i, j)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elem_byvalPfoo4(
-! CHECK-SAME: %[[VAL_93:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_74:[^:]+]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[VAL_93:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_74:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine foo4(i, j)
   integer :: i(10), j(10)
 ! CHECK-DAG:   %[[VAL_67:.*]] = arith.constant 0 : i64
@@ -167,8 +161,7 @@ end subroutine
 ! modified on the caller side.
 
 ! CHECK-LABEL: func @_QMchar_elem_byvalPfoo5(
-! CHECK-SAME: %[[VAL_116:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_113:[^:]+]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[VAL_116:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_113:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine foo5(i, j)
   integer :: i(10), j(10)
 ! CHECK-DAG:   %[[VAL_95:.*]] = arith.constant 5 : index

--- a/flang/test/Lower/array-elemental-calls-char.f90
+++ b/flang/test/Lower/array-elemental-calls-char.f90
@@ -19,8 +19,7 @@ end interface
 contains
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo1(
-! CHECK-SAME: %[[VAL_15:.*]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_4:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_15:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_4:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo1(i, c)
   integer :: i(10)
   character(*) :: c(10)
@@ -49,8 +48,7 @@ subroutine foo1(i, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo1b(
-! CHECK-SAME: %[[VAL_33:.*]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_21:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_33:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_21:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo1b(i, c)
   integer :: i(10)
   character(10) :: c(10)
@@ -80,9 +78,7 @@ subroutine foo1b(i, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo2(
-! CHECK-SAME: %[[VAL_50:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_47:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_39:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_50:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_47:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_39:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo2(i, j, c)
 ! CHECK-DAG:   %[[VAL_35:.*]] = arith.constant 10 : index
 ! CHECK-DAG:   %[[VAL_36:.*]] = arith.constant 0 : index
@@ -110,9 +106,7 @@ subroutine foo2(i, j, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo2b(
-! CHECK-SAME: %[[VAL_67:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_64:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_56:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[VAL_67:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_64:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_56:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo2b(i, j, c)
   integer :: i(10), j(10)
   character(10) :: c
@@ -140,8 +134,7 @@ subroutine foo2b(i, j, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo3(
-! CHECK-SAME: %[[VAL_88:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_79:[^:]+]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[VAL_88:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_79:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}})
 subroutine foo3(i, j)
   integer :: i(10), j(10)
 ! CHECK-DAG:   %[[VAL_69:.*]] = arith.constant 10 : index
@@ -174,8 +167,7 @@ subroutine foo3(i, j)
 end subroutine
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo4(
-! CHECK-SAME: %[[VAL_106:[^:]+]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_103:[^:]+]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[VAL_106:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_103:[^:]+]]: !fir.ref<!fir.array<10xi32>>{{.*}})
 subroutine foo4(i, j)
   integer :: i(10), j(10)
 ! CHECK-DAG:   %[[VAL_90:.*]] = arith.constant 5 : index
@@ -205,7 +197,8 @@ end subroutine
 
 ! Test character return for elemental functions.
 
-! CHECK-LABEL: func @_QMchar_elemPelem_return_char(%arg0: !fir.ref<!fir.char<1,?>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QMchar_elemPelem_return_char(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.char<1,?>>{{.*}}, %{{.*}}: index{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}) -> !fir.boxchar<1>
 elemental function elem_return_char(c)
  character(*), intent(in) :: c
  character(len(c)) :: elem_return_char
@@ -213,7 +206,7 @@ elemental function elem_return_char(c)
 end function
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo6(
-! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo6(c)
   ! CHECK-DAG: %[[VAL_1:.*]] = arith.constant false
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant 32 : i8

--- a/flang/test/Lower/array-elemental-calls.f90
+++ b/flang/test/Lower/array-elemental-calls.f90
@@ -16,8 +16,7 @@ elemental integer function elem_by_valueref(a,b) result(r)
 end function
 
 ! CHECK-LABEL: func @_QMscalar_in_elemPtest_elem_by_ref(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 subroutine test_elem_by_ref(i, j)
   integer :: i(100), j(100)
   ! CHECK: %[[tmp:.*]] = fir.alloca f32
@@ -32,8 +31,7 @@ subroutine test_elem_by_ref(i, j)
 end
 
 ! CHECK-LABEL: func @_QMscalar_in_elemPtest_elem_by_valueref(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 subroutine test_elem_by_valueref(i, j)
   integer :: i(100), j(100)
   ! CHECK-DAG: %[[tmpA:.*]] = fir.alloca i32 {adapt.valuebyref}
@@ -69,8 +67,7 @@ subroutine test_loop_order(i, j)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_loop_order(
-! CHECK-SAME:                           %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME:                           %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_3:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>

--- a/flang/test/Lower/array-elemental-subroutines.f90
+++ b/flang/test/Lower/array-elemental-subroutines.f90
@@ -2,10 +2,7 @@
 ! RUN: bbc -o - -emit-fir %s | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest_elem_sub(
-! CHECK-SAME:                         %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>,
-! CHECK-SAME:                         %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>,
-! CHECK-SAME:                         %[[VAL_2:.*]]: !fir.ref<i32>,
-! CHECK-SAME:                         %[[VAL_3:.*]]: !fir.ref<!fir.complex<4>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<!fir.complex<4>>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.complex<4> {adapt.valuebyref}
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_6:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_5]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
@@ -53,8 +50,7 @@ subroutine test_elem_sub(x, c, i, z)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_elem_sub_no_array_args(
-! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<i32>,
-! CHECK-SAME:                                       %[[VAL_1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine test_elem_sub_no_array_args(i, j)
   integer :: i, j
   interface

--- a/flang/test/Lower/array-expression-assumed-size.f90
+++ b/flang/test/Lower/array-expression-assumed-size.f90
@@ -15,7 +15,7 @@ subroutine assumed_size_forall_test(b)
 end subroutine assumed_size_forall_test
 
 ! CHECK-LABEL: func @_QPassumed_size_test(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_2:.*]] = fir.undefined index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
@@ -75,7 +75,7 @@ end subroutine assumed_size_forall_test
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPassumed_size_forall_test(
-! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_3:.*]] = fir.undefined index
@@ -138,7 +138,7 @@ end subroutine assumed_size_forall_test
 ! CHECK:       }
 
 ! PostOpt-LABEL: func @_QPassumed_size_test(
-! PostOpt-SAME:                             %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! PostOpt-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
 ! PostOpt:         %[[VAL_1:.*]] = arith.constant 10 : index
 ! PostOpt:         %[[VAL_2:.*]] = arith.constant 1 : index
 ! PostOpt:         %[[VAL_3:.*]] = arith.constant 2 : index
@@ -216,7 +216,7 @@ end subroutine assumed_size_forall_test
 ! PostOpt:       }
 
 ! PostOpt-LABEL: func @_QPassumed_size_forall_test(
-! PostOpt-SAME:                                    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>) {
+! PostOpt-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
 ! PostOpt:         %[[VAL_1:.*]] = arith.constant 3 : index
 ! PostOpt:         %[[VAL_2:.*]] = arith.constant 10 : index
 ! PostOpt:         %[[VAL_3:.*]] = arith.constant 2 : index

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -381,7 +381,7 @@ program p
 end program p
 
 ! CHECK-LABEL: func @_QPsub(
-! CHECK-SAME:               %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:               %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK-DAG:     %[[VAL_1:.*]] = arith.constant 5 : index
 ! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 2 : index
 ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 1 : index

--- a/flang/test/Lower/array-expression-subscript.f90
+++ b/flang/test/Lower/array-expression-subscript.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc --emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest1a(
-! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 20 : index
@@ -49,7 +49,7 @@ subroutine test1a(a,b,c)
 end subroutine test1a
 
 ! CHECK-LABEL: func @_QPtest1b(
-! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 20 : index
@@ -97,7 +97,7 @@ subroutine test1b(a,b,c)
 end subroutine test1b
 
 ! CHECK-LABEL: func @_QPtest2a(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 10 : index
@@ -141,7 +141,7 @@ subroutine test2a(a,b,c,d)
 end subroutine test2a
 
 ! CHECK-LABEL: func @_QPtest2b(
-! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 10 : index
@@ -185,7 +185,7 @@ subroutine test2b(a,b,c,d)
 end subroutine test2b
 
 ! CHECK-LABEL: func @_QPtest1c(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<20xi32>>{{.*}}, %[[VAL_3:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 ! CHECK:         return
 ! CHECK:       }
 subroutine test1c(a,b,c,d)

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -38,7 +38,7 @@ subroutine test1b(a,b,c,d,n)
 end subroutine test1b
 
 ! CHECK-LABEL: func @_QPtest2(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>, %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>>, %[[VAL_2:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_4:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_3]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_5:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
@@ -112,7 +112,7 @@ subroutine test5(a,b,c)
 end subroutine test5
 
 ! CHECK-LABEL: func @_QPtest6(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_2:.*]]: !fir.ref<f32>, %[[VAL_3:.*]]: !fir.ref<i32>, %[[VAL_4:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_4:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> i64
 ! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
@@ -159,8 +159,7 @@ subroutine test6(a,b,c,n,m)
 end subroutine test6
 
 ! CHECK-LABEL: func @_QPtest6a(
-! CHECK-SAME:                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x50xf32>>,
-! CHECK-SAME:                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x50xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 50 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -200,8 +199,7 @@ subroutine test6a(a,b)
 end subroutine test6a
 
 ! CHECK-LABEL: func @_QPtest6b(
-! CHECK-SAME:                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x50xf32>>,
-! CHECK-SAME:                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x50xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 50 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -247,7 +245,7 @@ subroutine test6b(a,b)
 end subroutine test6b
 
 ! CHECK-LABEL: func @_QPtest7(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i32) -> i64
 ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
@@ -284,8 +282,7 @@ subroutine test7(a,b,n)
 end subroutine test7
 
 ! CHECK-LABEL: func @_QPtest8(
-! CHECK-SAME:                 %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>,
-! CHECK-SAME:                 %[[VAL_1:.*]]: !fir.ref<!fir.array<100xi32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]](%[[VAL_3]]) : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.array<100xi32>
@@ -330,7 +327,7 @@ subroutine test10(a,b,c,d)
 end subroutine test10
 
 ! CHECK-LABEL: func @_QPtest11(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<100xf32>>, %[[VAL_3:.*]]: !fir.ref<!fir.array<100xf32>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[VAL_3:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 100 : index
@@ -435,8 +432,7 @@ end subroutine test13
 
 ! Test elemental call to function f
 ! CHECK-LABEL: func @_QPtest14(
-! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>,
-! CHECK-SAME: %[[b:.*]]: !fir.ref<!fir.array<100xf32>>)
+! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[b:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}})
 subroutine test14(a,b)
   ! CHECK: %[[barr:.*]] = fir.array_load %[[b]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
   interface
@@ -457,8 +453,7 @@ end subroutine test14
 
 ! Test elemental intrinsic function (abs)
 ! CHECK-LABEL: func @_QPtest15(
-! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>,
-! CHECK-SAME: %[[b:.*]]: !fir.ref<!fir.array<100xf32>>)
+! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[b:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}})
 subroutine test15(a,b)
   ! CHECK-DAG: %[[barr:.*]] = fir.array_load %[[b]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
   ! CHECK-DAG: %[[aarr:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
@@ -474,8 +469,7 @@ end subroutine test15
 
 ! Test elemental call to function f2 with VALUE attribute
 ! CHECK-LABEL: func @_QPtest16(
-! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>,
-! CHECK-SAME: %[[b:.*]]: !fir.ref<!fir.array<100xf32>>)
+! CHECK-SAME: %[[a:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[b:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}})
 subroutine test16(a,b)
   ! CHECK: %[[tmp:.*]] = fir.alloca f32 {adapt.valuebyref
   ! CHECK-DAG: %[[aarr:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
@@ -499,9 +493,7 @@ end subroutine test16
 ! Test elemental impure call to function f3.
 !
 ! CHECK-LABEL: func @_QPtest17(
-! CHECK-SAME: %[[a:[^:]+]]: !fir.ref<!fir.array<100xf32>>,
-! CHECK-SAME: %[[b:[^:]+]]: !fir.ref<!fir.array<100xf32>>,
-! CHECK-SAME: %[[c:.*]]: !fir.ref<!fir.array<100xf32>>)
+! CHECK-SAME: %[[a:[^:]+]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[b:[^:]+]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[c:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}})
 subroutine test17(a,b,c)
   ! CHECK-DAG: %[[aarr:.*]] = fir.array_load %[[a]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
   ! CHECK-DAG: %[[barr:.*]] = fir.array_load %[[b]](%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shapeshift<1>) -> !fir.array<100xf32>
@@ -568,7 +560,7 @@ subroutine test18
 end subroutine test18
 
 ! CHECK-LABEL: func @_QPtest_column_and_row_order(
-! CHECK-SAME:              %[[VAL_0:.*]]: !fir.ref<!fir.array<2x3xf32>>) {
+! CHECK-SAME:              %[[VAL_0:.*]]: !fir.ref<!fir.array<2x3xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 2 : index
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 3 : index
 ! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_1]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
@@ -596,7 +588,7 @@ subroutine test_column_and_row_order(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_assigning_to_assumed_shape_slices(
-! CHECK-SAME:                %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>) {
+! CHECK-SAME:                %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 2 : i64
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (i64) -> index
@@ -630,7 +622,7 @@ subroutine test_assigning_to_assumed_shape_slices(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest19a(
-! CHECK-SAME:      %[[VAL_0:.*]]: !fir.boxchar<1>, %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1,10>>>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -669,8 +661,7 @@ subroutine test19a(a,b)
 end subroutine test19a
 
 ! CHECK-LABEL: func @_QPtest19b(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.boxchar<2>,
-! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.boxchar<2>) {
+! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.boxchar<2>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<2>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<2>) -> (!fir.ref<!fir.char<2,?>>, index)
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<2,?>>) -> !fir.ref<!fir.array<20x!fir.char<2,8>>>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 20 : index
@@ -723,7 +714,7 @@ subroutine test19b(a,b)
 end subroutine test19b
 
 ! CHECK-LABEL: func @_QPtest19c(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<4>, %[[VAL_1:.*]]: !fir.boxchar<4>, %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<4>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<4>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<4>) -> (!fir.ref<!fir.char<4,?>>, index)
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]]#0 : (!fir.ref<!fir.char<4,?>>) -> !fir.ref<!fir.array<30x!fir.char<4,10>>>
@@ -781,7 +772,7 @@ subroutine test19c(a,b,i)
 end subroutine test19c
 
 ! CHECK-LABEL: func @_QPtest19d(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>, %[[VAL_1:.*]]: !fir.boxchar<1>, %[[VAL_2:.*]]: !fir.ref<i32>, %[[VAL_3:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -843,8 +834,7 @@ subroutine test19d(a,b,i,j)
 end subroutine test19d
 
 ! CHECK-LABEL: func @_QPtest19e(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<50x!fir.char<1,?>>>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 50 : index
@@ -895,8 +885,7 @@ subroutine test19e(a,b)
 end subroutine test19e
 
 ! CHECK-LABEL: func @_QPtest19f(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<60x!fir.char<1,?>>>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 60 : index
@@ -969,9 +958,7 @@ subroutine test19f(a,b)
 end subroutine test19f
 
 ! CHECK-LABEL: func @_QPtest19g(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.boxchar<4>,
-! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.boxchar<2>,
-! CHECK-SAME:                   %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:            %[[VAL_0:.*]]: !fir.boxchar<4>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<2>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<2>) -> (!fir.ref<!fir.char<2,?>>, index)
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 13 : index
 ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]]#0 : (!fir.ref<!fir.char<2,?>>) -> !fir.ref<!fir.array<140x!fir.char<2,13>>>
@@ -1054,7 +1041,7 @@ subroutine test19g(a,b,i)
 end subroutine test19g
 
 ! CHECK-LABEL: func @_QPtest19h(
-! CHECK-SAME:       %[[VAL_0:.*]]: !fir.boxchar<1>, %[[VAL_1:.*]]: !fir.boxchar<1>, %[[VAL_2:.*]]: !fir.ref<i32>, %[[VAL_3:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 0 : i32
@@ -1120,7 +1107,7 @@ subroutine test19h(a,b,i,j)
 end subroutine test19h
 
 ! CHECK-LABEL: func @_QPtest_elemental_character_intrinsic(
-! CHECK-SAME:        %[[VAL_0:.*]]: !fir.boxchar<1>, %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1,?>>>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index

--- a/flang/test/Lower/array-substring.f90
+++ b/flang/test/Lower/array-substring.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.boxchar<1>) -> !fir.array<1x!fir.logical<4>> {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) -> !fir.array<1x!fir.logical<4>> {
 ! CHECK-DAG:         %[[VAL_1:.*]] = arith.constant 1 : index
 ! CHECK-DAG:         %[[VAL_2:.*]] = arith.constant 0 : index
 ! CHECK-DAG:         %[[VAL_3:.*]] = arith.constant 0 : i32

--- a/flang/test/Lower/array-user-def-assignments.f90
+++ b/flang/test/Lower/array-user-def-assignments.f90
@@ -27,7 +27,7 @@ module defined_assignments
 end module
 
 ! CHECK-LABEL: func @_QPtest_derived(
-! CHECK-SAME:                        %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_2:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_3:.*]] = fir.array_load %[[VAL_0]](%[[VAL_2]]) : (!fir.ref<!fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>>, !fir.shape<1>) -> !fir.array<100x!fir.type<_QMdefined_assignmentsTt{i:i32}>>
@@ -54,7 +54,7 @@ end module
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_intrinsic(
-! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>) {
+! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.logical<4>
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
@@ -86,8 +86,7 @@ end module
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_intrinsic_2(
-! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>,
-! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>) {
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 100 : index
@@ -110,8 +109,7 @@ end module
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPfrom_char(
-! CHECK-SAME:                     %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME:                     %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK-SAME:                     %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_3:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
@@ -132,8 +130,7 @@ end module
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPto_char(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME:                   %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_4:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_3]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>, index) -> (index, index, index)
@@ -203,8 +200,7 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest_in_forall_1(
-! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
-! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -242,8 +238,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_in_forall_2(
-! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
-! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.logical<4>
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -281,9 +276,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_intrinsic_where_1(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>,
-! CHECK-SAME:                                  %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>) {
+! CHECK-SAME:             %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca f32
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
@@ -335,9 +328,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_intrinsic_where_2(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>,
-! CHECK-SAME:                                  %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>) {
+! CHECK-SAME:           %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.logical<4>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
@@ -391,8 +382,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_scalar_func_but_not_elemental(
-! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>,
-! CHECK-SAME:                                              %[[VAL_1:.*]]: !fir.ref<!fir.array<100xi32>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<100x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 100 : index
@@ -430,8 +420,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPtest_in_forall_with_cleanup(
-! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>,
-! CHECK-SAME:                                       %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = ".result"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
@@ -530,8 +519,7 @@ subroutine test_in_forall_with_cleanup(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_forall_array(
-! CHECK-SAME:                             %[[VAL_0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>,
-! CHECK-SAME:                             %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca f32
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32
@@ -598,8 +586,7 @@ subroutine test_forall_array(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfrom_char_forall(
-! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i32) -> index
@@ -633,8 +620,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPto_char_forall(
-! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME:                          %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32
@@ -694,8 +680,7 @@ subroutine to_char_forall(i, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfrom_char_forall_array(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i32) -> index
@@ -755,8 +740,7 @@ end subroutine
 ! CHECK:       }
 
 ! CHECK-LABEL: func @_QPto_char_forall_array(
-! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME:                                %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.char<1,?>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/associate-construct-2.f90
+++ b/flang/test/Lower/associate-construct-2.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest1(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>, %[[VAL_1:.*]]: !fir.ref<i32>, %[[VAL_2:.*]]: !fir.ref<i32>, %[[VAL_3:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> i64
@@ -35,7 +35,7 @@ subroutine test1(a,i,j,k)
 end subroutine test1
 
 ! CHECK-LABEL: func @_QPtest2(
-! CHECK-SAME: %[[nadd:.*]]: !fir.ref<i32>)
+! CHECK-SAME: %[[nadd:.*]]: !fir.ref<i32>{{.*}})
 subroutine test2(n)
   integer :: n
   integer, external :: foo

--- a/flang/test/Lower/assumed-shape-callee.f90
+++ b/flang/test/Lower/assumed-shape-callee.f90
@@ -8,7 +8,7 @@
 ! of making a new fir.box and this would break all these tests. In fact, for non
 ! contiguous arrays, this is the case. Find a better way to tests symbol lowering/mapping.
 
-! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.contiguous}) 
+! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "x", fir.contiguous}) 
 subroutine test_assumed_shape_1(x)
   integer, contiguous :: x(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
@@ -26,7 +26,7 @@ subroutine test_assumed_shape_1(x)
 end subroutine
 
 ! lower bounds all ones
-! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.contiguous})
+! CHECK-LABEL:  func @_QPtest_assumed_shape_2(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.bindc_name = "x", fir.contiguous})
 subroutine test_assumed_shape_2(x)
   real, contiguous :: x(1:, 1:)
   ! CHECK: fir.box_addr
@@ -38,7 +38,7 @@ subroutine test_assumed_shape_2(x)
 end subroutine
 
 ! explicit lower bounds different from 1
-! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>> {fir.contiguous})
+! CHECK-LABEL: func @_QPtest_assumed_shape_3(%arg0: !fir.box<!fir.array<?x?x?xi32>> {fir.bindc_name = "x", fir.contiguous})
 subroutine test_assumed_shape_3(x)
   integer, contiguous :: x(2:, 3:, 42:)
   ! CHECK: fir.box_addr
@@ -57,7 +57,7 @@ subroutine test_assumed_shape_3(x)
 end subroutine
 
 ! Constant length
-! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>> {fir.contiguous})
+! func @_QPtest_assumed_shape_char(%arg0: !fir.box<!fir.array<?x!fir.char<1,10>>> {fir.bindc_name = "c", fir.contiguous})
 subroutine test_assumed_shape_char(c)
   character(10), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,10>>>) -> !fir.ref<!fir.array<?x!fir.char<1,10>>>
@@ -71,7 +71,7 @@ subroutine test_assumed_shape_char(c)
 end subroutine
 
 ! Assumed length
-! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.contiguous})
+! CHECK-LABEL: func @_QPtest_assumed_shape_char_2(%arg0: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.bindc_name = "c", fir.contiguous})
 subroutine test_assumed_shape_char_2(c)
   character(*), contiguous :: c(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
@@ -87,7 +87,7 @@ end subroutine
 
 
 ! lower bounds all 1.
-! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>> {fir.contiguous})
+! CHECK: func @_QPtest_assumed_shape_char_3(%arg0: !fir.box<!fir.array<?x?x!fir.char<1,?>>> {fir.bindc_name = "c", fir.contiguous})
 subroutine test_assumed_shape_char_3(c)
   character(*), contiguous :: c(1:, 1:)
   ! CHECK: fir.box_addr

--- a/flang/test/Lower/assumed-shape-caller.f90
+++ b/flang/test/Lower/assumed-shape-caller.f90
@@ -26,7 +26,7 @@ end subroutine
 
 
 ! Test passing character array as assumed shape.
-! CHECK-LABEL: func @_QPfoo_char(%arg0: !fir.boxchar<1>)
+! CHECK-LABEL: func @_QPfoo_char(%arg0: !fir.boxchar<1>{{.*}})
 subroutine foo_char(x)
   interface
     subroutine bar_char(x)

--- a/flang/test/Lower/attributes.f90
+++ b/flang/test/Lower/attributes.f90
@@ -4,10 +4,10 @@
 
 
 ! CHECK-LABEL: func @_QPfoo1(
-! CHECK-SAME: %arg0: !fir.ref<f32> {fir.optional},
-! CHECK-SAME: %arg1: !fir.box<!fir.array<?xf32>> {fir.optional},
-! CHECK-SAME: %arg2: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.optional},
-! CHECK-SAME: %arg3: !fir.boxchar<1> {fir.optional}
+! CHECK-SAME: %arg0: !fir.ref<f32> {fir.bindc_name = "x", fir.optional},
+! CHECK-SAME: %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "y", fir.optional},
+! CHECK-SAME: %arg2: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "i", fir.optional},
+! CHECK-SAME: %arg3: !fir.boxchar<1> {fir.bindc_name = "c", fir.optional}
 subroutine foo1(x, y, i, c)
   real, optional :: x, y(:)
   integer, allocatable, optional :: i(:)
@@ -15,15 +15,15 @@ subroutine foo1(x, y, i, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo2(
-! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous},
-! CHECK-SAME: %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {fir.contiguous}
+! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous},
+! CHECK-SAME: %arg1: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {fir.bindc_name = "i", fir.contiguous}
 subroutine foo2(x, i)
   real, contiguous :: x(:)
   integer, pointer, contiguous :: i(:)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo3
-! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous, fir.optional}
+! CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous, fir.optional}
 subroutine foo3(x)
   real, optional, contiguous :: x(:)
 end subroutine

--- a/flang/test/Lower/call-copy-in-out.f90
+++ b/flang/test/Lower/call-copy-in-out.f90
@@ -3,7 +3,7 @@
 
 ! Nominal test
 ! CHECK-LABEL: func @_QPtest_assumed_shape_to_array(
-! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_assumed_shape_to_array(x)
   real :: x(:)
 ! Creating temp
@@ -44,7 +44,7 @@ end subroutine
 ! Test that copy-in/copy-out does not trigger the re-evaluation of
 ! the designator expression.
 ! CHECK-LABEL: func @_QPeval_expr_only_once(
-! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<200xf32>>) {
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<200xf32>>{{.*}}) {
 subroutine eval_expr_only_once(x)
   integer :: only_once
   real :: x(200)
@@ -80,7 +80,7 @@ end subroutine
 
 ! Test the parenthesis are preventing copy-out.
 ! CHECK: func @_QPtest_parenthesis(
-! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_parenthesis(x)
   real :: x(:)
 ! CHECK: %[[dim:.*]]:3 = fir.box_dims %[[x]], %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
@@ -96,7 +96,7 @@ end subroutine
 
 ! Test copy-in in is skipped for intent(out) arguments.
 ! CHECK: func @_QPtest_intent_out(
-! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_intent_out(x)
   real :: x(:)
   interface
@@ -117,7 +117,7 @@ end subroutine
 
 ! Test copy-out is skipped for intent(out) arguments.
 ! CHECK: func @_QPtest_intent_in(
-! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_intent_in(x)
   real :: x(:)
   interface
@@ -138,7 +138,7 @@ end subroutine
 
 ! Test copy-in/copy-out is done for intent(inout)
 ! CHECK: func @_QPtest_intent_inout(
-! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_intent_inout(x)
   real :: x(:)
   interface
@@ -159,7 +159,7 @@ end subroutine
 
 ! Test characters are handled correctly
 ! CHECK-LABEL: func @_QPtest_char(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,10>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,10>>>{{.*}}) {
 subroutine test_char(x)
   ! CHECK: %[[VAL_1:.*]] = arith.constant 10 : index
   ! CHECK: %[[VAL_2:.*]] = arith.constant 0 : index
@@ -235,7 +235,7 @@ subroutine test_scalar_substring_does_no_trigger_copy_inout(c, i, j)
 end subroutine
 
 ! CHECK-LABEL: func @_QPissue871(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFissue871Tt{i:i32}>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFissue871Tt{i:i32}>>>>{{.*}})
 subroutine issue871(p)
   ! Test passing implicit derived from scalar pointer (no copy-in/out).
   type t

--- a/flang/test/Lower/call-parenthesized-arg.f90
+++ b/flang/test/Lower/call-parenthesized-arg.f90
@@ -3,7 +3,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPfoo_num_scalar(
-! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:      %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine foo_num_scalar(x)
   integer :: x
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32
@@ -19,7 +19,7 @@ subroutine foo_num_scalar(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo_char_scalar(
-! CHECK-SAME:                           %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:         %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo_char_scalar(x)
   character(5) :: x
 ! CHECK:         %[[VAL_1:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -45,7 +45,7 @@ subroutine foo_char_scalar(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo_num_array(
-! CHECK-SAME:                         %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>) {
+! CHECK-SAME:                         %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 subroutine foo_num_array(x)
   integer :: x(100)
   call bar_num_array(x)
@@ -77,7 +77,7 @@ subroutine foo_num_array(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo_char_array(
-! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine foo_char_array(x)
   ! CHECK: %[[VAL_1:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[VAL_2:.*]] = arith.constant 10 : index
@@ -126,7 +126,7 @@ subroutine foo_char_array(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo_num_array_box(
-! CHECK-SAME:                             %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>) {
+! CHECK-SAME:                             %[[VAL_0:.*]]: !fir.ref<!fir.array<100xi32>>{{.*}}) {
 subroutine foo_num_array_box(x)
   ! CHECK: %[[VAL_1:.*]] = arith.constant 100 : index
   ! CHECK: %[[VAL_2:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
@@ -169,8 +169,7 @@ subroutine foo_num_array_box(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPfoo_char_array_box(
-! CHECK-SAME:                              %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME:                              %[[VAL_1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:          %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine foo_char_array_box(x, n)
   ! CHECK: %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK: %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1,10>>>

--- a/flang/test/Lower/character-local-variables.f90
+++ b/flang/test/Lower/character-local-variables.f90
@@ -47,7 +47,7 @@ subroutine dyn_array_cst_len(n)
 end subroutine
 
 ! CHECK: func @_QPdyn_array_dyn_len
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.ref<i32>
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>
 subroutine dyn_array_dyn_len(l, n)
   integer :: l, n
   character(l) :: c(n)
@@ -89,7 +89,7 @@ subroutine dyn_array_cst_len_lb(n)
 end subroutine
 
 ! CHECK-LABEL: func @_QPdyn_array_dyn_len_lb
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>, %[[arg1:.*]]: !fir.ref<i64>
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>{{.*}}, %[[arg1:.*]]: !fir.ref<i64>
 subroutine dyn_array_dyn_len_lb(l, n)
   integer(8) :: l, n
   character(l) :: c(11:n)

--- a/flang/test/Lower/character-substrings.f90
+++ b/flang/test/Lower/character-substrings.f90
@@ -3,8 +3,7 @@
 
 ! Test substring lower where the parent is a scalar-char-literal-constant
 ! CHECK-LABEL: func @_QPscalar_substring_embox(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine scalar_substring_embox(i, j)
   ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,18>>
   ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
@@ -30,7 +29,7 @@ subroutine scalar_substring_embox(i, j)
 end subroutine scalar_substring_embox
 
 ! CHECK-LABEL: func @_QParray_substring_embox(
-! CHECK-SAME:                                 %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_2:.*]] = fir.convert %[[VAL_1]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<4x!fir.char<1,7>>>
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 4 : index
@@ -68,8 +67,7 @@ subroutine array_substring_embox(arr)
 end subroutine array_substring_embox
 
 ! CHECK-LABEL: func @_QPsubstring_assignment(
-! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME:                                %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine substring_assignment(a,b)
   ! CHECK:         %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   ! CHECK:         %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -129,7 +127,7 @@ subroutine substring_assignment(a,b)
 end subroutine substring_assignment
 
 ! CHECK-LABEL: func @_QParray_substring_assignment(
-! CHECK-SAME:                                      %[[VAL_0:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_2:.*]] = fir.convert %[[VAL_1]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<6x!fir.char<1,5>>>
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 6 : index
@@ -222,7 +220,7 @@ subroutine array_substring_assignment(a)
 end subroutine array_substring_assignment
 
 ! CHECK-LABEL: func @_QParray_substring_assignment2(
-! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 8 : index
 ! CHECK:         %[[VAL_2:.*]] = fir.field_index ch, !fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>
 ! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
@@ -307,7 +305,7 @@ subroutine array_substring_assignment2(a)
 end subroutine array_substring_assignment2
 
 ! CHECK-LABEL: func @_QParray_substring_assignment3(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 8 : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 8 : index
 ! CHECK:         %[[VAL_4:.*]] = fir.field_index ch, !fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>

--- a/flang/test/Lower/components.f90
+++ b/flang/test/Lower/components.f90
@@ -122,7 +122,7 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPlhs_char_section(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFlhs_char_sectionTt{c:!fir.char<1,5>}>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFlhs_char_sectionTt{c:!fir.char<1,5>}>>>{{.*}}) {
 subroutine lhs_char_section(a)
   ! CHECK-DAG: %[[VAL_1:.*]] = arith.constant 5 : index
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant false
@@ -157,8 +157,7 @@ subroutine lhs_char_section(a)
 end subroutine
 
 ! CHECK-LABEL: func @_QPrhs_char_section(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFrhs_char_sectionTt{c:!fir.char<1,10>}>>>,
-! CHECK-SAME:    %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFrhs_char_sectionTt{c:!fir.char<1,10>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine rhs_char_section(a, c)
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant false
   ! CHECK-DAG: %[[VAL_3:.*]] = arith.constant 10 : index
@@ -195,8 +194,7 @@ subroutine rhs_char_section(a, c)
 end subroutine
 
 ! CHECK-LABEL: func @_QPelemental_char_section(
-! CHECK-SAME: %[[A:.*]]: !fir.ref<!fir.array<{{.*}}>>,
-! CHECK-SAME: %[[I:.*]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[A:.*]]: !fir.ref<!fir.array<{{.*}}>>{{.*}}, %[[I:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine elemental_char_section(a, i)
   type t
    character(10) :: c

--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -75,7 +75,7 @@ contains
   ! Test that optional intent(out) are default initialized only when
   ! present.
   ! CHECK-LABEL: func @_QMtest_dinitPintent_out_optional(
-  ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>> {fir.optional})
+  ! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.type<_QMtest_dinitTt{i:i32}>> {fir.bindc_name = "x", fir.optional})
   subroutine intent_out_optional(x)
     ! CHECK: %[[isPresent:.*]] = fir.is_present %[[x]] : (!fir.box<!fir.type<_QMtest_dinitTt{i:i32}>>) -> i1
     ! CHECK: fir.if %[[isPresent]] {

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -74,10 +74,7 @@ contains
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMacompPref_scalar_real_a(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>,
-! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>>,
-! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>{{.*}}, %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a0{p:!fir.box<!fir.heap<f32>>}>>>{{.*}}, %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}) {
 subroutine ref_scalar_real_a(a0_0, a1_0, a0_1, a1_1)
   type(real_a0) :: a0_0, a0_1(100)
   type(real_a1) :: a1_0, a1_1(100)
@@ -124,8 +121,7 @@ subroutine ref_scalar_real_a(a0_0, a1_0, a0_1, a1_1)
 end subroutine
 
 ! CHECK-LABEL: func @_QMacompPref_array_real_a(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.field_index p, !fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>
 ! CHECK:         %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QMacompTreal_a1{p:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>

--- a/flang/test/Lower/derived-assignments.f90
+++ b/flang/test/Lower/derived-assignments.f90
@@ -44,8 +44,7 @@ contains
 
   ! Swap elements on assignment.
   ! CHECK-LABEL: func @_QMm2Pt_to_t(
-  ! CHECK-SAME: %[[a1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>,
-  ! CHECK-SAME: %[[b1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>)
+  ! CHECK-SAME: %[[a1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>{{.*}}, %[[b1:[^:]*]]: !fir.ref<!fir.type<_QMm2Tt{a:i32,b:i32}>>{{.*}}) {
   subroutine t_to_t(a1,b1)
     type(t), intent(out) :: a1
     type(t), intent(in) :: b1
@@ -97,8 +96,7 @@ subroutine test3
 end subroutine test3
 
 ! CHECK-LABEL: func @_QPtest_array_comp(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>)
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.type<_QFtest_array_compTt{m_x:!fir.array<10xf32>,m_i:i32}>>{{.*}}) {
 subroutine test_array_comp(t1, t2)
   type t
      real :: m_x(10)
@@ -127,8 +125,7 @@ subroutine test_array_comp(t1, t2)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_ptr_comp(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>,
-! CHECK-SAME: %[[VAL_1]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>)
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>{{.*}}, %[[VAL_1]]: !fir.ref<!fir.type<_QFtest_ptr_compTt{ptr:!fir.box<!fir.ptr<!fir.array<?x!fir.complex<4>>>>,m_i:i32}>>{{.*}}) {
 subroutine test_ptr_comp(t1, t2)
   type t
      complex, pointer :: ptr(:)
@@ -150,8 +147,7 @@ subroutine test_ptr_comp(t1, t2)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_box_assign(
-! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>,
-! CHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>)
+! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>{{.*}}, %[[t2:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.type<_QFtest_box_assignTt{i:i32}>>>>{{.*}}) {
 subroutine test_box_assign(t1, t2)
   type t
      integer :: i
@@ -171,8 +167,7 @@ subroutine test_box_assign(t1, t2)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_alloc_comp(
-! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>,
-! CHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>)
+! CHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>{{.*}}, %[[t2:.*]]: !fir.ref<!fir.type<_QFtest_alloc_compTt{x:!fir.box<!fir.heap<!fir.array<?x?xf32>>>,i:i32}>>{{.*}}) {
 subroutine test_alloc_comp(t1, t2)
 ! Test that derived type assignment with allocatable components are using the
 ! runtime to handle the deep copy.
@@ -218,8 +213,7 @@ end subroutine
 
 !contains
 !  ! cHECK-LABEL: func @_QMcomponent_with_user_def_assignPtest(
-!  ! cHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>,
-!  ! cHECK-SAME: %[[t2:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>)
+!  ! cHECK-SAME: %[[t1:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>{{.*}}, %[[t2:.*]]: !fir.ref<!fir.type<_QMcomponent_with_user_def_assignTt{a:!fir.type<_QMcomponent_with_user_def_assignTt0{i:i32,j:i32}>,i:i32}>>{{.*}}) {
 !  subroutine test(t1, t2)
 !    type(t) :: t1, t2
 !    ! cHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.type<_QMcomponent_with_user_def_assignTt{{.*}}>>

--- a/flang/test/Lower/derived-pointer-components.f90
+++ b/flang/test/Lower/derived-pointer-components.f90
@@ -74,10 +74,7 @@ contains
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMpcompPref_scalar_real_p(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>,
-! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>>,
-! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>{{.*}}, %[[arg2:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p0{p:!fir.box<!fir.ptr<f32>>}>>>{{.*}}, %[[arg3:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>{{.*}}) {
 subroutine ref_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
   type(real_p0) :: p0_0, p0_1(100)
   type(real_p1) :: p1_0, p1_1(100)
@@ -122,8 +119,7 @@ subroutine ref_scalar_real_p(p0_0, p1_0, p0_1, p1_1)
 end subroutine
 
 ! CHECK-LABEL: func @_QMpcompPref_array_real_p(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>) {
+! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<100x!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.field_index p, !fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
 ! CHECK:         %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.type<_QMpcompTreal_p1{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.field) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>

--- a/flang/test/Lower/derived-types.f90
+++ b/flang/test/Lower/derived-types.f90
@@ -22,15 +22,14 @@ contains
 !            Test simple derived type symbol lowering 
 ! -----------------------------------------------------------------------------
 
-! CHECK-LABEL: @_QMdPderived_dummy
-! CHECK-SAME: (%{{.*}}: !fir.ref<!fir.type<_QMdTr{x:f32}>>,
-! CHECK-SAME: %{{.*}}: !fir.ref<!fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>
+! CHECK-LABEL: func @_QMdPderived_dummy(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.type<_QMdTr{x:f32}>>{{.*}}, %{{.*}}: !fir.ref<!fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>{{.*}}) {
 subroutine derived_dummy(some_r, some_c2)
   type(r) :: some_r
   type(c2) :: some_c2
 end subroutine
 
-! CHECK-LABEL: @_QMdPlocal_derived
+! CHECK-LABEL: func @_QMdPlocal_derived(
 subroutine local_derived()
   ! CHECK-DAG: fir.alloca !fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>
   ! CHECK-DAG: fir.alloca !fir.type<_QMdTr{x:f32}>
@@ -38,7 +37,7 @@ subroutine local_derived()
   type(c2) :: some_c2
 end subroutine
 
-! CHECK-LABEL: @_QMdPsaved_derived
+! CHECK-LABEL: func @_QMdPsaved_derived(
 subroutine saved_derived()
   ! CHECK-DAG: fir.address_of(@_QMdFsaved_derivedEsome_c2) : !fir.ref<!fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>
   ! CHECK-DAG: fir.address_of(@_QMdFsaved_derivedEsome_r) : !fir.ref<!fir.type<_QMdTr{x:f32}>>
@@ -52,7 +51,7 @@ end subroutine
 !            Test simple derived type references 
 ! -----------------------------------------------------------------------------
 
-! CHECK-LABEL: @_QMdPscalar_numeric_ref 
+! CHECK-LABEL: func @_QMdPscalar_numeric_ref(
 subroutine scalar_numeric_ref()
   ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<_QMdTr{x:f32}>
   type(r) :: some_r
@@ -61,7 +60,7 @@ subroutine scalar_numeric_ref()
   call real_bar(some_r%x)
 end subroutine
 
-! CHECK-LABEL: @_QMdPscalar_character_ref 
+! CHECK-LABEL: func @_QMdPscalar_character_ref(
 subroutine scalar_character_ref()
   ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<_QMdTc{ch:!fir.char<1,10>}>
   type(c) :: some_c
@@ -76,7 +75,7 @@ end subroutine
 ! FIXME: coordinate of generated for derived%array_comp(i) are not zero based as they
 ! should be.
 
-! CHECK-LABEL: @_QMdParray_comp_elt_ref
+! CHECK-LABEL: func @_QMdParray_comp_elt_ref(
 subroutine array_comp_elt_ref()
   type(r2) :: some_r2
   ! CHECK: %[[alloc:.*]] = fir.alloca !fir.type<_QMdTr2{x_array:!fir.array<10x20xf32>}>
@@ -89,7 +88,7 @@ subroutine array_comp_elt_ref()
 end subroutine
 
 
-! CHECK-LABEL: @_QMdPchar_array_comp_elt_ref
+! CHECK-LABEL: func @_QMdPchar_array_comp_elt_ref(
 subroutine char_array_comp_elt_ref()
   type(c2) :: some_c2
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %{{.*}}, %{{.*}} : (!fir.ref<!fir.type<_QMdTc2{ch_array:!fir.array<20x30x!fir.char<1,10>>}>>, !fir.field) -> !fir.ref<!fir.array<20x30x!fir.char<1,10>>>
@@ -128,7 +127,7 @@ end subroutine
 ! components. This one requires loading a component which tests other code paths
 ! in lowering.
 
-! CHECK-LABEL: @_QMdPscalar_numeric_load
+! CHECK-LABEL: func @_QMdPscalar_numeric_load(
 ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMdTr{x:f32}>>
 real function scalar_numeric_load(some_r)
   type(r) :: some_r
@@ -142,7 +141,7 @@ end function
 !            Test returned derived types (no length parameters)
 ! -----------------------------------------------------------------------------
 
-! CHECK-LABEL: @_QMdPbar_return_derived() -> !fir.type<_QMdTr{x:f32}>
+! CHECK-LABEL: func @_QMdPbar_return_derived() -> !fir.type<_QMdTr{x:f32}>
 function bar_return_derived()
   ! CHECK: %[[res:.*]] = fir.alloca !fir.type<_QMdTr{x:f32}>
   type(r) :: bar_return_derived
@@ -150,7 +149,7 @@ function bar_return_derived()
   ! CHECK: return %[[resLoad]] : !fir.type<_QMdTr{x:f32}>
 end function
 
-! CHECK-LABEL: @_QMdPcall_bar_return_derived
+! CHECK-LABEL: func @_QMdPcall_bar_return_derived(
 subroutine call_bar_return_derived()
   ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMdTr{x:f32}>
   ! CHECK: %[[call:.*]] = fir.call @_QMdPbar_return_derived() : () -> !fir.type<_QMdTr{x:f32}>
@@ -171,8 +170,8 @@ module d2
     type(recursive_t), pointer :: ptr
   end type
 contains
-! CHECK-LABEL: @_QMd2Ptest_recursive_type
-! CHECK: (%{{.*}}: !fir.ref<!fir.type<_QMd2Trecursive_t{x:f32,ptr:!fir.box<!fir.ptr<!fir.type<_QMd2Trecursive_t>>>}>>)
+! CHECK-LABEL: func @_QMd2Ptest_recursive_type(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.type<_QMd2Trecursive_t{x:f32,ptr:!fir.box<!fir.ptr<!fir.type<_QMd2Trecursive_t>>>}>>{{.*}}) {
 subroutine test_recursive_type(some_recursive)
   type(recursive_t) :: some_recursive
 end subroutine

--- a/flang/test/Lower/dummy-argument-contiguous.f90
+++ b/flang/test/Lower/dummy-argument-contiguous.f90
@@ -8,7 +8,7 @@
 ! attribute to the fir argument and that is takes the contiguity into account
 ! In practice, test that the input fir.box is not propagated to fir operations.
 
-! CHECK-LABEL: func @_QPtest_element_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! CHECK-LABEL: func @_QPtest_element_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! ArrayCoorCHECK-LABEL: func @_QPtest_element_ref
 subroutine test_element_ref(x, y)
   real, contiguous :: x(:)
@@ -37,7 +37,7 @@ subroutine test_element_ref(x, y)
   ! ArrayCoorCHECK: fir.array_coor %arg1(%[[shift]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_element_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! CHECK-LABEL: func @_QPtest_element_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>{{.*}}) {
 !  ArrayCoorCHECK-LABEL: func @_QPtest_element_assign
 subroutine test_element_assign(x, y)
   real, contiguous :: x(:)
@@ -61,7 +61,7 @@ subroutine test_element_assign(x, y)
   ! ArrayCoorCHECK: fir.array_coor %arg1(%[[shift]]) %[[c100_1]] : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, index) -> !fir.ref<f32>
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_ref_in_array_expr(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! CHECK-LABEL: func @_QPtest_ref_in_array_expr(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_ref_in_array_expr(x, y)
   real, contiguous :: x(:)
   ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -73,7 +73,7 @@ subroutine test_ref_in_array_expr(x, y)
 end subroutine
 
 
-! CHECK-LABEL: func @_QPtest_assign_in_array_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>) {
+! CHECK-LABEL: func @_QPtest_assign_in_array_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_assign_in_array_ref(x, y)
   real, contiguous :: x(:)
   ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -88,7 +88,7 @@ subroutine test_assign_in_array_ref(x, y)
   ! CHECK: fir.array_merge_store %[[yload]], %[[yloop]] to %arg1 : !fir.array<?xf32>, !fir.array<?xf32>, !fir.box<!fir.array<?xf32>>
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_slice_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+! CHECK-LABEL: func @_QPtest_slice_ref(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
 subroutine test_slice_ref(x, y, z1, z2, i, j, k, n)
   real, contiguous :: x(:)
   ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -103,7 +103,7 @@ subroutine test_slice_ref(x, y, z1, z2, i, j, k, n)
   ! CHECK: fir.array_load %arg1 {{.*}}%[[yslice]]{{.*}} : (!fir.box<!fir.array<?xf32>>, !fir.slice<1>) -> !fir.array<?xf32>
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_slice_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
+! CHECK-LABEL: func @_QPtest_slice_assign(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous}, %arg1: !fir.box<!fir.array<?xf32>>
 subroutine test_slice_assign(x, y, i, j, k)
   real, contiguous :: x(:)
   ! CHECK: %[[xaddr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
@@ -127,7 +127,7 @@ end subroutine
 
 ! Test that non-contiguous dummy are propagated with their memory layout (we
 ! mainly do not want to create a new box that would ignore the original layout).
-! CHECK: func @_QPpropagate(%arg0: !fir.box<!fir.array<?xf32>>)
+! CHECK: func @_QPpropagate(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"})
 subroutine propagate(x)
   interface
     subroutine bar3(x)

--- a/flang/test/Lower/dummy-argument-optional-2.f90
+++ b/flang/test/Lower/dummy-argument-optional-2.f90
@@ -35,7 +35,7 @@ contains
 ! allocation/association status match the dummy presence status.
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>>{{.*}}) {
 subroutine pass_pointer_scalar(i)
   integer, pointer :: i
   call takes_opt_scalar(i)
@@ -46,7 +46,7 @@ subroutine pass_pointer_scalar(i)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_scalar(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>{{.*}}) {
 subroutine pass_allocatable_scalar(i)
   integer, allocatable :: i
   call takes_opt_scalar(i)
@@ -57,7 +57,7 @@ subroutine pass_allocatable_scalar(i)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_scalar_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>{{.*}}) {
 subroutine pass_pointer_scalar_char(c)
   character(:), pointer :: c
   call takes_opt_scalar_char(c)
@@ -70,7 +70,7 @@ subroutine pass_pointer_scalar_char(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_scalar_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>{{.*}}) {
 subroutine pass_allocatable_scalar_char(c)
   character(:), allocatable :: c
   call takes_opt_scalar_char(c)
@@ -90,7 +90,7 @@ end subroutine
 ! correct present/absent aspect.
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}) {
 subroutine pass_pointer_array(i)
   real, pointer :: i(:)
   call takes_opt_explicit_shape(i)
@@ -124,7 +124,7 @@ subroutine pass_pointer_array(i)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_pointer_array_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>{{.*}}) {
 subroutine pass_pointer_array_char(c)
   character(:), pointer :: c(:)
   call takes_opt_explicit_shape_char(c)
@@ -201,7 +201,7 @@ end subroutine
 ! shape presence.
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
 subroutine pass_opt_assumed_shape(x)
   real, optional :: x(:)
   call takes_opt_explicit_shape(x)
@@ -234,7 +234,7 @@ subroutine pass_opt_assumed_shape(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.bindc_name = "c", fir.optional}) {
 subroutine pass_opt_assumed_shape_char(c)
   character(*), optional :: c(:)
   call takes_opt_explicit_shape_char(c)
@@ -272,7 +272,7 @@ end subroutine
 ! There should be no copy-in/copy-out
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_contiguous_assumed_shape(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.contiguous, fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.contiguous, fir.optional}) {
 subroutine pass_opt_contiguous_assumed_shape(x)
   real, optional, contiguous :: x(:)
   call takes_opt_explicit_shape(x)
@@ -288,7 +288,7 @@ subroutine pass_opt_contiguous_assumed_shape(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_contiguous_assumed_shape_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.contiguous, fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.bindc_name = "c", fir.contiguous, fir.optional}) {
 subroutine pass_opt_contiguous_assumed_shape_char(c)
   character(*), optional, contiguous :: c(:)
   call takes_opt_explicit_shape_char(c)
@@ -313,7 +313,7 @@ end subroutine
 ! copy-in/copy-out.
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>{{.*}}) {
 subroutine pass_allocatable_array(i)
   real, allocatable :: i(:)
   call takes_opt_explicit_shape(i)
@@ -324,7 +324,7 @@ subroutine pass_allocatable_array(i)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_allocatable_array_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>{{.*}}) {
 subroutine pass_allocatable_array_char(c)
   character(:), allocatable :: c(:)
   call takes_opt_explicit_shape_char(c)
@@ -337,7 +337,7 @@ subroutine pass_allocatable_array_char(c)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_contiguous_pointer_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.contiguous}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "i", fir.contiguous}) {
 subroutine pass_contiguous_pointer_array(i)
   real, pointer, contiguous :: i(:)
   call takes_opt_explicit_shape(i)
@@ -348,7 +348,7 @@ subroutine pass_contiguous_pointer_array(i)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_contiguous_pointer_array_char(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>> {fir.contiguous}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "c", fir.contiguous}) {
 subroutine pass_contiguous_pointer_array_char(c)
   character(:), pointer, contiguous :: c(:)
   call takes_opt_explicit_shape_char(c)
@@ -369,7 +369,7 @@ end subroutine
 ! intent(out), there should be no copy-in.
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_to_intentin(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
 subroutine pass_opt_assumed_shape_to_intentin(x)
   real, optional :: x(:)
   call takes_opt_explicit_shape_intentin(x)
@@ -397,7 +397,7 @@ subroutine pass_opt_assumed_shape_to_intentin(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMoptional_testsPpass_opt_assumed_shape_to_intentout(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
 subroutine pass_opt_assumed_shape_to_intentout(x)
   real, optional :: x(:)
   call takes_opt_explicit_shape_intentout(x)

--- a/flang/test/Lower/dummy-argument-optional.f90
+++ b/flang/test/Lower/dummy-argument-optional.f90
@@ -9,8 +9,8 @@ module opt
 contains
 
 ! Test simple scalar optional
-! CHECK-LABEL: func @_QMoptPintrinsic_scalar
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<f32> {fir.optional})
+! CHECK-LABEL: func @_QMoptPintrinsic_scalar(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f32> {fir.bindc_name = "x", fir.optional}) {
 subroutine intrinsic_scalar(x)
   real, optional :: x
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<f32>) -> i1
@@ -28,8 +28,8 @@ subroutine call_intrinsic_scalar()
 end subroutine
 
 ! Test explicit shape array optional
-! CHECK-LABEL: func @_QMoptPintrinsic_f77_array
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.array<100xf32>> {fir.optional})
+! CHECK-LABEL: func @_QMoptPintrinsic_f77_array(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "x", fir.optional}) {
 subroutine intrinsic_f77_array(x)
   real, optional :: x(100)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.array<100xf32>>) -> i1
@@ -47,8 +47,8 @@ subroutine call_intrinsic_f77_array()
 end subroutine
 
 ! Test optional character scalar
-! CHECK-LABEL: func @_QMoptPcharacter_scalar
-! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1> {fir.optional})
+! CHECK-LABEL: func @_QMoptPcharacter_scalar(
+! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1> {fir.bindc_name = "x", fir.optional}) {
 subroutine character_scalar(x)
   ! CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
   character(10), optional :: x
@@ -69,8 +69,8 @@ subroutine call_character_scalar()
 end subroutine
 
 ! Test optional assumed shape
-! CHECK-LABEL: func @_QMoptPassumed_shape
-! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xf32>> {fir.optional})
+! CHECK-LABEL: func @_QMoptPassumed_shape(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
 subroutine assumed_shape(x)
   real, optional :: x(:)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> i1
@@ -90,8 +90,8 @@ subroutine call_assumed_shape()
 end subroutine
 
 ! Test optional allocatable
-! CHECK: func @_QMoptPallocatable_array
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.optional})
+! CHECK: func @_QMoptPallocatable_array(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "x", fir.optional}) {
 subroutine allocatable_array(x)
   real, allocatable, optional :: x(:)
   ! CHECK: fir.is_present %[[arg0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> i1
@@ -108,8 +108,8 @@ subroutine call_allocatable_array()
   call allocatable_array()
 end subroutine
 
-! CHECK: func @_QMoptPallocatable_to_assumed_optional_array
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
+! CHECK: func @_QMoptPallocatable_to_assumed_optional_array(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>{{.*}}) {
 subroutine allocatable_to_assumed_optional_array(x)
   real, allocatable :: x(:)
 
@@ -124,7 +124,7 @@ subroutine allocatable_to_assumed_optional_array(x)
   call assumed_shape(x)
 end subroutine
 
-! CHECK-LABEL: func @_QMoptPalloc_component_to_optional_assumed_shape
+! CHECK-LABEL: func @_QMoptPalloc_component_to_optional_assumed_shape(
 subroutine alloc_component_to_optional_assumed_shape(x)
   type(t) :: x(100)
   ! CHECK-DAG: %[[isAlloc:.*]] = arith.cmpi ne
@@ -134,7 +134,7 @@ subroutine alloc_component_to_optional_assumed_shape(x)
   call assumed_shape(x(55)%p)
 end subroutine
 
-! CHECK-LABEL: func @_QMoptPalloc_component_eval_only_once
+! CHECK-LABEL: func @_QMoptPalloc_component_eval_only_once(
 subroutine alloc_component_eval_only_once(x)
   integer, external :: ifoo
   type(t) :: x(100)

--- a/flang/test/Lower/dummy-arguments.f90
+++ b/flang/test/Lower/dummy-arguments.f90
@@ -32,8 +32,8 @@ end function sub2
 
 ! Test TARGET attribute lowering
 ! CHECK-LABEL: func @_QPtest_target(
-! CHECK-SAME: !fir.ref<i32> {fir.target},
-! CHECK-SAME: !fir.box<!fir.array<?xf32>> {fir.target})
+! CHECK-SAME: !fir.ref<i32> {fir.bindc_name = "i", fir.target},
+! CHECK-SAME: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.target})
 subroutine test_target(i, x)
   integer, target :: i
   real, target :: x(:)

--- a/flang/test/Lower/dummy-procedure-character.f90
+++ b/flang/test/Lower/dummy-procedure-character.f90
@@ -53,8 +53,8 @@ subroutine cst_len_2()
   call foo2(bar2)
 end subroutine
 
-! CHECK-LABEL: func @_QPdyn_len
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32>) {
+! CHECK-LABEL: func @_QPdyn_len(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine dyn_len(n)
   integer :: n
   character(n) :: bar3

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -3,7 +3,8 @@
 ! Test dummy procedures
 
 ! Test of dummy procedure call
-! CHECK-LABEL: func @_QPfoo(%arg0: () -> ()) -> f32
+! CHECK-LABEL: func @_QPfoo(
+! CHECK-SAME: %{{.*}}: () -> (){{.*}}) -> f32
 real function foo(bar)
   real :: bar, x
   ! CHECK: %[[x:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Ex"}
@@ -14,7 +15,8 @@ real function foo(bar)
 end function
 
 ! Test case where dummy procedure is only transiting.
-! CHECK-LABEL: func @_QPprefoo(%arg0: () -> ()) -> f32
+! CHECK-LABEL: func @_QPprefoo(
+! CHECK-SAME: %{{.*}}: () -> (){{.*}}) -> f32
 real function prefoo(bar)
   external :: bar
   ! CHECK: fir.call @_QPfoo(%arg0) : (() -> ()) -> f32
@@ -22,7 +24,8 @@ real function prefoo(bar)
 end function
 
 ! Function that will be passed as dummy argument
-!CHECK-LABEL: func @_QPfunc(%arg0: !fir.ref<f32>) -> f32
+! CHECK-LABEL: func @_QPfunc(
+! CHECK-SAME: %{{.*}}: !fir.ref<f32>{{.*}}) -> f32
 real function func(x)
   real :: x
   func = x + 0.5
@@ -41,7 +44,8 @@ end function
 
 ! Repeat test with dummy subroutine
 
-! CHECK-LABEL: func @_QPfoo_sub(%arg0: () -> ())
+! CHECK-LABEL: func @_QPfoo_sub(
+! CHECK-SAME: %{{.*}}: () -> (){{.*}})
 subroutine foo_sub(bar_sub)
   ! CHECK: %[[x:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Ex"}
   x = 42.
@@ -51,7 +55,8 @@ subroutine foo_sub(bar_sub)
 end subroutine
 
 ! Test case where dummy procedure is only transiting.
-! CHECK-LABEL: func @_QPprefoo_sub(%arg0: () -> ())
+! CHECK-LABEL: func @_QPprefoo_sub(
+! CHECK-SAME: %{{.*}}: () -> (){{.*}})
 subroutine prefoo_sub(bar_sub)
   external :: bar_sub
   ! CHECK: fir.call @_QPfoo_sub(%arg0) : (() -> ()) -> ()
@@ -59,7 +64,8 @@ subroutine prefoo_sub(bar_sub)
 end subroutine
 
 ! Subroutine that will be passed as dummy argument
-!CHECK-LABEL: func @_QPsub(%arg0: !fir.ref<f32>)
+! CHECK-LABEL: func @_QPsub(
+! CHECK-SAME: %{{.*}}: !fir.ref<f32>{{.*}})
 subroutine sub(x)
   real :: x
   print *, x
@@ -137,7 +143,8 @@ end subroutine
 ! TODO: exhaustive test of unrestricted intrinsic table 16.2 
 
 ! TODO: improve dummy procedure types when interface is given.
-! CHECK: func @_QPtodo3(%arg0: () -> ())
+! CHECK: func @_QPtodo3(
+! CHECK-SAME: %{{.*}}: () -> (){{.*}})
 ! SHOULD-CHECK: func @_QPtodo3(%arg0: (!fir.ref<f32>) -> f32)
 subroutine todo3(dummy_proc)
   intrinsic :: acos

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -1,14 +1,16 @@
 ! RUN: bbc -emit-fir -o - %s | FileCheck %s
 
 
-! CHECK-LABEL: func @_QPcompare1(%arg0: !fir.ref<!fir.logical<4>>, %arg1: !fir.boxchar<1>, %arg2: !fir.boxchar<1>)
+! CHECK-LABEL: func @_QPcompare1(
+! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.logical<4>>{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}) {
 subroutine compare1(x, c1, c2)
   character(*) c1, c2, d1, d2
   logical x, y
   x = c1 < c2
   return
 
-! CHECK-LABEL: func @_QPcompare2(%arg0: !fir.ref<!fir.logical<4>>, %arg1: !fir.boxchar<1>, %arg2: !fir.boxchar<1>)
+! CHECK-LABEL: func @_QPcompare2(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.logical<4>>{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}) {
 entry compare2(y, d2, d1)
   y = d1 < d2
 end
@@ -37,7 +39,8 @@ program entries
 6 continue
 end
 
-! CHECK-LABEL: func @_QPss(%arg0: !fir.ref<i32>)
+! CHECK-LABEL: func @_QPss(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) {
 subroutine ss(n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
@@ -46,7 +49,8 @@ subroutine ss(n1)
   n1 = nx + 10
   return
 
-! CHECK-LABEL: func @_QPe1(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>)
+! CHECK-LABEL: func @_QPe1(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) {
 entry e1(n2, n17)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
@@ -54,38 +58,44 @@ entry e1(n2, n17)
   n2 = ny + 20
   return
 
-! CHECK-LABEL: func @_QPe2(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>)
+  ! CHECK-LABEL: func @_QPe2(
+  ! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) {
 entry e2(n3, n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
 
-! CHECK-LABEL: func @_QPe3(%arg0: !fir.ref<i32>)
+! CHECK-LABEL: func @_QPe3(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) {
 entry e3(n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   n1 = 30
 end
 
-! CHECK-LABEL: func @_QPjj(%arg0: !fir.ref<i32>) -> i32
+! CHECK-LABEL: func @_QPjj(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) -> i32
 function jj(n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ejj"}
   jj = 100
   jj = jj + n1
   return
 
-! CHECK-LABEL: func @_QPrr(%arg0: !fir.ref<i32>) -> f32
+  ! CHECK-LABEL: func @_QPrr(
+  ! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) -> f32
 entry rr(n2)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Ejj"}
   rr = 200.0
   rr = rr + n2
 end
 
-! CHECK-LABEL: func @_QPhh(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPhh(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.char<1,10>>{{.*}}, %{{.*}}: index{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}) -> !fir.boxchar<1>
 function hh(c1)
   character(10) c1, hh, qq
   hh = c1
   return
-! CHECK-LABEL: func @_QPqq(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.boxchar<1>) -> !fir.boxchar<1>
+  ! CHECK-LABEL: func @_QPqq(
+  ! CHECK-SAME: %{{.*}}: !fir.ref<!fir.char<1,10>>{{.*}}, %{{.*}}: index{{.*}}, %{{.*}}: !fir.boxchar<1>{{.*}}) -> !fir.boxchar<1>
 entry qq(c1)
   qq = c1
 end
@@ -93,7 +103,8 @@ end
 ! CHECK-LABEL: func @_QPchar_array()
 function char_array()
   character(10), c(5)
-! CHECK-LABEL: func @_QPchar_array_entry(%arg0: !fir.boxchar<1>)
+! CHECK-LABEL: func @_QPchar_array_entry(
+! CHECK-SAME: %{{.*}}: !fir.boxchar<1>{{.*}}) -> f32 {
 entry char_array_entry(c)
 end
 

--- a/flang/test/Lower/explicit-interface-results.f90
+++ b/flang/test/Lower/explicit-interface-results.f90
@@ -8,7 +8,8 @@ function return_cst_array()
   real :: return_cst_array(20, 30)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_dyn_array(%{{.*}}: !fir.ref<i32>, %{{.*}}: !fir.ref<i32>) -> !fir.array<?x?xf32>
+! CHECK-LABEL: func @_QMcalleePreturn_dyn_array(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.array<?x?xf32>
 function return_dyn_array(m, n)
   integer :: m, n
   real :: return_dyn_array(m, n)
@@ -19,19 +20,22 @@ function return_cst_char_cst_array()
   character(10) :: return_cst_char_cst_array(20, 30)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_cst_array(%{{.*}}: !fir.ref<i32>) -> !fir.array<20x30x!fir.char<1,?>>
+! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_cst_array(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.array<20x30x!fir.char<1,?>>
 function return_dyn_char_cst_array(l)
   integer :: l
   character(l) :: return_dyn_char_cst_array(20, 30)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_cst_char_dyn_array(%{{.*}}: !fir.ref<i32>, %{{.*}}: !fir.ref<i32>) -> !fir.array<?x?x!fir.char<1,10>>
+! CHECK-LABEL: func @_QMcalleePreturn_cst_char_dyn_array(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.array<?x?x!fir.char<1,10>>
 function return_cst_char_dyn_array(m, n)
   integer :: m, n
   character(10) :: return_cst_char_dyn_array(m, n)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_dyn_array(%{{.*}}: !fir.ref<i32>, %{{.*}}: !fir.ref<i32>, %{{.*}}: !fir.ref<i32>) -> !fir.array<?x?x!fir.char<1,?>>
+! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_dyn_array(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.array<?x?x!fir.char<1,?>>
 function return_dyn_char_dyn_array(l, m, n)
   integer :: l, m, n
   character(l) :: return_dyn_char_dyn_array(m, n)
@@ -47,7 +51,8 @@ function return_cst_char_alloc()
   character(10), allocatable :: return_cst_char_alloc(:)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_alloc(%{{.*}}: !fir.ref<i32>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_alloc(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
 function return_dyn_char_alloc(l)
   integer :: l
   character(l), allocatable :: return_dyn_char_alloc(:)
@@ -68,7 +73,8 @@ function return_cst_char_pointer()
   character(10), pointer :: return_cst_char_pointer(:)
 end function
 
-! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_pointer(%{{.*}}: !fir.ref<i32>) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
+! CHECK-LABEL: func @_QMcalleePreturn_dyn_char_pointer(
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>
 function return_dyn_char_pointer(l)
   integer :: l
   character(l), pointer :: return_dyn_char_pointer(:)
@@ -171,8 +177,8 @@ subroutine def_char_pointer()
   ! CHECK-NOT: fir.freemem
 end subroutine
 
-! CHECK-LABEL: func @_QMcallerPdyn_array
-! CHECK-SAME: (%[[m:.*]]: !fir.ref<i32>, %[[n:.*]]: !fir.ref<i32>)
+! CHECK-LABEL: func @_QMcallerPdyn_array(
+! CHECK-SAME: %[[m:.*]]: !fir.ref<i32>{{.*}}, %[[n:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine dyn_array(m, n)
   integer :: m, n
   ! CHECK-DAG: %[[mload:.*]] = fir.load %[[m]] : !fir.ref<i32>
@@ -192,8 +198,8 @@ subroutine dyn_array(m, n)
   print *, return_dyn_array(m, n)
 end subroutine
 
-! CHECK-LABEL: func @_QMcallerPdyn_char_cst_array
-! CHECK-SAME: (%[[l:.*]]: !fir.ref<i32>)
+! CHECK-LABEL: func @_QMcallerPdyn_char_cst_array(
+! CHECK-SAME: %[[l:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine dyn_char_cst_array(l)
   integer :: l
   ! CHECK: %[[lload:.*]] = fir.load %[[l]] : !fir.ref<i32>
@@ -206,8 +212,8 @@ subroutine dyn_char_cst_array(l)
   print *, return_dyn_char_cst_array(l)
 end subroutine
 
-! CHECK-LABEL: func @_QMcallerPcst_char_dyn_array
-! CHECK-SAME: (%[[m:.*]]: !fir.ref<i32>, %[[n:.*]]: !fir.ref<i32>)
+! CHECK-LABEL: func @_QMcallerPcst_char_dyn_array(
+! CHECK-SAME: %[[m:.*]]: !fir.ref<i32>{{.*}}, %[[n:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine cst_char_dyn_array(m, n)
   integer :: m, n
   ! CHECK-DAG: %[[mload:.*]] = fir.load %[[m]] : !fir.ref<i32>
@@ -227,8 +233,8 @@ subroutine cst_char_dyn_array(m, n)
   print *, return_cst_char_dyn_array(m, n)
 end subroutine
 
-! CHECK-LABEL: func @_QMcallerPdyn_char_dyn_array
-! CHECK-SAME: (%[[l:.*]]: !fir.ref<i32>, %[[m:.*]]: !fir.ref<i32>, %[[n:.*]]: !fir.ref<i32>)
+! CHECK-LABEL: func @_QMcallerPdyn_char_dyn_array(
+! CHECK-SAME: %[[l:.*]]: !fir.ref<i32>{{.*}}, %[[m:.*]]: !fir.ref<i32>{{.*}}, %[[n:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine dyn_char_dyn_array(l, m, n)
   ! CHECK-DAG: %[[mload:.*]] = fir.load %[[m]] : !fir.ref<i32>
   ! CHECK-DAG: %[[mcast:.*]] = fir.convert %[[mload]] : (i32) -> i64
@@ -306,8 +312,8 @@ subroutine test_result_depends_on_equiv_sym()
   print *, result_depends_on_equiv_sym()
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_depends_on_descriptor
-! CHECK-SAME: (%[[x:.*]]: !fir.box<!fir.array<?xf32>>)
+! CHECK-LABEL: func @_QPtest_depends_on_descriptor(
+! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine test_depends_on_descriptor(x)
   interface
     function depends_on_descriptor(x)
@@ -323,8 +329,8 @@ subroutine test_depends_on_descriptor(x)
   print *, depends_on_descriptor(x)
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_symbol_indirection
-! CHECK-SAME: (%[[n:.*]]: !fir.ref<i64>)
+! CHECK-LABEL: func @_QPtest_symbol_indirection(
+! CHECK-SAME: %[[n:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine test_symbol_indirection(n)
   interface
     function symbol_indirection(c, n)
@@ -344,8 +350,8 @@ subroutine test_symbol_indirection(n)
   print *, symbol_indirection(c, n)
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_recursion
-! CHECK-SAME: (%[[res:.*]]: !fir.ref<!fir.char<1,?>>, %[[resLen:.*]]: index, %[[n:.*]]: !fir.ref<i64>)
+! CHECK-LABEL: func @_QPtest_recursion(
+! CHECK-SAME: %[[res:.*]]: !fir.ref<!fir.char<1,?>>{{.*}}, %[[resLen:.*]]: index{{.*}}, %[[n:.*]]: !fir.ref<i64>{{.*}}) -> !fir.boxchar<1> {
 function test_recursion(n) result(res)
   integer(8) :: n
   character(n) :: res
@@ -389,14 +395,14 @@ function test_recursion(n) result(res)
 end function
 
 ! Test call to character function for which only the result type is explicit
-!CHECK-LABEL:func @_QPtest_not_entirely_explicit_interface(
-!CHECK-SAME: %[[n_arg:.*]]: !fir.ref<i64>) {
+! CHECK-LABEL:func @_QPtest_not_entirely_explicit_interface(
+! CHECK-SAME: %[[n_arg:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine test_not_entirely_explicit_interface(n)
   integer(8) :: n
   character(n) :: return_dyn_char_2
   print *, return_dyn_char_2(10)
-  !CHECK: %[[n:.*]] = fir.load %[[n_arg]] : !fir.ref<i64>
-  !CHECK: %[[len:.*]] = fir.convert %[[n]] : (i64) -> index
-  !CHECK: %[[result:.*]] = fir.alloca !fir.char<1,?>(%[[len]] : index) {bindc_name = ".result"}
-  !CHECK: fir.call @_QPreturn_dyn_char_2(%[[result]], %[[len]], %{{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
+  ! CHECK: %[[n:.*]] = fir.load %[[n_arg]] : !fir.ref<i64>
+  ! CHECK: %[[len:.*]] = fir.convert %[[n]] : (i64) -> index
+  ! CHECK: %[[result:.*]] = fir.alloca !fir.char<1,?>(%[[len]] : index) {bindc_name = ".result"}
+  ! CHECK: fir.call @_QPreturn_dyn_char_2(%[[result]], %[[len]], %{{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
 end subroutine

--- a/flang/test/Lower/forall-2.f90
+++ b/flang/test/Lower/forall-2.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPimplied_iters_allocatable(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFimplied_iters_allocatableTt{oui:!fir.logical<4>,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>,
-! CHECK-SAME %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFimplied_iters_allocatableTt{oui:!fir.logical<4>,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 subroutine implied_iters_allocatable(thing, a1)
   ! No dependence between lhs and rhs.
   ! Lhs may need to be reallocated to conform.
@@ -23,7 +22,7 @@ subroutine implied_iters_allocatable(thing, a1)
 end subroutine implied_iters_allocatable
 
 ! CHECK-LABEL: func @_QPconflicting_allocatable(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFconflicting_allocatableTt{oui:!fir.logical<4>,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, %[[VAL_1:.*]]: !fir.ref<i32>, %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFconflicting_allocatableTt{oui:!fir.logical<4>,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine conflicting_allocatable(thing, lo, hi)
   ! Introduce a crossing dependence to incite a (deep) copy.
   integer :: lo,hi
@@ -43,9 +42,7 @@ subroutine conflicting_allocatable(thing, lo, hi)
 end subroutine conflicting_allocatable
 
 ! CHECK-LABEL: func @_QPforall_pointer_assign(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>> {fir.target},
-! CHECK-SAME: %[[VAL_2:.*]]: !fir.ref<i32>, %[[VAL_3:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTt{ptr:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.type<_QFforall_pointer_assignTu{targ:!fir.array<20xf32>}>>> {fir.bindc_name = "at", fir.target}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine forall_pointer_assign(ap, at, ii, ij)
   ! Set pointer members in an array of derived type to targets.
   ! No conflicts (multiple-assignment being forbidden, of course).
@@ -128,8 +125,7 @@ subroutine slice_with_explicit_iters
 end subroutine slice_with_explicit_iters
 
 ! CHECK-LABEL: func @_QPembox_argument_with_slice(
-! CHECK-SAME:                                     %[[VAL_0:.*]]: !fir.ref<!fir.array<1xi32>>,
-! CHECK-SAME:                                     %[[VAL_1:.*]]: !fir.ref<!fir.array<2x2xi32>>) {
+! CHECK-SAME:                                     %[[VAL_0:.*]]: !fir.ref<!fir.array<1xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<2x2xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : index

--- a/flang/test/Lower/forall/forall-allocatable-2.f90
+++ b/flang/test/Lower/forall/forall-allocatable-2.f90
@@ -15,7 +15,7 @@ subroutine forall_with_allocatable2(a1)
 end subroutine forall_with_allocatable2
 
 ! CHECK-LABEL: func @_QPforall_with_allocatable2(
-! CHECK-SAME:                                    %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME:                                    %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "thing", uniq_name = "_QFforall_with_allocatable2Ething"}
 ! CHECK:         %[[VAL_3:.*]] = fir.embox %[[VAL_2]] : (!fir.ref<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>

--- a/flang/test/Lower/forall/forall-allocatable.f90
+++ b/flang/test/Lower/forall/forall-allocatable.f90
@@ -11,7 +11,7 @@ subroutine forall_with_allocatable(a1)
 end subroutine forall_with_allocatable
 
 ! CHECK-LABEL: func @_QPforall_with_allocatable(
-! CHECK-SAME:                                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME:                                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {bindc_name = "arr", uniq_name = "_QFforall_with_allocatableEarr"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {uniq_name = "_QFforall_with_allocatableEarr.addr"}

--- a/flang/test/Lower/forall/forall-array.f90
+++ b/flang/test/Lower/forall/forall-array.f90
@@ -18,7 +18,7 @@ subroutine test_forall_with_array_assignment(aa,bb)
 end subroutine test_forall_with_array_assignment
 
 ! CHECK-LABEL: func @_QPtest_forall_with_array_assignment(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index

--- a/flang/test/Lower/forall/forall-construct-2.f90
+++ b/flang/test/Lower/forall/forall-construct-2.f90
@@ -12,8 +12,7 @@ subroutine test2_forall_construct(a,b)
 end subroutine test2_forall_construct
 
 ! CHECK-LABEL: func @_QPtest2_forall_construct(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<100x400xf32>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<200x200xf32>>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<100x400xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<200x200xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}

--- a/flang/test/Lower/forall/forall-construct-3.f90
+++ b/flang/test/Lower/forall/forall-construct-3.f90
@@ -13,9 +13,7 @@ subroutine test3_forall_construct(a,b, mask)
 end subroutine test3_forall_construct
 
 ! CHECK-LABEL: func @_QPtest3_forall_construct(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<!fir.array<100x400xf32>>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<!fir.array<200x200xf32>>,
-! CHECK-SAME:                                  %[[VAL_2:.*]]: !fir.ref<!fir.array<100x200x!fir.logical<4>>>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<100x400xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<200x200xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<!fir.array<100x200x!fir.logical<4>>>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_4:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_5:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}

--- a/flang/test/Lower/forall/forall-construct.f90
+++ b/flang/test/Lower/forall/forall-construct.f90
@@ -12,7 +12,7 @@ subroutine test_forall_construct(a,b)
 end subroutine test_forall_construct
 
 ! CHECK-LABEL: func @_QPtest_forall_construct(
-! CHECK-SAME:     %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>) {
+! CHECK-SAME:     %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/forall/forall-slice.f90
+++ b/flang/test/Lower/forall/forall-slice.f90
@@ -3,8 +3,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest_forall_with_slice(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<i32>,
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index

--- a/flang/test/Lower/forall/forall-stmt.f90
+++ b/flang/test/Lower/forall/forall-stmt.f90
@@ -11,7 +11,7 @@ subroutine test_forall_stmt(x, mask)
 end subroutine test_forall_stmt
 
 ! CHECK-LABEL: func @_QPtest_forall_stmt(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<200xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<200x!fir.logical<4>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<200xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<200x!fir.logical<4>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 200 : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/forall/forall-where.f90
+++ b/flang/test/Lower/forall/forall-where.f90
@@ -21,7 +21,7 @@ subroutine test_nested_forall_where(a,b)
 end subroutine test_nested_forall_where
 
 ! CHECK-LABEL: func @_QPtest_nested_forall_where(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?x!fir.type<_QFtest_nested_forall_whereTt{data:!fir.array<100xf32>}>>>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "j"}

--- a/flang/test/Lower/forall/test9.f90
+++ b/flang/test/Lower/forall/test9.f90
@@ -16,7 +16,7 @@ subroutine test9(a,b,n)
 end subroutine test9
 
 ! CHECK-LABEL: func @_QPtest9(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
 ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> i64

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -7,7 +7,7 @@
 
 !!! Test scalar (with implicit none)
 
-! CHECK: func @_QPtest1(
+! CHECK-LABEL: func @_QPtest1(
 subroutine test1
   implicit none
   integer i
@@ -19,7 +19,8 @@ subroutine test1
   call test1_internal
   print *, i
 contains
-  ! CHECK: func @_QFtest1Ptest1_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
+  ! CHECK-LABEL: func @_QFtest1Ptest1_internal(
+  ! CHECK-SAME: %[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
   ! CHECK: %[[iaddr:.*]] = fir.coordinate_of %[[arg]], %c0
   ! CHECK: %[[i:.*]] = fir.load %[[iaddr]] : !fir.llvm_ptr<!fir.ref<i32>>
   ! CHECK: %[[val:.*]] = fir.call @_QPifoo() : () -> i32
@@ -32,7 +33,7 @@ end subroutine test1
 
 !!! Test scalar
 
-! CHECK: func @_QPtest2() {
+! CHECK-LABEL: func @_QPtest2() {
 subroutine test2
   a = 1.0
   b = 2.0
@@ -45,7 +46,8 @@ subroutine test2
   call test2_internal
   print *, a, b
 contains
-  ! CHECK: func @_QFtest2Ptest2_internal(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
+  ! CHECK-LABEL: func @_QFtest2Ptest2_internal(
+  ! CHECK-SAME: %[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
   subroutine test2_internal
     ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
     ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.llvm_ptr<!fir.ref<f32>>
@@ -59,7 +61,8 @@ contains
     call test2_inner
   end subroutine test2_internal
 
-  ! CHECK: func @_QFtest2Ptest2_inner(%[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
+  ! CHECK-LABEL: func @_QFtest2Ptest2_inner(
+  ! CHECK-SAME: %[[arg:[^:]*]]: !fir.ref<tuple<!fir.ref<f32>, !fir.ref<f32>>> {fir.host_assoc}) {
   subroutine test2_inner
     ! CHECK: %[[a:.*]] = fir.coordinate_of %[[arg]], %c0
     ! CHECK: %[[aa:.*]] = fir.load %[[a]] : !fir.llvm_ptr<!fir.ref<f32>>
@@ -107,9 +110,7 @@ end subroutine test6
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest3(
-! CHECK-SAME: %[[p:[^:]+]]: !fir.box<!fir.array<?xf32>>,
-! CHECK-SAME: %[[q:.*]]: !fir.box<!fir.array<?xf32>>,
-! CHECK-SAME: %[[i:.*]]: !fir.ref<i64>
+! CHECK-SAME: %[[p:[^:]+]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[q:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[i:.*]]: !fir.ref<i64>
 subroutine test3(p,q,i)
   integer(8) :: i
   real :: p(i:)
@@ -160,7 +161,7 @@ contains
 end subroutine test3
 
 ! CHECK-LABEL: func @_QPtest3a(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.array<10xf32>>) {
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.array<10xf32>>{{.*}}) {
 subroutine test3a(p)
   real :: p(10)
   real :: q(10)
@@ -293,8 +294,7 @@ end subroutine test5
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest7(
-! CHECK-SAME: %[[j:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[k:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-SAME: %[[j:.*]]: !fir.ref<i32>{{.*}}, %[[k:.*]]: !fir.box<!fir.array<?xi32>>
 subroutine test7(j, k)
   implicit none
   integer :: j
@@ -309,8 +309,7 @@ subroutine test7(j, k)
 contains
 
 ! CHECK-LABEL: func @_QFtest7Ptest7_inner(
-! CHECK-SAME: %[[i:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) -> i32 {
+! CHECK-SAME: %[[i:.*]]: !fir.ref<i32>{{.*}}, %[[tup:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) -> i32 {
 elemental integer function test7_inner(i)
   implicit none
   integer, intent(in) :: i
@@ -405,7 +404,7 @@ end subroutine
 
 ! Test capture of namelist
 ! CHECK-LABEL: func @_QPtest10(
-! CHECK-SAME: %[[i:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) {
+! CHECK-SAME: %[[i:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>{{.*}}) {
 subroutine test10(i)
  implicit none
  integer, pointer :: i(:)

--- a/flang/test/Lower/identical-block-merge-disable.f90
+++ b/flang/test/Lower/identical-block-merge-disable.f90
@@ -37,8 +37,7 @@ END SUBROUTINE DMUMPS_SOL_FWD_LR_SU
 END MODULE DMUMPS_SOL_LR
 
 ! CHECK-LABEL: func @_QMdmumps_sol_lrPdmumps_sol_fwd_lr_su(
-! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<i32>,
-! CHECK-SAME:                                              %[[VAL_1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 0 : i64
 ! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 0 : index
 ! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -1,6 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPchar_return_callee(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.ref<i32>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPchar_return_callee(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.char<1,10>>{{.*}}, %{{.*}}: index{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.boxchar<1> {
 function char_return_callee(i)
   character(10) :: char_return_callee
   integer :: i

--- a/flang/test/Lower/intrinsic-procedures/abs.f90
+++ b/flang/test/Lower/intrinsic-procedures/abs.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPabs_testi
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<i32>
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>
 subroutine abs_testi(a, b)
 ! CHECK:  %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
 ! CHECK:  %[[VAL_3:.*]] = arith.constant 31 : i32
@@ -16,8 +15,7 @@ subroutine abs_testi(a, b)
 end subroutine
 
 ! CHECK-LABEL: func @_QPabs_testr(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<f32>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<f32>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine abs_testr(a, b)
 ! CHECK: %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
 ! CHECK: %[[VAL_3:.*]] = fir.call @llvm.fabs.f32(%[[VAL_2]]) : (f32) -> f32
@@ -28,8 +26,7 @@ subroutine abs_testr(a, b)
 end subroutine
 
 ! CHECK-LABEL: func @_QPabs_testz(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.complex<4>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<f32>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.complex<4>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine abs_testz(a, b)
 ! CHECK:  %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.complex<4>>
 ! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_2]], [0 : index] : (!fir.complex<4>) -> f32

--- a/flang/test/Lower/intrinsic-procedures/aimag.f90
+++ b/flang/test/Lower/intrinsic-procedures/aimag.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPaimag_test(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.complex<4>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<f32>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.complex<4>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine aimag_test(a, b)
 ! CHECK: %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.complex<4>>
 ! CHECK: %[[VAL_3:.*]] = fir.extract_value %[[VAL_2]], [1 : index] : (!fir.complex<4>) -> f32

--- a/flang/test/Lower/intrinsic-procedures/aint.f90
+++ b/flang/test/Lower/intrinsic-procedures/aint.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPaint_test(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<f32>) {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine aint_test(a, b)
 ! CHECK: %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
 ! CHECK: %[[VAL_3:.*]] = fir.call @llvm.trunc.f32(%[[VAL_2]]) : (f32) -> f32

--- a/flang/test/Lower/intrinsic-procedures/all.f90
+++ b/flang/test/Lower/intrinsic-procedures/all.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: all_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.logical<4>
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}}) -> !fir.logical<4>
 logical function all_test(mask)
   logical :: mask(:)
 ! CHECK: %[[c1:.*]] = arith.constant 1 : index

--- a/flang/test/Lower/intrinsic-procedures/allocated.f90
+++ b/flang/test/Lower/intrinsic-procedures/allocated.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: allocated_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.heap<f32>>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>{{.*}})
 subroutine allocated_test(scalar, array)
   real, allocatable  :: scalar, array(:)
   ! CHECK: %[[scalar:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<f32>>>

--- a/flang/test/Lower/intrinsic-procedures/any.f90
+++ b/flang/test/Lower/intrinsic-procedures/any.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: any_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.logical<4>
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}}) -> !fir.logical<4>
 logical function any_test(mask)
   logical :: mask(:)
 ! CHECK: %[[c1:.*]] = arith.constant 1 : index

--- a/flang/test/Lower/intrinsic-procedures/associated.f90
+++ b/flang/test/Lower/intrinsic-procedures/associated.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: associated_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}}, %[[arg1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine associated_test(scalar, array)
   real, pointer :: scalar, array(:)
   real, target :: ziel

--- a/flang/test/Lower/intrinsic-procedures/count.f90
+++ b/flang/test/Lower/intrinsic-procedures/count.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: count_test1
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
 subroutine count_test1(rslt, mask)
   integer :: rslt
   logical :: mask(:)
@@ -13,7 +13,7 @@ subroutine count_test1(rslt, mask)
 end subroutine
 
 ! CHECK-LABEL: test_count2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg1:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>{{.*}})
 subroutine test_count2(rslt, mask)
   integer :: rslt(:)
   logical :: mask(:,:)
@@ -31,7 +31,7 @@ subroutine test_count2(rslt, mask)
 end subroutine
 
 ! CHECK-LABEL: test_count3
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
 subroutine test_count3(rslt, mask)
   integer :: rslt
   logical :: mask(:)

--- a/flang/test/Lower/intrinsic-procedures/date_and_time.f90
+++ b/flang/test/Lower/intrinsic-procedures/date_and_time.f90
@@ -1,10 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPdate_and_time_test(
-! CHECK-SAME: %[[date:[^:]+]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[time:[^:]+]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[zone:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[values:.*]]: !fir.box<!fir.array<?xi64>>) {
+! CHECK-SAME: %[[date:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[time:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[zone:.*]]: !fir.boxchar<1>{{.*}}, %[[values:.*]]: !fir.box<!fir.array<?xi64>>{{.*}}) {
 subroutine date_and_time_test(date, time, zone, values)
   character(*) :: date, time, zone
   integer(8) :: values(:)
@@ -23,7 +20,7 @@ subroutine date_and_time_test(date, time, zone, values)
 end subroutine
 
 ! CHECK-LABEL: func @_QPdate_and_time_test2(
-! CHECK-SAME: %[[date:.*]]: !fir.boxchar<1>)
+! CHECK-SAME: %[[date:.*]]: !fir.boxchar<1>{{.*}})
 subroutine date_and_time_test2(date)
   character(*) :: date
   ! CHECK: %[[dateUnbox:.*]]:2 = fir.unboxchar %[[date]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)

--- a/flang/test/Lower/intrinsic-procedures/dim.f90
+++ b/flang/test/Lower/intrinsic-procedures/dim.f90
@@ -1,9 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPdim_testr(
-! CHECK-SAME:                     %[[VAL_0:[a-z]+[0-9]]]: !fir.ref<f32>,
-! CHECK-SAME:                     %[[VAL_1:.*]]: !fir.ref<f32>,
-! CHECK-SAME:                     %[[VAL_2:.*]]: !fir.ref<f32>) {
+! CHECK-SAME:                     %[[VAL_0:[a-z]+[0-9]]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_2:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine dim_testr(x, y, z)
 ! CHECK: %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
 ! CHECK: %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<f32>
@@ -18,9 +16,7 @@ subroutine dim_testr(x, y, z)
 end subroutine
 
 ! CHECK-LABEL: func @_QPdim_testi(
-! CHECK-SAME: %[[VAL_0:[a-z]+[0-9]]]: !fir.ref<i32>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[VAL_2:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_0:[a-z]+[0-9]]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine dim_testi(i, j, k)
 ! CHECK: %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
 ! CHECK: %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>

--- a/flang/test/Lower/intrinsic-procedures/exit.f90
+++ b/flang/test/Lower/intrinsic-procedures/exit.f90
@@ -12,7 +12,7 @@ subroutine exit_test1
 end subroutine exit_test1
 
 ! CHECK-LABEL: func @_QPexit_test2(
-! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+! CHECK-SAME: %[[statusArg:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}) {
 subroutine exit_test2(status)
   integer :: status
   call exit(status)

--- a/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
+++ b/flang/test/Lower/intrinsic-procedures/get_command_argument.f90
@@ -2,7 +2,7 @@
 ! RUN: flang-new -fc1 -fdefault-integer-8 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK,CHECK-64 -DDEFAULT_INTEGER_SIZE=64 %s
 
 ! CHECK-LABEL: func @_QPnumber_only(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}) {
 subroutine number_only(num)
     integer :: num
     call get_command_argument(num)
@@ -12,8 +12,7 @@ subroutine number_only(num)
 end subroutine number_only
 
 ! CHECK-LABEL: func @_QPnumber_and_value_only(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[value:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[value:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine number_and_value_only(num, value)
 integer :: num
 character(len=32) :: value
@@ -31,11 +30,7 @@ call get_command_argument(num, value)
 end subroutine number_and_value_only
 
 ! CHECK-LABEL: func @_QPall_arguments(
-! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[value:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[length:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[num:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[value:.*]]: !fir.boxchar<1>{{.*}}, %[[length:[^:]*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[errmsg:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine all_arguments(num, value, length, status, errmsg)
     integer :: num, length, status
     character(len=32) :: value, errmsg
@@ -62,8 +57,7 @@ subroutine all_arguments(num, value, length, status, errmsg)
 end subroutine all_arguments
 
 ! CHECK-LABEL: func @_QPnumber_and_length_only(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[length:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[length:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}) {
 subroutine number_and_length_only(num, length)
     integer :: num, length
     call get_command_argument(num, LENGTH=length)
@@ -78,8 +72,7 @@ subroutine number_and_length_only(num, length)
 end subroutine number_and_length_only
 
 ! CHECK-LABEL: func @_QPnumber_and_status_only(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>) {
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[status:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}) {
 subroutine number_and_status_only(num, status)
     integer :: num, status
     call get_command_argument(num, STATUS=status)
@@ -95,8 +88,7 @@ subroutine number_and_status_only(num, status)
 end subroutine number_and_status_only
 
 ! CHECK-LABEL: func @_QPnumber_and_errmsg_only(
-! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>,
-! CHECK-SAME: %[[errmsg:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME: %[[num:.*]]: !fir.ref<i[[DEFAULT_INTEGER_SIZE]]>{{.*}}, %[[errmsg:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine number_and_errmsg_only(num, errmsg)
     integer :: num
     character(len=32) :: errmsg

--- a/flang/test/Lower/intrinsic-procedures/index.f90
+++ b/flang/test/Lower/intrinsic-procedures/index.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPindex_test(%
-! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
-! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+! CHECK-LABEL: func @_QPindex_test(
+! CHECK-SAME: %[[s:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function index_test(s1, s2)
   character(*) :: s1, s2
   ! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -15,9 +14,8 @@ integer function index_test(s1, s2)
   index_test = index(s1, s2)
 end function index_test
 
-! CHECK-LABEL: func @_QPindex_test2(%
-! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
-! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+! CHECK-LABEL: func @_QPindex_test2(
+! CHECK-SAME: %[[s:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function index_test2(s1, s2)
   character(*) :: s1, s2
   ! CHECK: %[[mut:.*]] = fir.alloca !fir.box<!fir.heap<i32>>

--- a/flang/test/Lower/intrinsic-procedures/lbound.f90
+++ b/flang/test/Lower/intrinsic-procedures/lbound.f90
@@ -2,9 +2,7 @@
 
 
 ! CHECK-LABEL: func @_QPlbound_test(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine lbound_test(a, dim, res)
   real, dimension(:, :) :: a
   integer(8):: dim, res
@@ -14,9 +12,7 @@ subroutine lbound_test(a, dim, res)
 end subroutine
 
 ! CHECK-LABEL: func @_QPlbound_test_2(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine lbound_test_2(a, dim, res)
   real, dimension(:, 2:) :: a
   integer(8):: dim, res
@@ -43,9 +39,7 @@ subroutine lbound_test_2(a, dim, res)
 end subroutine
 
 ! CHECK-LABEL: func @_QPlbound_test_3(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<9x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<9x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine lbound_test_3(a, dim, res)
   real, dimension(2:10, 3:*) :: a
   integer(8):: dim, res

--- a/flang/test/Lower/intrinsic-procedures/maxloc.f90
+++ b/flang/test/Lower/intrinsic-procedures/maxloc.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: maxloc_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPmaxloc_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine maxloc_test(arr,res)
   integer :: arr(:)
   integer :: res(:)
@@ -20,8 +19,8 @@ subroutine maxloc_test(arr,res)
 ! CHECK-DAG: fir.freemem %[[a14]] : !fir.heap<!fir.array<?xi32>>
 end subroutine
 
-! CHECK-LABEL: maxloc_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg2:.*]]: !fir.ref<i32>
+! CHECK-LABEL: func @_QPmaxloc_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg2:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine maxloc_test2(arr,res,d)
   integer :: arr(:)
   integer :: res(:)

--- a/flang/test/Lower/intrinsic-procedures/maxval.f90
+++ b/flang/test/Lower/intrinsic-procedures/maxval.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: maxval_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>) -> i32
+! CHECK-LABEL: func @_QPmaxval_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) -> i32
 integer function maxval_test(a)
   integer :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -13,10 +13,8 @@ integer function maxval_test(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranAMaxvalInteger4(%[[a4]], %{{.*}}, %{{.*}}, %[[a6]], %[[a7]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
 end function
 
-! CHECK-LABEL: maxval_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>,
-! CHECK-SAME: %[[arg1:.*]]: index,
-! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPmaxval_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>, %[[arg1:.*]]: index, %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>> {fir.bindc_name = "a"}) -> !fir.boxchar<1> {
 character function maxval_test2(a)
   character :: a(:)
 ! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
@@ -28,9 +26,8 @@ character function maxval_test2(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranAMaxvalCharacter(%[[a5]], %[[a6]], %{{.*}}, %{{.*}}, %[[a8]]) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32, !fir.box<none>) -> none
 end function
 
-! CHECK-LABEL: maxval_test3
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPmaxval_test3(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
 subroutine maxval_test3(a,r)
   integer :: a(:,:)
   integer :: r(:)

--- a/flang/test/Lower/intrinsic-procedures/merge.f90
+++ b/flang/test/Lower/intrinsic-procedures/merge.f90
@@ -1,11 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: merge_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>, 
-! CHECK-SAME: %[[arg1:.*]]: index, 
-! CHECK-SAME: %[[arg2:[^:]+]]: !fir.boxchar<1>, 
-! CHECK-SAME: %[[arg3:[^:]+]]: !fir.boxchar<1>, 
-! CHECK-SAME: %[[arg4:.*]]: !fir.ref<!fir.logical<4>>) -> !fir.boxchar<1> {
+! CHECK-LABEL: func @_QPmerge_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>{{.*}}, %[[arg1:.*]]: index{{.*}},  %[[arg2:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[arg3:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[arg4:.*]]: !fir.ref<!fir.logical<4>>{{.*}}) -> !fir.boxchar<1> {
 function merge_test(o1, o2, mask)
 character :: o1, o2, merge_test
 logical :: mask
@@ -18,10 +14,8 @@ merge_test = merge(o1, o2, mask)
 ! CHECK-DAG:  %{{.*}} = fir.convert %[[a4]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
 end
 
-! CHECK-LABEL: merge_test2
-! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<i32>, 
-! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<i32>, 
-! CHECK-SAME: %[[arg2:.*]]: !fir.ref<!fir.logical<4>>) -> i32 {
+! CHECK-LABEL: func @_QPmerge_test2(
+! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg1:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg2:.*]]: !fir.ref<!fir.logical<4>>{{.*}}) -> i32 {
 function merge_test2(o1, o2, mask)
 integer :: o1, o2, merge_test2
 logical :: mask
@@ -33,11 +27,8 @@ merge_test2 = merge(o1, o2, mask)
 ! CHECK:  %{{.*}} = select %[[a4]], %[[a1]], %[[a2]] : i32
 end
 
-! CHECK-LABEL: merge_test3
-! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<!fir.array<10x!fir.type<_QFmerge_test3Tt{i:i32}>>>, 
-! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>, 
-! CHECK-SAME: %[[arg2:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>, 
-! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.logical<4>>) {
+! CHECK-LABEL: func @_QPmerge_test3(
+! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<!fir.array<10x!fir.type<_QFmerge_test3Tt{i:i32}>>>{{.*}}, %[[arg1:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>{{.*}}, %[[arg2:[^:]+]]: !fir.ref<!fir.type<_QFmerge_test3Tt{i:i32}>>{{.*}}, %[[arg3:.*]]: !fir.ref<!fir.logical<4>>{{.*}}) {
 subroutine merge_test3(result, o1, o2, mask)
 type t
   integer :: i

--- a/flang/test/Lower/intrinsic-procedures/minloc.f90
+++ b/flang/test/Lower/intrinsic-procedures/minloc.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: minloc_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPminloc_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
 subroutine minloc_test(arr,res)
   integer :: arr(:)
   integer :: res(:)
@@ -20,8 +19,8 @@ subroutine minloc_test(arr,res)
 ! CHECK-DAG: fir.freemem %[[a14]] : !fir.heap<!fir.array<?xi32>>
 end subroutine
 
-! CHECK-LABEL: minloc_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>, %[[arg2:.*]]: !fir.ref<i32>
+! CHECK-LABEL: func @_QPminloc_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg2:.*]]: !fir.ref<i32>
 subroutine minloc_test2(arr,res,d)
   integer :: arr(:)
   integer :: res(:)
@@ -40,4 +39,3 @@ subroutine minloc_test2(arr,res,d)
 ! CHECK:  %[[a13:.*]] = fir.box_addr %[[a12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:  fir.freemem %[[a13]] : !fir.heap<i32>
 end subroutine
-

--- a/flang/test/Lower/intrinsic-procedures/minval.f90
+++ b/flang/test/Lower/intrinsic-procedures/minval.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: minval_test
-!CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>) -> i32
+! CHECK-LABEL: func @_QPminval_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) -> i32
 integer function minval_test(a)
   integer :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -13,10 +13,8 @@ integer function minval_test(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranAMinvalInteger4(%[[a4]], %{{.*}}, %{{.*}}, %[[a6]], %[[a7]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
 end function
 
-! CHECK-LABEL: minval_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>,
-! CHECK-SAME: %[[arg1:.*]]: index,
-! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>>) -> !fir.boxchar<1>
+! CHECK-LABEL: func @_QPminval_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.char<1>>{{.*}}, %[[arg1:.*]]: index{{.*}}, %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.char<1>>>{{.*}}) -> !fir.boxchar<1>
 character function minval_test2(a)
   character :: a(:)
 ! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>
@@ -28,9 +26,8 @@ character function minval_test2(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranAMinvalCharacter(%[[a5]], %[[a6]], %{{.*}}, %{{.*}}, %[[a8]]) : (!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32, !fir.box<none>) -> none
 end function
 
-! CHECK-LABEL: minval_test3
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPminval_test3(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}})
 subroutine minval_test3(a,r)
   integer :: a(:,:)
   integer :: r(:)

--- a/flang/test/Lower/intrinsic-procedures/modulo.f90
+++ b/flang/test/Lower/intrinsic-procedures/modulo.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: modulo_testr
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<f64>, %[[arg1:.*]]: !fir.ref<f64>, %[[arg2:.*]]: !fir.ref<f64>)
+! CHECK-LABEL: func @_QPmodulo_testr(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f64>{{.*}}, %[[arg1:.*]]: !fir.ref<f64>{{.*}}, %[[arg2:.*]]: !fir.ref<f64>{{.*}}) {
 subroutine modulo_testr(r, a, p)
   real(8) :: r, a, p
   ! CHECK-DAG: %[[a:.*]] = fir.load %[[arg1]] : !fir.ref<f64>
@@ -19,8 +19,8 @@ subroutine modulo_testr(r, a, p)
   r = modulo(a, p)
 end subroutine
 
-! CHECK-LABEL: modulo_testi
-! CHECK-SAME: (%[[arg0:.*]]: !fir.ref<i64>, %[[arg1:.*]]: !fir.ref<i64>, %[[arg2:.*]]: !fir.ref<i64>)
+! CHECK-LABEL: func @_QPmodulo_testi(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i64>{{.*}}, %[[arg1:.*]]: !fir.ref<i64>{{.*}}, %[[arg2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine modulo_testi(r, a, p)
   integer(8) :: r, a, p
   ! CHECK-DAG: %[[a:.*]] = fir.load %[[arg1]] : !fir.ref<i64>

--- a/flang/test/Lower/intrinsic-procedures/mvbits.f90
+++ b/flang/test/Lower/intrinsic-procedures/mvbits.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: mvbits_test
+! CHECK-LABEL: func @_QPmvbits_test(
 function mvbits_test(from, frompos, len, to, topos)
   ! CHECK: %[[result:.*]] = fir.alloca i32 {bindc_name = "mvbits_test"
   ! CHECK-DAG: %[[from:.*]] = fir.load %arg0 : !fir.ref<i32>
@@ -34,7 +34,7 @@ function mvbits_test(from, frompos, len, to, topos)
 end
 
 ! CHECK-LABEL: func @_QPmvbits_array_test(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>, %[[VAL_1:.*]]: !fir.ref<i32>, %[[VAL_2:.*]]: !fir.ref<i32>, %[[VAL_3:.*]]: !fir.box<!fir.array<?xi32>>, %[[VAL_4:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:    %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_3:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_4:.*]]: !fir.ref<i32>{{.*}}) {
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
 ! CHECK:         %[[VAL_6:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_5]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_7:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>

--- a/flang/test/Lower/intrinsic-procedures/product.f90
+++ b/flang/test/Lower/intrinsic-procedures/product.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: product_test
-! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xi32>>) -> i32
+! CHECK-LABEL: func @_QPproduct_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) -> i32
 integer function product_test(a)
   integer :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -13,9 +13,8 @@ integer function product_test(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranAProductInteger4(%[[a3]], %{{.*}}, %{{.*}}, %[[a5]], %[[a6]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
 end function
 
-! CHECK-LABEL: product_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPproduct_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
 subroutine product_test2(a,r)
   integer :: a(:,:)
   integer :: r(:)
@@ -32,8 +31,8 @@ subroutine product_test2(a,r)
 ! CHECK-DAG:  fir.freemem %[[a13]] : !fir.heap<!fir.array<?xi32>>
 end subroutine
 
-! CHECK-LABEL: product_test3
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.complex<4>
+! CHECK-LABEL: func @_QPproduct_test3(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>{{.*}}) -> !fir.complex<4>
 complex function product_test3(a)
   complex :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -47,8 +46,8 @@ complex function product_test3(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranACppProductComplex4(%[[a5]], %[[a6]], %{{.*}}, %{{.*}}, %[[a8]], %[[a9]]) : (!fir.ref<complex<f32>>, !fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> none
 end function
 
-! CHECK-LABEL: product_test4
-! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<10>>>) -> !fir.complex<10>
+! CHECK-LABEL: func @_QPproduct_test4(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<10>>>{{.*}}) -> !fir.complex<10>
 complex(10) function product_test4(x)
   complex(10):: x(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index

--- a/flang/test/Lower/intrinsic-procedures/repeat.f90
+++ b/flang/test/Lower/intrinsic-procedures/repeat.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: repeat_test
-! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1>, %[[arg1:.*]]: !fir.ref<i32>)
+! CHECK-LABEL: func @_QPrepeat_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine repeat_test(c, n)
   character(*) :: c
   integer :: n

--- a/flang/test/Lower/intrinsic-procedures/reshape.f90
+++ b/flang/test/Lower/intrinsic-procedures/reshape.f90
@@ -1,11 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: reshape_test
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>
-! CHECK-SAME: %[[arg1:[^:]+]]: !fir.box<!fir.array<?x?x?xi32>>,
-! CHECK-SAME: %[[arg2:[^:]+]]: !fir.box<!fir.array<?x?x?xi32>>
-! CHECK-SAME: %[[arg3:.*]]: !fir.ref<!fir.array<2xi32>>,
-! CHECK-SAME: %[[arg4:.*]]: !fir.ref<!fir.array<2xi32>>)
+! CHECK-LABEL: func @_QPreshape_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[arg1:[^:]+]]: !fir.box<!fir.array<?x?x?xi32>>{{.*}}, %[[arg2:[^:]+]]: !fir.box<!fir.array<?x?x?xi32>>{{.*}}, %[[arg3:.*]]: !fir.ref<!fir.array<2xi32>>{{.*}}, %[[arg4:.*]]: !fir.ref<!fir.array<2xi32>>{{.*}}) {
 subroutine reshape_test(x, source, pd, sh, ord)
   integer :: x(:,:)
   integer :: source(:,:,:)

--- a/flang/test/Lower/intrinsic-procedures/rrspacing.f90
+++ b/flang/test/Lower/intrinsic-procedures/rrspacing.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: rrspacing_test2
-! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f128>) -> f128
+! CHECK-LABEL: func @_QPrrspacing_test2(
+! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f128>{{.*}}) -> f128
 real*16 function rrspacing_test2(x)
   real*16 :: x
   rrspacing_test2 = rrspacing(x)

--- a/flang/test/Lower/intrinsic-procedures/scan.f90
+++ b/flang/test/Lower/intrinsic-procedures/scan.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPscan_test(%
-! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
-! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+! CHECK-LABEL: func @_QPscan_test(
+! CHECK-SAME: %[[s:[^:]+]]: !fir.boxchar<1>{{.*}}, %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function scan_test(s1, s2)
   character(*) :: s1, s2
 ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
@@ -22,9 +21,9 @@ integer function scan_test(s1, s2)
 ! CHECK: fir.freemem %[[tmpAddr]] : !fir.heap<i32>
 end function scan_test
 
-! CHECK-LABEL: func @_QPscan_test2(%
-! CHECK-SAME: [[s:[^:]+]]: !fir.boxchar<1>, %
-! CHECK-SAME: [[ss:[^:]+]]: !fir.boxchar<1>) -> i32
+! CHECK-LABEL: func @_QPscan_test2(
+! CHECK-SAME: %[[s:[^:]+]]: !fir.boxchar<1>{{.*}},
+! CHECK-SAME: %[[ss:[^:]+]]: !fir.boxchar<1>{{.*}}) -> i32
 integer function scan_test2(s1, s2)
   character(*) :: s1, s2
   ! CHECK: %[[st:[^:]*]]:2 = fir.unboxchar %[[s]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)

--- a/flang/test/Lower/intrinsic-procedures/spacing.f90
+++ b/flang/test/Lower/intrinsic-procedures/spacing.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: @_QPspacing_test
-! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f32>) -> f32
+! CHECK-LABEL: func @_QPspacing_test(
+! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f32>{{.*}}) -> f32
 real*4 function spacing_test(x)
   real*4 :: x
   spacing_test = spacing(x)
@@ -9,8 +9,8 @@ real*4 function spacing_test(x)
 ! CHECK: %{{.*}} = fir.call @_FortranASpacing4(%[[a1]]) : (f32) -> f32
 end function
 
-! CHECK-LABEL: @_QPspacing_test2
-! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f80>) -> f80
+! CHECK-LABEL: func @_QPspacing_test2(
+! CHECK-SAME: %[[x:[^:]+]]: !fir.ref<f80>{{.*}}) -> f80
 real*10 function spacing_test2(x)
   real*10 :: x
   spacing_test2 = spacing(x)

--- a/flang/test/Lower/intrinsic-procedures/spread.f90
+++ b/flang/test/Lower/intrinsic-procedures/spread.f90
@@ -1,10 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: spread_test
-! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<i32>,
-! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<i32>,
-! CHECK-SAME: %[[arg2:[^:]+]]: !fir.ref<i32>,
-! CHECK-SAME: %[[arg3:.*]]: !fir.box<!fir.array<?xi32>>)
+! CHECK-LABEL: func @_QPspread_test(
+! CHECK-SAME: %[[arg0:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg1:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg2:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg3:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine spread_test(s,d,n,r)
   integer :: s,d,n
   integer :: r(:)
@@ -22,11 +19,8 @@ subroutine spread_test(s,d,n,r)
 ! CHECK:  fir.freemem %[[a15]] : !fir.heap<!fir.array<?xi32>>
 end subroutine
 
-! CHECK-LABEL: spread_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME: %[[arg1:[^:]+]]: !fir.ref<i32>,
-! CHECK-SAME: %[[arg2:[^:]+]]: !fir.ref<i32>,
-! CHECK-SAME: %[[arg3:.*]]: !fir.box<!fir.array<?x?xi32>>)
+! CHECK-LABEL: func @_QPspread_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg2:[^:]+]]: !fir.ref<i32>{{.*}}, %[[arg3:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}) {
 subroutine spread_test2(s,d,n,r)
   integer :: s(:),d,n
   integer :: r(:,:)

--- a/flang/test/Lower/intrinsic-procedures/sum.f90
+++ b/flang/test/Lower/intrinsic-procedures/sum.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: sum_test
-! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?xi32>>) -> i32
+! CHECK-LABEL: func @_QPsum_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) -> i32 {
 integer function sum_test(a)
   integer :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -13,9 +13,8 @@ integer function sum_test(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranASumInteger4(%[[a3]], %{{.*}}, %{{.*}}, %[[a5]], %[[a6]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
 end function
 
-! CHECK-LABEL: sum_test2
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>
+! CHECK-LABEL: func @_QPsum_test2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine sum_test2(a,r)
   integer :: a(:,:)
   integer :: r(:)
@@ -32,8 +31,8 @@ subroutine sum_test2(a,r)
 ! CHECK-DAG:  fir.freemem %[[a13]] : !fir.heap<!fir.array<?xi32>>
 end subroutine
 
-! CHECK-LABEL: sum_test3
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>) -> !fir.complex<4>
+! CHECK-LABEL: func @_QPsum_test3(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>{{.*}}) -> !fir.complex<4> {
 complex function sum_test3(a)
   complex :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -47,8 +46,8 @@ complex function sum_test3(a)
 ! CHECK:  %{{.*}} = fir.call @_FortranACppSumComplex4(%[[a5]], %[[a6]], %{{.*}}, %{{.*}}, %[[a8]], %[[a9]]) : (!fir.ref<complex<f32>>, !fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> none
 end function
 
-! CHECK-LABEL: sum_test4
-! CHECK-SAME: (%[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<10>>>) -> !fir.complex<10>
+! CHECK-LABEL: func @_QPsum_test4(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x!fir.complex<10>>>{{.*}}) -> !fir.complex<10> {
 complex(10) function sum_test4(x)
   complex(10):: x(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
@@ -61,4 +60,3 @@ complex(10) function sum_test4(x)
 ! CHECK-DAG:  %[[a8:.*]] = fir.convert %[[a2]] : (!fir.box<i1>) -> !fir.box<none>
 ! CHECK: fir.call @_FortranACppSumComplex10(%[[a4]], %[[a5]], %{{.*}}, %{{.*}}, %[[a7]], %8) : (!fir.ref<complex<f80>>, !fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> ()
 end
-

--- a/flang/test/Lower/intrinsic-procedures/transfer.f90
+++ b/flang/test/Lower/intrinsic-procedures/transfer.f90
@@ -2,8 +2,7 @@
 
 subroutine trans_test(store, word)
   ! CHECK-LABEL: func @_QPtrans_test(
-  ! CHECK-SAME:                      %[[VAL_0:.*]]: !fir.ref<i32>,
-  ! CHECK-SAME:                      %[[VAL_1:.*]]: !fir.ref<f32>) {
+  ! CHECK-SAME:                      %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
   ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
   ! CHECK:         %[[VAL_3:.*]] = fir.embox %[[VAL_1]] : (!fir.ref<f32>) -> !fir.box<f32>
   ! CHECK:         %[[VAL_4:.*]] = fir.embox %[[VAL_0]] : (!fir.ref<i32>) -> !fir.box<i32>
@@ -30,8 +29,7 @@ subroutine trans_test(store, word)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtrans_test2(
-! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<3xi32>>,
-! CHECK-SAME:        %[[VAL_1:.*]]: !fir.ref<f32>) {
+! CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 3 : index
 ! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
@@ -80,7 +78,7 @@ end subroutine
 
 integer function trans_test3(p)
   ! CHECK-LABEL: func @_QPtrans_test3(
-  ! CHECK-SAME:                       %[[VAL_0:.*]]: !fir.ref<i32>) -> i32 {
+  ! CHECK-SAME:                       %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}) -> i32 {
   ! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>
   ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>
   ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QFtrans_test3Tobj{x:i32}> {bindc_name = "t", uniq_name = "_QFtrans_test3Et"}

--- a/flang/test/Lower/intrinsic-procedures/transpose.f90
+++ b/flang/test/Lower/intrinsic-procedures/transpose.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: transpose_test
-! CHECK-SAME: (%[[source:.*]]: !fir.ref<!fir.array<2x3xf32>>)
+! CHECK-LABEL: func @_QPtranspose_test(
+! CHECK-SAME: %[[source:.*]]: !fir.ref<!fir.array<2x3xf32>>{{.*}}) {
 subroutine transpose_test(mat)
 ! CHECK:  %[[resultDescr:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>>
    real :: mat(2,3)

--- a/flang/test/Lower/intrinsic-procedures/trim.f90
+++ b/flang/test/Lower/intrinsic-procedures/trim.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! CHECK-LABEL: @_QPtrim_test
-! CHECK-SAME: (%[[arg0:.*]]: !fir.boxchar<1>)
+! CHECK-LABEL: func @_QPtrim_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>{{.*}}) {
 subroutine trim_test(c)
   character(*) :: c
   ! CHECK: %[[tmpBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>>

--- a/flang/test/Lower/intrinsic-procedures/ubound.f90
+++ b/flang/test/Lower/intrinsic-procedures/ubound.f90
@@ -2,9 +2,7 @@
 
 
 ! CHECK-LABEL: func @_QPubound_test(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test(a, dim, res)
   real, dimension(:, :) :: a
   integer(8):: dim, res
@@ -23,9 +21,7 @@ subroutine ubound_test(a, dim, res)
 end subroutine
 
 ! CHECK-LABEL: func @_QPubound_test_2(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test_2(a, dim, res)
   real, dimension(2:, 3:) :: a
   integer(8):: dim, res
@@ -60,9 +56,7 @@ subroutine ubound_test_2(a, dim, res)
 end subroutine
 
 ! CHECK-LABEL: func @_QPubound_test_3(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x20x?xf32>>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i64>,
-! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<10x20x?xf32>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_2:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine ubound_test_3(a, dim, res)
   real, dimension(10, 20, *) :: a
   integer(8):: dim, res

--- a/flang/test/Lower/intrinsic-procedures/verify.f90
+++ b/flang/test/Lower/intrinsic-procedures/verify.f90
@@ -1,8 +1,7 @@
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPverify_test(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.boxchar<1>) -> i32 {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) -> i32 {
 integer function verify_test(s1, s2)
 ! CHECK: %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
 ! CHECK: %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -35,8 +34,7 @@ integer function verify_test(s1, s2)
 end function verify_test
 
 ! CHECK-LABEL: func @_QPverify_test2(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[VAL_1:.*]]: !fir.boxchar<1>) -> i32 {
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) -> i32 {
 integer function verify_test2(s1, s2)
 ! CHECK: %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK: %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -27,7 +27,7 @@ subroutine pass_assumed_len_char_array(carray)
 end
 
 ! CHECK-LABEL: func @_QPpass_array_slice_read(
-! CHECK-SAME:            %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME:            %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 5 : i32
 ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
@@ -53,7 +53,7 @@ subroutine pass_array_slice_read(x)
 end
 
 ! CHECK-LABEL: func @_QPpass_array_slice_write(
-! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>) {
+! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 1 : i32
 ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
@@ -83,7 +83,7 @@ end
 
 
 ! CHECK-LABEL: func @_QPpass_vector_subscript_write(
-! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>>, %[[j:.*]]: !fir.ref<!fir.array<10xi32>>)
+! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>>{{.*}}, %[[j:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}})
 subroutine pass_vector_subscript_write(x, j)
   ! Check that a temp is made for array with vector subscript in output IO.
   integer :: j(10)

--- a/flang/test/Lower/io-statement-3.f90
+++ b/flang/test/Lower/io-statement-3.f90
@@ -1,8 +1,8 @@
 ! Test lowering of IO read SIZE control-spec (12.6.2.15)
 ! RUN: bbc -emit-fir -o - %s | FileCheck %s
 
-! CHECK-LABEL: @_QPtest_read_size(
-! CHECK-SAME: %[[sizeVar:[^:]+]]: !fir.ref<i32>,
+! CHECK-LABEL: func @_QPtest_read_size(
+! CHECK-SAME: %[[sizeVar:[^:]+]]: !fir.ref<i32>{{[^,]*}},
 subroutine test_read_size(size, c1, c2, unit, stat)
   integer :: unit, size, stat
   character(*) :: c1, c2

--- a/flang/test/Lower/io-statement-clean-ups.f90
+++ b/flang/test/Lower/io-statement-clean-ups.f90
@@ -4,7 +4,7 @@
 ! RUN: bbc -emit-fir -o - %s | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest_temp_io_options(
-! CHECK-SAME:   %[[VAL_0:.*]]: !fir.ref<i32>) {
+! CHECK-SAME:   %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine test_temp_io_options(status)
   interface
     function gen_temp_character()

--- a/flang/test/Lower/llvm-math.f90
+++ b/flang/test/Lower/llvm-math.f90
@@ -6,7 +6,8 @@
       RETURN
       END
       
-! CHECK: func @_QPpow_wrapper(%arg0: !fir.ref<f64>, %arg1: !fir.ref<f64>, %arg2: !fir.ref<f32>)
+! CHECK-LABEL: func @_QPpow_wrapper(
+! CHECK-SAME: %{{.*}}: !fir.ref<f64>{{.*}}, %{{.*}}: !fir.ref<f64>{{.*}}, %{{.*}}: !fir.ref<f32>{{.*}}) {
 ! CHECK-NEXT:   %0 = fir.load %arg0 : !fir.ref<f64>
 ! CHECK-NEXT:   %1 = fir.load %arg1 : !fir.ref<f64>
 ! CHECK-NEXT:   %2 = fir.call @llvm.pow.f64(%0, %1) : (f64, f64) -> f64
@@ -17,7 +18,8 @@
       RETURN
       END
 
-! CHECK: func @_QPpowf_wrapper(%arg0: !fir.ref<f32>, %arg1: !fir.ref<f32>, %arg2: !fir.ref<f32>)
+! CHECK-LABEL: func @_QPpowf_wrapper(
+! CHECK-SAME: %{{.*}}: !fir.ref<f32>{{.*}}, %{{.*}}: !fir.ref<f32>{{.*}}, %{{.*}}: !fir.ref<f32>{{.*}}) {
 ! CHECK-NEXT:   %0 = fir.load %arg0 : !fir.ref<f32>
 ! CHECK-NEXT:   %1 = fir.load %arg1 : !fir.ref<f32>
 ! CHECK-NEXT:   %2 = fir.call @llvm.pow.f32(%0, %1) : (f32, f32) -> f32

--- a/flang/test/Lower/nullify.f90
+++ b/flang/test/Lower/nullify.f90
@@ -8,7 +8,7 @@
 
 
 ! CHECK-LABEL: func @_QPtest_scalar(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}})
 subroutine test_scalar(p)
   real, pointer :: p
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<f32>
@@ -18,7 +18,7 @@ subroutine test_scalar(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_scalar_char(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>{{.*}})
 subroutine test_scalar_char(p)
   character(:), pointer :: p
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
@@ -28,7 +28,7 @@ subroutine test_scalar_char(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine test_array(p)
   real, pointer :: p(:)
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
@@ -39,8 +39,7 @@ subroutine test_array(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_list(
-! CHECK-SAME: %[[p1:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
-! CHECK-SAME: %[[p2:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[p1:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}}, %[[p2:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine test_list(p1, p2)
   real, pointer :: p1, p2(:)
   ! CHECK: fir.zero_bits !fir.ptr<f32>

--- a/flang/test/Lower/pointer-assignments.f90
+++ b/flang/test/Lower/pointer-assignments.f90
@@ -9,8 +9,7 @@
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest_scalar(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.ref<f32> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}}, %[[x:.*]]: !fir.ref<f32> {{{.*}}, fir.target})
 subroutine test_scalar(p, x)
   real, target :: x
   real, pointer :: p
@@ -20,8 +19,7 @@ subroutine test_scalar(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_scalar_char(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>{{.*}}, %[[x:.*]]: !fir.boxchar<1> {{{.*}}, fir.target})
 subroutine test_scalar_char(p, x)
   character(*), target :: x
   character(:), pointer :: p
@@ -32,8 +30,7 @@ subroutine test_scalar_char(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}, %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {{{.*}}, fir.target})
 subroutine test_array(p, x)
   real, target :: x(100)
   real, pointer :: p(:)
@@ -44,8 +41,7 @@ subroutine test_array(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array_char(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target}) {
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>{{.*}}, %[[x:.*]]: !fir.boxchar<1> {{{.*}}, fir.target}) {
 subroutine test_array_char(p, x)
   character(*), target :: x(100)
   character(:), pointer :: p(:)
@@ -90,8 +86,7 @@ end subroutine
 
 ! Test F2018 10.2.2.3 point 9: bounds remapping
 ! CHECK-LABEL: func @_QPtest_array_remap(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>{{.*}}, %[[x:.*]]: !fir.ref<!fir.array<100xf32>> {{{.*}}, fir.target})
 subroutine test_array_remap(p, x)
   real, target :: x(100)
   real, pointer :: p(:, :)
@@ -111,8 +106,7 @@ subroutine test_array_remap(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array_char_remap(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.boxchar<1> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>>{{.*}}, %[[x:.*]]: !fir.boxchar<1> {{{.*}}, fir.target})
 subroutine test_array_char_remap(p, x)
   ! CHECK: %[[unbox:.*]]:2 = fir.unboxchar %[[x]]
   character(*), target :: x(100)
@@ -132,8 +126,7 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest_array_non_contig_rhs(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}, %[[x:.*]]: !fir.box<!fir.array<?xf32>> {{{.*}}, fir.target})
 subroutine test_array_non_contig_rhs(p, x)
   real, target :: x(:)
   real, pointer :: p(:)
@@ -145,8 +138,7 @@ end subroutine
 ! Test 10.2.2.3 point 10: lower bounds requirements:
 ! pointer takes lbounds from rhs if no bounds spec.
 ! CHECK-LABEL: func @_QPtest_array_non_contig_rhs_lbs(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}, %[[x:.*]]: !fir.box<!fir.array<?xf32>> {{{.*}}, fir.target})
 subroutine test_array_non_contig_rhs_lbs(p, x)
   real, target :: x(7:)
   real, pointer :: p(:)
@@ -159,8 +151,7 @@ subroutine test_array_non_contig_rhs_lbs(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array_non_contig_rhs2(
-! CHECK-SAME:                                      %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
-! CHECK-SAME:                                      %[[VAL_1:.*]]: !fir.ref<!fir.array<200xf32>> {fir.target}) {
+! CHECK-SAME:                                      %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<200xf32>> {{{.*}}, fir.target}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : i64
 ! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
@@ -190,8 +181,7 @@ end subroutine
 ! Test 10.2.2.3 point 10: lower bounds requirements:
 ! pointer takes lbounds from bound spec if specified
 ! CHECK-LABEL: func @_QPtest_array_non_contig_rhs_new_lbs(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}, %[[x:.*]]: !fir.box<!fir.array<?xf32>> {{{.*}}, fir.target})
 subroutine test_array_non_contig_rhs_new_lbs(p, x)
   real, target :: x(7:)
   real, pointer :: p(:)
@@ -204,8 +194,7 @@ end subroutine
 
 ! Test F2018 10.2.2.3 point 9: bounds remapping
 ! CHECK-LABEL: func @_QPtest_array_non_contig_remap(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
-! CHECK-SAME: %[[x:.*]]: !fir.box<!fir.array<?xf32>> {fir.target})
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>{{.*}}, %[[x:.*]]: !fir.box<!fir.array<?xf32>> {{{.*}}, fir.target})
 subroutine test_array_non_contig_remap(p, x)
   real, target :: x(:)
   real, pointer :: p(:, :)
@@ -222,8 +211,7 @@ end subroutine
 ! Test remapping a slice
 
 ! CHECK-LABEL: func @_QPtest_array_non_contig_remap_slice(
-! CHECK-SAME:                                             %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>,
-! CHECK-SAME:                                             %[[VAL_1:.*]]: !fir.ref<!fir.array<400xf32>> {fir.target}) {
+! CHECK-SAME:                                             %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.array<400xf32>> {{{.*}}, fir.target}) {
 ! CHECK:         %[[VAL_2:.*]] = arith.constant 400 : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 2 : i64
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 11 : i64
@@ -352,7 +340,7 @@ subroutine issue857_char(rhs)
 end subroutine
 
 ! CHECK-LABEL: func @_QPissue1180(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.target}) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {{{.*}}, fir.target}) {
 subroutine issue1180(x)
   integer, target :: x
   integer, pointer :: p

--- a/flang/test/Lower/pointer-disassociate.f90
+++ b/flang/test/Lower/pointer-disassociate.f90
@@ -8,7 +8,7 @@
 
 
 ! CHECK-LABEL: func @_QPtest_scalar(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}})
 subroutine test_scalar(p)
   real, pointer :: p
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<f32>
@@ -18,7 +18,7 @@ subroutine test_scalar(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_scalar_char(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>{{.*}})
 subroutine test_scalar_char(p)
   character(:), pointer :: p
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.char<1,?>>
@@ -28,7 +28,7 @@ subroutine test_scalar_char(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine test_array(p)
   real, pointer :: p(:)
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
@@ -40,7 +40,7 @@ end subroutine
 
 ! Test p(lb, ub) => NULL() which is none sens but is not illegal.
 ! CHECK-LABEL: func @_QPtest_array_remap(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine test_array_remap(p)
   real, pointer :: p(:)
   ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
@@ -55,7 +55,7 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPtest_scalar_mold(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>,
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{[^,]*}},
 subroutine test_scalar_mold(p, x)
   real, pointer :: p, x
   ! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<f32>>
@@ -70,7 +70,7 @@ subroutine test_scalar_mold(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_scalar_char_mold(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>,
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,?>>>>{{[^,]*}},
 subroutine test_scalar_char_mold(p, x)
   character(:), pointer :: p, x
   ! CHECK: %[[VAL_7:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.char<1,?>>>
@@ -87,7 +87,7 @@ subroutine test_scalar_char_mold(p, x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array_mold(
-! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>,
+! CHECK-SAME: %[[p:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{[^,]*}},
 subroutine test_array_mold(p, x)
   real, pointer :: p(:), x(:)
   ! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xf32>>>

--- a/flang/test/Lower/pointer-references.f90
+++ b/flang/test/Lower/pointer-references.f90
@@ -3,7 +3,7 @@
 
 ! Assigning/reading to scalar pointer target.
 ! CHECK-LABEL: func @_QPscal_ptr(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>>{{.*}})
 subroutine scal_ptr(p)
   real, pointer :: p
   real :: x
@@ -21,7 +21,7 @@ end subroutine
 
 ! Assigning/reading scalar character pointer target.
 ! CHECK-LABEL: func @_QPchar_ptr(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,12>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,12>>>>{{.*}})
 subroutine char_ptr(p)
   character(12), pointer :: p
   character(12) :: x
@@ -48,7 +48,7 @@ end subroutine
 
 ! Reading from pointer in array expression
 ! CHECK-LABEL: func @_QParr_ptr_read(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}})
 subroutine arr_ptr_read(p)
   real, pointer :: p(:)
   real :: x(100)
@@ -61,7 +61,7 @@ end subroutine
 
 ! Reading from contiguous pointer in array expression
 ! CHECK-LABEL: func @_QParr_contig_ptr_read(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.contiguous})
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {{{.*}}, fir.contiguous})
 subroutine arr_contig_ptr_read(p)
   real, pointer, contiguous :: p(:)
   real :: x(100)
@@ -76,7 +76,7 @@ end subroutine
 ! Assigning to pointer target in array expression
 
   ! CHECK-LABEL: func @_QParr_ptr_target_write(
-  ! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+  ! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>{{.*}}) {
   ! CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
   ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = "x", uniq_name = "_QFarr_ptr_target_writeEx"}
   ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
@@ -120,7 +120,7 @@ end subroutine
 ! Assigning to contiguous pointer target in array expression
 
   ! CHECK-LABEL: func @_QParr_contig_ptr_target_write(
-  ! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.contiguous}) {
+  ! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {{{.*}}, fir.contiguous}) {
   ! CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
   ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = "x", uniq_name = "_QFarr_contig_ptr_target_writeEx"}
   ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>

--- a/flang/test/Lower/procedure-declarations.f90
+++ b/flang/test/Lower/procedure-declarations.f90
@@ -18,21 +18,24 @@ subroutine pass_foo()
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo)
 end subroutine
-! CHECK-LABEL: func @_QPcall_foo(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo(i)
   integer :: i(10)
   ! %[[argconvert:*]] = fir.convert %arg0 :
   ! fir.call @_QPfoo(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
   call foo(i)
 end subroutine 
-! CHECK-LABEL: func @_QPfoo(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPfoo(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine foo(i)
   integer :: i(2, 5)
   call do_something(i)
 end subroutine
 
 ! call, pass, define
-! CHECK-LABEL: func @_QPcall_foo2(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo2(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo2(i)
   integer :: i(10)
   ! %[[argconvert:*]] = fir.convert %arg0 :
@@ -46,21 +49,24 @@ subroutine pass_foo2()
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo2)
 end subroutine
-! CHECK-LABEL: func @_QPfoo2(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPfoo2(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine foo2(i)
   integer :: i(2, 5)
   call do_something(i)
 end subroutine
 
 ! call, define, pass
-! CHECK-LABEL: func @_QPcall_foo3(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo3(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo3(i)
   integer :: i(10)
   ! %[[argconvert:*]] = fir.convert %arg0 :
   ! fir.call @_QPfoo3(%[[argconvert]]) : (!fir.ref<!fir.array<2x5xi32>>) -> ()
   call foo3(i)
 end subroutine 
-! CHECK-LABEL: func @_QPfoo3(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPfoo3(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine foo3(i)
   integer :: i(2, 5)
   call do_something(i)
@@ -74,12 +80,14 @@ subroutine pass_foo3()
 end subroutine
 
 ! define, call, pass
-! CHECK-LABEL: func @_QPfoo4(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPfoo4(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine foo4(i)
   integer :: i(2, 5)
   call do_something(i)
 end subroutine
-! CHECK-LABEL: func @_QPcall_foo4(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo4(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo4(i)
   integer :: i(10)
   ! %[[argconvert:*]] = fir.convert %arg0 :
@@ -95,7 +103,8 @@ subroutine pass_foo4()
 end subroutine
 
 ! define, pass, call
-! CHECK-LABEL: func @_QPfoo5(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPfoo5(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine foo5(i)
   integer :: i(2, 5)
   call do_something(i)
@@ -107,7 +116,8 @@ subroutine pass_foo5()
   ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
   call bar(foo5)
 end subroutine
-! CHECK-LABEL: func @_QPcall_foo5(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo5(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo5(i)
   integer :: i(10)
   ! %[[argconvert:*]] = fir.convert %arg0 :
@@ -120,7 +130,8 @@ end subroutine
 ! First use gives the function type
 
 ! call, pass
-! CHECK-LABEL: func @_QPcall_foo6(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo6(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo6(i)
   integer :: i(10)
   ! CHECK-NOT: convert
@@ -141,7 +152,8 @@ subroutine pass_foo7()
   ! CHECK-NOT: convert
   call bar(foo7)
 end subroutine
-! CHECK-LABEL: func @_QPcall_foo7(%arg0: !fir.ref<!fir.array<10xi32>>) -> f32 {
+! CHECK-LABEL: func @_QPcall_foo7(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) -> f32 {
 function call_foo7(i)
   integer :: i(10)
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo7) : () -> ()
@@ -152,13 +164,15 @@ end function
 
 
 ! call, call with different type
-! CHECK-LABEL: func @_QPcall_foo8(%arg0: !fir.ref<!fir.array<10xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo8(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<10xi32>>{{.*}}) {
 subroutine call_foo8(i)
   integer :: i(10)
   ! CHECK-NOT: convert
   call foo8(i)
 end subroutine 
-! CHECK-LABEL: func @_QPcall_foo8_2(%arg0: !fir.ref<!fir.array<2x5xi32>>) {
+! CHECK-LABEL: func @_QPcall_foo8_2(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.array<2x5xi32>>{{.*}}) {
 subroutine call_foo8_2(i)
   integer :: i(2, 5)
   ! %[[argconvert:*]] = fir.convert %arg0 :

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -3,7 +3,8 @@
 ! Test statement function lowering
 
 ! Simple case
-! CHECK-LABEL: func @_QPtest_stmt_0(%arg0: !fir.ref<f32>) -> f32
+  ! CHECK-LABEL: func @_QPtest_stmt_0(
+  ! CHECK-SAME: %{{.*}}: !fir.ref<f32>{{.*}}) -> f32
 real function test_stmt_0(x)
   real :: x, func, arg
   func(arg) = arg + 0.123456
@@ -118,8 +119,8 @@ integer function test_stmt_character_with_different_length(c)
    test_stmt_character = func(c)
 end function
 
-! CHECK-LABEL: @_QPtest_stmt_character_with_different_length_2
-! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>, %[[arg1:.*]]: !fir.ref<i32>
+! CHECK-LABEL: @_QPtest_stmt_character_with_different_length_2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>
 integer function test_stmt_character_with_different_length_2(c, n)
    integer :: func, ifoo
    character(n) :: argc

--- a/flang/test/Lower/structure-constructors.f90
+++ b/flang/test/Lower/structure-constructors.f90
@@ -28,7 +28,7 @@ module m_struct_ctor
   end type
 contains
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_simple(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>)
+  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>{{.*}})
   subroutine test_simple(x)
     real :: x
     ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_simple{x:f32}>
@@ -40,7 +40,7 @@ contains
   end subroutine
 
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_char_scalar(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>)
+  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>{{.*}})
   subroutine test_char_scalar(x)
     ! CHECK: %[[tmp:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>
     ! CHECK: %[[xfield:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_char_scalar{x:f32,c:!fir.char<1,3>}>
@@ -59,7 +59,7 @@ contains
   end subroutine
 
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_simple_array(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>, %[[j:.*]]: !fir.ref<!fir.array<5xi32>>)
+  ! CHECK-SAME: %[[x:.*]]: !fir.ref<f32>{{.*}}, %[[j:.*]]: !fir.ref<!fir.array<5xi32>>{{.*}})
   subroutine test_simple_array(x, j)
     real :: x
     integer :: j(5)
@@ -84,8 +84,7 @@ contains
   end subroutine
 
 ! CHECK-LABEL: func @_QMm_struct_ctorPtest_char_array(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<f32>,
-! CHECK-SAME:  %[[VAL_1:.*]]: !fir.boxchar<1>) {
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {
   subroutine test_char_array(x, c1)
   ! CHECK: %[[VAL_3:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_char_array{x:f32,c:!fir.array<5x!fir.char<1,3>>}>
   ! CHECK: %[[VAL_4:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
@@ -130,8 +129,7 @@ contains
   end subroutine
 
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_ptr(
-  ! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<f32>,
-  ! CHECK-SAME:    %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xi32>> {fir.target}) {
+  ! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.box<!fir.array<?x?xi32>> {{{.*}}, fir.target}) {
   ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>
   ! CHECK:         %[[VAL_4:.*]] = fir.field_index x, !fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>
   ! CHECK:         %[[VAL_5:.*]] = fir.coordinate_of %[[VAL_3]], %[[VAL_4]] : (!fir.ref<!fir.type<_QMm_struct_ctorTt_ptr{x:f32,p:!fir.box<!fir.ptr<!fir.array<?x?xi32>>>}>>, !fir.field) -> !fir.ref<f32>
@@ -166,8 +164,7 @@ contains
   end subroutine
 
   ! CHECK-LABEL: func @_QMm_struct_ctorPtest_nested(
-  ! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>,
-  ! CHECK-SAME: %[[VAL_1:.*]]: !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
+  ! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<!fir.type<_QMm_struct_ctorTt_array{x:f32,i:!fir.array<5xi32>}>>
   subroutine test_nested(x, d)
     real :: x
     type(t_array) :: d

--- a/flang/test/Lower/transformational-intrinsics.f90
+++ b/flang/test/Lower/transformational-intrinsics.f90
@@ -18,7 +18,7 @@ end interface
 contains
 
 ! CHECK-LABEL: func @_QMtest2Pin_io(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>) {
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>{{.*}}) {
 subroutine in_io(x)
   logical(1) :: x(:, :)
   ! CHECK: %[[res_desc:.]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<1>>>>
@@ -37,7 +37,7 @@ subroutine in_io(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMtest2Pin_call(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>) {
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>{{.*}}) {
 subroutine in_call(x)
   implicit none
   logical(1) :: x(:, :)
@@ -56,7 +56,7 @@ subroutine in_call(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMtest2Pin_implicit_call(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>) {
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>{{.*}}) {
 subroutine in_implicit_call(x)
   logical(1) :: x(:, :)
   ! CHECK: %[[res_desc:.]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<1>>>>
@@ -70,8 +70,7 @@ subroutine in_implicit_call(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QMtest2Pin_assignment(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>{{.*}})
 subroutine in_assignment(x, y)
   logical(1) :: x(:, :), y(:)
   ! CHECK: %[[res_desc:.]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<1>>>>
@@ -94,9 +93,7 @@ subroutine in_assignment(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QMtest2Pin_elem_expr(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>,
-! CHECK-SAME: %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>)
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x!fir.logical<1>>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>{{.*}}, %[[arg2:.*]]: !fir.box<!fir.array<?x!fir.logical<1>>>{{.*}})
 subroutine in_elem_expr(x, y, z)
   logical(1) :: x(:, :), y(:), z(:)
   ! CHECK: %[[res_desc:.]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.logical<1>>>>

--- a/flang/test/Lower/user-defined-operators.f90
+++ b/flang/test/Lower/user-defined-operators.f90
@@ -3,8 +3,7 @@
 
 ! Test user defined assignment
 ! CHECK-LABEL: func @_QPuser_assignment(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<{{.*}}>>,
-! CHECK-SAME: %[[arg1:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<{{.*}}>>{{.*}}, %[[arg1:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine user_assignment(a, i)
   type t
     real :: x

--- a/flang/test/Lower/vector-subscript-io.f90
+++ b/flang/test/Lower/vector-subscript-io.f90
@@ -2,8 +2,7 @@
 ! RUN: bbc %s -o - -I nowhere | FileCheck %s
 
 ! CHECK-LABEL: func @_QPsimple(
-! CHECK-SAME: %[[VAL_20:.*]]: !fir.ref<!fir.array<10xi32>>,
-! CHECK-SAME: %[[VAL_16:.*]]: !fir.ref<!fir.array<3xi32>>)
+! CHECK-SAME: %[[VAL_20:.*]]: !fir.ref<!fir.array<10xi32>>{{.*}}, %[[VAL_16:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}) {
 subroutine simple(x, y)
   integer :: y(3)
   integer :: x(10)
@@ -39,7 +38,7 @@ subroutine simple(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPonly_once(
-! CHECK-SAME: %[[VAL_51:.*]]: !fir.box<!fir.array<?x?xf32>>)
+! CHECK-SAME: %[[VAL_51:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}) {
 subroutine only_once(x)
   interface
     function get_vector()
@@ -97,8 +96,7 @@ subroutine only_once(x)
 end subroutine
 
 ! CHECK-LABEL: func @_QPwith_assumed_shapes(
-! CHECK-SAME: %[[VAL_78:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME: %[[VAL_69:.*]]: !fir.box<!fir.array<?xi32>>) {
+! CHECK-SAME: %[[VAL_78:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_69:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine with_assumed_shapes(x, y)
   integer :: y(:)
   integer :: x(:)
@@ -132,8 +130,7 @@ subroutine with_assumed_shapes(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPlower_bounds(
-! CHECK-SAME: %[[VAL_108:.*]]: !fir.ref<!fir.array<4x6xi32>>,
-! CHECK-SAME: %[[VAL_104:.*]]: !fir.ref<!fir.array<3xi32>>) {
+! CHECK-SAME: %[[VAL_108:.*]]: !fir.ref<!fir.array<4x6xi32>>{{.*}}, %[[VAL_104:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}) {
 subroutine lower_bounds(x, y)
   integer :: y(3)
   integer :: x(2:5,3:8)
@@ -173,9 +170,7 @@ subroutine lower_bounds(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtwo_vectors(
-! CHECK-SAME: %[[VAL_140:.*]]: !fir.ref<!fir.array<4x4xf32>>,
-! CHECK-SAME: %[[VAL_132:.*]]: !fir.ref<!fir.array<3xi32>>,
-! CHECK-SAME: %[[VAL_136:.*]]: !fir.ref<!fir.array<3xi32>>) {
+! CHECK-SAME: %[[VAL_140:.*]]: !fir.ref<!fir.array<4x4xf32>>{{.*}}, %[[VAL_132:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}, %[[VAL_136:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}) {
 subroutine two_vectors(x, y1, y2)
   integer :: y1(3), y2(3)
   real :: x(4, 4)
@@ -219,8 +214,7 @@ subroutine two_vectors(x, y1, y2)
 end subroutine
 
 ! CHECK-LABEL: func @_QPtriplets_and_vector(
-! CHECK-SAME: %[[VAL_170:.*]]: !fir.ref<!fir.array<4x4x!fir.complex<4>>>,
-! CHECK-SAME: %[[VAL_166:.*]]: !fir.ref<!fir.array<3xi32>>) {
+! CHECK-SAME:    %[[VAL_170:.*]]: !fir.ref<!fir.array<4x4x!fir.complex<4>>>{{.*}}, %[[VAL_166:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}) {
 subroutine triplets_and_vector(x, y)
   integer :: y(3)
   complex :: x(4, 4)
@@ -263,8 +257,7 @@ subroutine triplets_and_vector(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPsimple_char(
-! CHECK-SAME: %[[VAL_185:.*]]: !fir.boxchar<1>,
-! CHECK-SAME: %[[VAL_196:.*]]: !fir.ref<!fir.array<3xi32>>) {
+! CHECK-SAME: %[[VAL_185:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_196:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}) {
 subroutine simple_char(x, y)
   integer :: y(3)
   character(*) :: x(3:8)
@@ -302,10 +295,7 @@ subroutine simple_char(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPsubstring(
-! CHECK-SAME: %[[VAL_229:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>,
-! CHECK-SAME: %[[VAL_225:.*]]: !fir.ref<!fir.array<3xi32>>,
-! CHECK-SAME: %[[VAL_215:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[VAL_218:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_229:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>>{{.*}}, %[[VAL_225:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}, %[[VAL_215:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_218:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine substring(x, y, i, j)
   integer :: y(3), i, j
   character(*) :: x(:)
@@ -351,8 +341,7 @@ subroutine substring(x, y, i, j)
 end subroutine
 
 ! CHECK-LABEL: func @_QPcomplex_part(
-! CHECK-SAME: %[[VAL_262:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>,
-! CHECK-SAME: %[[VAL_253:.*]]: !fir.box<!fir.array<?xi32>>) {
+! CHECK-SAME: %[[VAL_262:.*]]: !fir.box<!fir.array<?x!fir.complex<4>>>{{.*}}, %[[VAL_253:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine complex_part(z, y)
   integer :: y(:)
   complex :: z(:)
@@ -395,8 +384,7 @@ module derived_types
 end module
 
 ! CHECK-LABEL: func @_QPsimple_derived(
-! CHECK-SAME: %[[VAL_287:.*]]: !fir.ref<!fir.array<6x!fir.type<_QMderived_typesTt{i:i32,c:!fir.char<1,2>}>>>,
-! CHECK-SAME: %[[VAL_283:.*]]: !fir.ref<!fir.array<4xi32>>) {
+! CHECK-SAME: %[[VAL_287:.*]]: !fir.ref<!fir.array<6x!fir.type<_QMderived_typesTt{i:i32,c:!fir.char<1,2>}>>>{{.*}}, %[[VAL_283:.*]]: !fir.ref<!fir.array<4xi32>>{{.*}}) {
 subroutine simple_derived(x, y)
   use derived_types
   integer :: y(4)
@@ -434,8 +422,7 @@ subroutine simple_derived(x, y)
 end subroutine
 
 ! CHECK-LABEL: func @_QPwith_path(
-! CHECK-SAME: [[VAL_326:.*]]: !fir.box<!fir.array<?x?x?x!fir.type<_QMderived_typesTt2{a:!fir.array<5x5x!fir.type<_QMderived_typesTt{i:i32,c:!fir.char<1,2>}>>}>>>,
-! CHECK-SAME: [[VAL_310:.*]]: !fir.box<!fir.array<?xi32>>) {
+! CHECK-SAME: [[VAL_326:.*]]: !fir.box<!fir.array<?x?x?x!fir.type<_QMderived_typesTt2{a:!fir.array<5x5x!fir.type<_QMderived_typesTt{i:i32,c:!fir.char<1,2>}>>}>>>{{.*}}, [[VAL_310:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}) {
 subroutine with_path(b, i)
   use derived_types
   type(t2) :: b(4:, 4:, 4:)
@@ -488,10 +475,7 @@ subroutine with_path(b, i)
 end subroutine
 
 ! CHECK-LABEL: func @_QPsimple_iostat(
-! CHECK-SAME: %[[VAL_357:.*]]: !fir.box<!fir.array<?xf32>>,
-! CHECK-SAME: %[[VAL_346:.*]]: !fir.box<!fir.array<?xi32>>,
-! CHECK-SAME: %[[VAL_361:.*]]: !fir.ref<i32>,
-! CHECK-SAME: %[[VAL_364:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_357:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}, %[[VAL_346:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[VAL_361:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_364:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine simple_iostat(x, y, j, stat)
   integer :: j, y(:), stat
   real :: x(:)
@@ -535,9 +519,7 @@ subroutine simple_iostat(x, y, j, stat)
 end subroutine
 
 ! CHECK-LABEL: func @_QPiostat_in_io_loop(
-! CHECK-SAME: %[[VAL_400:.*]]: !fir.ref<!fir.array<3x5xi32>>,
-! CHECK-SAME: %[[VAL_396:.*]]: !fir.ref<!fir.array<3xi32>>,
-! CHECK-SAME: %[[VAL_408:.*]]: !fir.ref<i32>) {
+! CHECK-SAME: %[[VAL_400:.*]]: !fir.ref<!fir.array<3x5xi32>>{{.*}}, %[[VAL_396:.*]]: !fir.ref<!fir.array<3xi32>>{{.*}}, %[[VAL_408:.*]]: !fir.ref<i32>{{.*}}) {
 subroutine iostat_in_io_loop(k, j, stat)
   integer :: k(3, 5)
   integer :: j(3)


### PR DESCRIPTION
surface syntax. This is to enable the eventual generation of debug
information, etc.

Modify all the tests to allow/require these annotations to appear.