### PR TITLE
Fix LEN intrinsics with allocatable and assumed shapes

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1366,7 +1366,7 @@ fir::ExtendedValue toExtendedValue(mlir::Value val, fir::FirOpBuilder &builder,
     if (extents.size() + 1 < arrayType.getShape().size())
       mlir::emitError(loc, "cannot retrieve array extents from type");
   } else if (type.isa<fir::BoxType>() || type.isa<fir::RecordType>()) {
-    mlir::emitError(loc, "descriptor or derived type not yet handled");
+    fir::emitFatalError(loc, "descriptor or derived type not yet handled");
   }
 
   if (!extents.empty())
@@ -2733,14 +2733,7 @@ IntrinsicLibrary::genLen(mlir::Type resultType,
                          llvm::ArrayRef<fir::ExtendedValue> args) {
   // Optional KIND argument reflected in result type and otherwise ignored.
   assert(args.size() == 1 || args.size() == 2);
-  mlir::Value len = args[0].match(
-      [](const fir::CharBoxValue &box) { return box.getLen(); },
-      [](const fir::CharArrayBoxValue &box) { return box.getLen(); },
-      [&](const auto &) {
-        return fir::factory::CharacterExprHelper(builder, loc)
-            .createUnboxChar(fir::getBase(args[0]))
-            .second;
-      });
+  mlir::Value len = fir::factory::readCharLen(builder, loc, args[0]);
   return builder.createConvert(loc, resultType, len);
 }
 

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -541,10 +541,9 @@ mlir::Value fir::factory::readCharLen(fir::FirOpBuilder &builder,
         return fir::factory::CharacterExprHelper{builder, loc}
             .readLengthFromBox(x.getAddr());
       },
-      [&](const fir::MutableBoxValue &) -> mlir::Value {
-        // MutableBoxValue must be read into another category to work with them
-        // outside of allocation/assignment contexts.
-        fir::emitFatalError(loc, "readCharLen on MutableBoxValue");
+      [&](const fir::MutableBoxValue &x) -> mlir::Value {
+        return readCharLen(builder, loc,
+                           fir::factory::genMutableBoxRead(builder, loc, x));
       },
       [&](const auto &) -> mlir::Value {
         fir::emitFatalError(
@@ -575,16 +574,16 @@ mlir::Value fir::factory::readExtent(fir::FirOpBuilder &builder,
             .getResult(1);
       },
       [&](const fir::MutableBoxValue &x) -> mlir::Value {
-        // MutableBoxValue must be read into another category to work with them
-        // outside of allocation/assignment contexts.
-        fir::emitFatalError(loc, "readExtents on MutableBoxValue");
+        return readExtent(builder, loc,
+                          fir::factory::genMutableBoxRead(builder, loc, x),
+                          dim);
       },
       [&](const auto &) -> mlir::Value {
         fir::emitFatalError(loc, "extent inquiry on scalar");
       });
 }
 
-mlir::Value fir::factory::readLowerBound(fir::FirOpBuilder &,
+mlir::Value fir::factory::readLowerBound(fir::FirOpBuilder &builder,
                                          mlir::Location loc,
                                          const fir::ExtendedValue &box,
                                          unsigned dim,
@@ -600,10 +599,10 @@ mlir::Value fir::factory::readLowerBound(fir::FirOpBuilder &,
       [&](const fir::BoxValue &x) -> mlir::Value {
         return x.getLBounds().empty() ? mlir::Value{} : x.getLBounds()[dim];
       },
-      [&](const fir::MutableBoxValue &) -> mlir::Value {
-        // MutableBoxValue must be read into another category to work with them
-        // outside of allocation/assignment contexts.
-        fir::emitFatalError(loc, "readLowerBound on MutableBoxValue");
+      [&](const fir::MutableBoxValue &x) -> mlir::Value {
+        return readLowerBound(builder, loc,
+                              fir::factory::genMutableBoxRead(builder, loc, x),
+                              dim, defaultValue);
       },
       [&](const auto &) -> mlir::Value {
         fir::emitFatalError(loc, "lower bound inquiry on scalar");

--- a/flang/test/Lower/intrinsic-procedures/len.f90
+++ b/flang/test/Lower/intrinsic-procedures/len.f90
@@ -20,3 +20,57 @@ subroutine len_test_array(i, c)
   ! CHECK: fir.store %[[xx]] to %[[arg0]]
   i = len(c)
 end subroutine
+
+! CHECK-LABEL: func @_QPlen_test_assumed_shape_array(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?x!fir.char<1,?>>> {fir.bindc_name = "c"}) {
+subroutine len_test_assumed_shape_array(i, c)
+  integer :: i
+  character(*) :: c(:)
+! CHECK:  %[[VAL_2:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (index) -> i32
+! CHECK:  fir.store %[[VAL_3]] to %[[VAL_0]] : !fir.ref<i32>
+  i = len(c)
+end subroutine
+
+! CHECK-LABEL: func @_QPlen_test_array_alloc(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "c"}) {
+subroutine len_test_array_alloc(i, c)
+  integer :: i
+  character(:), allocatable :: c(:)
+! CHECK:  %[[VAL_2:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:  %[[VAL_3:.*]] = fir.box_elesize %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (index) -> i32
+! CHECK:  fir.store %[[VAL_4]] to %[[VAL_0]] : !fir.ref<i32>
+  i = len(c)
+end subroutine
+
+! CHECK-LABEL: func @_QPlen_test_array_local_alloc(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"})
+subroutine len_test_array_local_alloc(i)
+  integer :: i
+  character(:), allocatable :: c(:)
+! CHECK:  %[[VAL_5:.*]] = fir.alloca index {uniq_name = "_QFlen_test_array_local_allocEc.len"}
+! CHECK:  %[[VAL_7:.*]] = arith.constant 10 : i32
+! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (i32) -> index
+! CHECK:  fir.store %[[VAL_10]] to %[[VAL_5]] : !fir.ref<index>
+  allocate(character(10):: c(100))
+! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_5]] : !fir.ref<index>
+! CHECK:  %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (index) -> i32
+! CHECK:  fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
+  i = len(c)
+end subroutine
+
+! CHECK-LABEL: func @_QPlen_test_alloc_explicit_len(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "i"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "n"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "c"}) {
+subroutine len_test_alloc_explicit_len(i, n, c)
+  integer :: i
+  integer :: n
+  character(n), allocatable :: c(:)
+! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:  fir.store %[[VAL_3]] to %[[VAL_0]] : !fir.ref<i32>
+  i = len(c)
+end subroutine


### PR DESCRIPTION
Follow up of #1450.

Still related to recent change that triggered an untested code path
to be used (intrinsic LEN used to be rewritten in most cases). The old
`genLen` code that was never properly tested was broken.

Add tests, and allow some other `fir::factory` inquiry helper to work
with MutableBox to be more future proof.