### PR TITLE
[flang][driver] Extend support for LLVM IR/BC files

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5476,8 +5476,6 @@ def emit_header_module : Flag<["-"], "emit-header-module">,
   HelpText<"Generate pre-compiled module file from a set of header files">;
 def emit_pch : Flag<["-"], "emit-pch">,
   HelpText<"Generate pre-compiled header file">;
-def emit_llvm_bc : Flag<["-"], "emit-llvm-bc">,
-  HelpText<"Build ASTs then convert to LLVM, emit .bc file">;
 def emit_llvm_only : Flag<["-"], "emit-llvm-only">,
   HelpText<"Build ASTs and convert to LLVM, discarding output">;
 def emit_codegen_only : Flag<["-"], "emit-codegen-only">,
@@ -5912,6 +5910,8 @@ def emit_obj : Flag<["-"], "emit-obj">,
   HelpText<"Emit native object files">;
 def init_only : Flag<["-"], "init-only">,
   HelpText<"Only execute frontend initialization">;
+def emit_llvm_bc : Flag<["-"], "emit-llvm-bc">,
+  HelpText<"Build ASTs then convert to LLVM, emit .bc file">;
 
 } // let Group = Action_Group
 

--- a/clang/include/clang/Driver/Types.h
+++ b/clang/include/clang/Driver/Types.h
@@ -66,6 +66,9 @@ namespace types {
   /// isAcceptedByClang - Can clang handle this input type.
   bool isAcceptedByClang(ID Id);
 
+  /// isAcceptedByFlang - Can flang handle this input type.
+  bool isAcceptedByFlang(ID Id);
+
   /// isDerivedFromC - Is the input derived from C.
   ///
   /// That is, does the lexer follow the rules of
@@ -91,9 +94,6 @@ namespace types {
 
   /// isOpenCL - Is this an "OpenCL" input.
   bool isOpenCL(ID Id);
-
-  /// isFortran - Is this a Fortran input.
-  bool isFortran(ID Id);
 
   /// isSrcFile - Is this a source file, i.e. something that still has to be
   /// preprocessed. The logic behind this is the same that decides if the first

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5460,7 +5460,7 @@ bool Driver::ShouldUseClangCompiler(const JobAction &JA) const {
 bool Driver::ShouldUseFlangCompiler(const JobAction &JA) const {
   // Say "no" if there is not exactly one input of a type flang understands.
   if (JA.size() != 1 ||
-      !types::isFortran((*JA.input_begin())->getType()))
+      !types::isAcceptedByFlang((*JA.input_begin())->getType()))
     return false;
 
   // And say "no" if this is not a kind of action flang understands.

--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -256,12 +256,14 @@ bool types::isHIP(ID Id) {
   }
 }
 
-bool types::isFortran(ID Id) {
+bool types::isAcceptedByFlang(ID Id) {
   switch (Id) {
   default:
     return false;
 
   case TY_Fortran: case TY_PP_Fortran:
+    return true;
+  case TY_LLVM_IR: case TY_LLVM_BC:
     return true;
   }
 }

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -168,6 +168,10 @@ class EmitLLVMAction : public CodeGenAction {
   void ExecuteAction() override;
 };
 
+class EmitLLVMBitcodeAction : public CodeGenAction {
+  void ExecuteAction() override;
+};
+
 class BackendAction : public CodeGenAction {
   public:
   enum class BackendAct {

--- a/flang/include/flang/Frontend/FrontendOptions.h
+++ b/flang/include/flang/Frontend/FrontendOptions.h
@@ -37,6 +37,9 @@ enum ActionKind {
   /// Emit a .llvm file
   EmitLLVM,
 
+  /// Emit a .bc file
+  EmitLLVMBitcode,
+
   /// Emit a .o file.
   EmitObj,
 

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -26,6 +26,7 @@ add_flang_library(flangFrontend
   clangBasic
   clangDriver
   LLVMAnalysis
+  LLVMPasses
   FIRDialect
   FIRAnalysis
   FIRSupport
@@ -39,6 +40,7 @@ add_flang_library(flangFrontend
 
   LINK_COMPONENTS
   Option
+  IRReader
   Support
   FrontendOpenACC
   FrontendOpenMP

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -8,6 +8,7 @@
 
 #include "flang/Frontend/CompilerInvocation.h"
 #include "flang/Common/Fortran-features.h"
+#include "flang/Frontend/FrontendActions.h"
 #include "flang/Frontend/PreprocessorOptions.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Version.inc"
@@ -132,6 +133,9 @@ static bool ParseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
       break;
     case clang::driver::options::OPT_emit_llvm:
       opts.programAction = EmitLLVM;
+      break;
+    case clang::driver::options::OPT_emit_llvm_bc:
+      opts.programAction = EmitLLVMBitcode;
       break;
     case clang::driver::options::OPT_emit_obj:
       opts.programAction = EmitObj;

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -36,10 +36,13 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
 #include <clang/Basic/Diagnostic.h>
@@ -66,6 +69,15 @@ bool PrescanAndSemaDebugAction::BeginSourceFileAction() {
 }
 
 bool CodeGenAction::BeginSourceFileAction() {
+  llvmCtx_ = std::make_unique<llvm::LLVMContext>();
+  if (this->currentInput().kind().GetLanguage() == Language::LLVM_IR) {
+    // Parse the bitcode...
+    SMDiagnostic err;
+    llvmModule_ = parseIRFile(currentInput().file(), err, *llvmCtx_);
+
+    return (nullptr != llvmModule_);
+  }
+
   bool res = RunPrescan() && RunParse() && RunSemanticChecks();
   if (!res)
     return res;
@@ -476,7 +488,6 @@ void CodeGenAction::GenerateLLVMIR() {
 
   // Translate to LLVM IR
   auto optName = mlirMod.getName();
-  llvmCtx_ = std::make_unique<llvm::LLVMContext>();
   llvmModule_ = mlir::translateModuleToLLVMIR(
       mlirMod, *llvmCtx_, optName ? *optName : "FIRModule");
 
@@ -490,13 +501,15 @@ void CodeGenAction::GenerateLLVMIR() {
 
 void EmitLLVMAction::ExecuteAction() {
   CompilerInstance &ci = this->instance();
-  GenerateLLVMIR();
+  // Generate an LLVM module if it's not already present (it will already be
+  // present if the input file is an LLVM IR/BC file).
+  if (!llvmModule_)
+    GenerateLLVMIR();
 
   // Print the generated LLVM IR. If there is no pre-defined output stream to
   // print to, create an output file.
   std::unique_ptr<llvm::raw_ostream> os;
   if (ci.IsOutputStreamNull()) {
-    // Lower from the LLVM dialect to LLVM IR
     os = ci.CreateDefaultOutputFile(
         /*Binary=*/true, /*InFile=*/GetCurrentFileOrBufferName(), "ll");
     if (!os) {
@@ -513,13 +526,56 @@ void EmitLLVMAction::ExecuteAction() {
   } else {
     llvmModule_->print(*os, /*AssemblyAnnotationWriter=*/nullptr);
   }
+}
 
-  return;
+void EmitLLVMBitcodeAction::ExecuteAction() {
+  CompilerInstance &ci = this->instance();
+  // Generate an LLVM module if it's not already present (it will already be
+  // present if the input file is an LLVM IR/BC file).
+  if (!llvmModule_)
+    GenerateLLVMIR();
+
+  ModulePassManager MPM;
+  ModuleAnalysisManager MAM;
+
+  // Create `Target`
+  std::string error;
+  std::string theTriple = llvmModule_->getTargetTriple();
+  const llvm::Target *theTarget =
+      TargetRegistry::lookupTarget(theTriple, error);
+  assert(theTarget && "Failed to create Target");
+
+  // Create `TargetMachine`
+  std::unique_ptr<TargetMachine> TM;
+
+  TM.reset(theTarget->createTargetMachine(
+      theTriple, /*CPU=*/"", /*Features=*/"", llvm::TargetOptions(), None));
+  llvmModule_->setDataLayout(TM->createDataLayout());
+  assert(TM && "Failed to create TargetMachine");
+
+  PassBuilder PB(TM.get());
+  PB.registerModuleAnalyses(MAM);
+
+  // Generate an output file
+  std::unique_ptr<llvm::raw_ostream> os = ci.CreateDefaultOutputFile(
+      /*Binary=*/true, /*InFile=*/GetCurrentFileOrBufferName(), "bc");
+  if (!os) {
+    unsigned diagID = ci.diagnostics().getCustomDiagID(
+        clang::DiagnosticsEngine::Error, "failed to create the output file");
+    ci.diagnostics().Report(diagID);
+    return;
+  }
+
+  MPM.addPass(BitcodeWriterPass(*os));
+  MPM.run(*llvmModule_, MAM);
 }
 
 void BackendAction::ExecuteAction() {
   CompilerInstance &ci = this->instance();
-  GenerateLLVMIR();
+  // Generate an LLVM module if it's not already present (it will already be
+  // present if the input file is an LLVM IR/BC file).
+  if (!llvmModule_)
+    GenerateLLVMIR();
 
   // Create `Target`
   std::string error;
@@ -582,13 +638,17 @@ void BackendAction::ExecuteAction() {
       ? llvm::CodeGenFileType::CGFT_AssemblyFile
       : llvm::CodeGenFileType::CGFT_ObjectFile;
   if (TM->addPassesToEmitFile(CodeGenPasses,
-          ci.IsOutputStreamNull() ? *os : ci.GetOutputStream(), nullptr, cgft))
-    assert(false && "Something went wrong");
+          ci.IsOutputStreamNull() ? *os : ci.GetOutputStream(), nullptr,
+          cgft)) {
+    unsigned diagID =
+        ci.diagnostics().getCustomDiagID(clang::DiagnosticsEngine::Error,
+            "emission of this file type is not supported");
+    ci.diagnostics().Report(diagID);
+    return;
+  }
 
   // Run the code-gen passes
   CodeGenPasses.run(*llvmModule_);
-
-  return;
 }
 
 void InitOnlyAction::ExecuteAction() {

--- a/flang/lib/Frontend/FrontendOptions.cpp
+++ b/flang/lib/Frontend/FrontendOptions.cpp
@@ -32,8 +32,11 @@ bool Fortran::frontend::mustBePreprocessed(llvm::StringRef suffix) {
 }
 
 InputKind FrontendOptions::GetInputKindForExtension(llvm::StringRef extension) {
-  if (isFixedFormSuffix(extension) || isFreeFormSuffix(extension)) {
+  if (isFixedFormSuffix(extension) || isFreeFormSuffix(extension))
     return Language::Fortran;
-  }
+
+  if (extension == "bc" || extension == "ll")
+    return Language::LLVM_IR;
+
   return Language::Unknown;
 }

--- a/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/flang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -37,6 +37,8 @@ static std::unique_ptr<FrontendAction> CreateFrontendBaseAction(
     return std::make_unique<EmitMLIRAction>();
   case EmitLLVM:
     return std::make_unique<EmitLLVMAction>();
+  case EmitLLVMBitcode:
+    return std::make_unique<EmitLLVMBitcodeAction>();
   case EmitObj:
     return std::make_unique<BackendAction>(
         BackendAction::BackendAct::Backend_EmitObj);

--- a/flang/test/Driver/code-gen-combined.f90
+++ b/flang/test/Driver/code-gen-combined.f90
@@ -1,0 +1,39 @@
+! Verify that:
+!   * `flang -emit-llvm file.f90` followed by `flang file.ll`
+! (and various combinations of this) generates identical output as when using
+!   * `flang -c file.f90`.
+! Linking is skipped. In both cases it would be a seperate invocation with
+! identical input (verified by this test).
+
+!--------------
+! Object files
+!--------------
+! RUN: rm -f %t_default.o %t.bc %t.ll %t_combined.o
+! RUN: %flang -c %s -o %t_default.o
+! RUN: %flang -c -emit-llvm %s -o %t.bc
+! RUN: %flang -S -emit-llvm %s -o %t.ll
+
+! RUN: %flang -c %t.bc -o %t_combined.o
+! RUN: diff %t_default.o %t_combined.o
+
+! RUN: %flang -c %t.ll -o %t_combined.o
+! RUN: diff %t_default.o %t_combined.o
+
+!----------------
+! Assembly files
+!----------------
+! RUN: rm -f %t_default.s %t.bc %t.ll %t_combined.s
+! RUN: %flang -S %s -o %t_default.s
+! RUN: %flang -c -emit-llvm %s -o %t.bc
+! RUN: %flang -S -emit-llvm %s -o %t.ll
+
+! RUN: %flang -S %t.bc -o %t_combined.s
+! RUN: diff %t_default.s %t_combined.s
+
+! RUN: %flang -S %t.ll -o %t_combined.s
+! RUN: diff %t_default.s %t_combined.s
+
+!----------------
+! Test input
+!----------------
+end program

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -71,6 +71,7 @@
 ! HELP-FC1-NEXT:OPTIONS:
 ! HELP-FC1-NEXT: -cpp                   Enable predefined and command line preprocessor macros
 ! HELP-FC1-NEXT: -D <macro>=<value>     Define <macro> to <value> (or 1 if <value> omitted)
+! HELP-FC1-NEXT: -emit-llvm-bc          Build ASTs then convert to LLVM, emit .bc file
 ! HELP-FC1-NEXT: -emit-llvm             Use the LLVM representation for assembler and object files
 ! HELP-FC1-NEXT: -emit-mlir             Build the parse tree, then lower it to MLIR and dump
 ! HELP-FC1-NEXT: -emit-obj Emit native object files

--- a/flang/test/Driver/emit-llvm-bc.f90
+++ b/flang/test/Driver/emit-llvm-bc.f90
@@ -1,0 +1,8 @@
+! RUN: %flang -emit-llvm -c %s -o - | llvm-dis -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-llvm-bc %s -o - | llvm-dis -o - | FileCheck %s
+
+! CHECK: define void @_QQmain()
+! CHECK-NEXT:  ret void
+! CHECK-NEXT: }
+
+end program

--- a/flang/test/Driver/emit-llvm.f90
+++ b/flang/test/Driver/emit-llvm.f90
@@ -1,4 +1,5 @@
 ! RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -emit-llvm -S %s -o - | FileCheck %s
 
 ! CHECK: ; ModuleID = 'FIRModule'
 ! CHECK: define void @_QQmain()


### PR DESCRIPTION
Before this change, `clangDriver` (i.e. the compiles driver library)
would always use `clang` to compile LLVM IR or LLVM BC files (even when
`flang-new` was used to invoke the driver). With this change, Flang will
finally accept LLVM IR and LLVM BC alongside e.g. Fortran input files.
This means that from now on it is up to the user to decide whether to
use Flang or Clang to compile an LLVM file (`flang-new -c file.bc` and
`clang -c file.bc`, respectively).

To complement this, support for generating LLVM BC files is added. This
requires the `BitcodeWriterPass` pass to be run on the input LLVM IR
module and is implemented as a dedicated frontend aciton.

The new functionality as seen by the user:
1. LLVM BC file generation (`flang-new -c -emit-llvm file.90` or
   `flang-new -fc1 -emit-llvm-bc file.f90`)
2. Ability to consume LLVM IR and BC files and to lower them to object
   files (`flang-new -c file.bc` or `flang-new -c file.ll`)

The new behaviour is consistent with `clang` and `clang -cc1`.