### PR TITLE
Fix character procedure dummy capture in host procedure caused by 1393

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -395,7 +395,10 @@ getOrDeclareFunction(llvm::StringRef name,
                      const Fortran::evaluate::ProcedureDesignator &,
                      Fortran::lower::AbstractConverter &);
 
-/// Return the type of an argument that is a dummy procedure.
+/// Return the type of an argument that is a dummy procedure. This may be an
+/// mlir::FunctionType, but it can also be a more elaborate type based on the
+/// function type (like a tuple<function type, length type> for character
+/// functions).
 mlir::Type getDummyProcedureType(const Fortran::semantics::Symbol &dummyProc,
                                  Fortran::lower::AbstractConverter &);
 

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -107,10 +107,8 @@ public:
     });
     addConversion([&](mlir::TupleType tuple) {
       LLVM_DEBUG(llvm::dbgs() << "type convert: " << tuple << '\n');
-      llvm::SmallVector<mlir::Type> inMembers;
-      tuple.getFlattenedTypes(inMembers);
       llvm::SmallVector<mlir::Type> members;
-      for (auto mem : inMembers) {
+      for (auto mem : tuple.getTypes()) {
         // Prevent fir.box from degenerating to a pointer to a descriptor in the
         // context of a tuple type.
         if (auto box = mem.dyn_cast<fir::BoxType>())

--- a/flang/test/Fir/types-to-llvm.fir
+++ b/flang/test/Fir/types-to-llvm.fir
@@ -338,3 +338,10 @@ func private @foo3(%arg : !fir.tdesc<!fir.type<derived7{f1:f32,f2:f32}>>)
 func private @foo0(%arg0: !fir.len)
 // CHECK-LABEL: foo0
 // CHECK-SAME: i64
+
+// -----
+
+// Test nested tuple types
+func private @foo0(%arg0: tuple<i64, tuple<f32, i64>>)
+// CHECK-LABEL: foo0
+// CHECK-SAME: !llvm.struct<(i64, struct<(f32, i64)>)>


### PR DESCRIPTION
#1393 changed character procedure passing so that the length is also
captured. This broke the usage of character procedure dummy of a
host procedure in its internal procedure.
Fix this and add a test.

This requires a codegen patch to prevent nested tuple from being translated to a flattened struct type (this broke fir.coordinate_of codegen, that ended-up accessing the wrong members). I will push it to LLVM when this patch is approved. 