### PR TITLE
Use boxproc abstraction.

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Character.h
+++ b/flang/include/flang/Optimizer/Builder/Character.h
@@ -14,7 +14,11 @@
 #define FORTRAN_OPTIMIZER_BUILDER_CHARACTER_H
 
 #include "flang/Optimizer/Builder/BoxValue.h"
-#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/LowLevelIntrinsics.h"
+
+namespace fir {
+class FirOpBuilder;
+}
 
 namespace fir::factory {
 
@@ -190,24 +194,6 @@ private:
   mlir::Location loc;
 };
 
-/// Get the LLVM intrinsic for `memcpy`. Use the 64 bit version.
-mlir::FuncOp getLlvmMemcpy(FirOpBuilder &builder);
-
-/// Get the LLVM intrinsic for `memmove`. Use the 64 bit version.
-mlir::FuncOp getLlvmMemmove(FirOpBuilder &builder);
-
-/// Get the LLVM intrinsic for `memset`. Use the 64 bit version.
-mlir::FuncOp getLlvmMemset(FirOpBuilder &builder);
-
-/// Get the C standard library `realloc` function.
-mlir::FuncOp getRealloc(FirOpBuilder &builder);
-
-/// Get the `llvm.stacksave` intrinsic.
-mlir::FuncOp getLlvmStackSave(FirOpBuilder &builder);
-
-/// Get the `llvm.stackrestore` intrinsic.
-mlir::FuncOp getLlvmStackRestore(FirOpBuilder &builder);
-
 //===----------------------------------------------------------------------===//
 // Tools to work with Character dummy procedures
 //===----------------------------------------------------------------------===//
@@ -216,15 +202,6 @@ mlir::FuncOp getLlvmStackRestore(FirOpBuilder &builder);
 /// as arguments along their length. The function type set in the tuple is the
 /// one provided by \p funcPointerType.
 mlir::Type getCharacterProcedureTupleType(mlir::Type funcPointerType);
-
-/// Is this tuple type holding a character function and its result length ?
-bool isCharacterProcedureTuple(mlir::Type type);
-
-/// Is \p tuple a value holding a character function address and its result
-/// length ?
-inline bool isCharacterProcedureTuple(mlir::Value tuple) {
-  return isCharacterProcedureTuple(tuple.getType());
-}
 
 /// Create a tuple<addr, len> given \p addr and \p len as well as the tuple
 /// type \p argTy. \p addr must be any function address, and \p len must be

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -108,6 +108,10 @@ public:
   /// Get the mlir float type that implements Fortran REAL(kind).
   mlir::Type getRealType(int kind);
 
+  fir::BoxProcType getBoxProcType(mlir::FunctionType funcTy) {
+    return fir::BoxProcType::get(getContext(), funcTy);
+  }
+
   /// Create a null constant memory reference of type \p ptrType.
   /// If \p ptrType is not provided, !fir.ref<none> type will be used.
   mlir::Value createNullConstant(mlir::Location loc, mlir::Type ptrType = {});
@@ -217,9 +221,16 @@ public:
   mlir::FuncOp getNamedFunction(llvm::StringRef name) {
     return getNamedFunction(getModule(), name);
   }
-
   static mlir::FuncOp getNamedFunction(mlir::ModuleOp module,
                                        llvm::StringRef name);
+
+  /// Get a function by symbol name. The result will be null if there is no
+  /// function with the given symbol in the module.
+  mlir::FuncOp getNamedFunction(mlir::SymbolRefAttr symbol) {
+    return getNamedFunction(getModule(), symbol);
+  }
+  static mlir::FuncOp getNamedFunction(mlir::ModuleOp module,
+                                       mlir::SymbolRefAttr symbol);
 
   fir::GlobalOp getNamedGlobal(llvm::StringRef name) {
     return getNamedGlobal(getModule(), name);

--- a/flang/include/flang/Optimizer/Builder/LowLevelIntrinsics.h
+++ b/flang/include/flang/Optimizer/Builder/LowLevelIntrinsics.h
@@ -1,0 +1,51 @@
+//===-- LowLevelIntrinsics.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FLANG_OPTIMIZER_BUILDER_LOWLEVELINTRINSICS_H
+#define FLANG_OPTIMIZER_BUILDER_LOWLEVELINTRINSICS_H
+
+namespace mlir {
+class FuncOp;
+}
+namespace fir {
+class FirOpBuilder;
+}
+
+namespace fir::factory {
+
+/// Get the LLVM intrinsic for `memcpy`. Use the 64 bit version.
+mlir::FuncOp getLlvmMemcpy(FirOpBuilder &builder);
+
+/// Get the LLVM intrinsic for `memmove`. Use the 64 bit version.
+mlir::FuncOp getLlvmMemmove(FirOpBuilder &builder);
+
+/// Get the LLVM intrinsic for `memset`. Use the 64 bit version.
+mlir::FuncOp getLlvmMemset(FirOpBuilder &builder);
+
+/// Get the C standard library `realloc` function.
+mlir::FuncOp getRealloc(FirOpBuilder &builder);
+
+/// Get the `llvm.stacksave` intrinsic.
+mlir::FuncOp getLlvmStackSave(FirOpBuilder &builder);
+
+/// Get the `llvm.stackrestore` intrinsic.
+mlir::FuncOp getLlvmStackRestore(FirOpBuilder &builder);
+
+/// Get the `llvm.init.trampoline` intrinsic.
+mlir::FuncOp getLlvmInitTrampoline(FirOpBuilder &builder);
+
+/// Get the `llvm.adjust.trampoline` intrinsic.
+mlir::FuncOp getLlvmAdjustTrampoline(FirOpBuilder &builder);
+
+} // namespace fir::factory
+
+#endif // FLANG_OPTIMIZER_BUILDER_LOWLEVELINTRINSICS_H

--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -64,4 +64,14 @@ def TargetRewrite : Pass<"target-rewrite", "mlir::ModuleOp"> {
   ];
 }
 
+def ProcedurePointerPass : Pass<"procedure-pointer", "mlir::ModuleOp"> {
+  let constructor = "::fir::createProcedurePointerPass()";
+  let options = [
+    Option<"useThunks", "use-thunks",
+           "bool", /*default=*/"true",
+           "Convert procedure pointer abstractions to a single code pointer, "
+           "deploying thunks wherever required.">
+  ];
+}
+
 #endif // FORTRAN_OPTIMIZER_CODEGEN_FIR_PASSES

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -46,6 +46,9 @@ std::unique_ptr<mlir::Pass> createLLVMDialectToLLVMPass(
     LLVMIRLoweringPrinter printer =
         [](llvm::Module &m, llvm::raw_ostream &out) { m.print(out, nullptr); });
 
+std::unique_ptr<mlir::Pass> createProcedurePointerPass();
+std::unique_ptr<mlir::Pass> createProcedurePointerPass(bool useThunks);
+
 // declarative passes
 #define GEN_PASS_REGISTRATION
 #include "flang/Optimizer/CodeGen/CGPasses.h.inc"

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -981,7 +981,8 @@ def fir_EmboxProcOp : fir_Op<"emboxproc", [NoSideEffect]> {
     then the form takes only the procedure's symbol.
 
     ```mlir
-      %0 = fir.emboxproc @f : ((i32) -> i32) -> !fir.boxproc<(i32) -> i32>
+      %f = ... : (i32) -> i32
+      %0 = fir.emboxproc %f : ((i32) -> i32) -> !fir.boxproc<(i32) -> i32>
     ```
 
     An internal procedure requiring a host instance for correct execution uses
@@ -991,20 +992,24 @@ def fir_EmboxProcOp : fir_Op<"emboxproc", [NoSideEffect]> {
     promotion of local values.
 
     ```mlir
-      %4 = ... : !fir.ref<tuple<i32, i32>>
-      %5 = fir.emboxproc @g, %4 : ((i32) -> i32, !fir.ref<tuple<i32, i32>>) -> !fir.boxproc<(i32) -> i32>
+      %4 = ... : !fir.ref<tuple<!fir.ref<i32>, !fir.ref<i32>>>
+      %g = ... : (i32) -> i32
+      %5 = fir.emboxproc %g, %4 : ((i32) -> i32, !fir.ref<tuple<!fir.ref<i32>, !fir.ref<i32>>>) -> !fir.boxproc<(i32) -> i32>
     ```
   }];
 
-  let arguments = (ins SymbolRefAttr:$funcname, AnyReferenceLike:$host);
-
+  let arguments = (ins FuncType:$func, Optional<fir_ReferenceType>:$host);
   let results = (outs fir_BoxProcType);
 
-  let parser = "return parseEmboxProcOp(parser, result);";
-
-  let printer = "::print(p, *this);";
+  let assemblyFormat = [{
+    $func (`,` $host^)? attr-dict `:` functional-type(operands, results)
+  }];
 
   let verifier = "return ::verify(*this);";
+
+  let extraClassDeclaration = [{
+    mlir::Value host() const { return {}; }
+  }];
 }
 
 def fir_UnboxCharOp : fir_SimpleOp<"unboxchar", [NoSideEffect]> {
@@ -1057,13 +1062,13 @@ def fir_BoxAddrOp : fir_SimpleOneResultOp<"box_addr", [NoSideEffect]> {
     ```mlir
       %51 = fir.box_addr %box : (!fir.box<f64>) -> !fir.ref<f64>
       %52 = fir.box_addr %boxchar : (!fir.boxchar<1>) -> !fir.ref<!fir.char<1>>
-      %53 = fir.box_addr %boxproc : (!fir.boxproc<!P>) -> !fir.ref<!P>
+      %53 = fir.box_addr %boxproc : (!fir.boxproc<!P>) -> !P
     ```
   }];
 
-  let arguments = (ins fir_BoxType:$val);
+  let arguments = (ins AnyBoxLike:$val);
 
-  let results = (outs AnyReferenceLike);
+  let results = (outs AnyCodeOrDataRefLike);
 
   let hasFolder = 1;
 }

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -238,6 +238,9 @@ inline bool isRecordWithTypeParameters(mlir::Type ty) {
   return false;
 }
 
+/// Is this tuple type holding a character function and its result length ?
+bool isCharacterProcedureTuple(mlir::Type type, bool acceptRawFunc = true);
+
 /// Apply the components specified by `path` to `rootTy` to determine the type
 /// of the resulting component element. `rootTy` should be an aggregate type.
 /// Returns null on error.

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -552,6 +552,11 @@ def AnyReferenceLike : TypeConstraint<Or<[fir_ReferenceType.predicate,
     fir_HeapType.predicate, fir_PointerType.predicate,
     fir_LLVMPointerType.predicate]>, "any reference">;
 
+def FuncType : TypeConstraint<FunctionType.predicate, "function type">;
+
+def AnyCodeOrDataRefLike : TypeConstraint<Or<[AnyReferenceLike.predicate,
+    FunctionType.predicate]>, "any code or data reference">;
+
 def RefOrLLVMPtr : TypeConstraint<Or<[fir_ReferenceType.predicate,
     fir_LLVMPointerType.predicate]>, "fir.ref or fir.llvm_ptr">;
 

--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -51,6 +51,8 @@ DisableOption(CodeGenRewrite, "codegen-rewrite", "rewrite FIR for codegen");
 DisableOption(TargetRewrite, "target-rewrite", "rewrite FIR for target");
 DisableOption(FirToLlvmIr, "fir-to-llvmir", "FIR to LLVM-IR dialect");
 DisableOption(LlvmIrToLlvm, "llvm", "conversion to LLVM");
+DisableOption(ProcedurePointerRewrite, "procedure-pointer-rewrite",
+    "rewrite abstract procedure pointers");
 #endif
 
 /// Generic for adding a pass to the pass manager if it is not disabled.
@@ -121,6 +123,11 @@ inline void addLLVMDialectToLLVMPass(
   addPassConditionally(pm, disableLlvmIrToLlvm,
       [&]() { return fir::createLLVMDialectToLLVMPass(output); });
 }
+
+inline void addProcedurePointerPass(mlir::PassManager &pm) {
+  addPassConditionally(pm, disableProcedurePointerRewrite,
+      [&]() { return fir::createProcedurePointerPass(); });
+}
 #endif
 
 /// Create a pass pipeline for running default optimization passes for
