### PR TITLE
[flang] Sync'ing changes in inquiry intrinsics after upstreaming

### DIFF
--- a/flang/include/flang/Runtime/inquiry.h
+++ b/flang/include/flang/Runtime/inquiry.h
@@ -23,7 +23,7 @@ extern "C" {
 
 std::int64_t RTNAME(LboundDim)(const Descriptor &array, int dim,
     const char *sourceFile = nullptr, int line = 0);
-void RTNAME(Ubound)(Descriptor &result, const Descriptor &descriptor, int kind,
+void RTNAME(Ubound)(Descriptor &result, const Descriptor &array, int kind,
     const char *sourceFile = nullptr, int line = 0);
 std::int64_t RTNAME(Size)(
     const Descriptor &array, const char *sourceFile = nullptr, int line = 0);

--- a/flang/runtime/inquiry.cpp
+++ b/flang/runtime/inquiry.cpp
@@ -56,7 +56,7 @@ void RTNAME(Ubound)(Descriptor &result, const Descriptor &array, int kind,
 
 std::int64_t RTNAME(Size)(
     const Descriptor &array, const char *sourceFile, int line) {
-  SubscriptValue result{1};
+  std::int64_t result{1};
   for (int i = 0; i < array.rank(); ++i) {
     const Dimension &dimension{array.GetDimension(i)};
     result *= dimension.Extent();


### PR DESCRIPTION
When I upstreamed the runtime changes for the inquiry intrinsics, Peter
requested some changes.  This update syncs those changes back to
fir-dev.

Associated changes for lowering have already been merged into fir-dev.