### PR TITLE
Emit a proper TODO for missing quad math runtime instead of assert

### DIFF
--- a/flang/test/Lower/intrinsic-procedures/missing-math-runtime.f90
+++ b/flang/test/Lower/intrinsic-procedures/missing-math-runtime.f90
@@ -1,0 +1,16 @@
+! There is no quad math runtime available in lowering
+! for now. Test that the TODO are emitted correctly.
+! RUN: bbc -emit-fir %s -o /dev/null 2>&1 | FileCheck %s
+
+ real(16) :: a, b
+ complex(16) :: z
+! CHECK: TODO: no math runtime available for 'f128 ** f128'
+ call next(a**b)
+! CHECK: TODO: no math runtime available for 'acos(f128)'
+ call next(acos(a))
+! CHECK: TODO: no math runtime available for 'atan2(f128, f128)'
+ call next(atan2(a, b))
+! CHECK: TODO: no math runtime available for '!fir.complex<16> ** !fir.complex<16>'
+ call nextc(a**z)
+end
+


### PR DESCRIPTION
`!bestMatchDistance.isLosingPrecision() && "runtime selection loses precision` was a cryptic way to say that the only math runtime available to lowering for now was not precise enough to implement an intrinsic call. This fires up a lot when dealing with quad math.

Replace that by a proper error message and do not die on the first instance of such intrinsic call, but keep on lowering so that all the spot with unsupported intrinsic call sites can be reported to the user. This will provide a better view to the user of how many parts of his program lack support.

An example of the TODOs is added in the test to illustrate what the user will see (the TODO are prefixed by `error (file:line) :` that do not appear in the test).