@@ -158,6 +165,7 @@ inline void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm) {
 
 #if !defined(FLANG_EXCLUDE_CODEGEN)
 inline void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm) {
+  fir::addProcedurePointerPass(pm);
   pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
   fir::addCodeGenRewritePass(pm);
   fir::addTargetRewritePass(pm);

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -38,14 +38,18 @@ mlir::Type getProcedureDesignatorType(
     const Fortran::evaluate::characteristics::Procedure *,
     Fortran::lower::AbstractConverter &converter) {
   // TODO: Get actual function type of the dummy procedure, at least when an
-  // interface is given.
+  // interface is given. The result type should be available even if the arity
+  // and type of the arguments is not.
+  llvm::SmallVector<mlir::Type> resultTys;
+  llvm::SmallVector<mlir::Type> inputTys;
   // In general, that is a nice to have but we cannot guarantee to find the
   // function type that will match the one of the calls, we may not even know
   // how many arguments the dummy procedure accepts (e.g. if a procedure
   // pointer is only transiting through the current procedure without being
   // called), so a function type cast must always be inserted.
-  return mlir::FunctionType::get(&converter.getMLIRContext(), llvm::None,
-                                 llvm::None);
+  auto *context = &converter.getMLIRContext();
+  auto untypedFunc = mlir::FunctionType::get(context, inputTys, resultTys);
+  return fir::BoxProcType::get(context, untypedFunc);
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -490,6 +490,42 @@ struct InitializerData {
   bool genRawVals;    // generate the rawVals vector if set.
 };
 
+/// If \p arg is the address of a function with a denoted host-association tuple
+/// argument, then return the host-associations tuple value of the current
+/// procedure. Otherwise, return nullptr.
+static mlir::Value
+argumentHostAssocs(Fortran::lower::AbstractConverter &converter,
+                   mlir::Value arg) {
+  if (auto addr = mlir::dyn_cast_or_null<fir::AddrOfOp>(arg.getDefiningOp())) {
+    auto &builder = converter.getFirOpBuilder();
+    if (auto funcOp = builder.getNamedFunction(addr.symbol()))
+      if (fir::anyFuncArgsHaveAttr(funcOp, fir::getHostAssocAttrName()))
+        return converter.hostAssocTupleValue();
+  }
+  return {};
+}
+
+/// \p argTy must be a tuple (pair) of boxproc and integral types. Convert the
+/// \p funcAddr argument to a boxproc value, with the host-association as
+/// required. Call the factory function to finish creating the tuple value.
+static mlir::Value
+createBoxProcCharTuple(Fortran::lower::AbstractConverter &converter,
+                       mlir::Type argTy, mlir::Value funcAddr,
+                       mlir::Value charLen) {
+  auto boxTy =
+      argTy.cast<mlir::TupleType>().getType(0).cast<fir::BoxProcType>();
+  mlir::Location loc = converter.getCurrentLocation();
+  auto &builder = converter.getFirOpBuilder();
+  auto boxProc = [&]() -> mlir::Value {
+    if (auto host = argumentHostAssocs(converter, funcAddr))
+      return builder.create<fir::EmboxProcOp>(
+          loc, boxTy, llvm::ArrayRef<mlir::Value>{funcAddr, host});
+    return builder.create<fir::EmboxProcOp>(loc, boxTy, funcAddr);
+  }();
+  return fir::factory::createCharacterProcedureTuple(builder, loc, argTy,
+                                                     boxProc, charLen);
+}
+
 namespace {
 
 /// Lowering of Fortran::evaluate::Expr<T> expressions
@@ -734,7 +770,8 @@ public:
       Fortran::lower::SymbolBox val = symMap.lookupSymbol(*symbol);
       assert(val && "Dummy procedure not in symbol map");
       funcPtr = val.getAddr();
-      if (fir::factory::isCharacterProcedureTuple(funcPtr))
+      if (fir::isCharacterProcedureTuple(funcPtr.getType(),
+                                         /*acceptRawFunc=*/false))
         std::tie(funcPtr, funcPtrResultLength) =
             fir::factory::extractCharacterProcedureTuple(builder, loc, funcPtr);
     } else {
@@ -2239,7 +2276,8 @@ public:
       funcPointer = symMap.lookupSymbol(*sym).getAddr();
       if (!funcPointer)
         fir::emitFatalError(loc, "failed to find indirect call symbol address");
-      if (fir::factory::isCharacterProcedureTuple(funcPointer))
+      if (fir::isCharacterProcedureTuple(funcPointer.getType(),
+                                         /*acceptRawFunc=*/false))
         std::tie(funcPointer, charFuncPointerLength) =
             fir::factory::extractCharacterProcedureTuple(builder, loc,
                                                          funcPointer);
@@ -2390,8 +2428,12 @@ public:
     // required function type for the call to handle procedures that have a
     // compatible interface in Fortran, but that have different signatures in
     // FIR.
-    if (funcPointer)
-      operands.push_back(builder.createConvert(loc, funcType, funcPointer));
+    if (funcPointer) {
+      operands.push_back(
+          funcPointer.getType().isa<fir::BoxProcType>()
+              ? builder.create<fir::BoxAddrOp>(loc, funcType, funcPointer)
+              : builder.createConvert(loc, funcType, funcPointer));
+    }
 
     // Deal with potential mismatches in arguments types. Passing an array to a
     // scalar argument should for instance be tolerated here.
@@ -2401,8 +2443,22 @@ public:
       // When passing arguments to a procedure that can be called an implicit
       // interface, allow character actual arguments to be passed to dummy
       // arguments of any type and vice versa
-      mlir::Value cast = builder.convertWithSemantics(getLoc(), snd, fst,
-                                                      callingImplicitInterface);
+      mlir::Value cast;
+      auto *context = builder.getContext();
+      if (snd.isa<fir::BoxProcType>() &&
+          fst.getType().isa<mlir::FunctionType>()) {
+        auto funcTy = mlir::FunctionType::get(context, llvm::None, llvm::None);
+        auto boxProcTy = builder.getBoxProcType(funcTy);
+        if (mlir::Value host = argumentHostAssocs(converter, fst)) {
+          cast = builder.create<fir::EmboxProcOp>(
+              loc, boxProcTy, llvm::ArrayRef<mlir::Value>{fst, host});
+        } else {
+          cast = builder.create<fir::EmboxProcOp>(loc, boxProcTy, fst);
+        }
+      } else {
+        cast = builder.convertWithSemantics(loc, snd, fst,
+                                            callingImplicitInterface);
+      }
       operands.push_back(cast);
     }
 
@@ -2808,8 +2864,8 @@ public:
                                           fir::getLen(argRef));
       } else if (arg.passBy == PassBy::CharProcTuple) {
         ExtValue argRef = genExtAddr(*expr);
-        mlir::Value tuple = fir::factory::createCharacterProcedureTuple(
-            builder, loc, argTy, fir::getBase(argRef), fir::getLen(argRef));
+        mlir::Value tuple = createBoxProcCharTuple(
+            converter, argTy, fir::getBase(argRef), fir::getLen(argRef));
         caller.placeInput(arg, tuple);
       } else {
         TODO(loc, "pass by value in non elemental function call");
@@ -4563,8 +4619,8 @@ private:
         break;
       case PassBy::CharProcTuple: {
         ExtValue argRef = asScalarRef(*expr);
-        mlir::Value tuple = fir::factory::createCharacterProcedureTuple(
-            builder, loc, argTy, fir::getBase(argRef), fir::getLen(argRef));
+        mlir::Value tuple = createBoxProcCharTuple(
+            converter, argTy, fir::getBase(argRef), fir::getLen(argRef));
         operands.emplace_back(
             [=](IterSpace iters) -> ExtValue { return tuple; });
       } break;

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -6,6 +6,7 @@ add_flang_library(FIRBuilder
   Complex.cpp
   DoLoopHelper.cpp
   FIRBuilder.cpp
+  LowLevelIntrinsics.cpp
   MutableBox.cpp
   Runtime/Assign.cpp
   Runtime/Character.cpp

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -13,6 +13,7 @@
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/DoLoopHelper.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "flang-lower-character"
@@ -316,60 +317,6 @@ mlir::Value fir::factory::CharacterExprHelper::getCharBoxBuffer(
     return newBuff;
   }
   return buff;
-}
-
-mlir::FuncOp fir::factory::getLlvmMemcpy(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
-                                        builder.getI1Type()};
-  auto memcpyTy =
-      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
-  return builder.addNamedFunction(builder.getUnknownLoc(),
-                                  "llvm.memcpy.p0i8.p0i8.i64", memcpyTy);
-}
-
-mlir::FuncOp fir::factory::getLlvmMemmove(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
-                                        builder.getI1Type()};
-  auto memmoveTy =
-      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
-  return builder.addNamedFunction(builder.getUnknownLoc(),
-                                  "llvm.memmove.p0i8.p0i8.i64", memmoveTy);
-}
-
-mlir::FuncOp fir::factory::getLlvmMemset(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
-                                        builder.getI1Type()};
-  auto memsetTy =
-      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
-  return builder.addNamedFunction(builder.getUnknownLoc(),
-                                  "llvm.memset.p0i8.p0i8.i64", memsetTy);
-}
-
-mlir::FuncOp fir::factory::getRealloc(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  llvm::SmallVector<mlir::Type> args = {ptrTy, builder.getI64Type()};
-  auto reallocTy = mlir::FunctionType::get(builder.getContext(), args, {ptrTy});
-  return builder.addNamedFunction(builder.getUnknownLoc(), "realloc",
-                                  reallocTy);
-}
-
-mlir::FuncOp fir::factory::getLlvmStackSave(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  auto funcTy =
-      mlir::FunctionType::get(builder.getContext(), llvm::None, {ptrTy});
-  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stacksave",
-                                  funcTy);
-}
-
-mlir::FuncOp fir::factory::getLlvmStackRestore(fir::FirOpBuilder &builder) {
-  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
-  auto funcTy =
-      mlir::FunctionType::get(builder.getContext(), {ptrTy}, llvm::None);
-  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stackrestore",
-                                  funcTy);
 }
 
 /// Create a loop to copy `count` characters from `src` to `dest`. Note that the
