### PR TITLE
Some of the convert optimizations were incorrect. For example, the se…

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CanonicalizationPatterns.td
+++ b/flang/include/flang/Optimizer/Dialect/CanonicalizationPatterns.td
@@ -23,28 +23,80 @@ def IdenticalTypePred : Constraint<CPred<"$0.getType() == $1.getType()">>;
 def IntegerTypePred : Constraint<CPred<"fir::isa_integer($0.getType())">>;
 def IndexTypePred : Constraint<CPred<"$0.getType().isa<mlir::IndexType>()">>;
 
-def SmallerWidthPred
-    : Constraint<CPred<"$0.getType().getIntOrFloatBitWidth() "
-                       "<= $1.getType().getIntOrFloatBitWidth()">>;
+// Widths are monotonic.
+//   $0.bits >= $1.bits >= $2.bits or $0.bits <= $1.bits <= $2.bits
+def MonotonicTypePred
+    : Constraint<CPred<"(($0.getType().isa<mlir::IntegerType>() && "
+                       "  $1.getType().isa<mlir::IntegerType>() && "
+                       "  $2.getType().isa<mlir::IntegerType>()) || "
+                       " ($0.getType().isa<mlir::FloatType>() && "
+                       "  $1.getType().isa<mlir::FloatType>() && "
+                       "  $2.getType().isa<mlir::FloatType>())) && "
+                       "(($0.getType().getIntOrFloatBitWidth() <= "
+                       "  $1.getType().getIntOrFloatBitWidth() && "
+                       "  $1.getType().getIntOrFloatBitWidth() <= "
+                       "  $2.getType().getIntOrFloatBitWidth()) || "
+                       " ($0.getType().getIntOrFloatBitWidth() >= "
+                       "  $1.getType().getIntOrFloatBitWidth() && "
+                       "  $1.getType().getIntOrFloatBitWidth() >= "
+                       "  $2.getType().getIntOrFloatBitWidth()))">>;
 
+def IntPred : Constraint<CPred<
+                       "$0.getType().isa<mlir::IntegerType>() && "
+                       "$1.getType().isa<mlir::IntegerType>()">>;
+                       
+// If both are int type and the first is smaller than the second.
+//   $0.bits <= $1.bits
+def SmallerWidthPred : Constraint<CPred<
+                       "$0.getType().getIntOrFloatBitWidth() <= "
+                       "$1.getType().getIntOrFloatBitWidth()">>;
+def StrictSmallerWidthPred : Constraint<CPred<
+                       "$0.getType().getIntOrFloatBitWidth() < "
+                       "$1.getType().getIntOrFloatBitWidth()">>;
+
+// floats or ints that undergo successive extensions or successive truncations.
 def ConvertConvertOptPattern
-    : Pat<(fir_ConvertOp (fir_ConvertOp $arg)),
+    : Pat<(fir_ConvertOp:$res (fir_ConvertOp:$irm $arg)),
           (fir_ConvertOp $arg),
-          [(IntegerTypePred $arg)]>;
+          [(MonotonicTypePred $res, $irm, $arg)]>;
 
+// Widths are increasingly monotonic to type index, so there is no
+// possibility of a truncation before the conversion to index.
+//   $res == index && $irm.bits >= $arg.bits
+def ConvertAscendingIndexOptPattern
+    : Pat<(fir_ConvertOp:$res (fir_ConvertOp:$irm $arg)),
+          (fir_ConvertOp $arg),
+          [(IndexTypePred $res), (IntPred $irm, $arg),
+           (SmallerWidthPred $arg, $irm)]>;
+
+// Widths are decreasingly monotonic from type index, so the truncations
+// continue to lop off more bits.
+//   $arg == index && $res.bits < $irm.bits
+def ConvertDescendingIndexOptPattern
+    : Pat<(fir_ConvertOp:$res (fir_ConvertOp:$irm $arg)),
+          (fir_ConvertOp $arg),
+          [(IndexTypePred $arg), (IntPred $irm, $res),
+           (SmallerWidthPred $res, $irm)]>;
+
+// Useless convert to exact same type.
 def RedundantConvertOptPattern
     : Pat<(fir_ConvertOp:$res $arg),
           (replaceWithValue $arg),
-          [(IdenticalTypePred $res, $arg)
-          ,(IntegerTypePred $arg)]>;
+          [(IdenticalTypePred $res, $arg)]>;
 
+// Useless extension followed by truncation to get same width integer.
 def CombineConvertOptPattern
     : Pat<(fir_ConvertOp:$res(fir_ConvertOp:$irm $arg)),
           (replaceWithValue $arg),
-          [(IdenticalTypePred $res, $arg)
-          ,(IntegerTypePred $arg)
-          ,(IntegerTypePred $irm)
-          ,(SmallerWidthPred $arg, $irm)]>;
+          [(IntPred $res, $arg), (IdenticalTypePred $res, $arg),
+           (IntPred $arg, $irm), (SmallerWidthPred $arg, $irm)]>;
+
+// Useless extension followed by truncation to get smaller width integer.
+def CombineConvertTruncOptPattern
+    : Pat<(fir_ConvertOp:$res(fir_ConvertOp:$irm $arg)),
+          (fir_ConvertOp $arg),
+          [(IntPred $res, $arg), (StrictSmallerWidthPred $res, $arg),
+           (IntPred $arg, $irm), (SmallerWidthPred $arg, $irm)]>;
 
 def createConstantOp
     : NativeCodeCall<"$_builder.create<mlir::arith::ConstantOp>"
@@ -55,7 +107,6 @@ def createConstantOp
 def ForwardConstantConvertPattern
     : Pat<(fir_ConvertOp:$res (Arith_ConstantOp:$cnt $attr)),
           (createConstantOp $res, $attr),
-          [(IndexTypePred $res)
-          ,(IntegerTypePred $cnt)]>;
+          [(IndexTypePred $res), (IntegerTypePred $cnt)]>;
 
 #endif // FORTRAN_FIR_REWRITE_PATTERNS

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -806,9 +806,10 @@ static mlir::LogicalResult verify(fir::ConstcOp &op) {
 
 void fir::ConvertOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<ConvertConvertOptPattern, RedundantConvertOptPattern,
-                 CombineConvertOptPattern, ForwardConstantConvertPattern>(
-      context);
+  results.insert<ConvertConvertOptPattern, ConvertAscendingIndexOptPattern,
+                 ConvertDescendingIndexOptPattern, RedundantConvertOptPattern,
+                 CombineConvertOptPattern, CombineConvertTruncOptPattern,
+                 ForwardConstantConvertPattern>(context);
 }
 
 mlir::OpFoldResult fir::ConvertOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
