### PR TITLE
Revert "Enable CI on Linux"

### DIFF
--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         os:
           - macOS-latest
-          - ubuntu-latest
     steps:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main


### PR DESCRIPTION
Reverts flang-compiler/f18-llvm-project#1449

The linux CI runs on a machine with lower memory resources and can fail, hence reverting.