### PR TITLE
Implement the hole in expression lowering when dealing with passing

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -73,7 +73,7 @@ public:
   /// after type conversion and the imaginary part is zero.
   mlir::Value convertWithSemantics(mlir::Location loc, mlir::Type toTy,
                                    mlir::Value val,
-                                   bool allowConversionsWithCharacters = false);
+                                   bool allowCharacterConversion = false);
 
   /// Get the entry block of the current Function
   mlir::Block *getEntryBlock() { return &getFunction().front(); }

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2605,22 +2605,10 @@ public:
                 // free-casting the base address to be a !fir.char reference and
                 // setting the LEN argument to undefined. What could go wrong?
                 auto dataPtr = fir::getBase(x);
-                if (auto boxTy =
-                        dataPtr.getType().template dyn_cast<fir::BoxType>()) {
-                  mlir::Type refTy = boxTy.getEleTy();
-                  if (!fir::isa_ref_type(refTy))
-                    refTy = builder.getRefType(refTy);
-                  dataPtr = builder.create<fir::BoxAddrOp>(loc, refTy, dataPtr);
-                }
-                auto charPtr = builder.createConvert(
-                    loc, builder.getRefType(helper.getCharType(argTy)),
-                    dataPtr);
-                auto charLen = builder.create<fir::UndefOp>(
-                    loc, builder.getCharacterLengthType());
-                auto boxCharTy = fir::BoxCharType::get(
-                    builder.getContext(), helper.getCharacterKind(argTy));
-                return builder.create<fir::EmboxCharOp>(loc, boxCharTy, charPtr,
-                                                        charLen);
+                assert(!dataPtr.getType().template isa<fir::BoxType>());
+                return builder.convertWithSemantics(
+                    loc, argTy, dataPtr,
+                    /*allowCharacterConversion=*/true);
               });
           caller.placeInput(arg, boxChar);
         }

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -265,7 +265,7 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
 mlir::Value
 fir::FirOpBuilder::convertWithSemantics(mlir::Location loc, mlir::Type toTy,
                                         mlir::Value val,
-                                        bool allowConversionsWithCharacters) {
+                                        bool allowCharacterConversion) {
   assert(toTy && "store location must be typed");
   auto fromTy = val.getType();
   if (fromTy == toTy)
@@ -287,7 +287,7 @@ fir::FirOpBuilder::convertWithSemantics(mlir::Location loc, mlir::Type toTy,
     auto rp = helper.extractComplexPart(val, /*isImagPart=*/false);
     return createConvert(loc, toTy, rp);
   }
-  if (allowConversionsWithCharacters) {
+  if (allowCharacterConversion) {
     if (fromTy.isa<fir::BoxCharType>()) {
       // Extract the address of the character string and pass it
       fir::factory::CharacterExprHelper charHelper{*this, loc};

--- a/flang/test/Lower/call-suspect.f90
+++ b/flang/test/Lower/call-suspect.f90
@@ -1,0 +1,35 @@
+! Note: flang will issue warnings for the following subroutines. These
+! are accepted regardless to maintain backwards compatibility with
+! other Fortran implementations.
+
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func @_QPs1() {
+! CHECK: %[[cast:.*]] = fir.convert %{{.*}} : (!fir.ref<f32>) -> !fir.ref<!fir.char<1,?>>
+! CHECK: %[[undef:.*]] = fir.undefined index
+! CHECK: %[[box:.*]] = fir.emboxchar %[[cast]], %[[undef]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK: fir.call @_QPs3(%[[box]]) : (!fir.boxchar<1>) -> ()
+
+! Pass a REAL by reference to a subroutine expecting a CHARACTER
+subroutine s1
+  call s3(r)
+end subroutine s1
+
+! CHECK-LABEL: func @_QPs2(
+! CHECK: %[[ptr:.*]] = fir.box_addr %{{.*}} : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
+! CHECK: %[[cast:.*]] = fir.convert %[[ptr]] : (!fir.ptr<f32>) -> !fir.ref<!fir.char<1,?>>
+! CHECK: %[[undef:.*]] = fir.undefined index
+! CHECK: %[[box:.*]] = fir.emboxchar %[[cast]], %[[undef]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK: fir.call @_QPs3(%[[box]]) : (!fir.boxchar<1>) -> ()
+
+! Pass a REAL, POINTER data reference to a subroutine expecting a CHARACTER
+subroutine s2(p)
+  real, pointer :: p
+  call s3(p)
+end subroutine s2
+
+! CHECK-LABEL: func @_QPs3(
+! CHECK-SAME: !fir.boxchar<1>
+subroutine s3(c)
+  character(8) c
+end subroutine s3

--- a/flang/test/Lower/call.f90
+++ b/flang/test/Lower/call.f90
@@ -1,5 +1,6 @@
 ! Test various aspects around call lowering. More detailed tests around core
 ! requirements are done in call-xxx.f90 and dummy-argument-xxx.f90 files.
+
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPtest_nested_calls


### PR DESCRIPTION
references to non-CHARACTER typed variables to a procedure that is
expecting a CHARACTER. This will cause flang to emit Warnings, but it is
allowed to maintain backwards compatibility with F77 implementations.

Add a regression test for the unboxed and boxed cases.