@@ -2243,7 +2244,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&...additionalArgs) {
+                        AdditionalArgs &&... additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -2244,7 +2244,7 @@ static constexpr llvm::StringRef getTargetOffsetAttr() {
 template <typename A, typename... AdditionalArgs>
 static A getSubOperands(unsigned pos, A allArgs,
                         mlir::DenseIntElementsAttr ranges,
-                        AdditionalArgs &&... additionalArgs) {
+                        AdditionalArgs &&...additionalArgs) {
   unsigned start = 0;
   for (unsigned i = 0; i < pos; ++i)
     start += (*(ranges.begin() + i)).getZExtValue();

--- a/flang/test/Fir/peephole.fir
+++ b/flang/test/Fir/peephole.fir
@@ -1,0 +1,126 @@
+// RUN: tco %s | FileCheck %s
+
+// Test peephole optimizations
+
+// CHECK-LABEL: define i8 @test_trunc(
+// CHECK-SAME: i256 %[[arg:.*]])
+// CHECK-NEXT: = trunc i256 %[[arg]] to i8
+// CHECK-NEXT: ret i8
+func @test_trunc(%0 : i256) -> i8 {
+  %1 = fir.convert %0 : (i256) -> i128
+  %2 = fir.convert %1 : (i128) -> i64
+  %3 = fir.convert %2 : (i64) -> i32
+  %4 = fir.convert %3 : (i32) -> i16
+  %5 = fir.convert %4 : (i16) -> i8
+  return %5 : i8
+}
+
+// CHECK-LABEL: define i256 @test_sext(
+// CHECK-SAME: i8 %[[arg:.*]])
+// CHECK-NEXT: = sext i8 %[[arg]] to i256
+// CHECK-NEXT: ret i256
+func @test_sext(%0 : i8) -> i256 {
+  %1 = fir.convert %0 : (i8) -> i16
+  %2 = fir.convert %1 : (i16) -> i32
+  %3 = fir.convert %2 : (i32) -> i64
+  %4 = fir.convert %3 : (i64) -> i128
+  %5 = fir.convert %4 : (i128) -> i256
+  return %5 : i256
+}
+
+// CHECK-LABEL: define half @test_fptrunc(
+// CHECK-SAME: fp128 %[[arg:.*]])
+// CHECK-NEXT: %[[res:.*]] = fptrunc fp128 %[[arg]] to half
+// CHECK-NEXT: ret half %[[res]]
+func @test_fptrunc(%0 : f128) -> f16 {
+  %2 = fir.convert %0 : (f128) -> f64
+  %3 = fir.convert %2 : (f64) -> f32
+  %4 = fir.convert %3 : (f32) -> f16
+  return %4 : f16
+}
+
+// CHECK-LABEL: define x86_fp80 @test_fpext(
+// CHECK-SAME: bfloat %[[arg:.*]])
+// CHECK-NEXT: = fpext bfloat %[[arg]] to x86_fp80
+// CHECK-NEXT: ret x86_fp80
+func @test_fpext(%0 : bf16) -> f80 {
+  %2 = fir.convert %0 : (bf16) -> f32
+  %3 = fir.convert %2 : (f32) -> f64
+  %4 = fir.convert %3 : (f64) -> f80
+  return %4 : f80
+}
+
+// CHECK-LABEL: define i64 @test_ascending(
+// CHECK-SAME: i8 %[[arg:.*]])
+// CHECK-NEXT: = sext i8 %[[arg]] to i64
+// CHECK-NEXT: ret i64
+func @test_ascending(%0 : i8) -> index {
+  %1 = fir.convert %0 : (i8) -> i16
+  %2 = fir.convert %1 : (i16) -> i32
+  %3 = fir.convert %2 : (i32) -> i64
+  %5 = fir.convert %3 : (i64) -> index
+  return %5 : index
+}
+
+// CHECK-LABEL: define i8 @test_descending(
+// CHECK-SAME: i64 %[[arg:.*]])
+// CHECK-NEXT: = trunc i64 %[[arg]] to i8
+// CHECK-NEXT: ret i8
+func @test_descending(%0 : index) -> i8 {
+  %2 = fir.convert %0 : (index) -> i64
+  %3 = fir.convert %2 : (i64) -> i32
+  %4 = fir.convert %3 : (i32) -> i16
+  %5 = fir.convert %4 : (i16) -> i8
+  return %5 : i8
+}
+
+// CHECK-LABEL: define float @test_useless(
+// CHECK-SAME: float %[[arg:.*]])
+// CHECK-NEXT: ret float %[[arg]]
+func @test_useless(%0 : f32) -> f32 {
+  %1 = fir.convert %0 : (f32) -> f32
+  return %1 : f32
+}
+
+// CHECK-LABEL: define float @test_useless_sext(
+// CHECK-SAME: i32 %[[arg:.*]])
+// CHECK-NEXT: %[[res:.*]] = sitofp i32 %[[arg]] to float
+// CHECK-NEXT: ret float %[[res]]
+func @test_useless_sext(%0 : i32) -> f32 {
+  %1 = fir.convert %0 : (i32) -> i64
+  %2 = fir.convert %1 : (i64) -> i32
+  %3 = fir.convert %2 : (i32) -> f32
+  return %3 : f32
+}
+
+// CHECK-LABEL: define i16 @test_hump(
+// CHECK-SAME: i32 %[[arg:.*]])
+// CHECK-NEXT: trunc i32 %[[arg]] to i16
+// CHECK-NEXT: ret i16
+func @test_hump(%0 : i32) -> i16 {
+  %1 = fir.convert %0 : (i32) -> i64
+  %2 = fir.convert %1 : (i64) -> i16
+  return %2 : i16
+}
+
+// CHECK-LABEL: define i16 @test_slump(
+// CHECK-SAME: i32 %[[arg:.*]])
+// CHECK-NEXT: %[[i:.*]] = trunc i32 %[[arg]] to i8
+// CHECK-NEXT: sext i8 %[[i]] to i16
+// CHECK-NEXT: ret i16
+func @test_slump(%0 : i32) -> i16 {
+  %1 = fir.convert %0 : (i32) -> i8
+  %2 = fir.convert %1 : (i8) -> i16
+  return %2 : i16
+}
+
+// CHECK-LABEL: define i64 @test_slump2(
+// CHECK-SAME: i64 %[[arg:.*]])
+// CHECK-NEXT: %[[i:.*]] = trunc i64 %[[arg]] to i16
+// CHECK-NEXT: sext i16 %[[i]] to i64
+// CHECK-NEXT: ret i64
+func @test_slump2(%0 : index) -> index {
+  %1 = fir.convert %0 : (index) -> i16
+  %2 = fir.convert %1 : (i16) -> index
+  return %2 : index
+}

--- a/flang/test/Lower/array-elemental-calls-char.f90
+++ b/flang/test/Lower/array-elemental-calls-char.f90
@@ -206,49 +206,56 @@ elemental function elem_return_char(c)
 end function
 
 ! CHECK-LABEL: func @_QMchar_elemPfoo6(
-! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}) {
+! CHECK-SAME:         %[[VAL_0:.*]]: !fir.boxchar<1> {fir.bindc_name = "c"}) {
 subroutine foo6(c)
-  ! CHECK-DAG: %[[VAL_1:.*]] = arith.constant false
-  ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant 32 : i8
-  ! CHECK-DAG: %[[VAL_3:.*]] = arith.constant 10 : index
-  ! CHECK-DAG: %[[VAL_4:.*]] = arith.constant 0 : index
-  ! CHECK-DAG: %[[VAL_5:.*]] = arith.constant 1 : index
-  ! CHECK: %[[VAL_6:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-  ! CHECK: %[[VAL_7:.*]] = fir.convert %[[VAL_6]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1,?>>>
-  ! CHECK: %[[VAL_8:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
-  ! CHECK: br ^bb1(%[[VAL_4]], %[[VAL_3]] : index, index)
-  ! CHECK: ^bb1(%[[VAL_9:.*]]: index, %[[VAL_10:.*]]: index):
-  ! CHECK: %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_4]] : index
-  ! CHECK: cond_br %[[VAL_11]], ^bb2, ^bb6
-  ! CHECK: ^bb2:
-  ! CHECK: %[[VAL_12:.*]] = arith.addi %[[VAL_9]], %[[VAL_5]] : index
-  ! CHECK: %[[VAL_13:.*]] = fir.array_coor %[[VAL_7]](%[[VAL_8]]) %[[VAL_12]] typeparams %[[VAL_6]]#1 : (!fir.ref<!fir.array<10x!fir.char<1,?>>>, !fir.shape<1>, index, index) -> !fir.ref<!fir.char<1,?>>
-  ! CHECK: %[[VAL_14:.*]] = fir.emboxchar %[[VAL_13]], %[[VAL_6]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[VAL_15:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_6]]#1 : index) {bindc_name = ".result"}
-  ! CHECK: %[[VAL_16:.*]] = fir.call @_QMchar_elemPelem_return_char(%[[VAL_15]], %[[VAL_6]]#1, %[[VAL_14]]) : (!fir.ref<!fir.char<1,?>>, index, !fir.boxchar<1>) -> !fir.boxchar<1>
-  ! CHECK: %[[VAL_17:.*]] = fir.convert %[[VAL_6]]#1 : (index) -> i64
-  ! CHECK: %[[VAL_18:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
-  ! CHECK: %[[VAL_19:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
-  ! CHECK: fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_18]], %[[VAL_19]], %[[VAL_17]], %[[VAL_1]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
-  ! CHECK: %[[VAL_20:.*]] = arith.subi %[[VAL_6]]#1, %[[VAL_5]] : index
-  ! CHECK: %[[VAL_21:.*]] = fir.undefined !fir.char<1>
-  ! CHECK: %[[VAL_22:.*]] = fir.insert_value %[[VAL_21]], %[[VAL_2]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
-  ! CHECK: %[[VAL_23:.*]] = arith.subi %[[VAL_20]], %[[VAL_6]]#1 : index
-  ! CHECK: %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_5]] : index
-  ! CHECK: br ^bb3(%[[VAL_6]]#1, %[[VAL_24]] : index, index)
-  ! CHECK: ^bb3(%[[VAL_25:.*]]: index, %[[VAL_26:.*]]: index):
-  ! CHECK: %[[VAL_27:.*]] = arith.cmpi sgt, %[[VAL_26]], %[[VAL_4]] : index
-  ! CHECK: cond_br %[[VAL_27]], ^bb4, ^bb5
-  ! CHECK: ^bb4:
-  ! CHECK: %[[VAL_28:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
-  ! CHECK: %[[VAL_29:.*]] = fir.coordinate_of %[[VAL_28]], %[[VAL_25]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-  ! CHECK: fir.store %[[VAL_22]] to %[[VAL_29]] : !fir.ref<!fir.char<1>>
-  ! CHECK: %[[VAL_30:.*]] = arith.addi %[[VAL_25]], %[[VAL_5]] : index
-  ! CHECK: %[[VAL_31:.*]] = arith.subi %[[VAL_26]], %[[VAL_5]] : index
-  ! CHECK: br ^bb3(%[[VAL_30]], %[[VAL_31]] : index, index)
-  ! CHECK: ^bb5:
-  ! CHECK: %[[VAL_32:.*]] = arith.subi %[[VAL_10]], %[[VAL_5]] : index
-  ! CHECK: br ^bb1(%[[VAL_12]], %[[VAL_32]] : index, index)
+  ! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
+  ! CHECK:         %[[VAL_2:.*]] = arith.constant 1 : index
+  ! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : index
+  ! CHECK:         %[[VAL_4:.*]] = arith.constant false
+  ! CHECK:         %[[VAL_5:.*]] = arith.constant 32 : i8
+  ! CHECK:         %[[VAL_6:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1,?>>>
+  ! CHECK:         %[[VAL_8:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
+  ! CHECK:         br ^bb1(%[[VAL_3]], %[[VAL_1]] : index, index)
+  ! CHECK:       ^bb1(%[[VAL_9:.*]]: index, %[[VAL_10:.*]]: index):
+  ! CHECK:         %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_3]] : index
+  ! CHECK:         cond_br %[[VAL_11]], ^bb2, ^bb6
+  ! CHECK:       ^bb2:
+  ! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_9]], %[[VAL_2]] : index
+  ! CHECK:         %[[VAL_13:.*]] = fir.array_coor %[[VAL_7]](%[[VAL_8]]) %[[VAL_12]] typeparams %[[VAL_6]]#1 : (!fir.ref<!fir.array<10x!fir.char<1,?>>>, !fir.shape<1>, index, index) -> !fir.ref<!fir.char<1,?>>
+  ! CHECK:         %[[VAL_14:.*]] = fir.emboxchar %[[VAL_13]], %[[VAL_6]]#1 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_6]]#1 : (index) -> i32
+  ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> index
+  ! CHECK:         %[[VAL_17:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+  ! CHECK:         %[[VAL_18:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_16]] : index) {bindc_name = ".result"}
+  ! CHECK:         %[[VAL_19:.*]] = fir.call @_QMchar_elemPelem_return_char(%[[VAL_18]], %[[VAL_16]], %[[VAL_14]]) : (!fir.ref<!fir.char<1,?>>, index, !fir.boxchar<1>) -> !fir.boxchar<1>
+  ! CHECK:         %[[VAL_20:.*]] = arith.cmpi slt, %[[VAL_6]]#1, %[[VAL_16]] : index
+  ! CHECK:         %[[VAL_21:.*]] = select %[[VAL_20]], %[[VAL_6]]#1, %[[VAL_16]] : index
+  ! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (index) -> i64
+  ! CHECK:         %[[VAL_23:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK:         %[[VAL_24:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  ! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_23]], %[[VAL_24]], %[[VAL_22]], %[[VAL_4]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  ! CHECK:         %[[VAL_25:.*]] = arith.subi %[[VAL_6]]#1, %[[VAL_2]] : index
+  ! CHECK:         %[[VAL_26:.*]] = fir.undefined !fir.char<1>
+  ! CHECK:         %[[VAL_27:.*]] = fir.insert_value %[[VAL_26]], %[[VAL_5]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+  ! CHECK:         %[[VAL_28:.*]] = arith.subi %[[VAL_25]], %[[VAL_21]] : index
+  ! CHECK:         %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_2]] : index
+  ! CHECK:         br ^bb3(%[[VAL_21]], %[[VAL_29]] : index, index)
+  ! CHECK:       ^bb3(%[[VAL_30:.*]]: index, %[[VAL_31:.*]]: index):
+  ! CHECK:         %[[VAL_32:.*]] = arith.cmpi sgt, %[[VAL_31]], %[[VAL_3]] : index
+  ! CHECK:         cond_br %[[VAL_32]], ^bb4, ^bb5
+  ! CHECK:       ^bb4:
+  ! CHECK:         %[[VAL_33:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  ! CHECK:         %[[VAL_34:.*]] = fir.coordinate_of %[[VAL_33]], %[[VAL_30]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  ! CHECK:         fir.store %[[VAL_27]] to %[[VAL_34]] : !fir.ref<!fir.char<1>>
+  ! CHECK:         %[[VAL_35:.*]] = arith.addi %[[VAL_30]], %[[VAL_2]] : index
+  ! CHECK:         %[[VAL_36:.*]] = arith.subi %[[VAL_31]], %[[VAL_2]] : index
+  ! CHECK:         br ^bb3(%[[VAL_35]], %[[VAL_36]] : index, index)
+  ! CHECK:       ^bb5:
+  ! CHECK:         fir.call @llvm.stackrestore(%[[VAL_17]]) : (!fir.ref<i8>) -> ()
+  ! CHECK:         %[[VAL_37:.*]] = arith.subi %[[VAL_10]], %[[VAL_2]] : index
+  ! CHECK:         br ^bb1(%[[VAL_12]], %[[VAL_37]] : index, index)
+  ! CHECK:       ^bb6:
 
   implicit none
   character(*) :: c(10)

--- a/flang/test/Lower/array-temp.f90
+++ b/flang/test/Lower/array-temp.f90
@@ -20,68 +20,367 @@ subroutine ss1
 ! print*, aa(1:2), aa(N-1:N)
 end
 
-! CHECK-LABEL: func @_QPss2
 subroutine ss2(N)
-  ! CHECK: %[[arg:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[n:[0-9]+]] = fir.convert %[[arg]] : (i32) -> index
-  ! CHECK: %[[aa:[0-9]+]] = fir.alloca !fir.array<?xf32>, %[[n]] {bindc_name = "aa", uniq_name = "_QFss2Eaa"}
   real aa(N)
-  ! CHECK: %[[shape:[0-9]+]] = fir.shape %[[n]] : (index) -> !fir.shape<1>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
   aa = -2
-  ! CHECK: %[[temp:[0-9]+]] = fir.allocmem !fir.array<?xf32>, %[[n]]
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}} : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) [{{.*}}] {{.*}} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) [{{.*}}] {{.*}} : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}} : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-  ! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?xf32>>
   aa(2:N) = aa(1:N-1) + 7.0
-! print*, aa(1:2), aa(N-1:N)
+  print*, aa(1:2), aa(N-1:N)
 end
 
-! CHECK-LABEL: func @_QPss3
 subroutine ss3(N)
-  ! CHECK: %[[arg:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[n:[0-9]+]] = fir.convert %[[arg]] : (i32) -> index
-  ! CHECK: %[[aa:[0-9]+]] = fir.alloca !fir.array<2x?xf32>, %[[n]] {bindc_name = "aa", uniq_name = "_QFss3Eaa"}
   real aa(2,N)
-  ! CHECK: %[[shape:[0-9]+]] = fir.shape {{.*}} %[[n]] : (index, index) -> !fir.shape<2>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
   aa = -2
-  ! CHECK: %[[temp:[0-9]+]] = fir.allocmem !fir.array<2x?xf32>, %[[n]]
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}}, {{.*}} : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) [{{.*}}] {{.*}}, {{.*}} : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) [{{.*}}] {{.*}}, {{.*}} : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}}, {{.*}} : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<2x?xf32>>
   aa(:,2:N) = aa(:,1:N-1) + 7.0
-! print*, aa(:,1:2), aa(:,N-1:N)
+  print*, aa(:,1:2), aa(:,N-1:N)
 end
 
-! CHECK-LABEL: func @_QPss4
 subroutine ss4(N)
-  ! CHECK: %[[arg:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[n:[0-9]+]] = fir.convert %[[arg]] : (i32) -> index
-  ! CHECK: %[[aa:[0-9]+]] = fir.alloca !fir.array<?x2xf32>, %[[n]] {bindc_name = "aa", uniq_name = "_QFss4Eaa"}
   real aa(N,2)
-  ! CHECK: %[[shape:[0-9]+]] = fir.shape %[[n]], {{.*}} : (index, index) -> !fir.shape<2>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
   aa = -2
-  ! CHECK: %[[temp:[0-9]+]] = fir.allocmem !fir.array<?x2xf32>, %[[n]]
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}}, {{.*}} : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) [{{.*}}] {{.*}}, {{.*}} : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) [{{.*}}] {{.*}}, {{.*}} : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[temp]](%[[shape]]) {{.*}}, {{.*}} : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.array_coor %[[aa]](%[[shape]]) {{.*}}, {{.*}} : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-  ! CHECK: fir.freemem %[[temp]] : !fir.heap<!fir.array<?x2xf32>>
   aa(2:N,:) = aa(1:N-1,:) + 7.0
-! print*, aa(1:2,:), aa(N-1:N,:)
+  print*, aa(1:2,:), aa(N-1:N,:)
 end
+
+! CHECK-LABEL: func @_QPss2(
+! CHECK-SAME:               %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:         %[[VAL_1:.*]] = arith.constant -1 : index
+! CHECK:         %[[VAL_2:.*]] = arith.constant -2 : i32
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_5:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : i32
+! CHECK:         %[[VAL_7:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:         %[[VAL_8:.*]] = arith.constant -1 : i32
+! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
+! CHECK:         %[[VAL_12:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_11]] {bindc_name = "aa", uniq_name = "_QFss2Eaa"}
+! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_11]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_2]] : (i32) -> f32
+! CHECK:         br ^bb1(%[[VAL_4]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_4]] : index
+! CHECK:         cond_br %[[VAL_17]], ^bb2, ^bb3
+! CHECK:       ^bb2:
+! CHECK:         %[[VAL_18:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_19:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_18]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_14]] to %[[VAL_19]] : !fir.ref<f32>
+! CHECK:         %[[VAL_20:.*]] = arith.subi %[[VAL_16]], %[[VAL_3]] : index
+! CHECK:         br ^bb1(%[[VAL_18]], %[[VAL_20]] : index, index)
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_21:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (i32) -> index
+! CHECK:         %[[VAL_23:.*]] = arith.addi %[[VAL_22]], %[[VAL_1]] : index
+! CHECK:         %[[VAL_24:.*]] = arith.cmpi sgt, %[[VAL_23]], %[[VAL_4]] : index
+! CHECK:         %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_23]], %[[VAL_4]] : index
+! CHECK:         %[[VAL_26:.*]] = fir.slice %[[VAL_5]], %[[VAL_22]], %[[VAL_3]] : (index, index, index) -> !fir.slice<1>
+! CHECK:         %[[VAL_27:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_11]]
+! CHECK:         br ^bb4(%[[VAL_4]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb4(%[[VAL_28:.*]]: index, %[[VAL_29:.*]]: index):
+! CHECK:         %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_4]] : index
+! CHECK:         cond_br %[[VAL_30]], ^bb5, ^bb6
+! CHECK:       ^bb5:
+! CHECK:         %[[VAL_31:.*]] = arith.addi %[[VAL_28]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_32:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_31]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_33:.*]] = fir.array_coor %[[VAL_27]](%[[VAL_13]]) %[[VAL_31]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_34:.*]] = fir.load %[[VAL_32]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_34]] to %[[VAL_33]] : !fir.ref<f32>
+! CHECK:         %[[VAL_35:.*]] = arith.subi %[[VAL_29]], %[[VAL_3]] : index
+! CHECK:         br ^bb4(%[[VAL_31]], %[[VAL_35]] : index, index)
+! CHECK:       ^bb6:
+! CHECK:         %[[VAL_36:.*]] = arith.subi %[[VAL_21]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> index
+! CHECK:         %[[VAL_38:.*]] = fir.slice %[[VAL_3]], %[[VAL_37]], %[[VAL_3]] : (index, index, index) -> !fir.slice<1>
+! CHECK:         br ^bb7(%[[VAL_4]], %[[VAL_25]] : index, index)
+! CHECK:       ^bb7(%[[VAL_39:.*]]: index, %[[VAL_40:.*]]: index):
+! CHECK:         %[[VAL_41:.*]] = arith.cmpi sgt, %[[VAL_40]], %[[VAL_4]] : index
+! CHECK:         cond_br %[[VAL_41]], ^bb8, ^bb9(%[[VAL_4]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb8:
+! CHECK:         %[[VAL_42:.*]] = arith.addi %[[VAL_39]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_43:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_38]]] %[[VAL_42]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_44:.*]] = fir.load %[[VAL_43]] : !fir.ref<f32>
+! CHECK:         %[[VAL_45:.*]] = arith.addf %[[VAL_44]], %[[VAL_7]] : f32
+! CHECK:         %[[VAL_46:.*]] = fir.array_coor %[[VAL_27]](%[[VAL_13]]) {{\[}}%[[VAL_26]]] %[[VAL_42]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_45]] to %[[VAL_46]] : !fir.ref<f32>
+! CHECK:         %[[VAL_47:.*]] = arith.subi %[[VAL_40]], %[[VAL_3]] : index
+! CHECK:         br ^bb7(%[[VAL_42]], %[[VAL_47]] : index, index)
+! CHECK:       ^bb9(%[[VAL_48:.*]]: index, %[[VAL_49:.*]]: index):
+! CHECK:         %[[VAL_50:.*]] = arith.cmpi sgt, %[[VAL_49]], %[[VAL_4]] : index
+! CHECK:         cond_br %[[VAL_50]], ^bb10, ^bb11
+! CHECK:       ^bb10:
+! CHECK:         %[[VAL_51:.*]] = arith.addi %[[VAL_48]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_52:.*]] = fir.array_coor %[[VAL_27]](%[[VAL_13]]) %[[VAL_51]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_53:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_51]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_54:.*]] = fir.load %[[VAL_52]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_54]] to %[[VAL_53]] : !fir.ref<f32>
+! CHECK:         %[[VAL_55:.*]] = arith.subi %[[VAL_49]], %[[VAL_3]] : index
+! CHECK:         br ^bb9(%[[VAL_51]], %[[VAL_55]] : index, index)
+! CHECK:       ^bb11:
+! CHECK:         fir.freemem %[[VAL_27]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:         %[[VAL_58:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_8]], %{{.*}}, %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:         %[[VAL_59:.*]] = fir.slice %[[VAL_3]], %[[VAL_5]], %[[VAL_3]] : (index, index, index) -> !fir.slice<1>
+! CHECK:         %[[VAL_60:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_59]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_61:.*]] = fir.convert %[[VAL_60]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_62:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_58]], %[[VAL_61]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_63:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_64:.*]] = arith.subi %[[VAL_63]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_65:.*]] = fir.convert %[[VAL_64]] : (i32) -> index
+! CHECK:         %[[VAL_66:.*]] = fir.convert %[[VAL_63]] : (i32) -> index
+! CHECK:         %[[VAL_67:.*]] = fir.slice %[[VAL_65]], %[[VAL_66]], %[[VAL_3]] : (index, index, index) -> !fir.slice<1>
+! CHECK:         %[[VAL_68:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_67]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:         %[[VAL_69:.*]] = fir.convert %[[VAL_68]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_70:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_58]], %[[VAL_69]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_71:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_58]]) : (!fir.ref<i8>) -> i32
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func @_QPss3(
+! CHECK-SAME:               %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:         %[[VAL_1:.*]] = arith.constant -1 : index
+! CHECK:         %[[VAL_2:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant -2 : i32
+! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : i32
+! CHECK:         %[[VAL_7:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:         %[[VAL_8:.*]] = arith.constant -1 : i32
+! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
+! CHECK:         %[[VAL_12:.*]] = fir.alloca !fir.array<2x?xf32>, %[[VAL_11]] {bindc_name = "aa", uniq_name = "_QFss3Eaa"}
+! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_2]], %[[VAL_11]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_4]] : (i32) -> f32
+! CHECK:         br ^bb1(%[[VAL_5]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_17]], ^bb2(%[[VAL_5]], %[[VAL_2]] : index, index), ^bb5
+! CHECK:       ^bb2(%[[VAL_18:.*]]: index, %[[VAL_19:.*]]: index):
+! CHECK:         %[[VAL_20:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_20]], ^bb3, ^bb4
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_21:.*]] = arith.addi %[[VAL_18]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_22:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_23:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_21]], %[[VAL_22]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_14]] to %[[VAL_23]] : !fir.ref<f32>
+! CHECK:         %[[VAL_24:.*]] = arith.subi %[[VAL_19]], %[[VAL_3]] : index
+! CHECK:         br ^bb2(%[[VAL_21]], %[[VAL_24]] : index, index)
+! CHECK:       ^bb4:
+! CHECK:         %[[VAL_25:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_26:.*]] = arith.subi %[[VAL_16]], %[[VAL_3]] : index
+! CHECK:         br ^bb1(%[[VAL_25]], %[[VAL_26]] : index, index)
+! CHECK:       ^bb5:
+! CHECK:         %[[VAL_27:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i32) -> index
+! CHECK:         %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_1]] : index
+! CHECK:         %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_31:.*]] = select %[[VAL_30]], %[[VAL_29]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_32:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]], %[[VAL_2]], %[[VAL_28]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_33:.*]] = fir.allocmem !fir.array<2x?xf32>, %[[VAL_11]]
+! CHECK:         br ^bb6(%[[VAL_5]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb6(%[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index):
+! CHECK:         %[[VAL_36:.*]] = arith.cmpi sgt, %[[VAL_35]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_36]], ^bb7(%[[VAL_5]], %[[VAL_2]] : index, index), ^bb10
+! CHECK:       ^bb7(%[[VAL_37:.*]]: index, %[[VAL_38:.*]]: index):
+! CHECK:         %[[VAL_39:.*]] = arith.cmpi sgt, %[[VAL_38]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_39]], ^bb8, ^bb9
+! CHECK:       ^bb8:
+! CHECK:         %[[VAL_40:.*]] = arith.addi %[[VAL_37]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_41:.*]] = arith.addi %[[VAL_34]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_42:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_40]], %[[VAL_41]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_43:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) %[[VAL_40]], %[[VAL_41]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_44:.*]] = fir.load %[[VAL_42]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_44]] to %[[VAL_43]] : !fir.ref<f32>
+! CHECK:         %[[VAL_45:.*]] = arith.subi %[[VAL_38]], %[[VAL_3]] : index
+! CHECK:         br ^bb7(%[[VAL_40]], %[[VAL_45]] : index, index)
+! CHECK:       ^bb9:
+! CHECK:         %[[VAL_46:.*]] = arith.addi %[[VAL_34]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_47:.*]] = arith.subi %[[VAL_35]], %[[VAL_3]] : index
+! CHECK:         br ^bb6(%[[VAL_46]], %[[VAL_47]] : index, index)
+! CHECK:       ^bb10:
+! CHECK:         %[[VAL_48:.*]] = arith.subi %[[VAL_27]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> index
+! CHECK:         %[[VAL_50:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]], %[[VAL_3]], %[[VAL_49]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         br ^bb11(%[[VAL_5]], %[[VAL_31]] : index, index)
+! CHECK:       ^bb11(%[[VAL_51:.*]]: index, %[[VAL_52:.*]]: index):
+! CHECK:         %[[VAL_53:.*]] = arith.cmpi sgt, %[[VAL_52]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_53]], ^bb12(%[[VAL_5]], %[[VAL_2]] : index, index), ^bb15(%[[VAL_5]], %[[VAL_11]] : index, index)
+! CHECK:       ^bb12(%[[VAL_54:.*]]: index, %[[VAL_55:.*]]: index):
+! CHECK:         %[[VAL_56:.*]] = arith.cmpi sgt, %[[VAL_55]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_56]], ^bb13, ^bb14
+! CHECK:       ^bb13:
+! CHECK:         %[[VAL_57:.*]] = arith.addi %[[VAL_54]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_58:.*]] = arith.addi %[[VAL_51]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_59:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_50]]] %[[VAL_57]], %[[VAL_58]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_60:.*]] = fir.load %[[VAL_59]] : !fir.ref<f32>
+! CHECK:         %[[VAL_61:.*]] = arith.addf %[[VAL_60]], %[[VAL_7]] : f32
+! CHECK:         %[[VAL_62:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) {{\[}}%[[VAL_32]]] %[[VAL_57]], %[[VAL_58]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_61]] to %[[VAL_62]] : !fir.ref<f32>
+! CHECK:         %[[VAL_63:.*]] = arith.subi %[[VAL_55]], %[[VAL_3]] : index
+! CHECK:         br ^bb12(%[[VAL_57]], %[[VAL_63]] : index, index)
+! CHECK:       ^bb14:
+! CHECK:         %[[VAL_64:.*]] = arith.addi %[[VAL_51]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_65:.*]] = arith.subi %[[VAL_52]], %[[VAL_3]] : index
+! CHECK:         br ^bb11(%[[VAL_64]], %[[VAL_65]] : index, index)
+! CHECK:       ^bb15(%[[VAL_66:.*]]: index, %[[VAL_67:.*]]: index):
+! CHECK:         %[[VAL_68:.*]] = arith.cmpi sgt, %[[VAL_67]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_68]], ^bb16(%[[VAL_5]], %[[VAL_2]] : index, index), ^bb19
+! CHECK:       ^bb16(%[[VAL_69:.*]]: index, %[[VAL_70:.*]]: index):
+! CHECK:         %[[VAL_71:.*]] = arith.cmpi sgt, %[[VAL_70]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_71]], ^bb17, ^bb18
+! CHECK:       ^bb17:
+! CHECK:         %[[VAL_72:.*]] = arith.addi %[[VAL_69]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_73:.*]] = arith.addi %[[VAL_66]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_74:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) %[[VAL_72]], %[[VAL_73]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_75:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_72]], %[[VAL_73]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_76:.*]] = fir.load %[[VAL_74]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_76]] to %[[VAL_75]] : !fir.ref<f32>
+! CHECK:         %[[VAL_77:.*]] = arith.subi %[[VAL_70]], %[[VAL_3]] : index
+! CHECK:         br ^bb16(%[[VAL_72]], %[[VAL_77]] : index, index)
+! CHECK:       ^bb18:
+! CHECK:         %[[VAL_78:.*]] = arith.addi %[[VAL_66]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_79:.*]] = arith.subi %[[VAL_67]], %[[VAL_3]] : index
+! CHECK:         br ^bb15(%[[VAL_78]], %[[VAL_79]] : index, index)
+! CHECK:       ^bb19:
+! CHECK:         fir.freemem %[[VAL_33]] : !fir.heap<!fir.array<2x?xf32>>
+! CHECK:         %[[VAL_82:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_8]], %{{.*}}, %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:         %[[VAL_83:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_84:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_83]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_85:.*]] = fir.convert %[[VAL_84]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_86:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_82]], %[[VAL_85]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_87:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_88:.*]] = arith.subi %[[VAL_87]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_89:.*]] = fir.convert %[[VAL_88]] : (i32) -> index
+! CHECK:         %[[VAL_90:.*]] = fir.convert %[[VAL_87]] : (i32) -> index
+! CHECK:         %[[VAL_91:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]], %[[VAL_89]], %[[VAL_90]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_92:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_91]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_93:.*]] = fir.convert %[[VAL_92]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_94:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_82]], %[[VAL_93]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_95:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_82]]) : (!fir.ref<i8>) -> i32
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func @_QPss4(
+! CHECK-SAME:               %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:         %[[VAL_1:.*]] = arith.constant -1 : index
+! CHECK:         %[[VAL_2:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant -2 : i32
+! CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : i32
+! CHECK:         %[[VAL_7:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:         %[[VAL_8:.*]] = arith.constant -1 : i32
+! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
+! CHECK:         %[[VAL_12:.*]] = fir.alloca !fir.array<?x2xf32>, %[[VAL_11]] {bindc_name = "aa", uniq_name = "_QFss4Eaa"}
+! CHECK:         %[[VAL_13:.*]] = fir.shape %[[VAL_11]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_4]] : (i32) -> f32
+! CHECK:         br ^bb1(%[[VAL_5]], %[[VAL_2]] : index, index)
+! CHECK:       ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_17]], ^bb2(%[[VAL_5]], %[[VAL_11]] : index, index), ^bb5
+! CHECK:       ^bb2(%[[VAL_18:.*]]: index, %[[VAL_19:.*]]: index):
+! CHECK:         %[[VAL_20:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_20]], ^bb3, ^bb4
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_21:.*]] = arith.addi %[[VAL_18]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_22:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_23:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_21]], %[[VAL_22]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_14]] to %[[VAL_23]] : !fir.ref<f32>
+! CHECK:         %[[VAL_24:.*]] = arith.subi %[[VAL_19]], %[[VAL_3]] : index
+! CHECK:         br ^bb2(%[[VAL_21]], %[[VAL_24]] : index, index)
+! CHECK:       ^bb4:
+! CHECK:         %[[VAL_25:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_26:.*]] = arith.subi %[[VAL_16]], %[[VAL_3]] : index
+! CHECK:         br ^bb1(%[[VAL_25]], %[[VAL_26]] : index, index)
+! CHECK:       ^bb5:
+! CHECK:         %[[VAL_27:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (i32) -> index
+! CHECK:         %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_1]] : index
+! CHECK:         %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_29]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_31:.*]] = select %[[VAL_30]], %[[VAL_29]], %[[VAL_5]] : index
+! CHECK:         %[[VAL_32:.*]] = fir.slice %[[VAL_2]], %[[VAL_28]], %[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_33:.*]] = fir.allocmem !fir.array<?x2xf32>, %[[VAL_11]]
+! CHECK:         br ^bb6(%[[VAL_5]], %[[VAL_2]] : index, index)
+! CHECK:       ^bb6(%[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index):
+! CHECK:         %[[VAL_36:.*]] = arith.cmpi sgt, %[[VAL_35]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_36]], ^bb7(%[[VAL_5]], %[[VAL_11]] : index, index), ^bb10
+! CHECK:       ^bb7(%[[VAL_37:.*]]: index, %[[VAL_38:.*]]: index):
+! CHECK:         %[[VAL_39:.*]] = arith.cmpi sgt, %[[VAL_38]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_39]], ^bb8, ^bb9
+! CHECK:       ^bb8:
+! CHECK:         %[[VAL_40:.*]] = arith.addi %[[VAL_37]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_41:.*]] = arith.addi %[[VAL_34]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_42:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_40]], %[[VAL_41]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_43:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) %[[VAL_40]], %[[VAL_41]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_44:.*]] = fir.load %[[VAL_42]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_44]] to %[[VAL_43]] : !fir.ref<f32>
+! CHECK:         %[[VAL_45:.*]] = arith.subi %[[VAL_38]], %[[VAL_3]] : index
+! CHECK:         br ^bb7(%[[VAL_40]], %[[VAL_45]] : index, index)
+! CHECK:       ^bb9:
+! CHECK:         %[[VAL_46:.*]] = arith.addi %[[VAL_34]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_47:.*]] = arith.subi %[[VAL_35]], %[[VAL_3]] : index
+! CHECK:         br ^bb6(%[[VAL_46]], %[[VAL_47]] : index, index)
+! CHECK:       ^bb10:
+! CHECK:         %[[VAL_48:.*]] = arith.subi %[[VAL_27]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> index
+! CHECK:         %[[VAL_50:.*]] = fir.slice %[[VAL_3]], %[[VAL_49]], %[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         br ^bb11(%[[VAL_5]], %[[VAL_2]] : index, index)
+! CHECK:       ^bb11(%[[VAL_51:.*]]: index, %[[VAL_52:.*]]: index):
+! CHECK:         %[[VAL_53:.*]] = arith.cmpi sgt, %[[VAL_52]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_53]], ^bb12(%[[VAL_5]], %[[VAL_31]] : index, index), ^bb15(%[[VAL_5]], %[[VAL_2]] : index, index)
+! CHECK:       ^bb12(%[[VAL_54:.*]]: index, %[[VAL_55:.*]]: index):
+! CHECK:         %[[VAL_56:.*]] = arith.cmpi sgt, %[[VAL_55]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_56]], ^bb13, ^bb14
+! CHECK:       ^bb13:
+! CHECK:         %[[VAL_57:.*]] = arith.addi %[[VAL_54]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_58:.*]] = arith.addi %[[VAL_51]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_59:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_50]]] %[[VAL_57]], %[[VAL_58]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_60:.*]] = fir.load %[[VAL_59]] : !fir.ref<f32>
+! CHECK:         %[[VAL_61:.*]] = arith.addf %[[VAL_60]], %[[VAL_7]] : f32
+! CHECK:         %[[VAL_62:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) {{\[}}%[[VAL_32]]] %[[VAL_57]], %[[VAL_58]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_61]] to %[[VAL_62]] : !fir.ref<f32>
+! CHECK:         %[[VAL_63:.*]] = arith.subi %[[VAL_55]], %[[VAL_3]] : index
+! CHECK:         br ^bb12(%[[VAL_57]], %[[VAL_63]] : index, index)
+! CHECK:       ^bb14:
+! CHECK:         %[[VAL_64:.*]] = arith.addi %[[VAL_51]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_65:.*]] = arith.subi %[[VAL_52]], %[[VAL_3]] : index
+! CHECK:         br ^bb11(%[[VAL_64]], %[[VAL_65]] : index, index)
+! CHECK:       ^bb15(%[[VAL_66:.*]]: index, %[[VAL_67:.*]]: index):
+! CHECK:         %[[VAL_68:.*]] = arith.cmpi sgt, %[[VAL_67]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_68]], ^bb16(%[[VAL_5]], %[[VAL_11]] : index, index), ^bb19
+! CHECK:       ^bb16(%[[VAL_69:.*]]: index, %[[VAL_70:.*]]: index):
+! CHECK:         %[[VAL_71:.*]] = arith.cmpi sgt, %[[VAL_70]], %[[VAL_5]] : index
+! CHECK:         cond_br %[[VAL_71]], ^bb17, ^bb18
+! CHECK:       ^bb17:
+! CHECK:         %[[VAL_72:.*]] = arith.addi %[[VAL_69]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_73:.*]] = arith.addi %[[VAL_66]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_74:.*]] = fir.array_coor %[[VAL_33]](%[[VAL_13]]) %[[VAL_72]], %[[VAL_73]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_75:.*]] = fir.array_coor %[[VAL_12]](%[[VAL_13]]) %[[VAL_72]], %[[VAL_73]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:         %[[VAL_76:.*]] = fir.load %[[VAL_74]] : !fir.ref<f32>
+! CHECK:         fir.store %[[VAL_76]] to %[[VAL_75]] : !fir.ref<f32>
+! CHECK:         %[[VAL_77:.*]] = arith.subi %[[VAL_70]], %[[VAL_3]] : index
+! CHECK:         br ^bb16(%[[VAL_72]], %[[VAL_77]] : index, index)
+! CHECK:       ^bb18:
+! CHECK:         %[[VAL_78:.*]] = arith.addi %[[VAL_66]], %[[VAL_3]] : index
+! CHECK:         %[[VAL_79:.*]] = arith.subi %[[VAL_67]], %[[VAL_3]] : index
+! CHECK:         br ^bb15(%[[VAL_78]], %[[VAL_79]] : index, index)
+! CHECK:       ^bb19:
+! CHECK:         fir.freemem %[[VAL_33]] : !fir.heap<!fir.array<?x2xf32>>
+! CHECK:         %[[VAL_82:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_8]], %{{.*}}, %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:         %[[VAL_83:.*]] = fir.slice %[[VAL_3]], %[[VAL_2]], %[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_84:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_83]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_85:.*]] = fir.convert %[[VAL_84]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_86:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_82]], %[[VAL_85]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_87:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_88:.*]] = arith.subi %[[VAL_87]], %[[VAL_6]] : i32
+! CHECK:         %[[VAL_89:.*]] = fir.convert %[[VAL_88]] : (i32) -> index
+! CHECK:         %[[VAL_90:.*]] = fir.convert %[[VAL_87]] : (i32) -> index
+! CHECK:         %[[VAL_91:.*]] = fir.slice %[[VAL_89]], %[[VAL_90]], %[[VAL_3]], %[[VAL_3]], %[[VAL_2]], %[[VAL_3]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:         %[[VAL_92:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) {{\[}}%[[VAL_91]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:         %[[VAL_93:.*]] = fir.convert %[[VAL_92]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:         %[[VAL_94:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_82]], %[[VAL_93]]) : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:         %[[VAL_95:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_82]]) : (!fir.ref<i8>) -> i32
+! CHECK:         return
+! CHECK:       }
+
 
 ! CHECK-LABEL: func @_QPtt1
 subroutine tt1


### PR DESCRIPTION
…quence

```mlir
  %1 = fir.convert %0 : (i32) -> i8
  %2 = fir.convert %1 : (i8) -> i16
```
must be preserved since the first truncation can modify the observed
value that is extended in the second op.

Refactor the transformations to catch this case, extend cases that were
not being caught, and deal with errors with respect to index type.

Fix tests that now had bugs because of missing truncations.