@@ -757,15 +704,20 @@ fir::factory::extractCharacterProcedureTuple(fir::FirOpBuilder &builder,
                                              mlir::Location loc,
                                              mlir::Value tuple) {
   mlir::TupleType tupleType = tuple.getType().cast<mlir::TupleType>();
-  mlir::Value addr = builder.create<fir::ExtractValueOp>(
+  auto addr = builder.create<fir::ExtractValueOp>(
       loc, tupleType.getType(0), tuple,
       builder.getArrayAttr(
           {builder.getIntegerAttr(builder.getIndexType(), 0)}));
+  mlir::Value proc = [&]() -> mlir::Value {
+    if (auto addrTy = addr.getType().dyn_cast<fir::BoxProcType>())
+      return builder.create<fir::BoxAddrOp>(loc, addrTy.getEleTy(), addr);
+    return addr;
+  }();
   mlir::Value len = builder.create<fir::ExtractValueOp>(
       loc, tupleType.getType(1), tuple,
       builder.getArrayAttr(
           {builder.getIntegerAttr(builder.getIndexType(), 1)}));
-  return {addr, len};
+  return {proc, len};
 }
 
 mlir::Value fir::factory::createCharacterProcedureTuple(
@@ -784,13 +736,6 @@ mlir::Value fir::factory::createCharacterProcedureTuple(
       builder.getArrayAttr(
           {builder.getIntegerAttr(builder.getIndexType(), 1)}));
   return tuple;
-}
-
-bool fir::factory::isCharacterProcedureTuple(mlir::Type ty) {
-  mlir::TupleType tuple = ty.dyn_cast<mlir::TupleType>();
-  return tuple && tuple.size() == 2 &&
-         tuple.getType(0).isa<mlir::FunctionType>() &&
-         fir::isa_integer(tuple.getType(1));
 }
 
 mlir::Type

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -43,6 +43,11 @@ mlir::FuncOp fir::FirOpBuilder::getNamedFunction(mlir::ModuleOp modOp,
   return modOp.lookupSymbol<mlir::FuncOp>(name);
 }
 
+mlir::FuncOp fir::FirOpBuilder::getNamedFunction(mlir::ModuleOp modOp,
+                                                 mlir::SymbolRefAttr symbol) {
+  return modOp.lookupSymbol<mlir::FuncOp>(symbol);
+}
+
 fir::GlobalOp fir::FirOpBuilder::getNamedGlobal(mlir::ModuleOp modOp,
                                                 llvm::StringRef name) {
   return modOp.lookupSymbol<fir::GlobalOp>(name);

--- a/flang/lib/Optimizer/Builder/LowLevelIntrinsics.cpp
+++ b/flang/lib/Optimizer/Builder/LowLevelIntrinsics.cpp
@@ -1,0 +1,91 @@
+//===-- LowLevelIntrinsics.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+//
+// Low level intrinsic functions.
+//
+// These include LLVM intrinsic calls and standard C library calls.
+// Target-specific calls, such as OS functions, should be factored in other
+// file(s).
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/LowLevelIntrinsics.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+
+mlir::FuncOp fir::factory::getLlvmMemcpy(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
+                                        builder.getI1Type()};
+  auto memcpyTy =
+      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.memcpy.p0i8.p0i8.i64", memcpyTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmMemmove(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
+                                        builder.getI1Type()};
+  auto memmoveTy =
+      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.memmove.p0i8.p0i8.i64", memmoveTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmMemset(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, ptrTy, builder.getI64Type(),
+                                        builder.getI1Type()};
+  auto memsetTy =
+      mlir::FunctionType::get(builder.getContext(), args, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.memset.p0i8.p0i8.i64", memsetTy);
+}
+
+mlir::FuncOp fir::factory::getRealloc(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  llvm::SmallVector<mlir::Type> args = {ptrTy, builder.getI64Type()};
+  auto reallocTy = mlir::FunctionType::get(builder.getContext(), args, {ptrTy});
+  return builder.addNamedFunction(builder.getUnknownLoc(), "realloc",
+                                  reallocTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmStackSave(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy =
+      mlir::FunctionType::get(builder.getContext(), llvm::None, {ptrTy});
+  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stacksave",
+                                  funcTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmStackRestore(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy =
+      mlir::FunctionType::get(builder.getContext(), {ptrTy}, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(), "llvm.stackrestore",
+                                  funcTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmInitTrampoline(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy = mlir::FunctionType::get(builder.getContext(),
+                                        {ptrTy, ptrTy, ptrTy}, llvm::None);
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.init.trampoline", funcTy);
+}
+
+mlir::FuncOp fir::factory::getLlvmAdjustTrampoline(fir::FirOpBuilder &builder) {
+  auto ptrTy = builder.getRefType(builder.getIntegerType(8));
+  auto funcTy = mlir::FunctionType::get(builder.getContext(), {ptrTy}, {ptrTy});
+  return builder.addNamedFunction(builder.getUnknownLoc(),
+                                  "llvm.adjust.trampoline", funcTy);
+}

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -3,6 +3,7 @@ add_flang_library(FIRCodeGen
   CGOps.cpp
   CodeGen.cpp
   PreCGRewrite.cpp
+  ProcedurePointer.cpp
   Target.cpp
   TargetRewrite.cpp
 

--- a/flang/lib/Optimizer/CodeGen/ProcedurePointer.cpp
+++ b/flang/lib/Optimizer/CodeGen/ProcedurePointer.cpp
@@ -1,0 +1,302 @@
+//===-- ProcedurePointer.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/LowLevelIntrinsics.h"
+#include "flang/Optimizer/CodeGen/CodeGen.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/FIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#define DEBUG_TYPE "flang-procedure-pointer"
+
+using namespace fir;
+
+namespace {
+/// Options to the procedure pointer pass.
+struct ProcedurePointerOptions {
+  // Lower the boxproc abstraction to function pointers and thunks where
+  // required.
+  bool useThunks = true;
+};
+
+/// This type converter rewrites all `!fir.boxproc<Func>` types to `Func` types.
+class BoxprocTypeRewriter : public mlir::TypeConverter {
+public:
+  using mlir::TypeConverter::convertType;
+
+  BoxprocTypeRewriter() {
+    addConversion([](mlir::Type ty) { return ty; });
+    addConversion([](BoxProcType boxproc) { return boxproc.getEleTy(); });
+    addConversion([&](mlir::TupleType tupTy) {
+      llvm::SmallVector<mlir::Type> memTys;
+      for (auto ty : tupTy.getTypes())
+        memTys.push_back(convertType(ty));
+      return mlir::TupleType::get(tupTy.getContext(), memTys);
+    });
+    addArgumentMaterialization(materializeProcedure);
+    addSourceMaterialization(materializeProcedure);
+    addTargetMaterialization(materializeProcedure);
+  }
+
+  static mlir::Value materializeProcedure(mlir::OpBuilder &builder,
+                                          BoxProcType type,
+                                          mlir::ValueRange inputs,
+                                          mlir::Location loc) {
+    assert(inputs.size() == 1);
+    return builder.create<ConvertOp>(loc, unwrapRefType(type.getEleTy()),
+                                     inputs[0]);
+  }
+};
+
+/// Rewrite all `fir.emboxproc` ops to either `fir.convert` or a thunk as
+/// required.
+class EmboxprocConversion : public mlir::OpRewritePattern<EmboxProcOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  EmboxprocConversion(mlir::MLIRContext *ctx) : OpRewritePattern(ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(EmboxProcOp embox,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Type toTy = embox.getType().cast<BoxProcType>().getEleTy();
+    if (embox.host()) {
+      // Create the thunk.
+      auto module = embox->getParentOfType<mlir::ModuleOp>();
+      FirOpBuilder builder(rewriter, getKindMapping(module));
+      auto loc = embox.getLoc();
+      mlir::Type i8Ty = builder.getI8Type();
+      mlir::Type i8Ptr = builder.getRefType(i8Ty);
+      mlir::Type buffTy = SequenceType::get({32}, i8Ty);
+      auto buffer = builder.create<AllocaOp>(loc, buffTy);
+      mlir::Value closure = builder.createConvert(loc, i8Ptr, embox.host());
+      mlir::Value tramp = builder.createConvert(loc, i8Ptr, buffer);
+      mlir::Value func = builder.createConvert(loc, i8Ptr, embox.func());
+      builder.create<fir::CallOp>(
+          loc, factory::getLlvmInitTrampoline(builder),
+          llvm::ArrayRef<mlir::Value>{tramp, func, closure});
+      auto adjustCall = builder.create<fir::CallOp>(
+          loc, factory::getLlvmAdjustTrampoline(builder),
+          llvm::ArrayRef<mlir::Value>{tramp});
+      rewriter.replaceOpWithNewOp<ConvertOp>(embox, toTy,
+                                             adjustCall.getResult(0));
+    } else {
+      // Just forward the function as a pointer.
+      rewriter.replaceOpWithNewOp<ConvertOp>(embox, toTy, embox.func());
+    }
+    return mlir::success();
+  }
+};
+
+class FuncConversion : public mlir::OpRewritePattern<mlir::FuncOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  FuncConversion(mlir::MLIRContext *ctx, BoxprocTypeRewriter &tc)
+      : OpRewritePattern(ctx), typeConverter(tc) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::FuncOp func,
+                  mlir::PatternRewriter &rewriter) const override {
+    llvm::SmallVector<mlir::Type> inTys;
+    llvm::SmallVector<mlir::Type> resTys;
+    rewriter.startRootUpdate(func);
+    mlir::FunctionType funcTy = func.getType();
+    for (auto ty : funcTy.getInputs())
+      inTys.push_back(typeConverter.convertType(ty));
+    for (auto ty : funcTy.getResults())
+      resTys.push_back(typeConverter.convertType(ty));
+    setTypeAndArguments(func, rewriter.getFunctionType(inTys, resTys));
+    rewriter.finalizeRootUpdate(func);
+    return mlir::success();
+  }
+
+  // We have to set the type on the FuncOp but we also have to set the types on
+  // the block arguments to type check.
+  void setTypeAndArguments(mlir::FuncOp func,
+                           mlir::FunctionType toFuncTy) const {
+    if (!func.empty()) {
+      for (auto e : llvm::enumerate(toFuncTy.getInputs())) {
+        unsigned i = e.index();
+        auto &block = func.front();
+        block.insertArgument(i, e.value());
+        block.getArgument(i + 1).replaceAllUsesWith(block.getArgument(i));
+        block.eraseArgument(i + 1);
+      }
+    }
+    func.setType(toFuncTy);
+  }
+
+  BoxprocTypeRewriter &typeConverter;
+};
+
+class UndefConversion : public mlir::OpRewritePattern<UndefOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  UndefConversion(mlir::MLIRContext *ctx, BoxprocTypeRewriter &tc)
+      : OpRewritePattern(ctx), typeConverter(tc) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(UndefOp undef,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto tupTy = undef.getType().cast<mlir::TupleType>();
+    auto newTupTy = typeConverter.convertType(tupTy);
+    rewriter.replaceOpWithNewOp<fir::UndefOp>(undef, newTupTy);
+    return mlir::success();
+  }
+
+  BoxprocTypeRewriter &typeConverter;
+};
+
+class InsertValueConversion : public mlir::OpRewritePattern<InsertValueOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  InsertValueConversion(mlir::MLIRContext *ctx, BoxprocTypeRewriter &tc)
+      : OpRewritePattern(ctx), typeConverter(tc) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(InsertValueOp ins,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto tupTy = ins.getType().cast<mlir::TupleType>();
+    auto newTupTy = typeConverter.convertType(tupTy);
+    rewriter.replaceOpWithNewOp<InsertValueOp>(ins, newTupTy, ins.adt(),
+                                               ins.val(), ins.coor());
+    return mlir::success();
+  }
+
+  BoxprocTypeRewriter &typeConverter;
+};
+
+class ExtractValueConversion : public mlir::OpRewritePattern<ExtractValueOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  ExtractValueConversion(mlir::MLIRContext *ctx, BoxprocTypeRewriter &tc)
+      : OpRewritePattern(ctx), typeConverter(tc) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(ExtractValueOp ext,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto boxTy = ext.getType().cast<BoxProcType>();
+    auto newTy = typeConverter.convertType(boxTy);
+    rewriter.replaceOpWithNewOp<ExtractValueOp>(ext, newTy, ext.adt(),
+                                                ext.coor());
+    return mlir::success();
+  }
+
+  BoxprocTypeRewriter &typeConverter;
+};
+
+/// Rewrite all `fir.box_addr` ops on values of type `!fir.boxproc` or function
+/// type to be `fir.convert` ops.
+class BoxaddrConversion : public mlir::OpRewritePattern<BoxAddrOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  BoxaddrConversion(mlir::MLIRContext *ctx) : OpRewritePattern(ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(BoxAddrOp addr,
+                  mlir::PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ConvertOp>(addr, addr.getType(), addr.val());
+    return mlir::success();
+  }
+};
+
+/// A `boxproc` is an abstraction for a Fortran procedure reference. Typically,
+/// Fortran procedures can be referenced directly through a function pointer.
+/// However, Fortran has one-level dynamic scoping between a host procedure and
+/// its internal procedures. This allows internal procedures to directly access
+/// and modify the state of the host procedure's variables.
+///
+/// There are any number of possible implementations possible.
+///
+/// The implementation used here is to convert `boxproc` values to function
+/// pointers everywhere. If a `boxproc` value includes a frame pointer to the
+/// host procedure's data, then a thunk will be created at runtime to capture
+/// the frame pointer during execution. In LLVM IR, the frame pointer is
+/// designated with the `nest` attribute. The thunk's address will then be used
+/// as the call target instead of the original function's address directly.
+class ProcedurePointerPass
+    : public ProcedurePointerPassBase<ProcedurePointerPass> {
+public:
+  ProcedurePointerPass() { options = {true}; }
+  ProcedurePointerPass(bool useThunks) { options = {useThunks}; }
+
+  inline mlir::ModuleOp getModule() { return getOperation(); }
+
+  inline static bool isBoxProc(mlir::Type ty) { return ty.isa<BoxProcType>(); };
+
+  // Functions returning a CHARACTER may use a tuple type of
+  // `tuple<boxproc<() -> ()>, i64>`. These values must be type converted.
+  inline static bool isTupledBoxProc(mlir::Type ty) {
+    if (auto tupTy = ty.dyn_cast<mlir::TupleType>())
+      if (mlir::Type subTy = tupTy.getType(0))
+        return subTy.isa<fir::BoxProcType>();
+    return false;
+  }
+
+  inline static bool usesBoxProc(mlir::Type ty) {
+    return isBoxProc(ty) || isTupledBoxProc(ty);
+  }
+
+  void runOnOperation() override final {
+    if (options.useThunks) {
+      auto *context = &getContext();
+      mlir::OwningRewritePatternList pattern(context);
+      mlir::ConversionTarget target(*context);
+      BoxprocTypeRewriter typeConverter;
+      target.addLegalDialect<FIROpsDialect, mlir::StandardOpsDialect,
+                             mlir::arith::ArithmeticDialect>();
+      target.addDynamicallyLegalOp<BoxAddrOp>([&](BoxAddrOp addr) {
+        mlir::Type ty = addr.val().getType();
+        return !(ty.isa<BoxProcType>() || ty.isa<mlir::FunctionType>());
+      });
+      target.addDynamicallyLegalOp<mlir::FuncOp>([&](mlir::FuncOp func) {
+        mlir::FunctionType ty = func.getType();
+        return !(llvm::any_of(ty.getInputs(), usesBoxProc) ||
+                 llvm::any_of(ty.getResults(), usesBoxProc));
+      });
+      target.addDynamicallyLegalOp<UndefOp>(
+          [&](UndefOp undef) { return !isTupledBoxProc(undef.getType()); });
+      target.addDynamicallyLegalOp<InsertValueOp>(
+          [&](InsertValueOp ins) { return !isTupledBoxProc(ins.getType()); });
+      target.addDynamicallyLegalOp<ExtractValueOp>(
+          [&](ExtractValueOp ext) { return !isBoxProc(ext.getType()); });
+      target.addIllegalOp<EmboxProcOp>();
+      pattern.insert<EmboxprocConversion, BoxaddrConversion>(context);
+      pattern.insert<FuncConversion, UndefConversion, InsertValueConversion,
+                     ExtractValueConversion>(context, typeConverter);
+      if (mlir::failed(mlir::applyPartialConversion(getModule(), target,
+                                                    std::move(pattern))))
+        signalPassFailure();
+    }
+    // TODO: any alternative implementation. Note: currently, the default code
+    // gen will not be able to handle boxproc and will give an error.
+  }
+
+private:
+  ProcedurePointerOptions options;
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> fir::createProcedurePointerPass() {
+  return std::make_unique<ProcedurePointerPass>();
+}
+
+std::unique_ptr<mlir::Pass> fir::createProcedurePointerPass(bool useThunks) {
+  return std::make_unique<ProcedurePointerPass>(useThunks);
+}

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -18,6 +18,7 @@
 #include "Target.h"
 #include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/Character.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
@@ -271,12 +272,12 @@ public:
             rewriteCallComplexInputType(cmplx, oper, newInTys, newOpers);
           })
           .template Case<mlir::TupleType>([&](mlir::TupleType tuple) {
-            if (factory::isCharacterProcedureTuple(tuple)) {
+            if (isCharacterProcedureTuple(tuple)) {
               mlir::ModuleOp module = getModule();
               if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
                 if (callOp.callee()) {
                   llvm::StringRef charProcAttr =
-                      fir::getCharacterProcedureDummyAttrName();
+                      getCharacterProcedureDummyAttrName();
                   // The charProcAttr attribute is only used as a safety to
                   // confirm that this is a dummy procedure and should be split.
                   // It cannot be used to match because attributes are not
@@ -400,7 +401,7 @@ public:
             lowerComplexSignatureArg(ty, newInTys);
           })
           .Case<mlir::TupleType>([&](mlir::TupleType tuple) {
-            if (factory::isCharacterProcedureTuple(tuple)) {
+            if (isCharacterProcedureTuple(tuple)) {
               newInTys.push_back(tuple.getType(0));
               trailingInTys.push_back(tuple.getType(1));
             } else {
@@ -443,7 +444,7 @@ public:
         return false;
       }
     for (auto ty : func.getInputs())
-      if (((ty.isa<BoxCharType>() || factory::isCharacterProcedureTuple(ty)) &&
+      if (((ty.isa<BoxCharType>() || isCharacterProcedureTuple(ty)) &&
            !noCharacterConversion) ||
           (isa_complex(ty) && !noComplexConversion)) {
         LLVM_DEBUG(llvm::dbgs() << "rewrite " << signature << " for target\n");
@@ -452,11 +453,21 @@ public:
     return true;
   }
 
+  /// Determine if the signature has host associations. The host association
+  /// argument may need special target specific rewriting.
+  static bool hasHostAssociations(mlir::FuncOp func) {
+    std::size_t end = func.getType().getInputs().size();
+    for (std::size_t i = 0; i < end; ++i)
+      if (func.getArgAttrOfType<mlir::UnitAttr>(i, getHostAssocAttrName()))
+        return true;
+    return false;
+  }
+
   /// Rewrite the signatures and body of the `FuncOp`s in the module for
   /// the immediately subsequent target code gen.
   void convertSignature(mlir::FuncOp func) {
     auto funcTy = func.getType().cast<mlir::FunctionType>();
-    if (hasPortableSignature(funcTy))
+    if (hasPortableSignature(funcTy) && !hasHostAssociations(func))
       return;
     llvm::SmallVector<mlir::Type> newResTys;
     llvm::SmallVector<mlir::Type> newInTys;
@@ -527,7 +538,7 @@ public:
               doComplexArg(func, cmplx, newInTys, fixups);
           })
           .Case<mlir::TupleType>([&](mlir::TupleType tuple) {
-            if (factory::isCharacterProcedureTuple(tuple)) {
+            if (isCharacterProcedureTuple(tuple)) {
               fixups.emplace_back(FixupTy::Codes::TrailingCharProc,
                                   newInTys.size(), trailingTys.size());
               newInTys.push_back(tuple.getType(0));
@@ -537,6 +548,10 @@ public:
             }
           })
           .Default([&](mlir::Type ty) { newInTys.push_back(ty); });
+      if (func.getArgAttrOfType<mlir::UnitAttr>(index,
+                                                getHostAssocAttrName())) {
+        func.setArgAttr(index, "llvm.nest", rewriter->getUnitAttr());
+      }
     }
 
     if (!func.empty()) {
@@ -666,7 +681,7 @@ public:
           func.front().eraseArgument(fixup.index + 1);
         } break;
         case FixupTy::Codes::TrailingCharProc: {
-          // The FIR character procedure argument tuple has been split into a
+          // The FIR character procedure argument tuple must be split into a
           // pair of distinct arguments. The first part of the pair appears in
           // the original argument position. The second part of the pair is
           // appended after all the original arguments.

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -276,10 +276,9 @@ public:
   // fir.boxproc<any>  -->  llvm<"{ any*, i8* }">
   mlir::Type convertBoxProcType(BoxProcType boxproc) {
     auto funcTy = convertType(boxproc.getEleTy());
-    auto ptrTy = mlir::LLVM::LLVMPointerType::get(funcTy);
     auto i8PtrTy = mlir::LLVM::LLVMPointerType::get(
         mlir::IntegerType::get(&getContext(), 8));
-    llvm::SmallVector<mlir::Type, 2> tuple = {ptrTy, i8PtrTy};
+    llvm::SmallVector<mlir::Type, 2> tuple = {funcTy, i8PtrTy};
     return mlir::LLVM::LLVMStructType::getLiteral(&getContext(), tuple,
                                                   /*isPacked=*/false);
   }

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -915,6 +915,15 @@ bool fir::VectorType::isValidElementType(mlir::Type t) {
   return isa_real(t) || isa_integer(t);
 }
 
+bool fir::isCharacterProcedureTuple(mlir::Type ty,
+                                             bool acceptRawFunc) {
+  mlir::TupleType tuple = ty.dyn_cast<mlir::TupleType>();
+  return tuple && tuple.size() == 2 &&
+         (tuple.getType(0).isa<fir::BoxProcType>() ||
+          (acceptRawFunc && tuple.getType(0).isa<mlir::FunctionType>())) &&
+         fir::isa_integer(tuple.getType(1));
+}
+
 //===----------------------------------------------------------------------===//
 // FIROpsDialect
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -915,8 +915,7 @@ bool fir::VectorType::isValidElementType(mlir::Type t) {
   return isa_real(t) || isa_integer(t);
 }
 
-bool fir::isCharacterProcedureTuple(mlir::Type ty,
-                                             bool acceptRawFunc) {
+bool fir::isCharacterProcedureTuple(mlir::Type ty, bool acceptRawFunc) {
   mlir::TupleType tuple = ty.dyn_cast<mlir::TupleType>();
   return tuple && tuple.size() == 2 &&
          (tuple.getType(0).isa<fir::BoxProcType>() ||

--- a/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
+++ b/flang/lib/Optimizer/Transforms/AnnotateConstant.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Transforms/Passes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
@@ -30,6 +31,10 @@ struct AnnotateConstantOperands
           if (auto constOp = mlir::dyn_cast_or_null<mlir::arith::ConstantOp>(
                   opnd.getDefiningOp())) {
             attrs.push_back(constOp.value());
+            hasOneOrMoreConstOpnd = true;
+          } else if (auto addrOp = mlir::dyn_cast_or_null<fir::AddrOfOp>(
+                         opnd.getDefiningOp())) {
+            attrs.push_back(addrOp.symbol());
             hasOneOrMoreConstOpnd = true;
           } else {
             attrs.push_back(mlir::UnitAttr::get(context));

--- a/flang/test/Fir/boxproc.fir
+++ b/flang/test/Fir/boxproc.fir
@@ -1,0 +1,338 @@
+// RUN: tco %s | FileCheck %s
+
+// CHECK-LABEL: define void @_QPtest_proc_dummy()
+// CHECK:         %[[VAL_0:.*]] = alloca i32, i64 1, align 4
+// CHECK:         %[[VAL_1:.*]] = alloca { i32* }, i64 1, align 8
+// CHECK:         %[[VAL_2:.*]] = getelementptr { i32* }, { i32* }* %[[VAL_1]], i64 0, i32 0
+// CHECK:         store i32* %[[VAL_0]], i32** %[[VAL_2]], align 8
+// CHECK:         store i32 1, i32* %[[VAL_0]], align 4
+// CHECK:         %[[VAL_3:.*]] = alloca [32 x i8], i64 1, align 1
+// CHECK:         %[[VAL_4:.*]] = bitcast { i32* }* %[[VAL_1]] to i8*
+// CHECK:         %[[VAL_5:.*]] = bitcast [32 x i8]* %[[VAL_3]] to i8*
+// CHECK:         call void @llvm.init.trampoline(i8* %[[VAL_5]], i8* bitcast (void (i32*, { i32* }*)* @_QFtest_proc_dummyPtest_proc_dummy_a to i8*), i8* %[[VAL_4]])
+// CHECK:         %[[VAL_6:.*]] = call i8* @llvm.adjust.trampoline(i8* %[[VAL_5]])
+// CHECK:         %[[VAL_7:.*]] = bitcast i8* %[[VAL_6]] to void ()*
+// CHECK:         call void @_QPtest_proc_dummy_other(void ()* %[[VAL_7]])
+
+// CHECK-LABEL: define void @_QFtest_proc_dummyPtest_proc_dummy_a(i32*
+// CHECK-SAME:              %[[VAL_0:.*]], { i32* }* nest %[[VAL_1:.*]])
+
+// CHECK-LABEL: define void @_QPtest_proc_dummy_other(void ()*
+// CHECK-SAME:              %[[VAL_0:.*]])
+// CHECK:         %[[VAL_1:.*]] = alloca i32, i64 1, align 4
+// CHECK:         store i32 4, i32* %[[VAL_1]], align 4
+// CHECK:         %[[VAL_2:.*]] = bitcast void ()* %[[VAL_0]] to void (i32*)*
+// CHECK:         call void %[[VAL_2]](i32* %[[VAL_1]])
+
+func @_QPtest_proc_dummy() {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c-1_i32 = arith.constant -1 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %0 = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFtest_proc_dummyEi"}
+  %1 = fir.alloca tuple<!fir.ref<i32>>
+  %2 = fir.coordinate_of %1, %c0_i32 : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  fir.store %0 to %2 : !fir.llvm_ptr<!fir.ref<i32>>
+  fir.store %c1_i32 to %0 : !fir.ref<i32>
+  %3 = fir.address_of(@_QFtest_proc_dummyPtest_proc_dummy_a) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> ()
+  %4 = fir.emboxproc %3, %1 : ((!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> (), !fir.ref<tuple<!fir.ref<i32>>>) -> !fir.boxproc<() -> ()>
+  fir.call @_QPtest_proc_dummy_other(%4) : (!fir.boxproc<() -> ()>) -> ()
+  %5 = fir.address_of(@_QQcl.2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %6 = fir.convert %5 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
+  %7 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %6, %c5_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+  %8 = fir.load %0 : !fir.ref<i32>
+  %9 = fir.call @_FortranAioOutputInteger32(%7, %8) : (!fir.ref<i8>, i32) -> i1
+  %10 = fir.call @_FortranAioEndIoStatement(%7) : (!fir.ref<i8>) -> i32
+  return
+}
+func @_QFtest_proc_dummyPtest_proc_dummy_a(%arg0: !fir.ref<i32> {fir.bindc_name = "j"}, %arg1: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = fir.coordinate_of %arg1, %c0_i32 : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+  %1 = fir.load %0 : !fir.llvm_ptr<!fir.ref<i32>>
+  %2 = fir.load %1 : !fir.ref<i32>
+  %3 = fir.load %arg0 : !fir.ref<i32>
+  %4 = arith.addi %2, %3 : i32
+  fir.store %4 to %1 : !fir.ref<i32>
+  return
+}
+func @_QPtest_proc_dummy_other(%arg0: !fir.boxproc<() -> ()>) {
+  %c4_i32 = arith.constant 4 : i32
+  %0 = fir.alloca i32 {adapt.valuebyref}
+  fir.store %c4_i32 to %0 : !fir.ref<i32>
+  %1 = fir.box_addr %arg0 : (!fir.boxproc<() -> ()>) -> ((!fir.ref<i32>) -> ())
+  fir.call %1(%0) : (!fir.ref<i32>) -> ()
+  return
+}
+
+// CHECK-LABEL: define void @_QPtest_proc_dummy_char()
+// CHECK:         %[[VAL_0:.*]] = alloca [40 x i8], i64 1, align 1
+// CHECK:         %[[VAL_1:.*]] = alloca [10 x i8], i64 1, align 1
+// CHECK:         %[[VAL_2:.*]] = alloca { { i8*, i64 } }, i64 1, align 8
+// CHECK:         %[[VAL_3:.*]] = getelementptr { { i8*, i64 } }, { { i8*, i64 } }* %[[VAL_2]], i64 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = bitcast [10 x i8]* %[[VAL_1]] to i8*
+// CHECK:         %[[VAL_5:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_4]], 0
+// CHECK:         %[[VAL_6:.*]] = insertvalue { i8*, i64 } %[[VAL_5]], i64 10, 1
+// CHECK:         store { i8*, i64 } %[[VAL_6]], { i8*, i64 }* %[[VAL_3]], align 8
+// CHECK:         %[[VAL_7:.*]] = bitcast [10 x i8]* %[[VAL_1]] to i8*
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* %[[VAL_7]], i8* getelementptr inbounds ([9 x i8], [9 x i8]*
+// CHECK:         br label %[[VAL_8:.*]]
+// CHECK:         %[[VAL_11:.*]] = phi 
+// CHECK:         %[[VAL_13:.*]] = phi 
+// CHECK:         %[[VAL_15:.*]] = icmp sgt i64 %[[VAL_13]], 0
+// CHECK:         %[[VAL_17:.*]] = bitcast [10 x i8]* %[[VAL_1]] to [10 x [1 x i8]]*
+// CHECK:         %[[VAL_18:.*]] = getelementptr [10 x [1 x i8]], [10 x [1 x i8]]* %[[VAL_17]], i64 0, i64 %[[VAL_11]]
+// CHECK:         store [1 x i8] c" ", [1 x i8]* %[[VAL_18]], align 1
+// CHECK:         %[[VAL_20:.*]] = alloca [32 x i8], i64 1, align 1
+// CHECK:         %[[VAL_21:.*]] = bitcast { { i8*, i64 } }* %[[VAL_2]] to i8*
+// CHECK:         %[[VAL_22:.*]] = bitcast [32 x i8]* %[[VAL_20]] to i8*
+// CHECK:         call void @llvm.init.trampoline(i8* %[[VAL_22]], i8* bitcast ({ i8*, i64 } ([10 x i8]*, i64, { { i8*, i64 } }*)* @_QFtest_proc_dummy_charPgen_message to i8*), i8* %[[VAL_21]])
+// CHECK:         %[[VAL_23:.*]] = call i8* @llvm.adjust.trampoline(i8* %[[VAL_22]])
+// CHECK:         %[[VAL_24:.*]] = bitcast i8* %[[VAL_23]] to void ()*
+// CHECK:         %[[VAL_25:.*]] = insertvalue { void ()*, i64 } undef, void ()* %[[VAL_24]], 0
+// CHECK:         %[[VAL_26:.*]] = insertvalue { void ()*, i64 } %[[VAL_25]], i64 10, 1
+// CHECK:         %[[VAL_27:.*]] = call i8* @llvm.stacksave()
+// CHECK:         %[[VAL_28:.*]] = extractvalue { void ()*, i64 } %[[VAL_26]], 0
+// CHECK:         %[[VAL_29:.*]] = extractvalue { void ()*, i64 } %[[VAL_26]], 1
+// CHECK:         %[[VAL_30:.*]] = call { i8*, i64 } @_QPget_message([40 x i8]* %[[VAL_0]], i64 40, void ()* %[[VAL_28]], i64 %[[VAL_29]])
+// CHECK:         %[[VAL_31:.*]] = bitcast [40 x i8]* %[[VAL_0]] to i8*
+// CHECK:         %[[VAL_32:.*]] = call i1 @_FortranAioOutputAscii(i8* %{{.*}}, i8* %[[VAL_31]], i64 40)
+// CHECK:         call void @llvm.stackrestore(i8* %[[VAL_27]])
+
+// CHECK-LABEL: define { i8*, i64 } @_QFtest_proc_dummy_charPgen_message([10 x i8]*
+// CHECK-SAME:                %[[VAL_0:.*]], i64 %[[VAL_1:.*]], { { i8*, i64 } }* nest %[[VAL_2:.*]])
+// CHECK:         %[[VAL_3:.*]] = getelementptr { { i8*, i64 } }, { { i8*, i64 } }* %[[VAL_2]], i64 0, i32 0
+// CHECK:         %[[VAL_4:.*]] = load { i8*, i64 }, { i8*, i64 }* %[[VAL_3]], align 8
+// CHECK:         %[[VAL_5:.*]] = extractvalue { i8*, i64 } %[[VAL_4]], 0
+// CHECK:         %[[VAL_6:.*]] = extractvalue { i8*, i64 } %[[VAL_4]], 1
+// CHECK:         %[[VAL_7:.*]] = bitcast [10 x i8]* %[[VAL_0]] to i8*
+// CHECK:         %[[VAL_8:.*]] = icmp slt i64 10, %[[VAL_6]]
+// CHECK:         %[[VAL_9:.*]] = select i1 %[[VAL_8]], i64 10, i64 %[[VAL_6]]
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* %[[VAL_7]], i8* %[[VAL_5]], i64 %[[VAL_9]], i1 false)
+// CHECK:         %[[VAL_10:.*]] = sub i64 10, %[[VAL_9]]
+// CHECK:         br label %[[VAL_11:.*]]
+// CHECK:         %[[VAL_14:.*]] = phi i64
+// CHECK:         %[[VAL_16:.*]] = phi i64
+// CHECK:         %[[VAL_18:.*]] = icmp sgt i64 %[[VAL_16]], 0
+// CHECK:         %[[VAL_20:.*]] = bitcast i8* %[[VAL_7]] to [1 x i8]*
+// CHECK:         %[[VAL_21:.*]] = getelementptr [1 x i8], [1 x i8]* %[[VAL_20]], i64 %[[VAL_14]]
+// CHECK:         store [1 x i8] c" ", [1 x i8]* %[[VAL_21]], align 1
+// CHECK:         %[[VAL_22:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_7]], 0
+// CHECK:         %[[VAL_23:.*]] = insertvalue { i8*, i64 } %[[VAL_22]], i64 10, 1
+// CHECK:         ret { i8*, i64 } %[[VAL_23]]
+// CHECK:       }
+
+// CHECK-LABEL: define { i8*, i64 } @_QPget_message([40 x i8]*
+// CHECK-SAME:                  %[[VAL_0:.*]], i64 %[[VAL_1:.*]], void ()* %[[VAL_2:.*]], i64
+// CHECK-SAME:                                                 %[[VAL_3:.*]])
+// CHECK:         %[[VAL_4:.*]] = insertvalue { void ()*, i64 } undef, void ()* %[[VAL_2]], 0
+// CHECK:         %[[VAL_5:.*]] = insertvalue { void ()*, i64 } %[[VAL_4]], i64 %[[VAL_3]], 1
+// CHECK:         %[[VAL_6:.*]] = bitcast [40 x i8]* %[[VAL_0]] to i8*
+// CHECK:         %[[VAL_7:.*]] = extractvalue { void ()*, i64 } %[[VAL_5]], 0
+// CHECK:         %[[VAL_8:.*]] = extractvalue { void ()*, i64 } %[[VAL_5]], 1
+// CHECK:         %[[VAL_9:.*]] = call i8* @llvm.stacksave()
+// CHECK:         %[[VAL_10:.*]] = alloca i8, i64 %[[VAL_8]], align 1
+// CHECK:         %[[VAL_11:.*]] = bitcast void ()* %[[VAL_7]] to { i8*, i64 } (i8*, i64)*
+// CHECK:         %[[VAL_12:.*]] = call { i8*, i64 } %[[VAL_11]](i8* %[[VAL_10]], i64 %[[VAL_8]])
+// CHECK:         %[[VAL_13:.*]] = add i64 %[[VAL_8]], 12
+// CHECK:         %[[VAL_14:.*]] = alloca i8, i64 %[[VAL_13]], align 1
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* %[[VAL_14]], i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_QQcl.6D6573736167652069733A20, i32 0, i32 0), i64 12, i1 false)
+// CHECK:         %[[VAL_18:.*]] = phi i64
+// CHECK:         %[[VAL_20:.*]] = phi i64
+// CHECK:         %[[VAL_22:.*]] = icmp sgt i64 %[[VAL_20]], 0
+// CHECK:         %[[VAL_24:.*]] = sub i64 %[[VAL_18]], 12
+// CHECK:         %[[VAL_25:.*]] = bitcast i8* %[[VAL_10]] to [1 x i8]*
+// CHECK:         %[[VAL_26:.*]] = getelementptr [1 x i8], [1 x i8]* %[[VAL_25]], i64 %[[VAL_24]]
+// CHECK:         %[[VAL_27:.*]] = load [1 x i8], [1 x i8]* %[[VAL_26]], align 1
+// CHECK:         %[[VAL_28:.*]] = bitcast i8* %[[VAL_14]] to [1 x i8]*
+// CHECK:         %[[VAL_29:.*]] = getelementptr [1 x i8], [1 x i8]* %[[VAL_28]], i64 %[[VAL_18]]
+// CHECK:         store [1 x i8] %[[VAL_27]], [1 x i8]* %[[VAL_29]], align 1
+// CHECK:         %[[VAL_30:.*]] = icmp slt i64 40, %[[VAL_13]]
+// CHECK:         %[[VAL_31:.*]] = select i1 %[[VAL_30]], i64 40, i64 %[[VAL_13]]
+// CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* %[[VAL_6]], i8* %[[VAL_14]], i64 %[[VAL_31]], i1 false)
+// CHECK:         %[[VAL_32:.*]] = sub i64 40, %[[VAL_31]]
+// CHECK:         %[[VAL_35:.*]] = phi i64
+// CHECK:         %[[VAL_37:.*]] = phi i64
+// CHECK:         %[[VAL_39:.*]] = icmp sgt i64 %[[VAL_37]], 0
+// CHECK:         %[[VAL_41:.*]] = bitcast i8* %[[VAL_6]] to [1 x i8]*
+// CHECK:         %[[VAL_42:.*]] = getelementptr [1 x i8], [1 x i8]* %[[VAL_41]], i64 %[[VAL_35]]
+// CHECK:         store [1 x i8] c" ", [1 x i8]* %[[VAL_42]], align 1
+// CHECK:         call void @llvm.stackrestore(i8* %[[VAL_9]])
+// CHECK:         %[[VAL_43:.*]] = insertvalue { i8*, i64 } undef, i8* %[[VAL_6]], 0
+// CHECK:         %[[VAL_44:.*]] = insertvalue { i8*, i64 } %[[VAL_43]], i64 40, 1
+// CHECK:         ret { i8*, i64 } %[[VAL_44]]
+// CHECK:       }
+
+func @_QPtest_proc_dummy_char() {
+  %c10 = arith.constant 10 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c9 = arith.constant 9 : index
+  %false = arith.constant false
+  %c1 = arith.constant 1 : index
+  %c32_i8 = arith.constant 32 : i8
+  %c-1_i32 = arith.constant -1 : i32
+  %c6_i32 = arith.constant 6 : i32
+  %c10_i64 = arith.constant 10 : i64
+  %c40 = arith.constant 40 : index
+  %c0 = arith.constant 0 : index
+  %0 = fir.alloca !fir.char<1,40> {bindc_name = ".result"}
+  %1 = fir.alloca !fir.char<1,10> {bindc_name = "message", uniq_name = "_QFtest_proc_dummy_charEmessage"}
+  %2 = fir.alloca tuple<!fir.boxchar<1>>
+  %3 = fir.coordinate_of %2, %c0_i32 : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+  %4 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+  %5 = fir.emboxchar %4, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  fir.store %5 to %3 : !fir.ref<!fir.boxchar<1>>
+  %6 = fir.address_of(@_QQcl.486920746865726521) : !fir.ref<!fir.char<1,9>>
+  %7 = fir.convert %c9 : (index) -> i64
+  %8 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
+  %9 = fir.convert %6 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
+  fir.call @llvm.memmove.p0i8.p0i8.i64(%8, %9, %7, %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  %10 = fir.undefined !fir.char<1>
+  %11 = fir.insert_value %10, %c32_i8, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+  br ^bb1(%c9, %c1 : index, index)
+^bb1(%12: index, %13: index):  // 2 preds: ^bb0, ^bb2
+  %14 = arith.cmpi sgt, %13, %c0 : index
+  cond_br %14, ^bb2, ^bb3
+^bb2:  // pred: ^bb1
+  %15 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.array<10x!fir.char<1>>>
+  %16 = fir.coordinate_of %15, %12 : (!fir.ref<!fir.array<10x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  fir.store %11 to %16 : !fir.ref<!fir.char<1>>
+  %17 = arith.addi %12, %c1 : index
+  %18 = arith.subi %13, %c1 : index
+  br ^bb1(%17, %18 : index, index)
+^bb3:  // pred: ^bb1
+  %19 = fir.address_of(@_QQcl.2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %20 = fir.convert %19 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
+  %21 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %20, %c6_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+  %22 = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
+  %23 = fir.emboxproc %22, %2 : ((!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxproc<() -> ()>
+  %24 = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+  %25 = fir.insert_value %24, %23, [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+  %26 = fir.insert_value %25, %c10_i64, [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+  %27 = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+  %28 = fir.call @_QPget_message(%0, %c40, %26) : (!fir.ref<!fir.char<1,40>>, index, tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxchar<1>
+  %29 = fir.convert %0 : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<i8>
+  %30 = fir.convert %c40 : (index) -> i64
+  %31 = fir.call @_FortranAioOutputAscii(%21, %29, %30) : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+  fir.call @llvm.stackrestore(%27) : (!fir.ref<i8>) -> ()
+  %32 = fir.call @_FortranAioEndIoStatement(%21) : (!fir.ref<i8>) -> i32
+  return
+}
+func @_QFtest_proc_dummy_charPgen_message(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: index, %arg2: !fir.ref<tuple<!fir.boxchar<1>>> {fir.host_assoc}) -> !fir.boxchar<1> {
+  %c0_i32 = arith.constant 0 : i32
+  %c10 = arith.constant 10 : index
+  %false = arith.constant false
+  %c1 = arith.constant 1 : index
+  %c32_i8 = arith.constant 32 : i8
+  %c0 = arith.constant 0 : index
+  %0 = fir.coordinate_of %arg2, %c0_i32 : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+  %1 = fir.load %0 : !fir.ref<!fir.boxchar<1>>
+  %2:2 = fir.unboxchar %1 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  %3 = fir.convert %arg0 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+  %4 = arith.cmpi slt, %c10, %2#1 : index
+  %5 = select %4, %c10, %2#1 : index
+  %6 = fir.convert %5 : (index) -> i64
+  %7 = fir.convert %3 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  %8 = fir.convert %2#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  fir.call @llvm.memmove.p0i8.p0i8.i64(%7, %8, %6, %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  %9 = fir.undefined !fir.char<1>
+  %10 = fir.insert_value %9, %c32_i8, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+  %11 = arith.subi %c10, %5 : index
+  br ^bb1(%5, %11 : index, index)
+^bb1(%12: index, %13: index):  // 2 preds: ^bb0, ^bb2
+  %14 = arith.cmpi sgt, %13, %c0 : index
+  cond_br %14, ^bb2, ^bb3
+^bb2:  // pred: ^bb1
+  %15 = fir.convert %3 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  %16 = fir.coordinate_of %15, %12 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  fir.store %10 to %16 : !fir.ref<!fir.char<1>>
+  %17 = arith.addi %12, %c1 : index
+  %18 = arith.subi %13, %c1 : index
+  br ^bb1(%17, %18 : index, index)
+^bb3:  // pred: ^bb1
+  %19 = fir.emboxchar %3, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  return %19 : !fir.boxchar<1>
+}
+func @_QPget_message(%arg0: !fir.ref<!fir.char<1,40>>, %arg1: index, %arg2: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) -> !fir.boxchar<1> {
+  %c40 = arith.constant 40 : index
+  %c12 = arith.constant 12 : index
+  %false = arith.constant false
+  %c1 = arith.constant 1 : index
+  %c32_i8 = arith.constant 32 : i8
+  %c0 = arith.constant 0 : index
+  %0 = fir.convert %arg0 : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<!fir.char<1,?>>
+  %1 = fir.address_of(@_QQcl.6D6573736167652069733A20) : !fir.ref<!fir.char<1,12>>
+  %2 = fir.extract_value %arg2, [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+  %3 = fir.box_addr %2 : (!fir.boxproc<() -> ()>) -> (() -> ())
+  %4 = fir.extract_value %arg2, [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
+  %5 = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+  %6 = fir.alloca !fir.char<1,?>(%4 : i64) {bindc_name = ".result"}
+  %7 = fir.convert %3 : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>)
+  %8 = fir.convert %4 : (i64) -> index
+  %9 = fir.call %7(%6, %8) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  %10 = arith.addi %8, %c12 : index
+  %11 = fir.alloca !fir.char<1,?>(%10 : index) {bindc_name = ".chrtmp"}
+  %12 = fir.convert %c12 : (index) -> i64
+  %13 = fir.convert %11 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  %14 = fir.convert %1 : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
+  fir.call @llvm.memmove.p0i8.p0i8.i64(%13, %14, %12, %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  br ^bb1(%c12, %8 : index, index)
+^bb1(%15: index, %16: index):  // 2 preds: ^bb0, ^bb2
+  %17 = arith.cmpi sgt, %16, %c0 : index
+  cond_br %17, ^bb2, ^bb3
+^bb2:  // pred: ^bb1
+  %18 = arith.subi %15, %c12 : index
+  %19 = fir.convert %6 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  %20 = fir.coordinate_of %19, %18 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  %21 = fir.load %20 : !fir.ref<!fir.char<1>>
+  %22 = fir.convert %11 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  %23 = fir.coordinate_of %22, %15 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  fir.store %21 to %23 : !fir.ref<!fir.char<1>>
+  %24 = arith.addi %15, %c1 : index
+  %25 = arith.subi %16, %c1 : index
+  br ^bb1(%24, %25 : index, index)
+^bb3:  // pred: ^bb1
+  %26 = arith.cmpi slt, %c40, %10 : index
+  %27 = select %26, %c40, %10 : index
+  %28 = fir.convert %27 : (index) -> i64
+  %29 = fir.convert %0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+  fir.call @llvm.memmove.p0i8.p0i8.i64(%29, %13, %28, %false) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+  %30 = fir.undefined !fir.char<1>
+  %31 = fir.insert_value %30, %c32_i8, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+  %32 = arith.subi %c40, %27 : index
+  br ^bb4(%27, %32 : index, index)
+^bb4(%33: index, %34: index):  // 2 preds: ^bb3, ^bb5
+  %35 = arith.cmpi sgt, %34, %c0 : index
+  cond_br %35, ^bb5, ^bb6
+^bb5:  // pred: ^bb4
+  %36 = fir.convert %0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+  %37 = fir.coordinate_of %36, %33 : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+  fir.store %31 to %37 : !fir.ref<!fir.char<1>>
+  %38 = arith.addi %33, %c1 : index
+  %39 = arith.subi %34, %c1 : index
+  br ^bb4(%38, %39 : index, index)
+^bb6:  // pred: ^bb4
+  fir.call @llvm.stackrestore(%5) : (!fir.ref<i8>) -> ()
+  %40 = fir.emboxchar %0, %c40 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  return %40 : !fir.boxchar<1>
+}
+fir.global linkonce @_QQcl.486920746865726521 constant : !fir.char<1,9> {
+  %0 = fir.string_lit "Hi there!"(9) : !fir.char<1,9>
+  fir.has_value %0 : !fir.char<1,9>
+}
+func private @llvm.memmove.p0i8.p0i8.i64(!fir.ref<i8>, !fir.ref<i8>, i64, i1)
+fir.global linkonce @_QQcl.2E2F682E66393000 constant : !fir.char<1,8> {
+  %0 = fir.string_lit "./h.f90\00"(8) : !fir.char<1,8>
+  fir.has_value %0 : !fir.char<1,8>
+}
+func private @llvm.stacksave() -> !fir.ref<i8>
+func private @llvm.stackrestore(!fir.ref<i8>)
+fir.global linkonce @_QQcl.6D6573736167652069733A20 constant : !fir.char<1,12> {
+  %0 = fir.string_lit "message is: "(12) : !fir.char<1,12>
+  fir.has_value %0 : !fir.char<1,12>
+}
+
+func private @_FortranAioOutputAscii(!fir.ref<i8>, !fir.ref<i8>, i64) -> i1 attributes {fir.io, fir.runtime}
+func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
+func private @_FortranAioOutputInteger32(!fir.ref<i8>, i32) -> i1 attributes {fir.io, fir.runtime}
+func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fir.io, fir.runtime}
+

--- a/flang/test/Fir/external-mangling-emboxproc.fir
+++ b/flang/test/Fir/external-mangling-emboxproc.fir
@@ -3,9 +3,10 @@
 
 func @_QPfoo() {  
   %e6 = fir.alloca tuple<i32,f64>
-  %0 = fir.emboxproc @_QPfoo_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>  
+  %ao = fir.address_of(@_QPfoo_impl) : (!fir.box<!fir.type<derived3{f:f32}>>) -> ()
+  %0 = fir.emboxproc %ao, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>  
   return
 }
 func private @_QPfoo_impl(!fir.ref<i32>)
 
-// CHECK: %{{.*}}= fir.emboxproc @foo_impl_
+// CHECK: fir.address_of(@foo_impl_)

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -53,13 +53,20 @@ func @instructions() {
   %6 = fir.embox %5 : (!fir.heap<!fir.array<100xf32>>) -> !fir.box<!fir.array<100xf32>>
 
 // CHECK: [[VAL_7:%.*]] = fir.box_addr [[VAL_6]] : (!fir.box<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>>
+  %7 = fir.box_addr %6 : (!fir.box<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>>
+// CHECK: %[[WAL_2:.*]] = fir.undefined !fir.boxproc<() -> ()>
+  %ba1 = fir.undefined !fir.boxproc<() -> ()>
+// CHECK: %{{.*}} = fir.box_addr %[[WAL_2]] : (!fir.boxproc<() -> ()>) -> (() -> ())
+  %ba2 = fir.box_addr %ba1 : (!fir.boxproc<() -> ()>) -> (() -> ())
+  %ba3 = fir.undefined !fir.boxchar<1>
+// CHECK: %{{.*}} = fir.box_addr %{{.*}} : (!fir.boxchar<1>) -> !fir.ref<!fir.char<1>>
+  %ba4 = fir.box_addr %ba3 : (!fir.boxchar<1>) -> !fir.ref<!fir.char<1>>
+  %c0 = arith.constant 0 : index
+  %d1:3 = fir.box_dims %6, %c0 : (!fir.box<!fir.array<100xf32>>, index) -> (index, index, index)
 // CHECK: [[VAL_8:%.*]] = arith.constant 0 : index
 // CHECK: [[VAL_9:%.*]]:3 = fir.box_dims [[VAL_6]], [[VAL_8]] : (!fir.box<!fir.array<100xf32>>, index) -> (index, index, index)
 // CHECK: fir.call @print_index3([[VAL_9]]#0, [[VAL_9]]#1, [[VAL_9]]#2) : (index, index, index) -> ()
 // CHECK: [[VAL_10:%.*]] = fir.call @it1() : () -> !fir.int<4>
-  %7 = fir.box_addr %6 : (!fir.box<!fir.array<100xf32>>) -> !fir.ref<!fir.array<100xf32>>
-  %c0 = arith.constant 0 : index
-  %d1:3 = fir.box_dims %6, %c0 : (!fir.box<!fir.array<100xf32>>, index) -> (index, index, index)
   fir.call @print_index3(%d1#0, %d1#1, %d1#2) : (index, index, index) -> ()
   %8 = fir.call @it1() : () -> !fir.int<4>
 
@@ -154,7 +161,8 @@ func @boxing_match() {
 // CHECK: [[VAL_53:%.*]] = arith.constant 4.213000e+01 : f64
 // CHECK: [[VAL_54:%.*]] = fir.insert_value [[VAL_48]], [[VAL_53]], [1 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, f64) -> !fir.type<qq2{f1:i32,f2:f64}>
 // CHECK: fir.store [[VAL_54]] to [[VAL_39]] : !fir.ref<!fir.type<qq2{f1:i32,f2:f64}>>
-// CHECK: [[VAL_55:%.*]] = fir.emboxproc @method_impl, [[VAL_41]] : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32, f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
+// CHECK: %[[WAL_1:.*]] = fir.address_of(@method_impl)
+// CHECK: [[VAL_55:%.*]] = fir.emboxproc %[[WAL_1]], [[VAL_41]] : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32, f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
 // CHECK: [[VAL_56:%.*]], [[VAL_57:%.*]] = fir.unboxproc [[VAL_55]] : (!fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>) -> ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<!fir.type<qq2{f1:i32,f2:f64}>>>)
 // CHECK: [[VAL_58:%.*]] = fir.call @box2() : () -> !fir.boxproc<(i32, i32) -> i64>
 // CHECK: [[VAL_59:%.*]], [[VAL_60:%.*]] = fir.unboxproc [[VAL_58]] : (!fir.boxproc<(i32, i32) -> i64>) -> ((i32, i32) -> i64, !fir.ref<tuple<!fir.type<qq1{f1:i32}>>>)
@@ -179,7 +187,8 @@ func @boxing_match() {
   %c42 = arith.constant 42.13 : f64
   %a3 = fir.insert_value %6, %c42, [1 : i32] : (!fir.type<qq2{f1:i32,f2:f64}>, f64) -> !fir.type<qq2{f1:i32,f2:f64}>
   fir.store %a3 to %d6 : !fir.ref<!fir.type<qq2{f1:i32,f2:f64}>>
-  %7 = fir.emboxproc @method_impl, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
+  %mi = fir.address_of(@method_impl) : (!fir.box<!fir.type<derived3{f:f32}>>) -> ()
+  %7 = fir.emboxproc %mi, %e6 : ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<i32,f64>>) -> !fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>
   %8:2 = fir.unboxproc %7 : (!fir.boxproc<(!fir.box<!fir.type<derived3{f:f32}>>) -> ()>) -> ((!fir.box<!fir.type<derived3{f:f32}>>) -> (), !fir.ref<tuple<!fir.type<qq2{f1:i32,f2:f64}>>>)
   %9 = fir.call @box2() : () -> !fir.boxproc<(i32, i32) -> i64>
   %10:2 = fir.unboxproc %9 : (!fir.boxproc<(i32, i32) -> i64>) -> ((i32, i32) -> i64, !fir.ref<tuple<!fir.type<qq1{f1:i32}>>>)

--- a/flang/test/Lower/dummy-procedure-character.f90
+++ b/flang/test/Lower/dummy-procedure-character.f90
@@ -15,11 +15,11 @@ subroutine cst_len()
   call foo1(bar1)
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar1) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
-! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
-! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo1(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_2:.*]] = fir.emboxproc %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo1(%[[VAL_5]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPcst_len_array
@@ -31,11 +31,11 @@ subroutine cst_len_array()
   end interface
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar1_array) : () -> !fir.array<10x!fir.char<1,7>>
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
-! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : (() -> !fir.array<10x!fir.char<1,7>>) -> (() -> ())
-! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo1b(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_2:.*]] = fir.emboxproc %[[VAL_0]] : (() -> !fir.array<10x!fir.char<1,7>>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo1b(%[[VAL_5]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo1b(bar1_array)
 end subroutine
 
@@ -45,11 +45,11 @@ subroutine cst_len_2()
   external :: bar2
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar2) : (!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 7 : i64
-! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> (() -> ())
-! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo2(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_2:.*]] = fir.emboxproc %[[VAL_0]] : ((!fir.ref<!fir.char<1,7>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_1]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo2(%[[VAL_5]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo2(bar2)
 end subroutine
 
@@ -65,11 +65,11 @@ subroutine dyn_len(n)
 ! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
 ! CHECK:  %[[VAL_5:.*]] = arith.cmpi sgt, %[[VAL_3]], %[[VAL_4]] : i64
 ! CHECK:  %[[VAL_6:.*]] = select %[[VAL_5]], %[[VAL_3]], %[[VAL_4]] : i64
-! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_1]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> (() -> ())
-! CHECK:  %[[VAL_8:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_9:.*]] = fir.insert_value %[[VAL_8]], %[[VAL_7]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_6]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo3(%[[VAL_10]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_7:.*]] = fir.emboxproc %[[VAL_1]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_8:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_9:.*]] = fir.insert_value %[[VAL_8]], %[[VAL_7]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_6]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo3(%[[VAL_10]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo3(bar3)
 end subroutine
 
@@ -83,12 +83,12 @@ subroutine cannot_compute_len_yet()
   end interface
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar4) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
 ! CHECK:  %[[VAL_1:.*]] = arith.constant -1 : index
-! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_2:.*]] = fir.emboxproc %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
 ! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (index) -> i64
-! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo4(%[[VAL_6]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo4(%[[VAL_6]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo4(bar4)
 end subroutine
 
@@ -98,40 +98,44 @@ subroutine cannot_compute_len_yet_2()
   external :: bar5
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QPbar5) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 ! CHECK:  %[[VAL_1:.*]] = arith.constant -1 : index
-! CHECK:  %[[VAL_2:.*]] = fir.convert %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> (() -> ())
+! CHECK:  %[[VAL_2:.*]] = fir.emboxproc %[[VAL_0]] : ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
 ! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (index) -> i64
-! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo5(%[[VAL_6]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_4:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %[[VAL_3]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo5(%[[VAL_6]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo5(bar5)
 end subroutine
 
 ! CHECK-LABEL: func @_QPforward_incoming_length
-! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) {
 subroutine forward_incoming_length(bar6)
   character(*) :: bar6
   external :: bar6
-! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
-! CHECK:  %[[VAL_2:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<() -> (), i64>) -> i64
-! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_1]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo6(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.boxproc<() -> ()>) -> (() -> ())
+! CHECK:  %[[VAL_2:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
+! CHECK:  %[[WAL_1:.*]] = fir.emboxproc %[[WAL_2]] : (() -> ()) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[WAL_1]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo6(%[[VAL_5]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo6(bar6)
 end subroutine
 
 ! CHECK-LABEL: func @_QPoverride_incoming_length
-! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) {
 subroutine override_incoming_length(bar7)
   character(7) :: bar7
   external :: bar7
-! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_1:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.boxproc<() -> ()>) -> (() -> ())
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 7 : i64
-! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<() -> (), i64>
-! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[VAL_1]], [0 : index] : (tuple<() -> (), i64>, () -> ()) -> tuple<() -> (), i64>
-! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<() -> (), i64>, i64) -> tuple<() -> (), i64>
-! CHECK:  fir.call @_QPfoo7(%[[VAL_5]]) : (tuple<() -> (), i64>) -> ()
+! CHECK:  %[[WAL_1:.*]] = fir.emboxproc %[[WAL_2]] : (() -> ()) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[VAL_3:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_4:.*]] = fir.insert_value %[[VAL_3]], %[[WAL_1]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:  fir.call @_QPfoo7(%[[VAL_5]]) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
   call foo7(bar7)
 end subroutine
 
@@ -140,35 +144,37 @@ end subroutine
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QPcall_assumed_length
-! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) {
 subroutine call_assumed_length(bar8)
   character(*) :: bar8
   external :: bar8
-! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
-! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<() -> (), i64>) -> i64
+! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_2:.*]] = fir.box_addr %[[VAL_3]] : (!fir.boxproc<() -> ()>) -> (() -> ())
+! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
 ! CHECK:  %[[VAL_6:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_4]] : i64) {bindc_name = ".result"}
-! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_3]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
+! CHECK:  %[[VAL_7:.*]] = fir.convert %[[WAL_2]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
 ! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
 ! CHECK:  fir.call %[[VAL_7]](%[[VAL_6]], %[[VAL_8]], %{{.*}}) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   call test(bar8(42))
 end subroutine
 
 ! CHECK-LABEL: func @_QPcall_explicit_length
-! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) {
 subroutine call_explicit_length(bar9)
   character(7) :: bar9
   external :: bar9
 ! CHECK:  %[[VAL_1:.*]] = fir.alloca !fir.char<1,7> {bindc_name = ".result"}
-! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_1:.*]] = fir.box_addr %[[VAL_4]] : (!fir.boxproc<() -> ()>) -> (() -> ())
 ! CHECK:  %[[VAL_5:.*]] = arith.constant 7 : i64
 ! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i64) -> index
-! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_4]] : (() -> ()) -> ((!fir.ref<!fir.char<1,7>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[WAL_1]] : (() -> ()) -> ((!fir.ref<!fir.char<1,7>>, index, !fir.ref<i32>) -> !fir.boxchar<1>)
 ! CHECK:  fir.call %[[VAL_8]](%[[VAL_1]], %[[VAL_6]], %{{.*}}) : (!fir.ref<!fir.char<1,7>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   call test(bar9(42))
 end subroutine
 
 ! CHECK-LABEL: func @_QPcall_explicit_length_with_iface
-! CHECK-SAME: %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc}) {
+! CHECK-SAME: %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) {
 subroutine call_explicit_length_with_iface(bar10)
   interface
     function bar10(n)
@@ -179,37 +185,39 @@ subroutine call_explicit_length_with_iface(bar10)
 ! CHECK:  %[[VAL_1:.*]] = fir.alloca i64
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 42 : i64
 ! CHECK:  fir.store %[[VAL_2]] to %[[VAL_1]] : !fir.ref<i64>
-! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+! CHECK:  %[[VAL_3:.*]] = fir.extract_value %[[VAL_0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_1:.*]] = fir.box_addr %[[VAL_3]] : (!fir.boxproc<() -> ()>) -> (() -> ())
 ! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
 ! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
 ! CHECK:  %[[VAL_6:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
 ! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_5]] : index) {bindc_name = ".result"}
-! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_3]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i64>) -> !fir.boxchar<1>)
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[WAL_1]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index, !fir.ref<i64>) -> !fir.boxchar<1>)
 ! CHECK:  fir.call %[[VAL_8]](%[[VAL_7]], %[[VAL_5]], %[[VAL_1]]) : (!fir.ref<!fir.char<1,?>>, index, !fir.ref<i64>) -> !fir.boxchar<1>
   call test(bar10(42_8))
 end subroutine
 
 
 ! CHECK-LABEL: func @_QPhost(
-! CHECK-SAME:  %[[VAL_0:.*]]: tuple<() -> (), i64>
+! CHECK-SAME:  %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64>
 subroutine host(f)
   character*(*) :: f
   external :: f
-  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1:.*]], %{{.*}} : (!fir.ref<tuple<tuple<() -> (), i64>>>, i32) -> !fir.ref<tuple<() -> (), i64>>
-  ! CHECK:  fir.store %[[VAL_0]] to %[[VAL_3]] : !fir.ref<tuple<() -> (), i64>>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1:.*]], %{{.*}} : (!fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>>, i32) -> !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+  ! CHECK:  fir.store %[[VAL_0]] to %[[VAL_3]] : !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
   ! CHECK: fir.call @_QFhostPintern(%[[VAL_1]])
   call intern()
 contains
 ! CHECK-LABEL: func @_QFhostPintern(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<tuple<() -> (), i64>>> {fir.host_assoc})
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>> {fir.host_assoc})
   subroutine intern()
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 0 : i32
-! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<tuple<tuple<() -> (), i64>>>, i32) -> !fir.ref<tuple<() -> (), i64>>
-! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_2]] : !fir.ref<tuple<() -> (), i64>>
-! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_3]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
-! CHECK:  %[[VAL_5:.*]] = fir.extract_value %[[VAL_3]], [1 : index] : (tuple<() -> (), i64>) -> i64
+! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>>, i32) -> !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_2]] : !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+! CHECK:  %[[VAL_4:.*]] = fir.extract_value %[[VAL_3]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:  %[[WAL_1:.*]] = fir.box_addr %[[VAL_4]] : (!fir.boxproc<() -> ()>) -> (() -> ())
+! CHECK:  %[[VAL_5:.*]] = fir.extract_value %[[VAL_3]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
 ! CHECK:  %[[VAL_7:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_5]] : i64) {bindc_name = ".result"}
-! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_4]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>)
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[WAL_1]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>)
 ! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_5]] : (i64) -> index
 ! CHECK:  fir.call %[[VAL_8]](%[[VAL_7]], %[[VAL_9]]) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
     call test(f())
@@ -217,28 +225,29 @@ contains
 end subroutine
 
 ! CHECK-LABEL: func @_QPhost2(
-! CHECK-SAME:  %[[VAL_0:.*]]: tuple<() -> (), i64> {fir.char_proc})
+! CHECK-SAME:  %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc})
 subroutine host2(f)
   ! Test that dummy length is overridden by local length even when used
   ! in the internal procedure. 
   character*(42) :: f
   external :: f
-  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1:.*]], %{{.*}} : (!fir.ref<tuple<tuple<() -> (), i64>>>, i32) -> !fir.ref<tuple<() -> (), i64>>
-  ! CHECK:  fir.store %[[VAL_0]] to %[[VAL_3]] : !fir.ref<tuple<() -> (), i64>>
+  ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1:.*]], %{{.*}} : (!fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>>, i32) -> !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+  ! CHECK:  fir.store %[[VAL_0]] to %[[VAL_3]] : !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
   ! CHECK: fir.call @_QFhost2Pintern(%[[VAL_1]])
   call intern()
 contains
 ! CHECK-LABEL: func @_QFhost2Pintern(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<tuple<() -> (), i64>>> {fir.host_assoc})
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>> {fir.host_assoc})
   subroutine intern()
     ! CHECK:  %[[VAL_1:.*]] = fir.alloca !fir.char<1,42> {bindc_name = ".result"}
     ! CHECK:  %[[VAL_2:.*]] = arith.constant 0 : i32
