### PR TITLE
[flang] Cleanup FIRType.h and FIRType.cpp

### DIFF
--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -244,8 +244,7 @@ public:
   bool isDerived() const { return getEleTy().isa<fir::RecordType>(); };
 
   bool isDerivedWithLengthParameters() const {
-    auto record = getEleTy().dyn_cast<fir::RecordType>();
-    return record && record.getNumLenParams() != 0;
+    return fir::isRecordWithTypeParameters(getEleTy());
   };
   /// Is this a CLASS(*)/TYPE(*) ?
   bool isUnlimitedPolymorphic() const {

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -162,16 +162,6 @@ inline bool sequenceWithNonConstantShape(fir::SequenceType seqTy) {
 /// Returns true iff the type `t` does not have a constant size.
 bool hasDynamicSize(mlir::Type t);
 
-inline unsigned getRankOfShapeType(mlir::Type t) {
-  if (auto shTy = t.dyn_cast<fir::ShapeType>())
-    return shTy.getRank();
-  if (auto shTy = t.dyn_cast<fir::ShapeShiftType>())
-    return shTy.getRank();
-  if (auto shTy = t.dyn_cast<fir::ShiftType>())
-    return shTy.getRank();
-  return 0;
-}
-
 /// If `t` is a SequenceType return its element type, otherwise return `t`.
 inline mlir::Type unwrapSequenceType(mlir::Type t) {
   if (auto seqTy = t.dyn_cast<fir::SequenceType>())
@@ -193,22 +183,6 @@ inline mlir::Type unwrapPassByRefType(mlir::Type t) {
   return t;
 }
 
-/// Unwrap all pointer and box types and return the element type if it is a
-/// sequence type, otherwise return null.
-inline fir::SequenceType unwrapUntilSeqType(mlir::Type t) {
-  while (true) {
-    if (!t)
-      return {};
-    if (auto ty = dyn_cast_ptrOrBoxEleTy(t)) {
-      t = ty;
-      continue;
-    }
-    if (auto seqTy = t.dyn_cast<fir::SequenceType>())
-      return seqTy;
-    return {};
-  }
-}
-
 #ifndef NDEBUG
 // !fir.ptr<X> and !fir.heap<X> where X is !fir.ptr, !fir.heap, or !fir.ref
 // is undefined and disallowed.
@@ -217,26 +191,11 @@ inline bool singleIndirectionLevel(mlir::Type ty) {
 }
 #endif
 
-/// Return true iff `ty` is the type of a POINTER entity or value.
-/// `isa_ref_type()` can be used to distinguish.
-bool isPointerType(mlir::Type ty);
-
 /// Return true iff `ty` is the type of an ALLOCATABLE entity or value.
 bool isAllocatableType(mlir::Type ty);
 
-/// Return true iff `ty` is the type of an unlimited polymorphic entity or
-/// value.
-bool isUnlimitedPolymorphicType(mlir::Type ty);
-
 /// Return true iff `ty` is a RecordType with members that are allocatable.
 bool isRecordWithAllocatableMember(mlir::Type ty);
-
-/// Return true iff `ty` is a RecordType with type parameters.
-inline bool isRecordWithTypeParameters(mlir::Type ty) {
-  if (auto recTy = ty.dyn_cast_or_null<fir::RecordType>())
-    return recTy.getNumLenParams() != 0;
-  return false;
-}
 
 /// Apply the components specified by `path` to `rootTy` to determine the type
 /// of the resulting component element. `rootTy` should be an aggregate type.

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -197,6 +197,13 @@ bool isAllocatableType(mlir::Type ty);
 /// Return true iff `ty` is a RecordType with members that are allocatable.
 bool isRecordWithAllocatableMember(mlir::Type ty);
 
+/// Return true iff `ty` is a RecordType with type parameters.
+inline bool isRecordWithTypeParameters(mlir::Type ty) {
+  if (auto recTy = ty.dyn_cast_or_null<fir::RecordType>())
+    return recTy.getNumLenParams() != 0;
+  return false;
+}
+
 /// Apply the components specified by `path` to `rootTy` to determine the type
 /// of the resulting component element. `rootTy` should be an aggregate type.
 /// Returns null on error.

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -246,27 +246,11 @@ bool hasDynamicSize(mlir::Type t) {
   return false;
 }
 
-bool isPointerType(mlir::Type ty) {
-  if (auto refTy = fir::dyn_cast_ptrEleTy(ty))
-    ty = refTy;
-  if (auto boxTy = ty.dyn_cast<fir::BoxType>())
-    return boxTy.getEleTy().isa<fir::PointerType>();
-  return false;
-}
-
 bool isAllocatableType(mlir::Type ty) {
   if (auto refTy = fir::dyn_cast_ptrEleTy(ty))
     ty = refTy;
   if (auto boxTy = ty.dyn_cast<fir::BoxType>())
     return boxTy.getEleTy().isa<fir::HeapType>();
-  return false;
-}
-
-bool isUnlimitedPolymorphicType(mlir::Type ty) {
-  if (auto refTy = fir::dyn_cast_ptrEleTy(ty))
-    ty = refTy;
-  if (auto boxTy = ty.dyn_cast<fir::BoxType>())
-    return boxTy.getEleTy().isa<mlir::NoneType>();
   return false;
 }
 


### PR DESCRIPTION
While looking at differences between fir-dev and upstream for the upstreaming process I noticed that these functions are not used. I propose to get rid of them unless there is a good reason. These functions are not upstreamed and will probably not be upstreamed if they are not useful. 