### PR TITLE
[flang] Implement the UBOUND intrinsic runtime routine

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Inquiry.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Inquiry.h
@@ -26,6 +26,12 @@ namespace fir::runtime {
 mlir::Value genLboundDim(fir::FirOpBuilder &builder, mlir::Location loc,
                          mlir::Value array, mlir::Value dim);
 
+/// Generate call to general `Ubound` runtime routine.  Calls to UBOUND
+/// with a DIM argument get transformed into an expression equivalent to
+/// SIZE() + LBOUND() - 1, so they don't have an intrinsic in the runtime.
+void genUbound(fir::FirOpBuilder &builder, mlir::Location loc,
+               mlir::Value resultBox, mlir::Value array, mlir::Value kind);
+
 /// Generate call to `Size` runtime routine. This routine is a specialized
 /// version when the DIM argument is not specified by the user.
 mlir::Value genSize(fir::FirOpBuilder &builder, mlir::Location loc,

--- a/flang/include/flang/Runtime/inquiry.h
+++ b/flang/include/flang/Runtime/inquiry.h
@@ -23,6 +23,8 @@ extern "C" {
 
 std::int64_t RTNAME(LboundDim)(const Descriptor &array, int dim,
     const char *sourceFile = nullptr, int line = 0);
+void RTNAME(Ubound)(Descriptor &result, const Descriptor &descriptor, int kind,
+    const char *sourceFile = nullptr, int line = 0);
 std::int64_t RTNAME(Size)(
     const Descriptor &array, const char *sourceFile = nullptr, int line = 0);
 std::int64_t RTNAME(SizeDim)(const Descriptor &array, int dim,

--- a/flang/lib/Optimizer/Builder/Runtime/Inquiry.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Inquiry.cpp
@@ -28,6 +28,23 @@ mlir::Value fir::runtime::genLboundDim(fir::FirOpBuilder &builder,
   return builder.create<fir::CallOp>(loc, lboundFunc, args).getResult(0);
 }
 
+/// Generate call to `Ubound` runtime routine.  Calls to UBOUND with a DIM
+/// argument get transformed into an expression equivalent to
+/// SIZE() + LBOUND() - 1, so they don't have an intrinsic in the runtime.
+void fir::runtime::genUbound(fir::FirOpBuilder &builder, mlir::Location loc,
+                             mlir::Value resultBox, mlir::Value array,
+                             mlir::Value kind) {
+  mlir::FuncOp uboundFunc =
+      fir::runtime::getRuntimeFunc<mkRTKey(Ubound)>(loc, builder);
+  auto fTy = uboundFunc.getType();
+  auto sourceFile = fir::factory::locationToFilename(builder, loc);
+  auto sourceLine =
+      fir::factory::locationToLineNo(builder, loc, fTy.getInput(2));
+  auto args = fir::runtime::createArguments(builder, loc, fTy, resultBox, array,
+                                            kind, sourceFile, sourceLine);
+  builder.create<fir::CallOp>(loc, uboundFunc, args).getResult(0);
+}
+
 /// Generate call to `Size` runtime routine. This routine is a version when
 /// the DIM argument is present.
 mlir::Value fir::runtime::genSizeDim(fir::FirOpBuilder &builder,

--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -182,15 +182,6 @@ count_t GetSystemClockCountMax(int kind, preferred_implementation,
 
 // DATE_AND_TIME (Fortran 2018 16.9.59)
 
-// Helper to store integer value in result[at].
-template <int KIND> struct StoreIntegerAt {
-  void operator()(const Fortran::runtime::Descriptor &result, std::size_t at,
-      std::int64_t value) const {
-    *result.ZeroBasedIndexedElement<Fortran::runtime::CppTypeFor<
-        Fortran::common::TypeCategory::Integer, KIND>>(at) = value;
-  }
-};
-
 // Helper to set an integer value to -HUGE
 template <int KIND> struct StoreNegativeHugeAt {
   void operator()(
@@ -319,8 +310,8 @@ static void GetDateAndTime(Fortran::runtime::Terminator &terminator, char *date,
     int kind{typeCode->second};
     RUNTIME_CHECK(terminator, kind != 1);
     auto storeIntegerAt = [&](std::size_t atIndex, std::int64_t value) {
-      Fortran::runtime::ApplyIntegerKind<StoreIntegerAt, void>(
-          kind, terminator, *values, atIndex, value);
+      Fortran::runtime::ApplyIntegerKind<Fortran::runtime::StoreIntegerAt,
+          void>(kind, terminator, *values, atIndex, value);
     };
     storeIntegerAt(0, localTime.tm_year + 1900);
     storeIntegerAt(1, localTime.tm_mon + 1);

--- a/flang/runtime/tools.h
+++ b/flang/runtime/tools.h
@@ -56,6 +56,15 @@ void CheckConformability(const Descriptor &to, const Descriptor &x,
     Terminator &, const char *funcName, const char *toName,
     const char *fromName);
 
+// Helper to store integer value in result[at].
+template <int KIND> struct StoreIntegerAt {
+  void operator()(const Fortran::runtime::Descriptor &result, std::size_t at,
+      std::int64_t value) const {
+    *result.ZeroBasedIndexedElement<Fortran::runtime::CppTypeFor<
+        Fortran::common::TypeCategory::Integer, KIND>>(at) = value;
+  }
+};
+
 // Validate a KIND= argument
 void CheckIntegerKind(Terminator &, int kind, const char *intrinsic);
 

--- a/flang/unittests/Runtime/Inquiry.cpp
+++ b/flang/unittests/Runtime/Inquiry.cpp
@@ -26,6 +26,44 @@ TEST(Inquiry, Lbound) {
   EXPECT_EQ(RTNAME(LboundDim)(*array, 2, __FILE__, __LINE__), std::int64_t{-1});
 }
 
+TEST(Inquiry, Ubound) {
+  // ARRAY  1 3 5
+  //        2 4 6
+  auto array{MakeArray<TypeCategory::Integer, 4>(
+      std::vector<int>{2, 3}, std::vector<std::int32_t>{1, 2, 3, 4, 5, 6})};
+  array->GetDimension(0).SetLowerBound(1000);
+  array->GetDimension(1).SetLowerBound(1);
+  StaticDescriptor<2, true> statDesc;
+
+  int intValue{1};
+  SubscriptValue extent[]{2};
+  Descriptor &result{statDesc.descriptor()};
+  result.Establish(TypeCategory::Integer, /*KIND=*/4,
+      static_cast<void *>(&intValue), 1, extent, CFI_attribute_pointer);
+  RTNAME(Ubound)(result, *array, /*KIND=*/4, __FILE__, __LINE__);
+  EXPECT_EQ(result.rank(), 1);
+  EXPECT_EQ(result.type().raw(), (TypeCode{TypeCategory::Integer, 4}.raw()));
+  // The lower bound of UBOUND's result array is always 1
+  EXPECT_EQ(result.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(result.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*result.ZeroBasedIndexedElement<std::int32_t>(0), 1001);
+  EXPECT_EQ(*result.ZeroBasedIndexedElement<std::int32_t>(1), 3);
+  result.Destroy();
+
+  result = statDesc.descriptor();
+  result.Establish(TypeCategory::Integer, /*KIND=*/1,
+      static_cast<void *>(&intValue), 1, extent, CFI_attribute_pointer);
+  RTNAME(Ubound)(result, *array, /*KIND=*/1, __FILE__, __LINE__);
+  EXPECT_EQ(result.rank(), 1);
+  EXPECT_EQ(result.type().raw(), (TypeCode{TypeCategory::Integer, 1}.raw()));
+  // The lower bound of UBOUND's result array is always 1
+  EXPECT_EQ(result.GetDimension(0).LowerBound(), 1);
+  EXPECT_EQ(result.GetDimension(0).Extent(), 2);
+  EXPECT_EQ(*result.ZeroBasedIndexedElement<std::int8_t>(0), -23);
+  EXPECT_EQ(*result.ZeroBasedIndexedElement<std::int8_t>(1), 3);
+  result.Destroy();
+}
+
 TEST(Inquiry, Size) {
   // ARRAY  1 3 5
   //        2 4 6


### PR DESCRIPTION
When UBOUND is called with its actual argument for ARRAY is a function call,
the appropriate runtime routine did not exist.  I implemented the processing of
the call in lowering, the runtime routine, the glue code, and a couple of
tests.