-    ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<tuple<tuple<() -> (), i64>>>, i32) -> !fir.ref<tuple<() -> (), i64>>
-    ! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<tuple<() -> (), i64>>
-    ! CHECK:  %[[VAL_5:.*]] = fir.extract_value %[[VAL_4]], [0 : index] : (tuple<() -> (), i64>) -> (() -> ())
+    ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>>, i32) -> !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+    ! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>
+    ! CHECK:  %[[VAL_5:.*]] = fir.extract_value %[[VAL_4]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+    ! CHECK:  %[[WAL_1:.*]] = fir.box_addr %[[VAL_5]] : (!fir.boxproc<() -> ()>) -> (() -> ())
     ! CHECK:  %[[VAL_6:.*]] = arith.constant 42 : i64
     ! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
-    ! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_5]] : (() -> ()) -> ((!fir.ref<!fir.char<1,42>>, index) -> !fir.boxchar<1>)
+    ! CHECK:  %[[VAL_9:.*]] = fir.convert %[[WAL_1]] : (() -> ()) -> ((!fir.ref<!fir.char<1,42>>, index) -> !fir.boxchar<1>)
     ! CHECK:  fir.call %[[VAL_9]](%[[VAL_1]], %[[VAL_7]]) : (!fir.ref<!fir.char<1,42>>, index) -> !fir.boxchar<1>
     call test(f())
   end subroutine

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -373,11 +373,11 @@ subroutine test8(dummy_proc)
  call bar()
 contains
 ! CHECK-LABEL: func @_QFtest8Pbar(
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<() -> ()>> {fir.host_assoc}) {
+! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.boxproc<() -> ()>>> {fir.host_assoc}) {
 subroutine bar()
-  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<() -> ()>>, i32) -> !fir.ref<() -> ()>
-  ! CHECK: %[[dummyProc:.*]] = fir.load %[[tupAddr]] : !fir.ref<() -> ()>
-  ! CHECK: %[[dummyProcCast:.*]] = fir.convert %[[dummyProc]] : (() -> ()) -> ((!fir.ref<f32>) -> f32)
+  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.boxproc<() -> ()>>>, i32) -> !fir.ref<!fir.boxproc<() -> ()>>
+  ! CHECK: %[[dummyProc:.*]] = fir.load %[[tupAddr]] : !fir.ref<!fir.boxproc<() -> ()>>
+  ! CHECK: %[[dummyProcCast:.*]] = fir.box_addr %[[dummyProc]] : (!fir.boxproc<() -> ()>) -> ((!fir.ref<f32>) -> f32)
   ! CHECK: fir.call %[[dummyProcCast]](%{{.*}}) : (!fir.ref<f32>) -> f32
  print *, dummy_proc(42.)
 end subroutine
