### PR TITLE
Lower MIN/MAX/ISHFTC dynamic optional arguments

### DIFF
--- a/flang/include/flang/Lower/CustomIntrinsicCall.h
+++ b/flang/include/flang/Lower/CustomIntrinsicCall.h
@@ -38,7 +38,7 @@ struct SpecificIntrinsic;
 namespace lower {
 
 /// Does the call \p procRef to \p intrinsic need to be handle via this custom
-/// framework due to optional arguments. Otherwise, the tools form
+/// framework due to optional arguments. Otherwise, the tools from
 /// IntrinsicCall.cpp should be used directly.
 bool intrinsicRequiresCustomOptionalHandling(
     const Fortran::evaluate::ProcedureRef &procRef,
@@ -50,10 +50,10 @@ bool intrinsicRequiresCustomOptionalHandling(
 using OperandPrepare = std::function<void(const Fortran::lower::SomeExpr &)>;
 
 /// Type of the callback to inquire about an argument presence, once the call
-/// prepartion was done. An absent optional means the argument is statically
+/// preparation was done. An absent optional means the argument is statically
 /// present. An mlir::Value means the presence must be checked at runtime, and
 /// that the value contains the "is present" boolean value.
-using OperandInquiry = std::function<llvm::Optional<mlir::Value>(std::size_t)>;
+using OperandPresent = std::function<llvm::Optional<mlir::Value>(std::size_t)>;
 
 /// Type of the callback to generate an argument reference after the call
 /// preparation was done. For optional arguments, the utility guarantees
@@ -70,7 +70,7 @@ using OperandGetter = std::function<fir::ExtendedValue(std::size_t)>;
 /// It is up to the caller to decide what argument preparation means,
 /// the only contract is that it should later allow the caller to provide
 /// callbacks to generate argument reference given an argument index without
-/// any further knowledge of the argument. The function simply visit
+/// any further knowledge of the argument. The function simply visits
 /// the actual arguments, deciding which ones are dynamically optional,
 /// and calling the callbacks accordingly in argument order.
 void prepareCustomIntrinsicArgument(
@@ -90,7 +90,7 @@ void prepareCustomIntrinsicArgument(
 fir::ExtendedValue
 lowerCustomIntrinsic(fir::FirOpBuilder &builder, mlir::Location loc,
                      llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
-                     const OperandInquiry &isPresentCheck,
+                     const OperandPresent &isPresentCheck,
                      const OperandGetter &getOperand, std::size_t numOperands,
                      Fortran::lower::StatementContext &stmtCtx);
 } // namespace lower

--- a/flang/include/flang/Lower/CustomIntrinsicCall.h
+++ b/flang/include/flang/Lower/CustomIntrinsicCall.h
@@ -1,0 +1,99 @@
+//===-- Lower/CustomIntrinsicCall.h -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+///
+/// Custom intrinsic lowering for the few intrinsic that have optional
+/// arguments that prevents them to be handled in a more generic way in
+/// IntrinsicCall.cpp.
+/// The core principle is that this interface provides the intrinsic arguments
+/// via callbacks to generate fir::ExtendedValue (instead of a list of
+/// precomputed fir::ExtendedValue as done in the default intrinsic call
+/// lowering). This gives more flexibility to only generate references to
+/// dynamically optional arguments (pointers, allocatables, OPTIONAL dummies) in
+/// a safe way.
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_LOWER_CUSTOMINTRINSICCALL_H
+#define FORTRAN_LOWER_CUSTOMINTRINSICCALL_H
+
+#include "flang/Lower/AbstractConverter.h"
+#include "llvm/ADT/Optional.h"
+#include <functional>
+
+namespace Fortran {
+
+namespace evaluate {
+class ProcedureRef;
+struct SpecificIntrinsic;
+} // namespace evaluate
+
+namespace lower {
+
+/// Does the call \p procRef to \p intrinsic need to be handle via this custom
+/// framework due to optional arguments. Otherwise, the tools form
+/// IntrinsicCall.cpp should be used directly.
+bool intrinsicRequiresCustomOptionalHandling(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    AbstractConverter &converter);
+
+/// Type of callback to be provided to prepare the arguments fetching from an
+/// actual argument expression.
+using OperandPrepare = std::function<void(const Fortran::lower::SomeExpr &)>;
+
+/// Type of the callback to inquire about an argument presence, once the call
+/// prepartion was done. An absent optional means the argument is statically
+/// present. An mlir::Value means the presence must be checked at runtime, and
+/// that the value contains the "is present" boolean value.
+using OperandInquiry = std::function<llvm::Optional<mlir::Value>(std::size_t)>;
+
+/// Type of the callback to generate an argument reference after the call
+/// preparation was done. For optional arguments, the utility guarantees
+/// these callbacks will only be called in regions where the presence was
+/// verified. This means the getter callback can dereference the argument
+/// without any special care.
+/// For elemental intrinsics, the getter must provide the current iteration
+/// element value.
+using OperandGetter = std::function<fir::ExtendedValue(std::size_t)>;
+
+/// Given a callback \p prepareOptionalArgument to prepare optional
+/// arguments and a callback \p prepareOtherArgument to prepare non-optional
+/// arguments prepare the intrinsic arguments calls.
+/// It is up to the caller to decide what argument preparation means,
+/// the only contract is that it should later allow the caller to provide
+/// callbacks to generate argument reference given an argument index without
+/// any further knowledge of the argument. The function simply visit
+/// the actual arguments, deciding which ones are dynamically optional,
+/// and calling the callbacks accordingly in argument order.
+void prepareCustomIntrinsicArgument(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    llvm::Optional<mlir::Type> retTy,
+    const OperandPrepare &prepareOptionalArgument,
+    const OperandPrepare &prepareOtherArgument, AbstractConverter &converter);
+
+/// Given a callback \p getOperand to generate a reference to the i-th argument,
+/// and a callback \p isPresentCheck to test if an argument is present, this
+/// function lowers the intrinsic calls to \p name whose argument were
+/// previously prepared with prepareCustomIntrinsicArgument. The elemental
+/// aspects must be taken into account by the caller (i.e, the function should
+/// be called during the loop nest generation for elemental intrinsics. It will
+/// not generate any implicit loop nest on its own).
+fir::ExtendedValue
+lowerCustomIntrinsic(fir::FirOpBuilder &builder, mlir::Location loc,
+                     llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
+                     const OperandInquiry &isPresentCheck,
+                     const OperandGetter &getOperand, std::size_t numOperands,
+                     Fortran::lower::StatementContext &stmtCtx);
+} // namespace lower
+} // namespace Fortran
+
+#endif // FORTRAN_LOWER_CUSTOMINTRINSICCALL_H

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flang_library(FortranLower
   ConvertExpr.cpp
   ConvertType.cpp
   ConvertVariable.cpp
+  CustomIntrinsicCall.cpp
   DumpEvaluateExpr.cpp
   HostAssociations.cpp
   IntrinsicCall.cpp

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -24,6 +24,7 @@
 #include "flang/Lower/ComponentPath.h"
 #include "flang/Lower/ConvertType.h"
 #include "flang/Lower/ConvertVariable.h"
+#include "flang/Lower/CustomIntrinsicCall.h"
 #include "flang/Lower/DumpEvaluateExpr.h"
 #include "flang/Lower/IntrinsicCall.h"
 #include "flang/Lower/Mangler.h"
@@ -456,59 +457,6 @@ static fir::ExtendedValue genOptionalBox(fir::FirOpBuilder &builder,
   auto boxOrAbsent =
       builder.create<mlir::SelectOp>(loc, boxType, isPresent, box, absent);
   return fir::BoxValue(boxOrAbsent);
-}
-
-/// Is this a call to MIN or MAX intrinsic with arguments that may be absent at
-/// runtime? This is a special case because MIN and MAX can have any number of
-/// arguments.
-static bool isMinOrMaxWithDynamicallyOptionalArg(
-    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
-    Fortran::evaluate::FoldingContext &foldingContex) {
-  if (name != "min" || name != "max")
-    return false;
-  const auto &args = procRef.arguments();
-  std::size_t argSize = args.size();
-  if (argSize <= 2)
-    return false;
-  for (std::size_t i = 2; i < argSize; ++i) {
-    if (auto *expr =
-            Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(args[i]))
-      if (Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex))
-        return true;
-  }
-  return false;
-}
-
-/// Is this a call to ISHFTC intrinsic with a SIZE argument that may be absent
-/// at runtime? This is a special case because the SIZE value to be applied
-/// when absent is not zero.
-static bool isIshftcWithDynamicallyOptionalArg(
-    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
-    Fortran::evaluate::FoldingContext &foldingContex) {
-  if (name != "ishftc" || procRef.arguments().size() < 3)
-    return false;
-  auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(
-      procRef.arguments()[2]);
-  return expr &&
-         Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex);
-}
-
-/// Is this a call to SYSTEM_CLOCK or RANDOM_SEED intrinsic with arguments that
-/// may be absent at runtime? This are special cases because that aspect cannot
-/// be delegated to the runtime via a null fir.box or address given the current
-/// runtime entry point.
-static bool isSystemClockOrRandomSeedWithOptionalArg(
-    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
-    Fortran::evaluate::FoldingContext &foldingContex) {
-  if (name != "system_clock" || name != "random_seed")
-    return false;
-  for (const auto &arg : procRef.arguments()) {
-    auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg);
-    if (expr &&
-        Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex))
-      return true;
-  }
-  return false;
 }
 
 /// Is this a call to an elemental procedure with at least one array argument?
@@ -2001,14 +1949,41 @@ public:
     llvm::SmallVector<ExtValue> operands;
 
     llvm::StringRef name = intrinsic.name;
+    mlir::Location loc = getLoc();
+    if (Fortran::lower::intrinsicRequiresCustomOptionalHandling(
+            procRef, intrinsic, converter)) {
+      using ExvAndPresence = std::pair<ExtValue, llvm::Optional<mlir::Value>>;
+      llvm::SmallVector<ExvAndPresence, 4> operands;
+      auto prepareOptionalArg = [&](const Fortran::lower::SomeExpr &expr) {
+        ExtValue optionalArg = lowerIntrinsicArgumentAsInquired(expr);
+        mlir::Value isPresent =
+            genActualIsPresentTest(builder, loc, optionalArg);
+        operands.emplace_back(optionalArg, isPresent);
+      };
+      auto prepareOtherArg = [&](const Fortran::lower::SomeExpr &expr) {
+        operands.emplace_back(genval(expr), llvm::None);
+      };
+      Fortran::lower::prepareCustomIntrinsicArgument(
+          procRef, intrinsic, resultType, prepareOptionalArg, prepareOtherArg,
+          converter);
+
+      llvm::StringRef name = intrinsic.name;
+      auto getArgument = [&](std::size_t i) -> ExtValue {
+        if (fir::conformsWithPassByRef(
+                fir::getBase(operands[i].first).getType()))
+          return ::genLoad(builder, loc, operands[i].first);
+        return operands[i].first;
+      };
+      auto isPresent = [&](std::size_t i) -> llvm::Optional<mlir::Value> {
+        return operands[i].second;
+      };
+      return Fortran::lower::lowerCustomIntrinsic(
+          builder, loc, name, resultType, isPresent, getArgument,
+          operands.size(), stmtCtx);
+    }
+
     const Fortran::lower::IntrinsicArgumentLoweringRules *argLowering =
         Fortran::lower::getIntrinsicArgumentLowering(name);
-    Fortran::evaluate::FoldingContext &fldCtx = converter.getFoldingContext();
-    if (isMinOrMaxWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
-        isIshftcWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
-        isSystemClockOrRandomSeedWithOptionalArg(name, procRef, fldCtx))
-      TODO(getLoc(),
-           "special handling of dynamically optional intrinsic argument");
     for (const auto &[arg, dummy] :
          llvm::zip(procRef.arguments(),
                    intrinsic.characteristics.value().dummyArguments)) {
@@ -2024,7 +1999,6 @@ public:
         continue;
       }
       // Ad-hoc argument lowering handling.
-      mlir::Location loc = getLoc();
       Fortran::lower::ArgLoweringRule argRules =
           Fortran::lower::lowerIntrinsicArgumentAs(loc, *argLowering,
                                                    dummy.name);
@@ -4375,13 +4349,49 @@ private:
     llvm::StringRef name = intrinsic.name;
     const Fortran::lower::IntrinsicArgumentLoweringRules *argLowering =
         Fortran::lower::getIntrinsicArgumentLowering(name);
-    if (isMinOrMaxWithDynamicallyOptionalArg(name, procRef,
-                                             converter.getFoldingContext()) ||
-        isIshftcWithDynamicallyOptionalArg(name, procRef,
-                                           converter.getFoldingContext()))
-      TODO(getLoc(),
-           "special handling of dynamically optional intrinsic argument");
     mlir::Location loc = getLoc();
+    if (Fortran::lower::intrinsicRequiresCustomOptionalHandling(
+            procRef, intrinsic, converter)) {
+      using CcPairT = std::pair<CC, llvm::Optional<mlir::Value>>;
+      llvm::SmallVector<CcPairT> operands;
+      auto prepareOptionalArg = [&](const Fortran::lower::SomeExpr &expr) {
+        if (expr.Rank() == 0) {
+          ExtValue optionalArg = this->asInquired(expr);
+          mlir::Value isPresent =
+              genActualIsPresentTest(builder, loc, optionalArg);
+          operands.emplace_back(
+              [=](IterSpace iters) -> ExtValue {
+                return genLoad(builder, loc, optionalArg);
+              },
+              isPresent);
+        } else {
+          auto [cc, isPresent, _] = this->genOptionalArrayFetch(expr);
+          operands.emplace_back(cc, isPresent);
+        }
+      };
+      auto prepareOtherArg = [&](const Fortran::lower::SomeExpr &expr) {
+        PushSemantics(ConstituentSemantics::RefTransparent);
+        operands.emplace_back(genElementalArgument(expr), llvm::None);
+      };
+      Fortran::lower::prepareCustomIntrinsicArgument(
+          procRef, intrinsic, retTy, prepareOptionalArg, prepareOtherArg,
+          converter);
+
+      fir::FirOpBuilder *bldr = &converter.getFirOpBuilder();
+      llvm::StringRef name = intrinsic.name;
+      return [=](IterSpace iters) -> ExtValue {
+        auto getArgument = [&](std::size_t i) -> ExtValue {
+          return operands[i].first(iters);
+        };
+        auto isPresent = [&](std::size_t i) -> llvm::Optional<mlir::Value> {
+          return operands[i].second;
+        };
+        return Fortran::lower::lowerCustomIntrinsic(
+            *bldr, loc, name, retTy, isPresent, getArgument, operands.size(),
+            getElementCtx());
+      };
+    }
+    /// Otherwise, pre-lower arguments and use intrinsic lowering utility.
     for (const auto &[arg, dummy] :
          llvm::zip(procRef.arguments(),
                    intrinsic.characteristics.value().dummyArguments)) {
@@ -4393,8 +4403,7 @@ private:
       } else if (!argLowering) {
         // No argument lowering instruction, lower by value.
         PushSemantics(ConstituentSemantics::RefTransparent);
-        auto lambda = genElementalArgument(*expr);
-        operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+        operands.emplace_back(genElementalArgument(*expr));
       } else {
         // Ad-hoc argument lowering handling.
         Fortran::lower::ArgLoweringRule argRules =
@@ -4416,14 +4425,12 @@ private:
         switch (argRules.lowerAs) {
         case Fortran::lower::LowerIntrinsicArgAs::Value: {
           PushSemantics(ConstituentSemantics::RefTransparent);
-          auto lambda = genElementalArgument(*expr);
-          operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+          operands.emplace_back(genElementalArgument(*expr));
         } break;
         case Fortran::lower::LowerIntrinsicArgAs::Addr: {
           // Note: assume does not have Fortran VALUE attribute semantics.
           PushSemantics(ConstituentSemantics::RefOpaque);
-          auto lambda = genElementalArgument(*expr);
-          operands.emplace_back([=](IterSpace iters) { return lambda(iters); });
+          operands.emplace_back(genElementalArgument(*expr));
         } break;
         case Fortran::lower::LowerIntrinsicArgAs::Box: {
           PushSemantics(ConstituentSemantics::RefOpaque);
@@ -5561,12 +5568,9 @@ private:
     return fir::substBase(exv, safeToReadBox);
   }
 
-  /// Generate a continuation to pass \p expr to an OPTIONAL argument of an
-  /// elemental procedure. This is meant to handle the cases where \p expr might
-  /// be dynamically absent (i.e. when it is a POINTER, and ALLOCATABLE or an
-  /// OPTIONAL variable). If p\ expr is guaranteed to be present genarr() can
-  /// directly be called instead.
-  CC genarrForwardOptionalArgumentToCall(const Fortran::lower::SomeExpr &expr) {
+  std::tuple<CC, mlir::Value, mlir::Type>
+  genOptionalArrayFetch(const Fortran::lower::SomeExpr &expr) {
+    assert(expr.Rank() > 0 && "expr must be an array");
     mlir::Location loc = getLoc();
     ExtValue optionalArg = asInquired(expr);
     mlir::Value isPresent = genActualIsPresentTest(builder, loc, optionalArg);
@@ -5594,16 +5598,6 @@ private:
     if (const auto *mutableBox = exv.getBoxOf<fir::MutableBoxValue>())
       exv = fir::factory::genMutableBoxRead(builder, loc, *mutableBox);
 
-    /// Handle scalar argument case
-    if (exv.rank() == 0) {
-      /// Only by-value numerical and logical.
-      if (semant != ConstituentSemantics::RefTransparent)
-        TODO(loc, "optional arguments in user defined elemental procedures");
-      mlir::Value elementValue =
-          fir::getBase(genOptionalValue(builder, loc, exv, isPresent));
-      return [=](IterSpace iters) -> ExtValue { return elementValue; };
-    }
-
     mlir::Value memref = fir::getBase(exv);
     mlir::Value shape = builder.createShape(loc, exv);
     mlir::Value noSlice;
@@ -5628,7 +5622,34 @@ private:
       return fir::factory::arraySectionElementToExtendedValue(
           builder, loc, exv, arrFetch, noSlice);
     };
+    return {cc, isPresent, eleType};
+  }
 
+  /// Generate a continuation to pass \p expr to an OPTIONAL argument of an
+  /// elemental procedure. This is meant to handle the cases where \p expr might
+  /// be dynamically absent (i.e. when it is a POINTER, and ALLOCATABLE or an
+  /// OPTIONAL variable). If p\ expr is guaranteed to be present genarr() can
+  /// directly be called instead.
+  CC genarrForwardOptionalArgumentToCall(const Fortran::lower::SomeExpr &expr) {
+    mlir::Location loc = getLoc();
+    // Only by-value numerical and logical so far.
+    if (semant != ConstituentSemantics::RefTransparent)
+      TODO(loc, "optional arguments in user defined elemental procedures");
+
+    // Handle scalar argument case (the if-then-else is generated outside of the
+    // implicit loop nest).
+    if (expr.Rank() == 0) {
+      ExtValue optionalArg = asInquired(expr);
+      mlir::Value isPresent = genActualIsPresentTest(builder, loc, optionalArg);
+      mlir::Value elementValue =
+          fir::getBase(genOptionalValue(builder, loc, optionalArg, isPresent));
+      return [=](IterSpace iters) -> ExtValue { return elementValue; };
+    }
+
+    CC cc;
+    mlir::Value isPresent;
+    mlir::Type eleType;
+    std::tie(cc, isPresent, eleType) = genOptionalArrayFetch(expr);
     return [=](IterSpace iters) -> ExtValue {
       mlir::Value elementValue =
           builder

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1967,11 +1967,10 @@ public:
           procRef, intrinsic, resultType, prepareOptionalArg, prepareOtherArg,
           converter);
 
-      llvm::StringRef name = intrinsic.name;
       auto getArgument = [&](std::size_t i) -> ExtValue {
         if (fir::conformsWithPassByRef(
                 fir::getBase(operands[i].first).getType()))
-          return ::genLoad(builder, loc, operands[i].first);
+          return genLoad(operands[i].first);
         return operands[i].first;
       };
       auto isPresent = [&](std::size_t i) -> llvm::Optional<mlir::Value> {
@@ -5627,7 +5626,7 @@ private:
 
   /// Generate a continuation to pass \p expr to an OPTIONAL argument of an
   /// elemental procedure. This is meant to handle the cases where \p expr might
-  /// be dynamically absent (i.e. when it is a POINTER, and ALLOCATABLE or an
+  /// be dynamically absent (i.e. when it is a POINTER, an ALLOCATABLE or an
   /// OPTIONAL variable). If p\ expr is guaranteed to be present genarr() can
   /// directly be called instead.
   CC genarrForwardOptionalArgumentToCall(const Fortran::lower::SomeExpr &expr) {

--- a/flang/lib/Lower/CustomIntrinsicCall.cpp
+++ b/flang/lib/Lower/CustomIntrinsicCall.cpp
@@ -17,12 +17,6 @@
 #include "flang/Lower/IntrinsicCall.h"
 #include "flang/Lower/Todo.h"
 
-// CC genMinMaxWithOptionalArgs(const Fortran::evaluate::ProcedureRef &procRef,
-// const Fortran::evaluate::SpecificIntrinsic &intrinsic,
-// llvm::Optional<mlir::Type> retTy) {
-//   };
-// }
-
 /// Is this a call to MIN or MAX intrinsic with arguments that may be absent at
 /// runtime? This is a special case because MIN and MAX can have any number of
 /// arguments.
@@ -122,7 +116,7 @@ static void prepareMinOrMaxArguments(
 static fir::ExtendedValue
 lowerMinOrMax(fir::FirOpBuilder &builder, mlir::Location loc,
               llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
-              const Fortran::lower::OperandInquiry &isPresentCheck,
+              const Fortran::lower::OperandPresent &isPresentCheck,
               const Fortran::lower::OperandGetter &getOperand,
               std::size_t numOperands,
               Fortran::lower::StatementContext &stmtCtx) {
@@ -193,7 +187,7 @@ static void prepareIshftcArguments(
 static fir::ExtendedValue
 lowerIshftc(fir::FirOpBuilder &builder, mlir::Location loc,
             llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
-            const Fortran::lower::OperandInquiry &isPresentCheck,
+            const Fortran::lower::OperandPresent &isPresentCheck,
             const Fortran::lower::OperandGetter &getOperand,
             std::size_t numOperands,
             Fortran::lower::StatementContext &stmtCtx) {
@@ -247,7 +241,7 @@ void Fortran::lower::prepareCustomIntrinsicArgument(
 
 fir::ExtendedValue Fortran::lower::lowerCustomIntrinsic(
     fir::FirOpBuilder &builder, mlir::Location loc, llvm::StringRef name,
-    llvm::Optional<mlir::Type> retTy, const OperandInquiry &isPresentCheck,
+    llvm::Optional<mlir::Type> retTy, const OperandPresent &isPresentCheck,
     const OperandGetter &getOperand, std::size_t numOperands,
     Fortran::lower::StatementContext &stmtCtx) {
   if (name == "min" || name == "max")

--- a/flang/lib/Lower/CustomIntrinsicCall.cpp
+++ b/flang/lib/Lower/CustomIntrinsicCall.cpp
@@ -1,0 +1,261 @@
+//===-- CustomIntrinsicCall.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Lower/CustomIntrinsicCall.h"
+#include "flang/Evaluate/expression.h"
+#include "flang/Evaluate/fold.h"
+#include "flang/Evaluate/tools.h"
+#include "flang/Lower/IntrinsicCall.h"
+#include "flang/Lower/Todo.h"
+
+// CC genMinMaxWithOptionalArgs(const Fortran::evaluate::ProcedureRef &procRef,
+// const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+// llvm::Optional<mlir::Type> retTy) {
+//   };
+// }
+
+/// Is this a call to MIN or MAX intrinsic with arguments that may be absent at
+/// runtime? This is a special case because MIN and MAX can have any number of
+/// arguments.
+static bool isMinOrMaxWithDynamicallyOptionalArg(
+    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
+    Fortran::evaluate::FoldingContext &foldingContex) {
+  if (name != "min" && name != "max")
+    return false;
+  const auto &args = procRef.arguments();
+  std::size_t argSize = args.size();
+  if (argSize <= 2)
+    return false;
+  for (std::size_t i = 2; i < argSize; ++i) {
+    if (auto *expr =
+            Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(args[i]))
+      if (Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex))
+        return true;
+  }
+  return false;
+}
+
+/// Is this a call to ISHFTC intrinsic with a SIZE argument that may be absent
+/// at runtime? This is a special case because the SIZE value to be applied
+/// when absent is not zero.
+static bool isIshftcWithDynamicallyOptionalArg(
+    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
+    Fortran::evaluate::FoldingContext &foldingContex) {
+  if (name != "ishftc" || procRef.arguments().size() < 3)
+    return false;
+  auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(
+      procRef.arguments()[2]);
+  return expr &&
+         Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex);
+}
+
+/// Is this a call to SYSTEM_CLOCK or RANDOM_SEED intrinsic with arguments that
+/// may be absent at runtime? This are special cases because that aspect cannot
+/// be delegated to the runtime via a null fir.box or address given the current
+/// runtime entry point.
+static bool isSystemClockOrRandomSeedWithOptionalArg(
+    llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
+    Fortran::evaluate::FoldingContext &foldingContex) {
+  if (name != "system_clock" || name != "random_seed")
+    return false;
+  for (const auto &arg : procRef.arguments()) {
+    auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg);
+    if (expr &&
+        Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex))
+      return true;
+  }
+  return false;
+}
+
+bool Fortran::lower::intrinsicRequiresCustomOptionalHandling(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    AbstractConverter &converter) {
+  llvm::StringRef name = intrinsic.name;
+  Fortran::evaluate::FoldingContext &fldCtx = converter.getFoldingContext();
+  return isMinOrMaxWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
+         isIshftcWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
+         isSystemClockOrRandomSeedWithOptionalArg(name, procRef, fldCtx);
+}
+
+static void prepareMinOrMaxArguments(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    llvm::Optional<mlir::Type> retTy,
+    const Fortran::lower::OperandPrepare &prepareOptionalArgument,
+    const Fortran::lower::OperandPrepare &prepareOtherArgument,
+    Fortran::lower::AbstractConverter &converter) {
+  assert(retTy && "MIN and MAX must have a return type");
+  mlir::Type resultType = retTy.getValue();
+  mlir::Location loc = converter.getCurrentLocation();
+  if (fir::isa_char(resultType))
+    TODO(loc,
+         "CHARACTER MIN and MAX lowering with dynamically optional arguments");
+  for (auto arg : llvm::enumerate(procRef.arguments())) {
+    const auto *expr =
+        Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg.value());
+    if (!expr)
+      continue;
+    if (arg.index() <= 1 || !Fortran::evaluate::MayBePassedAsAbsentOptional(
+                                *expr, converter.getFoldingContext())) {
+      // Non optional arguments.
+      prepareOtherArgument(*expr);
+    } else {
+      // Dynamically optional arguments.
+      // Subtle: even for scalar the if-then-else will be generated in the loop
+      // nest because the then part will require the current extremum value that
+      // may depend on previous array element argument and cannot be outlined.
+      prepareOptionalArgument(*expr);
+    }
+  }
+}
+
+static fir::ExtendedValue
+lowerMinOrMax(fir::FirOpBuilder &builder, mlir::Location loc,
+              llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
+              const Fortran::lower::OperandInquiry &isPresentCheck,
+              const Fortran::lower::OperandGetter &getOperand,
+              std::size_t numOperands,
+              Fortran::lower::StatementContext &stmtCtx) {
+  assert(numOperands >= 2 && !isPresentCheck(0) && !isPresentCheck(1) &&
+         "min/max must have at least two non-optional args");
+  assert(retTy && "MIN and MAX must have a return type");
+  mlir::Type resultType = retTy.getValue();
+  llvm::SmallVector<fir::ExtendedValue> args;
+  args.push_back(getOperand(0));
+  args.push_back(getOperand(1));
+  mlir::Value extremum = fir::getBase(Fortran::lower::genIntrinsicCall(
+      builder, loc, name, resultType, args, stmtCtx));
+
+  for (std::size_t opIndex = 2; opIndex < numOperands; ++opIndex) {
+    if (llvm::Optional<mlir::Value> isPresentRuntimeCheck =
+            isPresentCheck(opIndex)) {
+      // Argument is dynamically optional.
+      extremum =
+          builder
+              .genIfOp(loc, {resultType}, isPresentRuntimeCheck.getValue(),
+                       /*withElseRegion=*/true)
+              .genThen([&]() {
+                llvm::SmallVector<fir::ExtendedValue> args;
+                args.emplace_back(extremum);
+                args.emplace_back(getOperand(opIndex));
+                fir::ExtendedValue newExtremum =
+                    Fortran::lower::genIntrinsicCall(builder, loc, name,
+                                                     resultType, args, stmtCtx);
+                builder.create<fir::ResultOp>(loc, fir::getBase(newExtremum));
+              })
+              .genElse([&]() { builder.create<fir::ResultOp>(loc, extremum); })
+              .getResults()[0];
+    } else {
+      // Argument is know to be present at compile time.
+      llvm::SmallVector<fir::ExtendedValue> args;
+      args.emplace_back(extremum);
+      args.emplace_back(getOperand(opIndex));
+      extremum = fir::getBase(Fortran::lower::genIntrinsicCall(
+          builder, loc, name, resultType, args, stmtCtx));
+    }
+  }
+  return extremum;
+}
+
+static void prepareIshftcArguments(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    llvm::Optional<mlir::Type> retTy,
+    const Fortran::lower::OperandPrepare &prepareOptionalArgument,
+    const Fortran::lower::OperandPrepare &prepareOtherArgument,
+    Fortran::lower::AbstractConverter &converter) {
+  for (auto arg : llvm::enumerate(procRef.arguments())) {
+    const auto *expr =
+        Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg.value());
+    assert(expr && "expected all ISHFTC argument to be textually present here");
+    if (arg.index() == 2) {
+      assert(Fortran::evaluate::MayBePassedAsAbsentOptional(
+                 *expr, converter.getFoldingContext()) &&
+             "expected ISHFTC SIZE arg to be dynamically optional");
+      prepareOptionalArgument(*expr);
+    } else {
+      // Non optional arguments.
+      prepareOtherArgument(*expr);
+    }
+  }
+}
+
+static fir::ExtendedValue
+lowerIshftc(fir::FirOpBuilder &builder, mlir::Location loc,
+            llvm::StringRef name, llvm::Optional<mlir::Type> retTy,
+            const Fortran::lower::OperandInquiry &isPresentCheck,
+            const Fortran::lower::OperandGetter &getOperand,
+            std::size_t numOperands,
+            Fortran::lower::StatementContext &stmtCtx) {
+  assert(numOperands == 3 && !isPresentCheck(0) && !isPresentCheck(1) &&
+         isPresentCheck(2) &&
+         "only ISHFTC SIZE arg is expected to be dynamically optional here");
+  assert(retTy && "ISFHTC must have a return type");
+  mlir::Type resultType = retTy.getValue();
+  llvm::SmallVector<fir::ExtendedValue> args;
+  args.push_back(getOperand(0));
+  args.push_back(getOperand(1));
+  args.push_back(builder
+                     .genIfOp(loc, {resultType}, isPresentCheck(2).getValue(),
+                              /*withElseRegion=*/true)
+                     .genThen([&]() {
+                       fir::ExtendedValue sizeExv = getOperand(2);
+                       mlir::Value size = builder.createConvert(
+                           loc, resultType, fir::getBase(sizeExv));
+                       builder.create<fir::ResultOp>(loc, size);
+                     })
+                     .genElse([&]() {
+                       mlir::Value bitSize = builder.createIntegerConstant(
+                           loc, resultType,
+                           resultType.cast<mlir::IntegerType>().getWidth());
+                       builder.create<fir::ResultOp>(loc, bitSize);
+                     })
+                     .getResults()[0]);
+  return Fortran::lower::genIntrinsicCall(builder, loc, name, resultType, args,
+                                          stmtCtx);
+}
+
+void Fortran::lower::prepareCustomIntrinsicArgument(
+    const Fortran::evaluate::ProcedureRef &procRef,
+    const Fortran::evaluate::SpecificIntrinsic &intrinsic,
+    llvm::Optional<mlir::Type> retTy,
+    const OperandPrepare &prepareOptionalArgument,
+    const OperandPrepare &prepareOtherArgument, AbstractConverter &converter) {
+  llvm::StringRef name = intrinsic.name;
+  if (name == "min" || name == "max")
+    return prepareMinOrMaxArguments(procRef, intrinsic, retTy,
+                                    prepareOptionalArgument,
+                                    prepareOtherArgument, converter);
+  if (name == "ishftc")
+    return prepareIshftcArguments(procRef, intrinsic, retTy,
+                                  prepareOptionalArgument, prepareOtherArgument,
+                                  converter);
+  TODO(converter.getCurrentLocation(),
+       "unhandled dynamically optional arguments in SYSTEM_CLOCK or "
+       "RANDOM_SEED");
+}
+
+fir::ExtendedValue Fortran::lower::lowerCustomIntrinsic(
+    fir::FirOpBuilder &builder, mlir::Location loc, llvm::StringRef name,
+    llvm::Optional<mlir::Type> retTy, const OperandInquiry &isPresentCheck,
+    const OperandGetter &getOperand, std::size_t numOperands,
+    Fortran::lower::StatementContext &stmtCtx) {
+  if (name == "min" || name == "max")
+    return lowerMinOrMax(builder, loc, name, retTy, isPresentCheck, getOperand,
+                         numOperands, stmtCtx);
+  if (name == "ishftc")
+    return lowerIshftc(builder, loc, name, retTy, isPresentCheck, getOperand,
+                       numOperands, stmtCtx);
+  TODO(loc, "unhandled dynamically optional arguments in SYSTEM_CLOCK or "
+            "RANDOM_SEED");
+}

--- a/flang/test/Lower/intrinsic-procedures/ishftc.f90
+++ b/flang/test/Lower/intrinsic-procedures/ishftc.f90
@@ -40,3 +40,99 @@ function ishftc_test(i, j, k)
   ! CHECK: return %[[VAL_36]] : i32
   ishftc_test = ishftc(i, j, k)
 end
+
+! Test cases where the size argument presence can only be know at runtime
+module test_ishftc
+contains
+! CHECK-LABEL: func @_QMtest_ishftcPdyn_optional_scalar(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "shift"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "size", fir.optional}) {
+subroutine dyn_optional_scalar(i, shift, size)
+  integer, optional :: size
+  integer :: i, shift
+  print *, ishftc(i, shift, size)
+  ! CHECK:  %[[VAL_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+  ! CHECK:  %[[VAL_9:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+  ! CHECK:  %[[VAL_10:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<i32>) -> i1
+  ! CHECK:  %[[VAL_11:.*]] = fir.if %[[VAL_10]] -> (i32) {
+  ! CHECK:    %[[VAL_12:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+  ! CHECK:    fir.result %[[VAL_12]] : i32
+  ! CHECK:  } else {
+  ! CHECK:    %[[VAL_13:.*]] = arith.constant 32 : i32
+  ! CHECK:    fir.result %[[VAL_13]] : i32
+  ! CHECK:  }
+  ! CHECK:  %[[VAL_17:.*]] = arith.constant 31 : i32
+  ! CHECK:  %[[VAL_18:.*]] = arith.shrsi %[[VAL_9]], %[[VAL_17]] : i32
+  ! CHECK:  %[[VAL_19:.*]] = arith.xori %[[VAL_9]], %[[VAL_18]] : i32
+  ! CHECK:  %[[VAL_20:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : i32
+  ! CHECK:  %[[VAL_21:.*]] = arith.subi %[[VAL_11]], %[[VAL_20]] : i32
+  ! ... as in non optional case 
+end subroutine
+
+! CHECK-LABEL: func @_QMtest_ishftcPdyn_optional_array_scalar(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "shift"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "size", fir.optional}) {
+subroutine dyn_optional_array_scalar(i, shift, size)
+  integer, optional :: size
+  integer :: i(:), shift(:)
+! CHECK:  %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_11:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_12:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<i32>) -> i1
+! CHECK:  fir.do_loop %[[VAL_20:.*]] = %{{.*}} to %{{.*}}
+! CHECK:    %[[VAL_22:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_20]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_23:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_20]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_24:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:      %[[VAL_25:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:      fir.result %[[VAL_25]] : i32
+! CHECK:    } else {
+! CHECK:      %[[VAL_26:.*]] = arith.constant 32 : i32
+! CHECK:      fir.result %[[VAL_26]] : i32
+! CHECK:    }
+! ... as in non optional case 
+! CHECK:  }
+  print *, ishftc(i, shift, size)
+end subroutine
+
+! CHECK-LABEL: func @_QMtest_ishftcPdyn_optional_array(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "shift"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "size", fir.optional}) {
+subroutine dyn_optional_array(i, shift, size)
+  integer, optional :: size(:)
+  integer :: i(:), shift(:)
+! CHECK:  %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_11:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_12:.*]] = fir.is_present %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>) -> i1
+! CHECK:  %[[VAL_17:.*]] = select %[[VAL_12]], %[[VAL_2]], %{{.*}} : !fir.box<!fir.array<?xi32>>
+! CHECK:  %[[VAL_18:.*]] = fir.array_load %[[VAL_17]] {fir.optional} : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  fir.do_loop %[[VAL_26:.*]] = %{{.*}} to %{{.*}}
+! CHECK:    %[[VAL_28:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_29:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_30:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:      %[[VAL_31:.*]] = fir.array_fetch %[[VAL_18]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:      fir.result %[[VAL_31]] : i32
+! CHECK:    } else {
+! CHECK:      %[[VAL_32:.*]] = arith.constant 32 : i32
+! CHECK:      fir.result %[[VAL_32]] : i32
+! CHECK:    }
+! ... as in non optional case 
+! CHECK:    }
+  print *, ishftc(i, shift, size)
+end subroutine
+end module
+
+  use test_ishftc
+  integer :: i(4) = [333, 334, 335, 336]
+  integer :: shift(4) = [2, 1, -1, -2]
+  integer :: size(4) = [2, 4, 8, 16]
+  call dyn_optional_scalar(i(1), shift(1))
+  call dyn_optional_scalar(i(1), shift(1), size(1))
+
+  call dyn_optional_array_scalar(i, shift)
+  call dyn_optional_array_scalar(i, shift, size(1))
+
+  call dyn_optional_array(i, shift)
+  call dyn_optional_array(i, shift, size)
+end

--- a/flang/test/Lower/intrinsic-procedures/max.f90
+++ b/flang/test/Lower/intrinsic-procedures/max.f90
@@ -1,0 +1,139 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+module max_test
+contains
+! CHECK-LABEL: func @_QMmax_testPdynamic_optional(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "b"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "c", fir.optional}) {
+subroutine dynamic_optional(a, b, c)
+  integer :: a(:), b(:)
+  integer, optional :: c(:)
+! CHECK:  %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_11:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_12:.*]] = fir.is_present %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>) -> i1
+! CHECK:  %[[VAL_17:.*]] = select %[[VAL_12]], %[[VAL_2]], %{{.*}} : !fir.box<!fir.array<?xi32>>
+! CHECK:  %[[VAL_18:.*]] = fir.array_load %[[VAL_17]] {fir.optional} : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  fir.do_loop %[[VAL_26:.*]] = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%[[VAL_27:.*]] = %{{.*}}) -> (!fir.array<?xi32>) {
+! CHECK:    %[[VAL_28:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_29:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_30:.*]] = arith.cmpi sgt, %[[VAL_28]], %[[VAL_29]] : i32
+! CHECK:    %[[VAL_31:.*]] = select %[[VAL_30]], %[[VAL_28]], %[[VAL_29]] : i32
+! CHECK:    %[[VAL_32:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:      %[[VAL_33:.*]] = fir.array_fetch %[[VAL_18]], %[[VAL_26]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:      %[[VAL_34:.*]] = arith.cmpi sgt, %[[VAL_31]], %[[VAL_33]] : i32
+! CHECK:      %[[VAL_35:.*]] = select %[[VAL_34]], %[[VAL_31]], %[[VAL_33]] : i32
+! CHECK:      fir.result %[[VAL_35]] : i32
+! CHECK:    } else {
+! CHECK:      fir.result %[[VAL_31]] : i32
+! CHECK:    }
+! CHECK:    %[[VAL_36:.*]] = fir.array_update %[[VAL_27]], %[[VAL_32]], %[[VAL_26]] : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
+! CHECK:    fir.result %[[VAL_36]] : !fir.array<?xi32>
+! CHECK:  }
+  print *, max(a, b, c)
+end subroutine 
+
+! CHECK-LABEL: func @_QMmax_testPdynamic_optional_array_expr_scalar_optional(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "b"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "c", fir.optional}) {
+subroutine dynamic_optional_array_expr_scalar_optional(a, b, c)
+  integer :: a(:), b(:)
+  integer, optional :: c
+  print *, max(a, b, c)
+! CHECK:  %[[VAL_10:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_11:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:  %[[VAL_12:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<i32>) -> i1
+! CHECK:  fir.do_loop %[[VAL_20:.*]] = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%[[VAL_21:.*]] = %{{.*}}) -> (!fir.array<?xi32>) {
+! CHECK:    %[[VAL_22:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_20]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_23:.*]] = fir.array_fetch %[[VAL_11]], %[[VAL_20]] : (!fir.array<?xi32>, index) -> i32
+! CHECK:    %[[VAL_24:.*]] = arith.cmpi sgt, %[[VAL_22]], %[[VAL_23]] : i32
+! CHECK:    %[[VAL_25:.*]] = select %[[VAL_24]], %[[VAL_22]], %[[VAL_23]] : i32
+! CHECK:    %[[VAL_26:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:      %[[VAL_27:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:      %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_25]], %[[VAL_27]] : i32
+! CHECK:      %[[VAL_29:.*]] = select %[[VAL_28]], %[[VAL_25]], %[[VAL_27]] : i32
+! CHECK:      fir.result %[[VAL_29]] : i32
+! CHECK:    } else {
+! CHECK:      fir.result %[[VAL_25]] : i32
+! CHECK:    }
+! CHECK:    %[[VAL_30:.*]] = fir.array_update %[[VAL_21]], %[[VAL_26]], %[[VAL_20]] : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
+! CHECK:    fir.result %[[VAL_30]] : !fir.array<?xi32>
+! CHECK:  }
+end subroutine 
+
+! CHECK-LABEL: func @_QMmax_testPdynamic_optional_scalar(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "c", fir.optional}) {
+subroutine dynamic_optional_scalar(a, b, c)
+  integer :: a, b
+  integer, optional :: c
+  print *, max(a, b, c)
+! CHECK:  %[[VAL_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_9:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:  %[[VAL_10:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<i32>) -> i1
+! CHECK:  %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_8]], %[[VAL_9]] : i32
+! CHECK:  %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_8]], %[[VAL_9]] : i32
+! CHECK:  %[[VAL_13:.*]] = fir.if %[[VAL_10]] -> (i32) {
+! CHECK:    %[[VAL_14:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:    %[[VAL_15:.*]] = arith.cmpi sgt, %[[VAL_12]], %[[VAL_14]] : i32
+! CHECK:    %[[VAL_16:.*]] = select %[[VAL_15]], %[[VAL_12]], %[[VAL_14]] : i32
+! CHECK:    fir.result %[[VAL_16]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_12]] : i32
+! CHECK:  }
+! CHECK:  fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[VAL_13]]) : (!fir.ref<i8>, i32) -> i1
+end subroutine 
+
+! CHECK-LABEL: func @_QMmax_testPdynamic_optional_weird(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "c", fir.optional},
+! CHECK-SAME:  %[[VAL_3:.*]]: !fir.ref<i32> {fir.bindc_name = "d"},
+! CHECK-SAME:  %[[VAL_4:.*]]: !fir.ref<i32> {fir.bindc_name = "e", fir.optional}) {
+subroutine dynamic_optional_weird(a, b, c, d, e)
+  integer :: a, b, d
+  integer, optional :: c, e
+  ! a3, a4, a6, a8 statically missing. a5, a9 dynamically optional.
+  print *, max(a1=a, a2=b, a5=c, a7=d, a9 = e)
+! CHECK:  %[[VAL_10:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:  %[[VAL_11:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:  %[[VAL_12:.*]] = fir.is_present %[[VAL_2]] : (!fir.ref<i32>) -> i1
+! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_3]] : !fir.ref<i32>
+! CHECK:  %[[VAL_14:.*]] = fir.is_present %[[VAL_4]] : (!fir.ref<i32>) -> i1
+! CHECK:  %[[VAL_15:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_11]] : i32
+! CHECK:  %[[VAL_16:.*]] = select %[[VAL_15]], %[[VAL_10]], %[[VAL_11]] : i32
+! CHECK:  %[[VAL_17:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:    %[[VAL_18:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:    %[[VAL_19:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_18]] : i32
+! CHECK:    %[[VAL_20:.*]] = select %[[VAL_19]], %[[VAL_16]], %[[VAL_18]] : i32
+! CHECK:    fir.result %[[VAL_20]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_16]] : i32
+! CHECK:  }
+! CHECK:  %[[VAL_21:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_13]] : i32
+! CHECK:  %[[VAL_23:.*]] = select %[[VAL_21]], %[[VAL_17]], %[[VAL_13]] : i32
+! CHECK:  %[[VAL_24:.*]] = fir.if %[[VAL_14]] -> (i32) {
+! CHECK:    %[[VAL_25:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+! CHECK:    %[[VAL_26:.*]] = arith.cmpi sgt, %[[VAL_23]], %[[VAL_25]] : i32
+! CHECK:    %[[VAL_27:.*]] = select %[[VAL_26]], %[[VAL_23]], %[[VAL_25]] : i32
+! CHECK:    fir.result %[[VAL_27]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_23]] : i32
+! CHECK:  }
+! CHECK:  fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[VAL_24]]) : (!fir.ref<i8>, i32) -> i1
+end subroutine 
+end module
+
+  use :: max_test
+  integer :: a(4) = [1,12,23, 34]
+  integer :: b(4) = [31,22,13, 4]
+  integer :: c(4) = [21,32,3, 14]
+  call dynamic_optional(a, b)
+  call dynamic_optional(a, b, c)
+  call dynamic_optional_array_expr_scalar_optional(a, b)
+  call dynamic_optional_array_expr_scalar_optional(a, b, c(2))
+  call dynamic_optional_scalar(a(2), b(2))
+  call dynamic_optional_scalar(a(2), b(2), c(2))
+end


### PR DESCRIPTION
 MIN/MAX/ISHFTC cases cannot fit in the default handling of dynamically
optional arguments because what needs to be done when the argument
is absent in lowering is not simply using a zero value or making a
nullptr.

These intrinsics need custom handling to delay the argument evaluation until the
implementation of the intrinsic code. In the usual framework, all intrinsics
arguments are lowered to ExtendedValue and passed to genIntrinsicCall(xxx).
This does not work here because we cannot pre-evaluate optional arguments to ExtendedValue before
calling the helper generating the intrinsic code.

In this patch, a callback is passed to generate the argument values 
to the intrinsic implementation so that the intrinsic lowering
code can generate the optional argument reference inside regions where
it tested that the argument must be present.

To avoid bloating `ConvertExpr.cpp`, this is done in a new
`CustomIntrinsicCall.cpp` file. This is not done in IntrinsicCall.cpp to keep
this last file independent from lib/Evaluate.
The new utility API is composed of three functions:
- One function to tell if an intrinsic call requires custom handling
- One function to prepare the call before any potential elemental loop nest (analyze
argument presence, prepare lambdas or arguments).
- One function to lower the call given two lambdas: one to access argument at index `i`,
  and one to query about the presence of argument at index `i`.

This may sounds complex, but it allows a single implementation of the intrinsics for the scalar/array case, while allowing to move the code outside of `ConvertExpr.cpp` and abstracting which intrinsics exactly must be handled by this utility.
