### PR TITLE
The front end was folding away a function call that was an argument to

### DIFF
--- a/flang/lib/Evaluate/fold-integer.cpp
+++ b/flang/lib/Evaluate/fold-integer.cpp
@@ -677,7 +677,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
       return std::visit(
           [&](auto &kx) {
             if (auto len{kx.LEN()}) {
-              if (IsConstantExpr(len)) {
+              if (IsConstantExpr(*len)) {
                 return Fold(context, ConvertToType<T>(*std::move(len)));
               } else {
                 return Expr<T>{std::move(funcRef)};

--- a/flang/lib/Evaluate/fold-integer.cpp
+++ b/flang/lib/Evaluate/fold-integer.cpp
@@ -677,7 +677,11 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
       return std::visit(
           [&](auto &kx) {
             if (auto len{kx.LEN()}) {
-              return Fold(context, ConvertToType<T>(*std::move(len)));
+              if (IsConstantExpr(len)) {
+                return Fold(context, ConvertToType<T>(*std::move(len)));
+              } else {
+                return Expr<T>{std::move(funcRef)};
+              }
             } else {
               return Expr<T>{std::move(funcRef)};
             }

--- a/flang/test/Lower/intrinsic-procedures/len.f90
+++ b/flang/test/Lower/intrinsic-procedures/len.f90
@@ -5,8 +5,7 @@ subroutine len_test(i, c)
   integer :: i
   character(*) :: c
   ! CHECK: %[[c:.*]]:2 = fir.unboxchar %arg1
-  ! CHECK: %[[xx:.*]] = fir.convert %[[c]]#1 : (index) -> i64
-  ! CHECK: %[[x:.*]] = fir.convert %[[xx]] : (i64) -> i32
-  ! CHECK: fir.store %[[x]] to %arg0
+  ! CHECK: %[[xx:.*]] = fir.convert %[[c]]#1 : (index) -> i32
+  ! CHECK: fir.store %[[xx]] to %arg0
   i = len(c)
 end subroutine


### PR DESCRIPTION
the LEN intrinsic even when the result of the function call was not a
constant. This left LEN(func-name) in the expression which has no
semantics as the function had to be called with an argument to get the
return value's LEN property at runtime.

Update test to remove fir.convert.