@@ -393,11 +393,12 @@ subroutine test9(dummy_proc)
  call bar()
 contains
 ! CHECK-LABEL: func @_QFtest9Pbar(
-! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<() -> ()>> {fir.host_assoc}) {
+! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.boxproc<() -> ()>>> {fir.host_assoc}) {
 subroutine bar()
-  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<() -> ()>>, i32) -> !fir.ref<() -> ()>
-  ! CHECK: %[[dummyProc:.*]] = fir.load %[[tupAddr]] : !fir.ref<() -> ()>
-  ! CHECK: fir.call %[[dummyProc]]() : () -> ()
+  ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.boxproc<() -> ()>>>, i32) -> !fir.ref<!fir.boxproc<() -> ()>>
+  ! CHECK: %[[dummyProc:.*]] = fir.load %[[tupAddr]] : !fir.ref<!fir.boxproc<() -> ()>>
+  ! CHECK: %[[pa:.*]] = fir.box_addr %[[dummyProc]]
+  ! CHECK: fir.call %[[pa]]() : () -> ()
   call dummy_proc()
 end subroutine
 end subroutine
@@ -422,3 +423,230 @@ subroutine bar()
   read (88, NML = a_namelist) 
 end subroutine
 end subroutine
+
+! Test passing an internal procedure as a dummy argument.
+
+! CHECK-LABEL: func @_QPtest_proc_dummy() {
+! CHECK:         %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFtest_proc_dummyEi"}
+! CHECK:         %[[VAL_5:.*]] = fir.alloca tuple<!fir.ref<i32>>
+! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QFtest_proc_dummyPtest_proc_dummy_a) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> ()
+! CHECK:         %[[VAL_8:.*]] = fir.emboxproc %[[VAL_7]], %[[VAL_5]] : ((!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> (), !fir.ref<tuple<!fir.ref<i32>>>) -> !fir.boxproc<() -> ()>
+! CHECK:         fir.call @_QPtest_proc_dummy_other(%[[VAL_8]]) : (!fir.boxproc<() -> ()>) -> ()
+
+! CHECK-LABEL: func @_QFtest_proc_dummyPtest_proc_dummy_a(
+! CHECK-SAME:          %[[VAL_0:.*]]: !fir.ref<i32> {fir.bindc_name = "j"},
+! CHECK-SAME:          %[[VAL_1:.*]]: !fir.ref<tuple<!fir.ref<i32>>> {fir.host_assoc}) {
+! CHECK:         %[[VAL_2:.*]] = arith.constant 0 : i32
+! CHECK:         %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.llvm_ptr<!fir.ref<i32>>
+! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
+! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:         %[[VAL_7:.*]] = arith.addi %[[VAL_5]], %[[VAL_6]] : i32
+! CHECK:         fir.store %[[VAL_7]] to %[[VAL_4]] : !fir.ref<i32>
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func @_QPtest_proc_dummy_other(
+! CHECK-SAME:           %[[VAL_0:.*]]: !fir.boxproc<() -> ()>) {
+! CHECK:         %[[VAL_1:.*]] = arith.constant 4 : i32
+! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {adapt.valuebyref}
+! CHECK:         fir.store %[[VAL_1]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:         %[[VAL_3:.*]] = fir.box_addr %[[VAL_0]] : (!fir.boxproc<() -> ()>) -> ((!fir.ref<i32>) -> ())
+! CHECK:         fir.call %[[VAL_3]](%[[VAL_2]]) : (!fir.ref<i32>) -> ()
+! CHECK:         return
+! CHECK:       }
+
+subroutine test_proc_dummy
+  integer i
+  i = 1
+  call test_proc_dummy_other(test_proc_dummy_a)
+  print *, i
+contains
+  subroutine test_proc_dummy_a(j)
+    i = i + j
+  end subroutine test_proc_dummy_a
+end subroutine test_proc_dummy
+
+subroutine test_proc_dummy_other(proc)
+  call proc(4)
+end subroutine test_proc_dummy_other
+
+! CHECK-LABEL: func @_QPtest_proc_dummy_char() {
+! CHECK-DAG:         %[[VAL_0:.*]] = arith.constant 10 : index
+! CHECK-DAG:         %[[VAL_1:.*]] = arith.constant 0 : i32
+! CHECK-DAG:         %[[VAL_2:.*]] = arith.constant 9 : index
+! CHECK-DAG:         %[[VAL_3:.*]] = arith.constant false
+! CHECK-DAG:         %[[VAL_4:.*]] = arith.constant 1 : index
+! CHECK-DAG:         %[[VAL_5:.*]] = arith.constant 32 : i8
+! CHECK-DAG:         %[[VAL_6:.*]] = arith.constant -1 : i32
+! CHECK-DAG:         %[[VAL_8:.*]] = arith.constant 10 : i64
+! CHECK-DAG:         %[[VAL_9:.*]] = arith.constant 40 : index
+! CHECK-DAG:         %[[VAL_10:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_11:.*]] = fir.alloca !fir.char<1,40> {bindc_name = ".result"}
+! CHECK:         %[[VAL_12:.*]] = fir.alloca !fir.char<1,10> {bindc_name = "message", uniq_name = "_QFtest_proc_dummy_charEmessage"}
+! CHECK:         %[[VAL_13:.*]] = fir.alloca tuple<!fir.boxchar<1>>
+! CHECK:         %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_1]] : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_16:.*]] = fir.emboxchar %[[VAL_15]], %[[VAL_0]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         fir.store %[[VAL_16]] to %[[VAL_14]] : !fir.ref<!fir.boxchar<1>>
+! CHECK:         %[[VAL_17:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,9>>
+! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_2]] : (index) -> i64
+! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_17]] : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
+! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_19]], %[[VAL_20]], %[[VAL_18]], %[[VAL_3]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+! CHECK:         %[[VAL_21:.*]] = fir.undefined !fir.char<1>
+! CHECK:         %[[VAL_22:.*]] = fir.insert_value %[[VAL_21]], %[[VAL_5]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+! CHECK:         br ^bb1(%[[VAL_2]], %[[VAL_4]] : index, index)
+! CHECK:       ^bb1(%[[VAL_23:.*]]: index, %[[VAL_24:.*]]: index):
+! CHECK:         %[[VAL_25:.*]] = arith.cmpi sgt, %[[VAL_24]], %[[VAL_10]] : index
+! CHECK:         cond_br %[[VAL_25]], ^bb2, ^bb3
+! CHECK:       ^bb2:
+! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.array<10x!fir.char<1>>>
+! CHECK:         %[[VAL_27:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_23]] : (!fir.ref<!fir.array<10x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+! CHECK:         fir.store %[[VAL_22]] to %[[VAL_27]] : !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_28:.*]] = arith.addi %[[VAL_23]], %[[VAL_4]] : index
+! CHECK:         %[[VAL_29:.*]] = arith.subi %[[VAL_24]], %[[VAL_4]] : index
+! CHECK:         br ^bb1(%[[VAL_28]], %[[VAL_29]] : index, index)
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_30:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_32:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_31]], %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:         %[[VAL_33:.*]] = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
+! CHECK:         %[[VAL_34:.*]] = fir.emboxproc %[[VAL_33]], %[[VAL_13]] : ((!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxproc<() -> ()>
+! CHECK:         %[[VAL_35:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:         %[[VAL_36:.*]] = fir.insert_value %[[VAL_35]], %[[VAL_34]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:         %[[VAL_37:.*]] = fir.insert_value %[[VAL_36]], %[[VAL_8]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
+! CHECK:         %[[VAL_38:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+! CHECK:         %[[VAL_39:.*]] = fir.call @_QPget_message(%[[VAL_11]], %[[VAL_9]], %[[VAL_37]]) : (!fir.ref<!fir.char<1,40>>, index, tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxchar<1>
+! CHECK:         %[[VAL_40:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_41:.*]] = fir.convert %[[VAL_9]] : (index) -> i64
+! CHECK:         %[[VAL_42:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_32]], %[[VAL_40]], %[[VAL_41]]) : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:         fir.call @llvm.stackrestore(%[[VAL_38]]) : (!fir.ref<i8>) -> ()
+! CHECK:         %[[VAL_43:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_32]]) : (!fir.ref<i8>) -> i32
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func @_QFtest_proc_dummy_charPgen_message(
+! CHECK-SAME:                                            %[[VAL_0:.*]]: !fir.ref<!fir.char<1,10>>,
+! CHECK-SAME:                                            %[[VAL_1:.*]]: index,
+! CHECK-SAME:                                            %[[VAL_2:.*]]: !fir.ref<tuple<!fir.boxchar<1>>> {fir.host_assoc}) -> !fir.boxchar<1> {
+! CHECK:         %[[VAL_3:.*]] = arith.constant 0 : i32
+! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_5:.*]] = arith.constant false
+! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_7:.*]] = arith.constant 32 : i8
+! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_3]] : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
+! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_9]] : !fir.ref<!fir.boxchar<1>>
+! CHECK:         %[[VAL_11:.*]]:2 = fir.unboxchar %[[VAL_10]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_13:.*]] = arith.cmpi slt, %[[VAL_4]], %[[VAL_11]]#1 : index
+! CHECK:         %[[VAL_14:.*]] = select %[[VAL_13]], %[[VAL_4]], %[[VAL_11]]#1 : index
+! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (index) -> i64
+! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_11]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_16]], %[[VAL_17]], %[[VAL_15]], %[[VAL_5]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+! CHECK:         %[[VAL_18:.*]] = fir.undefined !fir.char<1>
+! CHECK:         %[[VAL_19:.*]] = fir.insert_value %[[VAL_18]], %[[VAL_7]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+! CHECK:         %[[VAL_20:.*]] = arith.subi %[[VAL_4]], %[[VAL_14]] : index
+! CHECK:         br ^bb1(%[[VAL_14]], %[[VAL_20]] : index, index)
+! CHECK:       ^bb1(%[[VAL_21:.*]]: index, %[[VAL_22:.*]]: index):
+! CHECK:         %[[VAL_23:.*]] = arith.cmpi sgt, %[[VAL_22]], %[[VAL_8]] : index
+! CHECK:         cond_br %[[VAL_23]], ^bb2, ^bb3
+! CHECK:       ^bb2:
+! CHECK:         %[[VAL_24:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+! CHECK:         %[[VAL_25:.*]] = fir.coordinate_of %[[VAL_24]], %[[VAL_21]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+! CHECK:         fir.store %[[VAL_19]] to %[[VAL_25]] : !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_26:.*]] = arith.addi %[[VAL_21]], %[[VAL_6]] : index
+! CHECK:         %[[VAL_27:.*]] = arith.subi %[[VAL_22]], %[[VAL_6]] : index
+! CHECK:         br ^bb1(%[[VAL_26]], %[[VAL_27]] : index, index)
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_28:.*]] = fir.emboxchar %[[VAL_12]], %[[VAL_4]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         return %[[VAL_28]] : !fir.boxchar<1>
+! CHECK:       }
+
+! CHECK-LABEL: func @_QPget_message(
+! CHECK-SAME:                       %[[VAL_0:.*]]: !fir.ref<!fir.char<1,40>>,
+! CHECK-SAME:                       %[[VAL_1:.*]]: index,
+! CHECK-SAME:                       %[[VAL_2:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc}) -> !fir.boxchar<1> {
+! CHECK:         %[[VAL_3:.*]] = arith.constant 40 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 12 : index
+! CHECK:         %[[VAL_5:.*]] = arith.constant false
+! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_7:.*]] = arith.constant 32 : i8
+! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<!fir.char<1,?>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,12>>
+! CHECK:         %[[VAL_11:.*]] = fir.extract_value %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
+! CHECK:         %[[VAL_12:.*]] = fir.box_addr %[[VAL_11]] : (!fir.boxproc<() -> ()>) -> (() -> ())
+! CHECK:         %[[VAL_13:.*]] = fir.extract_value %[[VAL_2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
+! CHECK:         %[[VAL_14:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+! CHECK:         %[[VAL_15:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_13]] : i64) {bindc_name = ".result"}
+! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_12]] : (() -> ()) -> ((!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>)
+! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_13]] : (i64) -> index
+! CHECK:         %[[VAL_18:.*]] = fir.call %[[VAL_16]](%[[VAL_15]], %[[VAL_17]]) : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         %[[VAL_19:.*]] = arith.addi %[[VAL_17]], %[[VAL_4]] : index
+! CHECK:         %[[VAL_20:.*]] = fir.alloca !fir.char<1,?>(%[[VAL_19]] : index) {bindc_name = ".chrtmp"}
+! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_4]] : (index) -> i64
+! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_20]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:         %[[VAL_23:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
+! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_22]], %[[VAL_23]], %[[VAL_21]], %[[VAL_5]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+! CHECK:         br ^bb1(%[[VAL_4]], %[[VAL_17]] : index, index)
+! CHECK:       ^bb1(%[[VAL_24:.*]]: index, %[[VAL_25:.*]]: index):
+! CHECK:         %[[VAL_26:.*]] = arith.cmpi sgt, %[[VAL_25]], %[[VAL_8]] : index
+! CHECK:         cond_br %[[VAL_26]], ^bb2, ^bb3
+! CHECK:       ^bb2:
+! CHECK:         %[[VAL_27:.*]] = arith.subi %[[VAL_24]], %[[VAL_4]] : index
+! CHECK:         %[[VAL_28:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+! CHECK:         %[[VAL_29:.*]] = fir.coordinate_of %[[VAL_28]], %[[VAL_27]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_30:.*]] = fir.load %[[VAL_29]] : !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_20]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+! CHECK:         %[[VAL_32:.*]] = fir.coordinate_of %[[VAL_31]], %[[VAL_24]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+! CHECK:         fir.store %[[VAL_30]] to %[[VAL_32]] : !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_33:.*]] = arith.addi %[[VAL_24]], %[[VAL_6]] : index
+! CHECK:         %[[VAL_34:.*]] = arith.subi %[[VAL_25]], %[[VAL_6]] : index
+! CHECK:         br ^bb1(%[[VAL_33]], %[[VAL_34]] : index, index)
+! CHECK:       ^bb3:
+! CHECK:         %[[VAL_35:.*]] = arith.cmpi slt, %[[VAL_3]], %[[VAL_19]] : index
+! CHECK:         %[[VAL_36:.*]] = select %[[VAL_35]], %[[VAL_3]], %[[VAL_19]] : index
+! CHECK:         %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (index) -> i64
+! CHECK:         %[[VAL_38:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:         fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_38]], %[[VAL_22]], %[[VAL_37]], %[[VAL_5]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
+! CHECK:         %[[VAL_39:.*]] = fir.undefined !fir.char<1>
+! CHECK:         %[[VAL_40:.*]] = fir.insert_value %[[VAL_39]], %[[VAL_7]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+! CHECK:         %[[VAL_41:.*]] = arith.subi %[[VAL_3]], %[[VAL_36]] : index
+! CHECK:         br ^bb4(%[[VAL_36]], %[[VAL_41]] : index, index)
+! CHECK:       ^bb4(%[[VAL_42:.*]]: index, %[[VAL_43:.*]]: index):
+! CHECK:         %[[VAL_44:.*]] = arith.cmpi sgt, %[[VAL_43]], %[[VAL_8]] : index
+! CHECK:         cond_br %[[VAL_44]], ^bb5, ^bb6
+! CHECK:       ^bb5:
+! CHECK:         %[[VAL_45:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<?x!fir.char<1>>>
+! CHECK:         %[[VAL_46:.*]] = fir.coordinate_of %[[VAL_45]], %[[VAL_42]] : (!fir.ref<!fir.array<?x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
+! CHECK:         fir.store %[[VAL_40]] to %[[VAL_46]] : !fir.ref<!fir.char<1>>
+! CHECK:         %[[VAL_47:.*]] = arith.addi %[[VAL_42]], %[[VAL_6]] : index
+! CHECK:         %[[VAL_48:.*]] = arith.subi %[[VAL_43]], %[[VAL_6]] : index
+! CHECK:         br ^bb4(%[[VAL_47]], %[[VAL_48]] : index, index)
+! CHECK:       ^bb6:
+! CHECK:         fir.call @llvm.stackrestore(%[[VAL_14]]) : (!fir.ref<i8>) -> ()
+! CHECK:         %[[VAL_49:.*]] = fir.emboxchar %[[VAL_9]], %[[VAL_3]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:         return %[[VAL_49]] : !fir.boxchar<1>
+! CHECK:       }
+
+subroutine test_proc_dummy_char
+  character(40) get_message
+  external get_message
+  character(10) message
+  message = "Hi there!"
+  print *, get_message(gen_message)
+contains
+  function gen_message
+    character(10) :: gen_message
+    gen_message = message
+  end function gen_message
+end subroutine test_proc_dummy_char
+
+function get_message(a)
+  character(40) :: get_message
+  character(*) :: a
+  get_message = "message is: " // a() 
+end function get_message

--- a/flang/test/Lower/procedure-declarations.f90
+++ b/flang/test/Lower/procedure-declarations.f90
@@ -15,7 +15,7 @@
 subroutine pass_foo()
   external :: foo
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo)
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo)
 end subroutine
 ! CHECK-LABEL: func @_QPcall_foo(
@@ -46,7 +46,7 @@ end subroutine
 subroutine pass_foo2()
   external :: foo2
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo2)
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo2)
 end subroutine
 ! CHECK-LABEL: func @_QPfoo2(
@@ -75,7 +75,7 @@ end subroutine
 subroutine pass_foo3()
   external :: foo3
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo3)
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo3)
 end subroutine
 
@@ -98,7 +98,7 @@ end subroutine
 subroutine pass_foo4()
   external :: foo4
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo4)
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo4)
 end subroutine
 
