### PR TITLE
Write a pass to annotate constant operands on FIR ops. This is a workaround for the

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.h
+++ b/flang/include/flang/Optimizer/Transforms/Passes.h
@@ -40,6 +40,7 @@ std::unique_ptr<mlir::Pass> createSimplifyRegionLitePass();
 std::unique_ptr<mlir::Pass> createMemoryAllocationPass();
 std::unique_ptr<mlir::Pass>
 createMemoryAllocationPass(bool dynOnHeap, std::size_t maxStackSize);
+std::unique_ptr<mlir::Pass> createAnnotateConstantOperandsPass();
 
 /// A pass to convert the FIR dialect from "Mem-SSA" form to "Reg-SSA" form.
 /// This pass is a port of LLVM's mem2reg pass, but modified for the FIR dialect

--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -55,11 +55,36 @@ def AffineDialectDemotion : FunctionPass<"demote-affine"> {
   ];
 }
 
+def AnnotateConstantOperands : Pass<"annotate-constant"> {
+  let summary = "Annotate constant operands to all FIR operations";
+  let description = [{
+    The MLIR canonicalizer makes a distinction between constants based on how
+    they are packaged in the IR. A constant value is wrapped in an Attr and that
+    Attr can be attached to an Op. There is a distinguished Op, ConstantOp, that
+    merely has one of these Attr attached.
+
+    The MLIR canonicalizer treats constants referenced by an Op and constants
+    referenced through a ConstantOp as having distinct semantics. This pass
+    eliminates that distinction, so hashconsing of Ops, basic blocks, etc.
+    behaves as one would expect.
+  }];
+  let constructor = "::fir::createAnnotateConstantOperandsPass()";
+  let dependentDialects = [
+    "fir::FIROpsDialect", "mlir::StandardOpsDialect"
+  ];
+}
+
 def FirLoopResultOpt : FunctionPass<"fir-loop-result-opt"> {
   let summary =
     "Optimizes `fir.do_loop` by removing unused final iteration values.";
   let description = [{
     TODO - do we need this if we overhaul fir.do_loop a bit?
+
+    It's not fir.do_loop's job to figure out if the iteration variable is
+    live-out of the loop to the rest of the function.
+
+    That said, doing live-out analysis, removing dead stores, etc. can be done
+    more generally and does not need to be a separate pass.
   }];
   let constructor = "::fir::createFirLoopResultOptPass()";
   let dependentDialects = [

--- a/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
+++ b/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
@@ -27,7 +27,7 @@ struct AnnotateConstantOperands
         llvm::SmallVector<mlir::Attribute> attrs;
         bool hasOneOrMoreConstOpnd = false;
         for (mlir::Value opnd : op->getOperands()) {
-          if (auto constOp = mlir::dyn_cast<mlir::arith::ConstantOp>(
+          if (auto constOp = mlir::dyn_cast_or_null<mlir::arith::ConstantOp>(
                   opnd.getDefiningOp())) {
             attrs.push_back(constOp.value());
             hasOneOrMoreConstOpnd = true;

--- a/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
+++ b/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
@@ -1,0 +1,50 @@
+//===-- AnnotateConstant.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+#define DEBUG_TYPE "flang-annotate-constant"
+
+using namespace fir;
+
+namespace {
+struct AnnotateConstantOperands
+    : AnnotateConstantOperandsBase<AnnotateConstantOperands> {
+  void runOnOperation() override {
+    auto *context = &getContext();
+    mlir::Dialect *firDialect = context->getLoadedDialect("fir");
+    getOperation()->walk([&](mlir::Operation *op) {
+      // We filter out other dialects even though they may undergo merging of
+      // non-equal constant values by the canonicalizer as well.
+      if (op->getDialect() == firDialect) {
+        llvm::SmallVector<mlir::Attribute> attrs;
+        bool hasOneOrMoreConstOpnd = false;
+        for (mlir::Value opnd : op->getOperands()) {
+          if (auto constOp = mlir::dyn_cast<mlir::arith::ConstantOp>(
+                  opnd.getDefiningOp())) {
+            attrs.push_back(constOp.value());
+            hasOneOrMoreConstOpnd = true;
+          } else {
+            attrs.push_back(mlir::UnitAttr::get(context));
+          }
+        }
+        if (hasOneOrMoreConstOpnd)
+          op->setAttr("canonicalize_constant_operands",
+                      mlir::ArrayAttr::get(context, attrs));
+      }
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> fir::createAnnotateConstantOperandsPass() {
+  return std::make_unique<AnnotateConstantOperands>();
+}

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_flang_library(FIRTransforms
   AbstractResult.cpp
   AffineDemotion.cpp
   AffinePromotion.cpp
+  AnnotateConstant.cpp
   ArrayValueCopy.cpp
   CharacterConversion.cpp
   ControlFlowConverter.cpp

--- a/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
+++ b/flang/lib/Optimizer/Transforms/ControlFlowConverter.cpp
@@ -16,15 +16,11 @@
 
 #include "PassDetail.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
-#include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #define DEBUG_TYPE "flang-cfg-converter"


### PR DESCRIPTION
bug in MLIR's canonicalizer that treats constants differently based on
how they are packaged and not their values and semantics.