@@ -113,7 +113,7 @@ end subroutine
 subroutine pass_foo5()
   external :: foo5
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo5)
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<2x5xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo5)
 end subroutine
 ! CHECK-LABEL: func @_QPcall_foo5(
@@ -141,7 +141,7 @@ end subroutine
 subroutine pass_foo6()
   external :: foo6
   ! CHECK: %[[f:.*]] = fir.address_of(@_QPfoo6) : (!fir.ref<!fir.array<10xi32>>) -> ()
-  ! CHECK: fir.convert %[[f]] : ((!fir.ref<!fir.array<10xi32>>) -> ()) -> (() -> ())
+  ! CHECK: fir.emboxproc %[[f]] : ((!fir.ref<!fir.array<10xi32>>) -> ()) -> !fir.boxproc<() -> ()>
   call bar(foo6)
 end subroutine
 

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -772,6 +772,14 @@ LogicalResult ModuleTranslation::convertOneFunction(LLVMFuncOp func) {
           llvmArg.getType()->getPointerElementType()));
     }
 
+    if (auto attr = func.getArgAttrOfType<UnitAttr>(argIdx, "llvm.nest")) {
+      auto argTy = mlirArg.getType();
+      if (!argTy.isa<LLVM::LLVMPointerType>())
+        return func.emitError(
+            "llvm.nest attribute attached to LLVM non-pointer argument");
+      llvmArg.addAttrs(llvm::AttrBuilder().addAttribute(llvm::Attribute::Nest));
+    }
+
     mapValue(mlirArg, &llvmArg);
     argIdx++;
   }

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -97,6 +97,11 @@ module {
     llvm.return
   }
 
+  // CHECK: llvm.func @nestattr(%{{.*}}: !llvm.ptr<i32> {llvm.nest})
+  llvm.func @nestattr(%arg0: !llvm.ptr<i32> {llvm.nest}) {
+    llvm.return
+  }
+
   // CHECK: llvm.func @variadic(...)
   llvm.func @variadic(...)
 

--- a/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
@@ -15,13 +15,20 @@ llvm.func @invalid_noalias(%arg0 : f32 {llvm.noalias}) -> f32 {
 // -----
 
 // expected-error @+1 {{llvm.sret attribute attached to LLVM non-pointer argument}}
-llvm.func @invalid_noalias(%arg0 : f32 {llvm.sret}) -> f32 {
+llvm.func @invalid_sret(%arg0 : f32 {llvm.sret}) -> f32 {
+  llvm.return %arg0 : f32
+}
+
+// -----
+
+// expected-error @+1 {{llvm.nest attribute attached to LLVM non-pointer argument}}
+llvm.func @invalid_nest(%arg0 : f32 {llvm.nest}) -> f32 {
   llvm.return %arg0 : f32
 }
 // -----
 
 // expected-error @+1 {{llvm.byval attribute attached to LLVM non-pointer argument}}
-llvm.func @invalid_noalias(%arg0 : f32 {llvm.byval}) -> f32 {
+llvm.func @invalid_byval(%arg0 : f32 {llvm.byval}) -> f32 {
   llvm.return %arg0 : f32
 }
 

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1033,6 +1033,11 @@ llvm.func @sretattr(%arg0: !llvm.ptr<i32> {llvm.sret}) {
   llvm.return
 }
 
+// CHECK-LABEL: define void @nestattr(i32* nest %
+llvm.func @nestattr(%arg0: !llvm.ptr<i32> {llvm.nest}) {
+  llvm.return
+}
+
 // CHECK-LABEL: define void @llvm_align(float* align 4 {{%*.}})
 llvm.func @llvm_align(%arg0: !llvm.ptr<f32> {llvm.align = 4}) {
   llvm.return


### PR DESCRIPTION
In FIR, we want to wrap function pointers in a special box known as a
boxproc value. Fortran has a limited form of dynamic scoping
[https://tinyurl.com/2p8v2hw7] between "host procedures" and "internal
procedures". There are a number of implementations possible.

Boxproc typed values abstract away the implementation details of when a
function pointer can be passed directly (as a raw address) and when a
function pointer has to account for the presence of a dynamic scope.
When lowering Fortran syntax to FIR, all function pointers are emboxed
as boxproc values.

When creating LLVM IR, we must strip away the abstraction and produce
low-level LLVM "assembly" code. This patch implements that
transformation as converting the boxproc values to either raw function
pointers or executable trampolines on the stack as needed. The
trampoline then captures the dynamic scope context within an executable
thunk that can be passed instead of the function's raw address.

Some extra handling is required for Fortran functions that return a
character value to deal with LEN values here.

Add tests for both Burnside and Tilikum bridges.