### PR TITLE
[flang][mlir][NFC] Replace uses of raw accessors with prefixed accessors

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -318,14 +318,14 @@ public:
         : ifOp{ifOp}, builder{builder} {}
     template <typename CC>
     IfBuilder &genThen(CC func) {
-      builder.setInsertionPointToStart(&ifOp.thenRegion().front());
+      builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
       func();
       return *this;
     }
     template <typename CC>
     IfBuilder &genElse(CC func) {
-      assert(!ifOp.elseRegion().empty() && "must have else region");
-      builder.setInsertionPointToStart(&ifOp.elseRegion().front());
+      assert(!ifOp.getElseRegion().empty() && "must have else region");
+      builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
       func();
       return *this;
     }

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -169,12 +169,12 @@ def fir_AllocaOp : fir_Op<"alloca", [AttrSizedOperandSegments,
 
   let extraClassDeclaration = [{
     mlir::Type getAllocatedType();
-    bool hasLenParams() { return !typeparams().empty(); }
-    bool hasShapeOperands() { return !shape().empty(); }
-    unsigned numLenParams() { return typeparams().size(); }
-    operand_range getLenParams() { return typeparams(); }
-    unsigned numShapeOperands() { return shape().size(); }
-    operand_range getShapeOperands() { return shape(); }
+    bool hasLenParams() { return !getTypeparams().empty(); }
+    bool hasShapeOperands() { return !getShape().empty(); }
+    unsigned numLenParams() { return getTypeparams().size(); }
+    operand_range getLenParams() { return getTypeparams(); }
+    unsigned numShapeOperands() { return getShape().size(); }
+    operand_range getShapeOperands() { return getShape(); }
     static mlir::Type getRefTy(mlir::Type ty);
   }];
 }
@@ -226,12 +226,12 @@ def fir_AllocMemOp : fir_Op<"allocmem",
 
   let extraClassDeclaration = [{
     mlir::Type getAllocatedType();
-    bool hasLenParams() { return !typeparams().empty(); }
-    bool hasShapeOperands() { return !shape().empty(); }
-    unsigned numLenParams() { return typeparams().size(); }
-    operand_range getLenParams() { return typeparams(); }
-    unsigned numShapeOperands() { return shape().size(); }
-    operand_range getShapeOperands() { return shape(); }
+    bool hasLenParams() { return !getTypeparams().empty(); }
+    bool hasShapeOperands() { return !getShape().empty(); }
+    unsigned numLenParams() { return getTypeparams().size(); }
+    operand_range getLenParams() { return getTypeparams(); }
+    unsigned numShapeOperands() { return getShape().size(); }
+    operand_range getShapeOperands() { return getShape(); }
     static mlir::Type getRefTy(mlir::Type ty);
   }];
 }
@@ -881,8 +881,8 @@ def fir_EmboxOp : fir_Op<"embox", [NoSideEffect, AttrSizedOperandSegments]> {
   let verifier = "return ::verify(*this);";
 
   let extraClassDeclaration = [{
-    bool hasLenParams() { return !typeparams().empty(); }
-    unsigned numLenParams() { return typeparams().size(); }
+    bool hasLenParams() { return !getTypeparams().empty(); }
+    unsigned numLenParams() { return getTypeparams().size(); }
   }];
 }
 
@@ -1821,7 +1821,7 @@ def fir_FieldIndexOp : fir_OneResultOp<"field_index", [NoSideEffect]> {
   let extraClassDeclaration = [{
     static constexpr llvm::StringRef getFieldAttrName() { return "field_id"; }
     static constexpr llvm::StringRef getTypeAttrName() { return "on_type"; }
-    llvm::StringRef getFieldName() { return field_id(); }
+    llvm::StringRef getFieldName() { return getFieldId(); }
     llvm::SmallVector<mlir::Attribute> getAttributes();
   }];
 }
@@ -1886,7 +1886,7 @@ def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
     // Logically unzip the origins from the extent values.
     std::vector<mlir::Value> getOrigins() {
       std::vector<mlir::Value> result;
-      for (auto i : llvm::enumerate(pairs()))
+      for (auto i : llvm::enumerate(getPairs()))
         if (!(i.index() & 1))
           result.push_back(i.value());
       return result;
@@ -1895,7 +1895,7 @@ def fir_ShapeShiftOp : fir_Op<"shape_shift", [NoSideEffect]> {
     // Logically unzip the extents from the origin values.
     std::vector<mlir::Value> getExtents() {
       std::vector<mlir::Value> result;
-      for (auto i : llvm::enumerate(pairs()))
+      for (auto i : llvm::enumerate(getPairs()))
         if (i.index() & 1)
           result.push_back(i.value());
       return result;
@@ -1988,7 +1988,7 @@ def fir_SliceOp : fir_Op<"slice", [NoSideEffect, AttrSizedOperandSegments]> {
   let verifier = "return ::verify(*this);";
 
   let extraClassDeclaration = [{
-    unsigned getOutRank() { return getOutputRank(triples()); }
+    unsigned getOutRank() { return getOutputRank(getTriples()); }
     static unsigned getOutputRank(mlir::ValueRange triples);
   }];
 }
@@ -2213,7 +2213,7 @@ def fir_DoLoopOp : region_Op<"do_loop",
     }
 
     /// Get the body of the loop
-    mlir::Block *getBody() { return &region().front(); }
+    mlir::Block *getBody() { return &getRegion().front(); }
 
     void setUnordered() {
       (*this)->setAttr(getUnorderedAttrName(),
@@ -2261,13 +2261,13 @@ def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
 
   let extraClassDeclaration = [{
     mlir::OpBuilder getThenBodyBuilder() {
-      assert(!thenRegion().empty() && "Unexpected empty 'where' region.");
-      mlir::Block &body = thenRegion().front();
+      assert(!getThenRegion().empty() && "Unexpected empty 'where' region.");
+      mlir::Block &body = getThenRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
     mlir::OpBuilder getElseBodyBuilder() {
-      assert(!elseRegion().empty() && "Unexpected empty 'other' region.");
-      mlir::Block &body = elseRegion().front();
+      assert(!getElseRegion().empty() && "Unexpected empty 'other' region.");
+      mlir::Block &body = getElseRegion().front();
       return mlir::OpBuilder(&body, std::prev(body.end()));
     }
 
@@ -2330,7 +2330,7 @@ def fir_IterWhileOp : region_Op<"iterate_while",
     static constexpr llvm::StringRef getFinalValueAttrNameStr() {
       return "finalValue";
     }
-    mlir::Block *getBody() { return &region().front(); }
+    mlir::Block *getBody() { return &getRegion().front(); }
     mlir::Value getIterateVar() { return getBody()->getArgument(1); }
     mlir::Value getInductionVar() { return getBody()->getArgument(0); }
     mlir::OpBuilder getBodyBuilder() {
@@ -2832,7 +2832,7 @@ def fir_GlobalOp : fir_Op<"global", [IsolatedFromAbove, Symbol]> {
     mlir::Type resultType();
 
     /// Return the initializer attribute if it exists, or a null attribute.
-    Attribute getValueOrNull() { return initVal().getValueOr(Attribute()); }
+    Attribute getValueOrNull() { return getInitVal().getValueOr(Attribute()); }
 
     /// Append the next initializer value to the `GlobalOp` to construct
     /// the variable's initial value.

--- a/flang/lib/Optimizer/Builder/Character.cpp
+++ b/flang/lib/Optimizer/Builder/Character.cpp
@@ -162,8 +162,8 @@ fir::factory::CharacterExprHelper::toExtendedValue(mlir::Value character,
     mlir::Value boxCharLen;
     if (auto definingOp = character.getDefiningOp()) {
       if (auto box = dyn_cast<fir::EmboxCharOp>(definingOp)) {
-        base = box.memref();
-        boxCharLen = box.len();
+        base = box.getMemref();
+        boxCharLen = box.getLen();
       }
     }
     if (!boxCharLen) {

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -451,7 +451,7 @@ void fir::factory::genFinalization(fir::FirOpBuilder &builder,
   auto ifOp = builder.create<fir::IfOp>(loc, isAllocated,
                                         /*withElseRegion=*/false);
   auto insPt = builder.saveInsertionPoint();
-  builder.setInsertionPointToStart(&ifOp.thenRegion().front());
+  builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
   genFinalizeAndFree(builder, loc, addr);
   builder.restoreInsertionPoint(insPt);
 }

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -31,15 +31,15 @@ using namespace fir;
 
 static void populateShape(llvm::SmallVectorImpl<mlir::Value> &vec,
                           ShapeOp shape) {
-  vec.append(shape.extents().begin(), shape.extents().end());
+  vec.append(shape.getExtents().begin(), shape.getExtents().end());
 }
 
 // Operands of fir.shape_shift split into two vectors.
 static void populateShapeAndShift(llvm::SmallVectorImpl<mlir::Value> &shapeVec,
                                   llvm::SmallVectorImpl<mlir::Value> &shiftVec,
                                   ShapeShiftOp shift) {
-  auto endIter = shift.pairs().end();
-  for (auto i = shift.pairs().begin(); i != endIter;) {
+  auto endIter = shift.getPairs().end();
+  for (auto i = shift.getPairs().begin(); i != endIter;) {
     shiftVec.push_back(*i++);
     shapeVec.push_back(*i++);
   }
@@ -47,7 +47,7 @@ static void populateShapeAndShift(llvm::SmallVectorImpl<mlir::Value> &shapeVec,
 
 static void populateShift(llvm::SmallVectorImpl<mlir::Value> &vec,
                           ShiftOp shift) {
-  vec.append(shift.origins().begin(), shift.origins().end());
+  vec.append(shift.getOrigins().begin(), shift.getOrigins().end());
 }
 
 namespace {
@@ -101,8 +101,8 @@ public:
       shapeOpers.push_back(extVal);
     }
     auto xbox = rewriter.create<cg::XEmboxOp>(
-        loc, embox.getType(), embox.memref(), shapeOpers, llvm::None,
-        llvm::None, llvm::None, llvm::None, embox.typeparams());
+        loc, embox.getType(), embox.getMemref(), shapeOpers, llvm::None,
+        llvm::None, llvm::None, llvm::None, embox.getTypeparams());
     LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
@@ -127,13 +127,16 @@ public:
     llvm::SmallVector<mlir::Value> substrOpers;
     if (auto s = embox.getSlice())
       if (auto sliceOp = dyn_cast_or_null<SliceOp>(s.getDefiningOp())) {
-        sliceOpers.assign(sliceOp.triples().begin(), sliceOp.triples().end());
-        subcompOpers.assign(sliceOp.fields().begin(), sliceOp.fields().end());
-        substrOpers.assign(sliceOp.substr().begin(), sliceOp.substr().end());
+        sliceOpers.assign(sliceOp.getTriples().begin(),
+                          sliceOp.getTriples().end());
+        subcompOpers.assign(sliceOp.getFields().begin(),
+                            sliceOp.getFields().end());
+        substrOpers.assign(sliceOp.getSubstr().begin(),
+                           sliceOp.getSubstr().end());
       }
     auto xbox = rewriter.create<cg::XEmboxOp>(
-        loc, embox.getType(), embox.memref(), shapeOpers, shiftOpers,
-        sliceOpers, subcompOpers, substrOpers, embox.typeparams());
+        loc, embox.getType(), embox.getMemref(), shapeOpers, shiftOpers,
+        sliceOpers, subcompOpers, substrOpers, embox.getTypeparams());
     LLVM_DEBUG(llvm::dbgs() << "rewriting " << embox << " to " << xbox << '\n');
     rewriter.replaceOp(embox, xbox.getOperation()->getResults());
     return mlir::success();
@@ -162,7 +165,7 @@ public:
     auto loc = rebox.getLoc();
     llvm::SmallVector<mlir::Value> shapeOpers;
     llvm::SmallVector<mlir::Value> shiftOpers;
-    if (auto shapeVal = rebox.shape()) {
+    if (auto shapeVal = rebox.getShape()) {
       if (auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp()))
         populateShape(shapeOpers, shapeOp);
       else if (auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp()))
@@ -175,16 +178,19 @@ public:
     llvm::SmallVector<mlir::Value> sliceOpers;
     llvm::SmallVector<mlir::Value> subcompOpers;
     llvm::SmallVector<mlir::Value> substrOpers;
-    if (auto s = rebox.slice())
+    if (auto s = rebox.getSlice())
       if (auto sliceOp = dyn_cast_or_null<SliceOp>(s.getDefiningOp())) {
-        sliceOpers.append(sliceOp.triples().begin(), sliceOp.triples().end());
-        subcompOpers.append(sliceOp.fields().begin(), sliceOp.fields().end());
-        substrOpers.append(sliceOp.substr().begin(), sliceOp.substr().end());
+        sliceOpers.append(sliceOp.getTriples().begin(),
+                          sliceOp.getTriples().end());
+        subcompOpers.append(sliceOp.getFields().begin(),
+                            sliceOp.getFields().end());
+        substrOpers.append(sliceOp.getSubstr().begin(),
+                           sliceOp.getSubstr().end());
       }
 
     auto xRebox = rewriter.create<cg::XReboxOp>(
-        loc, rebox.getType(), rebox.box(), shapeOpers, shiftOpers, sliceOpers,
-        subcompOpers, substrOpers);
+        loc, rebox.getType(), rebox.getBox(), shapeOpers, shiftOpers,
+        sliceOpers, subcompOpers, substrOpers);
     LLVM_DEBUG(llvm::dbgs()
                << "rewriting " << rebox << " to " << xRebox << '\n');
     rewriter.replaceOp(rebox, xRebox.getOperation()->getResults());
@@ -215,7 +221,7 @@ public:
     auto loc = arrCoor.getLoc();
     llvm::SmallVector<mlir::Value> shapeOpers;
     llvm::SmallVector<mlir::Value> shiftOpers;
-    if (auto shapeVal = arrCoor.shape()) {
+    if (auto shapeVal = arrCoor.getShape()) {
       if (auto shapeOp = dyn_cast<ShapeOp>(shapeVal.getDefiningOp()))
         populateShape(shapeOpers, shapeOp);
       else if (auto shiftOp = dyn_cast<ShapeShiftOp>(shapeVal.getDefiningOp()))
@@ -227,17 +233,20 @@ public:
     }
     llvm::SmallVector<mlir::Value> sliceOpers;
     llvm::SmallVector<mlir::Value> subcompOpers;
-    if (auto s = arrCoor.slice())
+    if (auto s = arrCoor.getSlice())
       if (auto sliceOp = dyn_cast_or_null<SliceOp>(s.getDefiningOp())) {
-        sliceOpers.append(sliceOp.triples().begin(), sliceOp.triples().end());
-        subcompOpers.append(sliceOp.fields().begin(), sliceOp.fields().end());
-        assert(sliceOp.substr().empty() &&
+        sliceOpers.append(sliceOp.getTriples().begin(),
+                          sliceOp.getTriples().end());
+        subcompOpers.append(sliceOp.getFields().begin(),
+                            sliceOp.getFields().end());
+        assert(sliceOp.getSubstr().empty() &&
                "Don't allow substring operations on array_coor. This "
                "restriction may be lifted in the future.");
       }
     auto xArrCoor = rewriter.create<cg::XArrayCoorOp>(
-        loc, arrCoor.getType(), arrCoor.memref(), shapeOpers, shiftOpers,
-        sliceOpers, subcompOpers, arrCoor.indices(), arrCoor.typeparams());
+        loc, arrCoor.getType(), arrCoor.getMemref(), shapeOpers, shiftOpers,
+        sliceOpers, subcompOpers, arrCoor.getIndices(),
+        arrCoor.getTypeparams());
     LLVM_DEBUG(llvm::dbgs()
                << "rewriting " << arrCoor << " to " << xArrCoor << '\n');
     rewriter.replaceOp(arrCoor, xArrCoor.getOperation()->getResults());

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -200,7 +200,7 @@ public:
     // to call.
     int dropFront = 0;
     if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
-      if (!callOp.callee().hasValue()) {
+      if (!callOp.getCallee().hasValue()) {
         newInTys.push_back(fnTy.getInput(0));
         newOpers.push_back(callOp.getOperand(0));
         dropFront = 1;
@@ -237,10 +237,10 @@ public:
           .template Case<BoxCharType>([&](BoxCharType boxTy) {
             bool sret;
             if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
-              sret = callOp.callee() &&
+              sret = callOp.getCallee() &&
                      functionArgIsSRet(index,
                                        getModule().lookupSymbol<mlir::FuncOp>(
-                                           *callOp.callee()));
+                                           *callOp.getCallee()));
             } else {
               // TODO: dispatch case; how do we put arguments on a call?
               // We cannot put both an sret and the dispatch object first.
@@ -275,7 +275,7 @@ public:
             if (isCharacterProcedureTuple(tuple)) {
               mlir::ModuleOp module = getModule();
               if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
-                if (callOp.callee()) {
+                if (callOp.getCallee()) {
                   llvm::StringRef charProcAttr =
                       getCharacterProcedureDummyAttrName();
                   // The charProcAttr attribute is only used as a safety to
@@ -283,7 +283,7 @@ public:
                   // It cannot be used to match because attributes are not
                   // available in case of indirect calls.
                   auto funcOp =
-                      module.lookupSymbol<mlir::FuncOp>(*callOp.callee());
+                      module.lookupSymbol<mlir::FuncOp>(*callOp.getCallee());
                   if (funcOp &&
                       !funcOp.template getArgAttrOfType<mlir::UnitAttr>(
                           index, charProcAttr))
@@ -315,8 +315,8 @@ public:
     newOpers.insert(newOpers.end(), trailingOpers.begin(), trailingOpers.end());
     if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
       fir::CallOp newCall;
-      if (callOp.callee().hasValue()) {
-        newCall = rewriter->create<A>(loc, callOp.callee().getValue(),
+      if (callOp.getCallee().hasValue()) {
+        newCall = rewriter->create<A>(loc, callOp.getCallee().getValue(),
                                       newResTys, newOpers);
       } else {
         // Force new type on the input operand.
@@ -415,7 +415,7 @@ public:
     // replace this op with a new one with the updated signature
     auto newTy = rewriter->getFunctionType(newInTys, newResTys);
     auto newOp =
-        rewriter->create<AddrOfOp>(addrOp.getLoc(), newTy, addrOp.symbol());
+        rewriter->create<AddrOfOp>(addrOp.getLoc(), newTy, addrOp.getSymbol());
     LLVM_DEBUG(llvm::dbgs()
                << "replacing " << addrOp << " with " << newOp << '\n');
     replaceOp(addrOp, newOp.getResult());

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -131,12 +131,13 @@ static mlir::ParseResult parseAllocatableOp(FN wrapResultType,
 
 template <typename OP>
 static void printAllocatableOp(mlir::OpAsmPrinter &p, OP &op) {
-  p << ' ' << op.in_type();
-  if (!op.typeparams().empty()) {
-    p << '(' << op.typeparams() << " : " << op.typeparams().getTypes() << ')';
+  p << ' ' << op.getInType();
+  if (!op.getTypeparams().empty()) {
+    p << '(' << op.getTypeparams() << " : " << op.getTypeparams().getTypes()
+      << ')';
   }
   // print the shape of the allocation (if any); all must be index type
-  for (auto sh : op.shape()) {
+  for (auto sh : op.getShape()) {
     p << ", ";
     p.printOperand(sh);
   }
@@ -321,13 +322,13 @@ static mlir::LogicalResult verify(fir::AllocMemOp &op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
-  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.getMemref().getType());
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
   auto arrDim = arrTy.getDimension();
 
-  if (auto shapeOp = op.shape()) {
+  if (auto shapeOp = op.getShape()) {
     auto shapeTy = shapeOp.getType();
     unsigned shapeTyRank = 0;
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
@@ -337,18 +338,18 @@ static mlir::LogicalResult verify(fir::ArrayCoorOp op) {
     } else {
       auto s = shapeTy.cast<fir::ShiftType>();
       shapeTyRank = s.getRank();
-      if (!op.memref().getType().isa<fir::BoxType>())
+      if (!op.getMemref().getType().isa<fir::BoxType>())
         return op.emitOpError("shift can only be provided with fir.box memref");
     }
     if (arrDim && arrDim != shapeTyRank)
       return op.emitOpError("rank of dimension mismatched");
-    if (shapeTyRank != op.indices().size())
+    if (shapeTyRank != op.getIndices().size())
       return op.emitOpError("number of indices do not match dim rank");
   }
 
-  if (auto sliceOp = op.slice()) {
+  if (auto sliceOp = op.getSlice()) {
     if (auto sl = mlir::dyn_cast_or_null<fir::SliceOp>(sliceOp.getDefiningOp()))
-      if (!sl.substr().empty())
+      if (!sl.getSubstr().empty())
         return op.emitOpError("array_coor cannot take a slice with substring");
     if (auto sliceTy = sliceOp.getType().dyn_cast<fir::SliceType>())
       if (sliceTy.getRank() != arrDim)
@@ -378,7 +379,7 @@ static mlir::Type adjustedElementType(mlir::Type t) {
 }
 
 std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
-  if (auto sh = shape())
+  if (auto sh = getShape())
     if (auto *op = sh.getDefiningOp()) {
       if (auto shOp = dyn_cast<fir::ShapeOp>(op)) {
         auto extents = shOp.getExtents();
@@ -390,13 +391,13 @@ std::vector<mlir::Value> fir::ArrayLoadOp::getExtents() {
 }
 
 static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
-  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.getMemref().getType());
   auto arrTy = eleTy.dyn_cast<fir::SequenceType>();
   if (!arrTy)
     return op.emitOpError("must be a reference to an array");
   auto arrDim = arrTy.getDimension();
 
-  if (auto shapeOp = op.shape()) {
+  if (auto shapeOp = op.getShape()) {
     auto shapeTy = shapeOp.getType();
     unsigned shapeTyRank = 0;
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>()) {
@@ -406,14 +407,14 @@ static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
     } else {
       auto s = shapeTy.cast<fir::ShiftType>();
       shapeTyRank = s.getRank();
-      if (!op.memref().getType().isa<fir::BoxType>())
+      if (!op.getMemref().getType().isa<fir::BoxType>())
         return op.emitOpError("shift can only be provided with fir.box memref");
     }
     if (arrDim && arrDim != shapeTyRank)
       return op.emitOpError("rank of dimension mismatched");
   }
 
-  if (auto sliceOp = op.slice()) {
+  if (auto sliceOp = op.getSlice()) {
     if (auto sl = mlir::dyn_cast_or_null<fir::SliceOp>(sliceOp.getDefiningOp()))
       if (!sl.substr().empty())
         return op.emitOpError("array_load cannot take a slice with substring");
@@ -430,25 +431,25 @@ static mlir::LogicalResult verify(fir::ArrayLoadOp op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayMergeStoreOp op) {
-  if (!isa<fir::ArrayLoadOp>(op.original().getDefiningOp()))
+  if (!isa<fir::ArrayLoadOp>(op.getOriginal().getDefiningOp()))
     return op.emitOpError("operand #0 must be result of a fir.array_load op");
-  if (auto sl = op.slice()) {
+  if (auto sl = op.getSlice()) {
     if (auto sliceOp =
             mlir::dyn_cast_or_null<fir::SliceOp>(sl.getDefiningOp())) {
       if (!sliceOp.substr().empty())
         return op.emitOpError(
             "array_merge_store cannot take a slice with substring");
-      if (!sliceOp.fields().empty()) {
+      if (!sliceOp.getFields().empty()) {
         // This is an intra-object merge, where the slice is projecting the
         // subfields that are to be overwritten by the merge operation.
-        auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
+        auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.getMemref().getType());
         if (auto seqTy = eleTy.dyn_cast<fir::SequenceType>()) {
           auto projTy =
-              fir::applyPathToType(seqTy.getEleTy(), sliceOp.fields());
-          if (fir::unwrapSequenceType(op.original().getType()) != projTy)
+              fir::applyPathToType(seqTy.getEleTy(), sliceOp.getFields());
+          if (fir::unwrapSequenceType(op.getOriginal().getType()) != projTy)
             return op.emitOpError(
                 "type of origin does not match sliced memref type");
-          if (fir::unwrapSequenceType(op.sequence().getType()) != projTy)
+          if (fir::unwrapSequenceType(op.getSequence().getType()) != projTy)
             return op.emitOpError(
                 "type of sequence does not match sliced memref type");
           return mlir::success();
@@ -458,10 +459,10 @@ static mlir::LogicalResult verify(fir::ArrayMergeStoreOp op) {
     }
     return mlir::success();
   }
-  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.memref().getType());
-  if (op.original().getType() != eleTy)
+  auto eleTy = fir::dyn_cast_ptrOrBoxEleTy(op.getMemref().getType());
+  if (op.getOriginal().getType() != eleTy)
     return op.emitOpError("type of origin does not match memref element type");
-  if (op.sequence().getType() != eleTy)
+  if (op.getSequence().getType() != eleTy)
     return op.emitOpError(
         "type of sequence does not match memref element type");
   return mlir::success();
@@ -474,23 +475,23 @@ static mlir::LogicalResult verify(fir::ArrayMergeStoreOp op) {
 // Template function used for both array_fetch and array_update verification.
 template <typename A>
 mlir::Type validArraySubobject(A op) {
-  auto ty = op.sequence().getType();
-  return fir::applyPathToType(ty, op.indices());
+  auto ty = op.getSequence().getType();
+  return fir::applyPathToType(ty, op.getIndices());
 }
 
 static mlir::LogicalResult verify(fir::ArrayFetchOp op) {
-  auto arrTy = op.sequence().getType().cast<fir::SequenceType>();
-  auto indSize = op.indices().size();
+  auto arrTy = op.getSequence().getType().cast<fir::SequenceType>();
+  auto indSize = op.getIndices().size();
   // indSize >= number of dimensions is ok
   if (indSize < arrTy.getDimension())
     return op.emitOpError("number of indices != dimension of array");
   if (indSize == arrTy.getDimension() &&
-      ::adjustedElementType(op.element().getType()) != arrTy.getEleTy())
+      ::adjustedElementType(op.getElement().getType()) != arrTy.getEleTy())
     return op.emitOpError("return type does not match array");
   auto ty = validArraySubobject(op);
   if (!ty || ty != ::adjustedElementType(op.getType()))
     return op.emitOpError("return type and/or indices do not type check");
-  if (!llvm::isa_and_nonnull<fir::ArrayLoadOp>(op.sequence().getDefiningOp()))
+  if (!llvm::isa_and_nonnull<fir::ArrayLoadOp>(op.getSequence().getDefiningOp()))
     return op.emitOpError("argument #0 must be result of fir.array_load");
   return mlir::success();
 }
@@ -500,8 +501,8 @@ static mlir::LogicalResult verify(fir::ArrayFetchOp op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayAccessOp op) {
-  auto arrTy = op.sequence().getType().cast<fir::SequenceType>();
-  std::size_t indSize = op.indices().size();
+  auto arrTy = op.getSequence().getType().cast<fir::SequenceType>();
+  std::size_t indSize = op.getIndices().size();
   if (indSize < arrTy.getDimension())
     return op.emitOpError("number of indices != dimension of array");
   if (indSize == arrTy.getDimension() &&
@@ -518,15 +519,15 @@ static mlir::LogicalResult verify(fir::ArrayAccessOp op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayUpdateOp op) {
-  auto arrTy = op.sequence().getType().cast<fir::SequenceType>();
-  auto indSize = op.indices().size();
+  auto arrTy = op.getSequence().getType().cast<fir::SequenceType>();
+  auto indSize = op.getIndices().size();
   if (indSize < arrTy.getDimension())
     return op.emitOpError("number of indices != dimension of array");
   if (indSize == arrTy.getDimension() &&
-      ::adjustedElementType(op.merge().getType()) != arrTy.getEleTy())
+      ::adjustedElementType(op.getMerge().getType()) != arrTy.getEleTy())
     return op.emitOpError("merged value does not have element type");
   auto ty = validArraySubobject(op);
-  if (!ty || ty != ::adjustedElementType(op.merge().getType()))
+  if (!ty || ty != ::adjustedElementType(op.getMerge().getType()))
     return op.emitOpError("merged value and/or indices do not type check");
   return mlir::success();
 }
@@ -536,8 +537,8 @@ static mlir::LogicalResult verify(fir::ArrayUpdateOp op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ArrayModifyOp op) {
-  auto arrTy = op.sequence().getType().cast<fir::SequenceType>();
-  auto indSize = op.indices().size();
+  auto arrTy = op.getSequence().getType().cast<fir::SequenceType>();
+  auto indSize = op.getIndices().size();
   if (indSize < arrTy.getDimension())
     return op.emitOpError("number of indices must match array dimension");
   return mlir::success();
@@ -548,11 +549,11 @@ static mlir::LogicalResult verify(fir::ArrayModifyOp op) {
 //===----------------------------------------------------------------------===//
 
 mlir::OpFoldResult fir::BoxAddrOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  if (auto *v = val().getDefiningOp()) {
+  if (auto *v = getVal().getDefiningOp()) {
     if (auto box = dyn_cast<fir::EmboxOp>(v))
-      return box.memref();
+      return box.getMemref();
     if (auto box = dyn_cast<fir::EmboxCharOp>(v))
-      return box.memref();
+      return box.getMemref();
   }
   return {};
 }
@@ -563,9 +564,9 @@ mlir::OpFoldResult fir::BoxAddrOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
 
 mlir::OpFoldResult
 fir::BoxCharLenOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  if (auto *v = val().getDefiningOp()) {
+  if (auto *v = getVal().getDefiningOp()) {
     if (auto box = dyn_cast<fir::EmboxCharOp>(v))
-      return box.len();
+      return box.getLen();
   }
   return {};
 }
@@ -592,7 +593,7 @@ mlir::FunctionType fir::CallOp::getFunctionType() {
 }
 
 static void printCallOp(mlir::OpAsmPrinter &p, fir::CallOp &op) {
-  auto callee = op.callee();
+  auto callee = op.getCallee();
   bool isDirect = callee.hasValue();
   p << ' ';
   if (isDirect)
@@ -673,8 +674,8 @@ static mlir::LogicalResult verify(fir::CharConvertOp op) {
     t = fir::unwrapSequenceType(fir::dyn_cast_ptrEleTy(t));
     return t.dyn_cast<fir::CharacterType>();
   };
-  auto inTy = unwrap(op.from().getType());
-  auto outTy = unwrap(op.to().getType());
+  auto inTy = unwrap(op.getFrom().getType());
+  auto outTy = unwrap(op.getTo().getType());
   if (!(inTy && outTy))
     return op.emitOpError("not a reference to a character");
   if (inTy.getFKind() == outTy.getFKind())
@@ -696,12 +697,12 @@ static void printCmpOp(OpAsmPrinter &p, OPTY op) {
   assert(predSym.hasValue() && "invalid symbol value for predicate");
   p << '"' << mlir::arith::stringifyCmpFPredicate(predSym.getValue()) << '"'
     << ", ";
-  p.printOperand(op.lhs());
+  p.printOperand(op.getLhs());
   p << ", ";
-  p.printOperand(op.rhs());
+  p.printOperand(op.getRhs());
   p.printOptionalAttrDict(op->getAttrs(),
                           /*elidedAttrs=*/{OPTY::getPredicateAttrName()});
-  p << " : " << op.lhs().getType();
+  p << " : " << op.getLhs().getType();
 }
 
 template <typename OPTY>
@@ -815,21 +816,22 @@ void fir::ConvertOp::getCanonicalizationPatterns(
 }
 
 mlir::OpFoldResult fir::ConvertOp::fold(llvm::ArrayRef<mlir::Attribute> opnds) {
-  if (value().getType() == getType())
-    return value();
-  if (matchPattern(value(), m_Op<fir::ConvertOp>())) {
-    auto inner = cast<fir::ConvertOp>(value().getDefiningOp());
+  if (getValue().getType() == getType())
+    return getValue();
+  if (matchPattern(getValue(), m_Op<fir::ConvertOp>())) {
+    auto inner = cast<fir::ConvertOp>(getValue().getDefiningOp());
     // (convert (convert 'a : logical -> i1) : i1 -> logical) ==> forward 'a
     if (auto toTy = getType().dyn_cast<fir::LogicalType>())
-      if (auto fromTy = inner.value().getType().dyn_cast<fir::LogicalType>())
+      if (auto fromTy = inner.getValue().getType().dyn_cast<fir::LogicalType>())
         if (inner.getType().isa<mlir::IntegerType>() && (toTy == fromTy))
-          return inner.value();
+          return inner.getValue();
     // (convert (convert 'a : i1 -> logical) : logical -> i1) ==> forward 'a
     if (auto toTy = getType().dyn_cast<mlir::IntegerType>())
-      if (auto fromTy = inner.value().getType().dyn_cast<mlir::IntegerType>())
+      if (auto fromTy =
+              inner.getValue().getType().dyn_cast<mlir::IntegerType>())
         if (inner.getType().isa<fir::LogicalType>() && (toTy == fromTy) &&
             (fromTy.getWidth() == 1))
-          return inner.value();
+          return inner.getValue();
   }
   return {};
 }
@@ -874,7 +876,7 @@ static mlir::LogicalResult verify(fir::ConvertOp &op) {
 //===----------------------------------------------------------------------===//
 
 static void print(mlir::OpAsmPrinter &p, fir::CoordinateOp op) {
-  p << ' ' << op.ref() << ", " << op.coor();
+  p << ' ' << op.getRef() << ", " << op.getCoor();
   p.printOptionalAttrDict(op->getAttrs(), /*elideAttrs=*/{"baseType"});
   p << " : ";
   p.printFunctionalType(op.getOperandTypes(), op->getResultTypes());
@@ -904,7 +906,7 @@ static mlir::ParseResult parseCoordinateCustom(mlir::OpAsmParser &parser,
 }
 
 static mlir::LogicalResult verify(fir::CoordinateOp op) {
-  auto refTy = op.ref().getType();
+  auto refTy = op.getRef().getType();
   if (fir::isa_ref_type(refTy)) {
     auto eleTy = fir::dyn_cast_ptrEleTy(refTy);
     if (auto arrTy = eleTy.dyn_cast<fir::SequenceType>()) {
@@ -920,11 +922,11 @@ static mlir::LogicalResult verify(fir::CoordinateOp op) {
   // Recovering a LEN type parameter only makes sense from a boxed value. For a
   // bare reference, the LEN type parameters must be passed as additional
   // arguments to `op`.
-  for (auto co : op.coor())
+  for (auto co : op.getCoor())
     if (dyn_cast_or_null<fir::LenParamIndexOp>(co.getDefiningOp())) {
       if (op.getNumOperands() != 2)
         return op.emitOpError("len_param_index must be last argument");
-      if (!op.ref().getType().isa<BoxType>())
+      if (!op.getRef().getType().isa<BoxType>())
         return op.emitOpError("len_param_index must be used on box type");
     }
   return mlir::success();
@@ -968,9 +970,9 @@ static mlir::ParseResult parseDispatchOp(mlir::OpAsmParser &parser,
 static void print(mlir::OpAsmPrinter &p, fir::DispatchOp &op) {
   p << ' ' << op.getMethodAttr() << '(';
   p.printOperand(op.object());
-  if (!op.args().empty()) {
+  if (!op.getArgs().empty()) {
     p << ", ";
-    p.printOperands(op.args());
+    p.printOperands(op.getArgs());
   }
   p << ") : ";
   p.printFunctionalType(op.getOperation()->getOperandTypes(),
@@ -1035,7 +1037,7 @@ static mlir::LogicalResult verify(fir::DispatchTableOp &op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::EmboxOp op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrEleTy(op.getMemref().getType());
   bool isArray = false;
   if (auto seqTy = eleTy.dyn_cast<fir::SequenceType>()) {
     eleTy = seqTy.getEleTy();
@@ -1053,7 +1055,7 @@ static mlir::LogicalResult verify(fir::EmboxOp op) {
     } else {
       return op.emitOpError("LEN parameters require CHARACTER or derived type");
     }
-    for (auto lp : op.typeparams())
+    for (auto lp : op.getTypeparams())
       if (!fir::isa_integer(lp.getType()))
         return op.emitOpError("LEN parameters must be integral type");
   }
@@ -1069,7 +1071,7 @@ static mlir::LogicalResult verify(fir::EmboxOp op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::EmboxCharOp &op) {
-  auto eleTy = fir::dyn_cast_ptrEleTy(op.memref().getType());
+  auto eleTy = fir::dyn_cast_ptrEleTy(op.getMemref().getType());
   if (!eleTy.dyn_cast_or_null<CharacterType>())
     return mlir::failure();
   return mlir::success();
@@ -1192,8 +1194,8 @@ static ParseResult parseGlobalOp(OpAsmParser &parser, OperationState &result) {
 }
 
 static void print(mlir::OpAsmPrinter &p, fir::GlobalOp &op) {
-  if (op.linkName().hasValue())
-    p << ' ' << op.linkName().getValue();
+  if (op.getLinkName().hasValue())
+    p << ' ' << op.getLinkName().getValue();
   p << ' ';
   p.printAttributeWithoutType(
       op.getOperation()->getAttr(fir::GlobalOp::getSymbolAttrNameStr()));
@@ -1341,9 +1343,9 @@ static void print(mlir::OpAsmPrinter &p, fir::FieldIndexOp &op) {
     << ", " << op.getOperation()->getAttr(fir::FieldIndexOp::getTypeAttrName());
   if (op.getNumOperands()) {
     p << '(';
-    p.printOperands(op.typeparams());
+    p.printOperands(op.getTypeparams());
     auto sep = ") : ";
-    for (auto op : op.typeparams()) {
+    for (auto op : op.getTypeparams()) {
       p << sep;
       if (op)
         p.printType(op.getType());
@@ -1376,12 +1378,12 @@ llvm::SmallVector<mlir::Attribute> fir::FieldIndexOp::getAttributes() {
 
 /// Range bounds must be nonnegative, and the range must not be empty.
 static mlir::LogicalResult verify(fir::InsertOnRangeOp op) {
-  if (fir::hasDynamicSize(op.seq().getType()))
+  if (fir::hasDynamicSize(op.getSeq().getType()))
     return op.emitOpError("must have constant shape and size");
-  if (op.coor().size() < 2 || op.coor().size() % 2 != 0)
+  if (op.getCoor().size() < 2 || op.getCoor().size() % 2 != 0)
     return op.emitOpError("has uneven number of values in ranges");
   bool rangeIsKnownToBeNonempty = false;
-  for (auto i = op.coor().end(), b = op.coor().begin(); i != b;) {
+  for (auto i = op.getCoor().end(), b = op.getCoor().begin(); i != b;) {
     int64_t ub = (*--i).cast<IntegerAttr>().getInt();
     int64_t lb = (*--i).cast<IntegerAttr>().getInt();
     if (lb < 0 || ub < 0)
@@ -1421,14 +1423,14 @@ struct UndoComplexPattern : public mlir::RewritePattern {
     if (!insval || !insval.getType().isa<fir::ComplexType>())
       return mlir::failure();
     auto insval2 =
-        dyn_cast_or_null<fir::InsertValueOp>(insval.adt().getDefiningOp());
+        dyn_cast_or_null<fir::InsertValueOp>(insval.getAdt().getDefiningOp());
     if (!insval2)
       return mlir::failure();
-    auto binf = dyn_cast_or_null<FltOp>(insval.val().getDefiningOp());
-    auto binf2 = dyn_cast_or_null<FltOp>(insval2.val().getDefiningOp());
-    if (!binf || !binf2 || insval.coor().size() != 1 ||
-        !isOne(insval.coor()[0]) || insval2.coor().size() != 1 ||
-        !isZero(insval2.coor()[0]))
+    auto binf = dyn_cast_or_null<FltOp>(insval.getVal().getDefiningOp());
+    auto binf2 = dyn_cast_or_null<FltOp>(insval2.getVal().getDefiningOp());
+    if (!binf || !binf2 || insval.getCoor().size() != 1 ||
+        !isOne(insval.getCoor()[0]) || insval2.getCoor().size() != 1 ||
+        !isZero(insval2.getCoor()[0]))
       return mlir::failure();
     auto eai =
         dyn_cast_or_null<fir::ExtractValueOp>(binf.lhs().getDefiningOp());
@@ -1438,14 +1440,14 @@ struct UndoComplexPattern : public mlir::RewritePattern {
         dyn_cast_or_null<fir::ExtractValueOp>(binf2.lhs().getDefiningOp());
     auto ebr =
         dyn_cast_or_null<fir::ExtractValueOp>(binf2.rhs().getDefiningOp());
-    if (!eai || !ebi || !ear || !ebr || ear.adt() != eai.adt() ||
-        ebr.adt() != ebi.adt() || eai.coor().size() != 1 ||
-        !isOne(eai.coor()[0]) || ebi.coor().size() != 1 ||
-        !isOne(ebi.coor()[0]) || ear.coor().size() != 1 ||
-        !isZero(ear.coor()[0]) || ebr.coor().size() != 1 ||
-        !isZero(ebr.coor()[0]))
+    if (!eai || !ebi || !ear || !ebr || ear.getAdt() != eai.getAdt() ||
+        ebr.getAdt() != ebi.getAdt() || eai.getCoor().size() != 1 ||
+        !isOne(eai.getCoor()[0]) || ebi.getCoor().size() != 1 ||
+        !isOne(ebi.getCoor()[0]) || ear.getCoor().size() != 1 ||
+        !isZero(ear.getCoor()[0]) || ebr.getCoor().size() != 1 ||
+        !isZero(ebr.getCoor()[0]))
       return mlir::failure();
-    rewriter.replaceOpWithNewOp<CpxOp>(op, ear.adt(), ebr.adt());
+    rewriter.replaceOpWithNewOp<CpxOp>(op, ear.getAdt(), ebr.getAdt());
     return mlir::success();
   }
 };
@@ -1596,7 +1598,7 @@ static mlir::LogicalResult verify(fir::IterWhileOp op) {
         "the induction variable");
 
   auto opNumResults = op.getNumResults();
-  if (op.finalValue()) {
+  if (op.getFinalValue()) {
     // Result type must be "(index, i1, ...)".
     if (!op.getResult(0).getType().isa<mlir::IndexType>())
       return op.emitOpError("result #0 expected to be index");
@@ -1620,7 +1622,7 @@ static mlir::LogicalResult verify(fir::IterWhileOp op) {
   auto iterOperands = op.getIterOperands();
   auto iterArgs = op.getRegionIterArgs();
   auto opResults =
-      op.finalValue() ? op.getResults().drop_front() : op.getResults();
+      op.getFinalValue() ? op.getResults().drop_front() : op.getResults();
   unsigned i = 0;
   for (auto e : llvm::zip(iterOperands, iterArgs, opResults)) {
     if (std::get<0>(e).getType() != std::get<2>(e).getType())
@@ -1636,8 +1638,8 @@ static mlir::LogicalResult verify(fir::IterWhileOp op) {
 }
 
 static void print(mlir::OpAsmPrinter &p, fir::IterWhileOp op) {
-  p << " (" << op.getInductionVar() << " = " << op.lowerBound() << " to "
-    << op.upperBound() << " step " << op.step() << ") and (";
+  p << " (" << op.getInductionVar() << " = " << op.getLowerBound() << " to "
+    << op.getUpperBound() << " step " << op.getStep() << ") and (";
   assert(op.hasIterOperands());
   auto regionArgs = op.getRegionIterArgs();
   auto operands = op.getIterOperands();
@@ -1649,21 +1651,21 @@ static void print(mlir::OpAsmPrinter &p, fir::IterWhileOp op) {
         [&](auto it) { p << std::get<0>(it) << " = " << std::get<1>(it); });
     p << ") -> (";
     llvm::interleaveComma(
-        llvm::drop_begin(op.getResultTypes(), op.finalValue() ? 0 : 1), p);
+        llvm::drop_begin(op.getResultTypes(), op.getFinalValue() ? 0 : 1), p);
     p << ")";
-  } else if (op.finalValue()) {
+  } else if (op.getFinalValue()) {
     p << " -> (" << op.getResultTypes() << ')';
   }
   p.printOptionalAttrDictWithKeyword(op->getAttrs(),
                                      {op.getFinalValueAttrNameStr()});
-  p.printRegion(op.region(), /*printEntryBlockArgs=*/false,
+  p.printRegion(op.getRegion(), /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/true);
 }
 
-mlir::Region &fir::IterWhileOp::getLoopBody() { return region(); }
+mlir::Region &fir::IterWhileOp::getLoopBody() { return getRegion(); }
 
 bool fir::IterWhileOp::isDefinedOutsideOfLoop(mlir::Value value) {
-  return !region().isAncestor(value.getParentRegion());
+  return !getRegion().isAncestor(value.getParentRegion());
 }
 
 mlir::LogicalResult
@@ -1674,23 +1676,23 @@ fir::IterWhileOp::moveOutOfLoop(llvm::ArrayRef<mlir::Operation *> ops) {
 }
 
 mlir::BlockArgument fir::IterWhileOp::iterArgToBlockArg(mlir::Value iterArg) {
-  for (auto i : llvm::enumerate(initArgs()))
+  for (auto i : llvm::enumerate(getInitArgs()))
     if (iterArg == i.value())
-      return region().front().getArgument(i.index() + 1);
+      return getRegion().front().getArgument(i.index() + 1);
   return {};
 }
 
 void fir::IterWhileOp::resultToSourceOps(
     llvm::SmallVectorImpl<mlir::Value> &results, unsigned resultNum) {
-  auto oper = finalValue() ? resultNum + 1 : resultNum;
-  auto *term = region().front().getTerminator();
+  auto oper = getFinalValue() ? resultNum + 1 : resultNum;
+  auto *term = getRegion().front().getTerminator();
   if (oper < term->getNumOperands())
     results.push_back(term->getOperand(oper));
 }
 
 mlir::Value fir::IterWhileOp::blockArgToSourceOp(unsigned blockArgNum) {
-  if (blockArgNum > 0 && blockArgNum <= initArgs().size())
-    return initArgs()[blockArgNum - 1];
+  if (blockArgNum > 0 && blockArgNum <= getInitArgs().size())
+    return getInitArgs()[blockArgNum - 1];
   return {};
 }
 
@@ -1771,9 +1773,9 @@ static mlir::ParseResult parseLoadOp(mlir::OpAsmParser &parser,
 
 static void print(mlir::OpAsmPrinter &p, fir::LoadOp &op) {
   p << ' ';
-  p.printOperand(op.memref());
+  p.printOperand(op.getMemref());
   p.printOptionalAttrDict(op.getOperation()->getAttrs(), {});
-  p << " : " << op.memref().getType();
+  p << " : " << op.getMemref().getType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1902,8 +1904,8 @@ static mlir::LogicalResult verify(fir::DoLoopOp op) {
   if (opNumResults == 0)
     return success();
 
-  if (op.finalValue()) {
-    if (op.unordered())
+  if (op.getFinalValue()) {
+    if (op.getUnordered())
       return op.emitOpError("unordered loop has no final value");
     opNumResults--;
   }
@@ -1916,7 +1918,7 @@ static mlir::LogicalResult verify(fir::DoLoopOp op) {
   auto iterOperands = op.getIterOperands();
   auto iterArgs = op.getRegionIterArgs();
   auto opResults =
-      op.finalValue() ? op.getResults().drop_front() : op.getResults();
+      op.getFinalValue() ? op.getResults().drop_front() : op.getResults();
   unsigned i = 0;
   for (auto e : llvm::zip(iterOperands, iterArgs, opResults)) {
     if (std::get<0>(e).getType() != std::get<2>(e).getType())
@@ -1933,9 +1935,9 @@ static mlir::LogicalResult verify(fir::DoLoopOp op) {
 
 static void print(mlir::OpAsmPrinter &p, fir::DoLoopOp op) {
   bool printBlockTerminators = false;
-  p << ' ' << op.getInductionVar() << " = " << op.lowerBound() << " to "
-    << op.upperBound() << " step " << op.step();
-  if (op.unordered())
+  p << ' ' << op.getInductionVar() << " = " << op.getLowerBound() << " to "
+    << op.getUpperBound() << " step " << op.getStep();
+  if (op.getUnordered())
     p << " unordered";
   if (op.hasIterOperands()) {
     p << " iter_args(";
@@ -1946,21 +1948,21 @@ static void print(mlir::OpAsmPrinter &p, fir::DoLoopOp op) {
     });
     p << ") -> (" << op.getResultTypes() << ')';
     printBlockTerminators = true;
-  } else if (op.finalValue()) {
+  } else if (op.getFinalValue()) {
     p << " -> " << op.getResultTypes();
     printBlockTerminators = true;
   }
   p.printOptionalAttrDictWithKeyword(op->getAttrs(),
                                      {fir::DoLoopOp::getUnorderedAttrNameStr(),
                                       fir::DoLoopOp::getFinalValueAttrNameStr()});
-  p.printRegion(op.region(), /*printEntryBlockArgs=*/false,
+  p.printRegion(op.getRegion(), /*printEntryBlockArgs=*/false,
                 printBlockTerminators);
 }
 
-mlir::Region &fir::DoLoopOp::getLoopBody() { return region(); }
+mlir::Region &fir::DoLoopOp::getLoopBody() { return getRegion(); }
 
 bool fir::DoLoopOp::isDefinedOutsideOfLoop(mlir::Value value) {
-  return !region().isAncestor(value.getParentRegion());
+  return !getRegion().isAncestor(value.getParentRegion());
 }
 
 mlir::LogicalResult
@@ -1973,9 +1975,9 @@ fir::DoLoopOp::moveOutOfLoop(llvm::ArrayRef<mlir::Operation *> ops) {
 /// Translate a value passed as an iter_arg to the corresponding block
 /// argument in the body of the loop.
 mlir::BlockArgument fir::DoLoopOp::iterArgToBlockArg(mlir::Value iterArg) {
-  for (auto i : llvm::enumerate(initArgs()))
+  for (auto i : llvm::enumerate(getInitArgs()))
     if (iterArg == i.value())
-      return region().front().getArgument(i.index() + 1);
+      return getRegion().front().getArgument(i.index() + 1);
   return {};
 }
 
@@ -1983,8 +1985,8 @@ mlir::BlockArgument fir::DoLoopOp::iterArgToBlockArg(mlir::Value iterArg) {
 /// to the `fir.result` Op.
 void fir::DoLoopOp::resultToSourceOps(
     llvm::SmallVectorImpl<mlir::Value> &results, unsigned resultNum) {
-  auto oper = finalValue() ? resultNum + 1 : resultNum;
-  auto *term = region().front().getTerminator();
+  auto oper = getFinalValue() ? resultNum + 1 : resultNum;
+  auto *term = getRegion().front().getTerminator();
   if (oper < term->getNumOperands())
     results.push_back(term->getOperand(oper));
 }
@@ -1992,8 +1994,8 @@ void fir::DoLoopOp::resultToSourceOps(
 /// Translate the block argument (by index number) to the corresponding value
 /// passed as an iter_arg to the parent DoLoopOp.
 mlir::Value fir::DoLoopOp::blockArgToSourceOp(unsigned blockArgNum) {
-  if (blockArgNum > 0 && blockArgNum <= initArgs().size())
-    return initArgs()[blockArgNum - 1];
+  if (blockArgNum > 0 && blockArgNum <= getInitArgs().size())
+    return getInitArgs()[blockArgNum - 1];
   return {};
 }
 
@@ -2049,7 +2051,7 @@ static unsigned getBoxRank(mlir::Type boxTy) {
 }
 
 static mlir::LogicalResult verify(fir::ReboxOp op) {
-  auto inputBoxTy = op.box().getType();
+  auto inputBoxTy = op.getBox().getType();
   if (fir::isa_unknown_size_box(inputBoxTy))
     return op.emitOpError("box operand must not have unknown rank or type");
   auto outBoxTy = op.getType();
@@ -2060,11 +2062,11 @@ static mlir::LogicalResult verify(fir::ReboxOp op) {
   auto outRank = getBoxRank(outBoxTy);
   auto outEleTy = getBoxScalarEleTy(outBoxTy);
 
-  if (auto slice = op.slice()) {
+  if (auto slice = op.getSlice()) {
     // Slicing case
     if (slice.getType().cast<fir::SliceType>().getRank() != inputRank)
       return op.emitOpError("slice operand rank must match box operand rank");
-    if (auto shape = op.shape()) {
+    if (auto shape = op.getShape()) {
       if (auto shiftTy = shape.getType().dyn_cast<fir::ShiftType>()) {
         if (shiftTy.getRank() != inputRank)
           return op.emitOpError("shape operand and input box ranks must match "
@@ -2083,7 +2085,7 @@ static mlir::LogicalResult verify(fir::ReboxOp op) {
   } else {
     // Reshaping case
     unsigned shapeRank = inputRank;
-    if (auto shape = op.shape()) {
+    if (auto shape = op.getShape()) {
       auto ty = shape.getType();
       if (auto shapeTy = ty.dyn_cast<fir::ShapeType>()) {
         shapeRank = shapeTy.getRank();
@@ -2107,7 +2109,7 @@ static mlir::LogicalResult verify(fir::ReboxOp op) {
     // Character input and output types may be different if there is a
     // substring in the slice, otherwise, they must match.
     if (!inputEleTy.isa<fir::RecordType>() &&
-        !(op.slice() && inputEleTy.isa<fir::CharacterType>()))
+        !(op.getSlice() && inputEleTy.isa<fir::CharacterType>()))
       return op.emitOpError(
           "op input and output element types must match for intrinsic types");
   return mlir::success();
@@ -2137,13 +2139,13 @@ static mlir::LogicalResult verify(fir::ResultOp op) {
 
 static mlir::LogicalResult verify(fir::SaveResultOp op) {
   auto resultType = op.value().getType();
-  if (resultType != fir::dyn_cast_ptrEleTy(op.memref().getType()))
+  if (resultType != fir::dyn_cast_ptrEleTy(op.getMemref().getType()))
     return op.emitOpError("value type must match memory reference type");
   if (fir::isa_unknown_size_box(resultType))
     return op.emitOpError("cannot save !fir.box of unknown rank or type");
 
   if (resultType.isa<fir::BoxType>()) {
-    if (op.shape() || !op.typeparams().empty())
+    if (op.getShape() || !op.getTypeparams().empty())
       return op.emitOpError(
           "must not have shape or length operands if the value is a fir.box");
     return mlir::success();
@@ -2151,7 +2153,7 @@ static mlir::LogicalResult verify(fir::SaveResultOp op) {
 
   // fir.record or fir.array case.
   unsigned shapeTyRank = 0;
-  if (auto shapeOp = op.shape()) {
+  if (auto shapeOp = op.getShape()) {
     auto shapeTy = shapeOp.getType();
     if (auto s = shapeTy.dyn_cast<fir::ShapeType>())
       shapeTyRank = s.getRank();
@@ -2172,15 +2174,15 @@ static mlir::LogicalResult verify(fir::SaveResultOp op) {
   }
 
   if (auto recTy = eleTy.dyn_cast<fir::RecordType>()) {
-    if (recTy.getNumLenParams() != op.typeparams().size())
+    if (recTy.getNumLenParams() != op.getTypeparams().size())
       op.emitOpError("length parameters number must match with the value type "
                      "length parameters");
   } else if (auto charTy = eleTy.dyn_cast<fir::CharacterType>()) {
-    if (op.typeparams().size() > 1)
+    if (op.getTypeparams().size() > 1)
       op.emitOpError("no more than one length parameter must be provided for "
                      "character value");
   } else {
-    if (!op.typeparams().empty())
+    if (!op.getTypeparams().empty())
       op.emitOpError(
           "length parameters must not be provided for this value type");
   }
@@ -2237,7 +2239,7 @@ fir::SelectOp::getCompareOperands(llvm::ArrayRef<mlir::Value>, unsigned) {
 
 llvm::Optional<mlir::MutableOperandRange>
 fir::SelectOp::getMutableSuccessorOperands(unsigned oper) {
-  return ::getMutableSuccessorOperands(oper, targetArgsMutable(),
+  return ::getMutableSuccessorOperands(oper, getTargetArgsMutable(),
                                        getTargetOffsetAttr());
 }
 
@@ -2264,7 +2266,7 @@ llvm::Optional<mlir::OperandRange>
 fir::SelectCaseOp::getCompareOperands(unsigned cond) {
   auto a = (*this)->getAttrOfType<mlir::DenseIntElementsAttr>(
       getCompareOffsetAttr());
-  return {getSubOperands(cond, compareArgs(), a)};
+  return {getSubOperands(cond, getCompareArgs(), a)};
 }
 
 llvm::Optional<llvm::ArrayRef<mlir::Value>>
@@ -2279,7 +2281,7 @@ fir::SelectCaseOp::getCompareOperands(llvm::ArrayRef<mlir::Value> operands,
 
 llvm::Optional<mlir::MutableOperandRange>
 fir::SelectCaseOp::getMutableSuccessorOperands(unsigned oper) {
-  return ::getMutableSuccessorOperands(oper, targetArgsMutable(),
+  return ::getMutableSuccessorOperands(oper, getTargetArgsMutable(),
                                        getTargetOffsetAttr());
 }
 
@@ -2530,7 +2532,7 @@ fir::SelectRankOp::getCompareOperands(llvm::ArrayRef<mlir::Value>, unsigned) {
 
 llvm::Optional<mlir::MutableOperandRange>
 fir::SelectRankOp::getMutableSuccessorOperands(unsigned oper) {
-  return ::getMutableSuccessorOperands(oper, targetArgsMutable(),
+  return ::getMutableSuccessorOperands(oper, getTargetArgsMutable(),
                                        getTargetOffsetAttr());
 }
 
@@ -2565,7 +2567,7 @@ fir::SelectTypeOp::getCompareOperands(llvm::ArrayRef<mlir::Value>, unsigned) {
 
 llvm::Optional<mlir::MutableOperandRange>
 fir::SelectTypeOp::getMutableSuccessorOperands(unsigned oper) {
-  return ::getMutableSuccessorOperands(oper, targetArgsMutable(),
+  return ::getMutableSuccessorOperands(oper, getTargetArgsMutable(),
                                        getTargetOffsetAttr());
 }
 
@@ -2708,7 +2710,7 @@ void fir::SelectTypeOp::build(mlir::OpBuilder &builder,
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ShapeOp &op) {
-  auto size = op.extents().size();
+  auto size = op.getExtents().size();
   auto shapeTy = op.getType().dyn_cast<fir::ShapeType>();
   assert(shapeTy && "must be a shape type");
   if (shapeTy.getRank() != size)
@@ -2721,7 +2723,7 @@ static mlir::LogicalResult verify(fir::ShapeOp &op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ShapeShiftOp &op) {
-  auto size = op.pairs().size();
+  auto size = op.getPairs().size();
   if (size < 2 || size > 16 * 2)
     return op.emitOpError("incorrect number of args");
   if (size % 2 != 0)
@@ -2738,7 +2740,7 @@ static mlir::LogicalResult verify(fir::ShapeShiftOp &op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::ShiftOp &op) {
-  auto size = op.origins().size();
+  auto size = op.getOrigins().size();
   auto shiftTy = op.getType().dyn_cast<fir::ShiftType>();
   assert(shiftTy && "must be a shift type");
   if (shiftTy.getRank() != size)
@@ -2774,7 +2776,7 @@ unsigned fir::SliceOp::getOutputRank(mlir::ValueRange triples) {
 }
 
 static mlir::LogicalResult verify(fir::SliceOp &op) {
-  auto size = op.triples().size();
+  auto size = op.getTriples().size();
   if (size < 3 || size > 16 * 3)
     return op.emitOpError("incorrect number of args for triple");
   if (size % 3 != 0)
@@ -2814,13 +2816,13 @@ static void print(mlir::OpAsmPrinter &p, fir::StoreOp &op) {
   p << ' ';
   p.printOperand(op.value());
   p << " to ";
-  p.printOperand(op.memref());
+  p.printOperand(op.getMemref());
   p.printOptionalAttrDict(op.getOperation()->getAttrs(), {});
-  p << " : " << op.memref().getType();
+  p << " : " << op.getMemref().getType();
 }
 
 static mlir::LogicalResult verify(fir::StoreOp &op) {
-  if (op.value().getType() != fir::dyn_cast_ptrEleTy(op.memref().getType()))
+  if (op.value().getType() != fir::dyn_cast_ptrEleTy(op.getMemref().getType()))
     return op.emitOpError("store value type must match memory reference type");
   if (fir::isa_unknown_size_box(op.value().getType()))
     return op.emitOpError("cannot store !fir.box of unknown rank or type");
@@ -2956,7 +2958,7 @@ static mlir::LogicalResult verify(fir::StringLitOp &op) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult verify(fir::UnboxProcOp &op) {
-  if (auto eleTy = fir::dyn_cast_ptrEleTy(op.refTuple().getType()))
+  if (auto eleTy = fir::dyn_cast_ptrEleTy(op.getRefTuple().getType()))
     if (eleTy.isa<mlir::TupleType>())
       return mlir::success();
   return op.emitOpError("second output argument has bad type");
@@ -3023,7 +3025,7 @@ static mlir::ParseResult parseIfOp(OpAsmParser &parser,
 }
 
 static LogicalResult verify(fir::IfOp op) {
-  if (op.getNumResults() != 0 && op.elseRegion().empty())
+  if (op.getNumResults() != 0 && op.getElseRegion().empty())
     return op.emitOpError("must have an else block if defining values");
 
   return mlir::success();
@@ -3031,16 +3033,16 @@ static LogicalResult verify(fir::IfOp op) {
 
 static void print(mlir::OpAsmPrinter &p, fir::IfOp op) {
   bool printBlockTerminators = false;
-  p << ' ' << op.condition();
+  p << ' ' << op.getCondition();
   if (!op.results().empty()) {
     p << " -> (" << op.getResultTypes() << ')';
     printBlockTerminators = true;
   }
-  p.printRegion(op.thenRegion(), /*printEntryBlockArgs=*/false,
+  p.printRegion(op.getThenRegion(), /*printEntryBlockArgs=*/false,
                 printBlockTerminators);
 
   // Print the 'else' regions if it exists and has a block.
-  auto &otherReg = op.elseRegion();
+  auto &otherReg = op.getElseRegion();
   if (!otherReg.empty()) {
     p << " else";
     p.printRegion(otherReg, /*printEntryBlockArgs=*/false,
@@ -3051,10 +3053,10 @@ static void print(mlir::OpAsmPrinter &p, fir::IfOp op) {
 
 void fir::IfOp::resultToSourceOps(llvm::SmallVectorImpl<mlir::Value> &results,
                                   unsigned resultNum) {
-  auto *term = thenRegion().front().getTerminator();
+  auto *term = getThenRegion().front().getTerminator();
   if (resultNum < term->getNumOperands())
     results.push_back(term->getOperand(resultNum));
-  term = elseRegion().front().getTerminator();
+  term = getElseRegion().front().getTerminator();
   if (resultNum < term->getNumOperands())
     results.push_back(term->getOperand(resultNum));
 }
@@ -3148,7 +3150,7 @@ bool fir::valueHasFirAttribute(mlir::Value value,
   if (value.getType().isa<fir::BoxType>())
     if (auto *definingOp = value.getDefiningOp())
       if (auto loadOp = mlir::dyn_cast<fir::LoadOp>(definingOp))
-        value = loadOp.memref();
+        value = loadOp.getMemref();
   // If this is a function argument, look in the argument attributes.
   if (auto blockArg = value.dyn_cast<mlir::BlockArgument>()) {
     if (blockArg.getOwner() && blockArg.getOwner()->isEntryBlock())
@@ -3171,7 +3173,7 @@ bool fir::valueHasFirAttribute(mlir::Value value,
         return true;
       if (auto module = definingOp->getParentOfType<mlir::ModuleOp>())
         if (auto globalOp =
-                module.lookupSymbol<fir::GlobalOp>(addressOfOp.symbol()))
+                module.lookupSymbol<fir::GlobalOp>(addressOfOp.getSymbol()))
           return globalOp->hasAttr(attributeName);
     }
   }

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -95,19 +95,19 @@ public:
       return mlir::failure();
     }
     auto argType = getResultArgumentType(result.getType(), options);
-    auto buffer = saveResult.memref();
+    auto buffer = saveResult.getMemref();
     mlir::Value arg = buffer;
     if (mustEmboxResult(result.getType(), options))
       arg = rewriter.create<fir::EmboxOp>(
-          loc, argType, buffer, saveResult.shape(), /*slice*/ mlir::Value{},
-          saveResult.typeparams());
+          loc, argType, buffer, saveResult.getShape(), /*slice*/ mlir::Value{},
+          saveResult.getTypeparams());
 
     llvm::SmallVector<mlir::Type> newResultTypes;
-    if (callOp.callee()) {
+    if (callOp.getCallee()) {
       llvm::SmallVector<mlir::Value> newOperands = {arg};
       newOperands.append(callOp.getOperands().begin(),
                          callOp.getOperands().end());
-      rewriter.create<fir::CallOp>(loc, callOp.callee().getValue(),
+      rewriter.create<fir::CallOp>(loc, callOp.getCallee().getValue(),
                                    newResultTypes, newOperands);
     } else {
       // Indirect calls.
@@ -163,8 +163,8 @@ public:
     bool replacedStorage = false;
     if (auto *op = returnedValue.getDefiningOp())
       if (auto load = mlir::dyn_cast<fir::LoadOp>(op)) {
-        auto resultStorage = load.memref();
-        load.memref().replaceAllUsesWith(options.newArg);
+        auto resultStorage = load.getMemref();
+        load.getMemref().replaceAllUsesWith(options.newArg);
         replacedStorage = true;
         if (auto *alloc = resultStorage.getDefiningOp())
           if (alloc->use_empty())
@@ -197,7 +197,7 @@ public:
     auto oldFuncTy = addrOf.getType().cast<mlir::FunctionType>();
     auto newFuncTy = getNewFunctionType(oldFuncTy, options);
     auto newAddrOf = rewriter.create<fir::AddrOfOp>(addrOf.getLoc(), newFuncTy,
-                                                    addrOf.symbol());
+                                                    addrOf.getSymbol());
     // Rather than converting all op a function pointer might transit through
     // (e.g calls, stores, loads, converts...), cast new type to the abstract
     // type. A conversion will be added when calling indirect calls of abstract

--- a/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
+++ b/flang/lib/Optimizer/Transforms/AffinePromotion.cpp
@@ -106,7 +106,7 @@ private:
 
   bool analyzeReference(mlir::Value memref, mlir::Operation *op) {
     if (auto acoOp = memref.getDefiningOp<ArrayCoorOp>()) {
-      if (acoOp.memref().getType().isa<fir::BoxType>()) {
+      if (acoOp.getMemref().getType().isa<fir::BoxType>()) {
         // TODO: Look if and how fir.box can be promoted to affine.
         LLVM_DEBUG(llvm::dbgs() << "AffineLoopAnalysis: cannot promote loop, "
                                    "array memory operation uses fir.box\n";
@@ -114,7 +114,7 @@ private:
         return false;
       }
       bool canPromote = true;
-      for (auto coordinate : acoOp.indices())
+      for (auto coordinate : acoOp.getIndices())
         canPromote = canPromote && analyzeCoordinate(coordinate, op);
       return canPromote;
     }
@@ -134,10 +134,10 @@ private:
 
   bool analyzeMemoryAccess(fir::DoLoopOp loopOperation) {
     for (auto loadOp : loopOperation.getOps<fir::LoadOp>())
-      if (!analyzeReference(loadOp.memref(), loadOp))
+      if (!analyzeReference(loadOp.getMemref(), loadOp))
         return false;
     for (auto storeOp : loopOperation.getOps<fir::StoreOp>())
-      if (!analyzeReference(storeOp.memref(), storeOp))
+      if (!analyzeReference(storeOp.getMemref(), storeOp))
         return false;
     return true;
   }
@@ -331,7 +331,8 @@ static Optional<int64_t> constantIntegerLike(const mlir::Value value) {
 }
 
 static mlir::Type coordinateArrayElement(fir::ArrayCoorOp op) {
-  if (auto refType = op.memref().getType().dyn_cast_or_null<ReferenceType>()) {
+  if (auto refType =
+          op.getMemref().getType().dyn_cast_or_null<ReferenceType>()) {
     if (auto seqType = refType.getEleTy().dyn_cast_or_null<SequenceType>()) {
       return seqType.getEleTy();
     }
@@ -346,7 +347,7 @@ static void populateIndexArgs(fir::ArrayCoorOp acoOp, fir::ShapeOp shape,
                               mlir::PatternRewriter &rewriter) {
   auto one = rewriter.create<mlir::arith::ConstantOp>(
       acoOp.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(1));
-  auto extents = shape.extents();
+  auto extents = shape.getExtents();
   for (auto i = extents.begin(); i < extents.end(); i++) {
     indexArgs.push_back(one);
     indexArgs.push_back(*i);
@@ -359,7 +360,7 @@ static void populateIndexArgs(fir::ArrayCoorOp acoOp, fir::ShapeShiftOp shape,
                               mlir::PatternRewriter &rewriter) {
   auto one = rewriter.create<mlir::arith::ConstantOp>(
       acoOp.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(1));
-  auto extents = shape.pairs();
+  auto extents = shape.getPairs();
   for (auto i = extents.begin(); i < extents.end();) {
     indexArgs.push_back(*i++);
     indexArgs.push_back(*i++);
@@ -370,7 +371,7 @@ static void populateIndexArgs(fir::ArrayCoorOp acoOp, fir::ShapeShiftOp shape,
 static void populateIndexArgs(fir::ArrayCoorOp acoOp, fir::SliceOp slice,
                               SmallVectorImpl<mlir::Value> &indexArgs,
                               mlir::PatternRewriter &rewriter) {
-  auto extents = slice.triples();
+  auto extents = slice.getTriples();
   for (auto i = extents.begin(); i < extents.end();) {
     indexArgs.push_back(*i++);
     indexArgs.push_back(*i++);
@@ -381,11 +382,11 @@ static void populateIndexArgs(fir::ArrayCoorOp acoOp, fir::SliceOp slice,
 static void populateIndexArgs(fir::ArrayCoorOp acoOp,
                               SmallVectorImpl<mlir::Value> &indexArgs,
                               mlir::PatternRewriter &rewriter) {
-  if (auto shape = acoOp.shape().getDefiningOp<ShapeOp>())
+  if (auto shape = acoOp.getShape().getDefiningOp<ShapeOp>())
     return populateIndexArgs(acoOp, shape, indexArgs, rewriter);
-  if (auto shapeShift = acoOp.shape().getDefiningOp<ShapeShiftOp>())
+  if (auto shapeShift = acoOp.getShape().getDefiningOp<ShapeShiftOp>())
     return populateIndexArgs(acoOp, shapeShift, indexArgs, rewriter);
-  if (auto slice = acoOp.shape().getDefiningOp<SliceOp>())
+  if (auto slice = acoOp.getShape().getDefiningOp<SliceOp>())
     return populateIndexArgs(acoOp, slice, indexArgs, rewriter);
   return;
 }
@@ -395,9 +396,9 @@ static std::pair<mlir::AffineApplyOp, fir::ConvertOp>
 createAffineOps(mlir::Value arrayRef, mlir::PatternRewriter &rewriter) {
   auto acoOp = arrayRef.getDefiningOp<ArrayCoorOp>();
   auto affineMap =
-      createArrayIndexAffineMap(acoOp.indices().size(), acoOp.getContext());
+      createArrayIndexAffineMap(acoOp.getIndices().size(), acoOp.getContext());
   SmallVector<mlir::Value> indexArgs;
-  indexArgs.append(acoOp.indices().begin(), acoOp.indices().end());
+  indexArgs.append(acoOp.getIndices().begin(), acoOp.getIndices().end());
 
   populateIndexArgs(acoOp, indexArgs, rewriter);
 
@@ -405,14 +406,14 @@ createAffineOps(mlir::Value arrayRef, mlir::PatternRewriter &rewriter) {
                                                           affineMap, indexArgs);
   auto arrayElementType = coordinateArrayElement(acoOp);
   auto newType = mlir::MemRefType::get({-1}, arrayElementType);
-  auto arrayConvert =
-      rewriter.create<fir::ConvertOp>(acoOp.getLoc(), newType, acoOp.memref());
+  auto arrayConvert = rewriter.create<fir::ConvertOp>(acoOp.getLoc(), newType,
+                                                      acoOp.getMemref());
   return std::make_pair(affineApply, arrayConvert);
 }
 
 static void rewriteLoad(fir::LoadOp loadOp, mlir::PatternRewriter &rewriter) {
   rewriter.setInsertionPoint(loadOp);
-  auto affineOps = createAffineOps(loadOp.memref(), rewriter);
+  auto affineOps = createAffineOps(loadOp.getMemref(), rewriter);
   rewriter.replaceOpWithNewOp<mlir::AffineLoadOp>(
       loadOp, affineOps.second.getResult(), affineOps.first.getResult());
 }
@@ -420,8 +421,8 @@ static void rewriteLoad(fir::LoadOp loadOp, mlir::PatternRewriter &rewriter) {
 static void rewriteStore(fir::StoreOp storeOp,
                          mlir::PatternRewriter &rewriter) {
   rewriter.setInsertionPoint(storeOp);
-  auto affineOps = createAffineOps(storeOp.memref(), rewriter);
-  rewriter.replaceOpWithNewOp<mlir::AffineStoreOp>(storeOp, storeOp.value(),
+  auto affineOps = createAffineOps(storeOp.getMemref(), rewriter);
+  rewriter.replaceOpWithNewOp<mlir::AffineStoreOp>(storeOp, storeOp.getValue(),
                                                    affineOps.second.getResult(),
                                                    affineOps.first.getResult());
 }
@@ -478,7 +479,7 @@ public:
 private:
   std::pair<mlir::AffineForOp, mlir::Value>
   createAffineFor(fir::DoLoopOp op, mlir::PatternRewriter &rewriter) const {
-    if (auto constantStep = constantIntegerLike(op.step()))
+    if (auto constantStep = constantIntegerLike(op.getStep()))
       if (constantStep.getValue() > 0)
         return positiveConstantStep(op, constantStep.getValue(), rewriter);
     return genericBounds(op, rewriter);
@@ -489,10 +490,10 @@ private:
   positiveConstantStep(fir::DoLoopOp op, int64_t step,
                        mlir::PatternRewriter &rewriter) const {
     auto affineFor = rewriter.create<mlir::AffineForOp>(
-        op.getLoc(), ValueRange(op.lowerBound()),
+        op.getLoc(), ValueRange(op.getLowerBound()),
         mlir::AffineMap::get(0, 1,
                              mlir::getAffineSymbolExpr(0, op.getContext())),
-        ValueRange(op.upperBound()),
+        ValueRange(op.getUpperBound()),
         mlir::AffineMap::get(0, 1,
                              1 + mlir::getAffineSymbolExpr(0, op.getContext())),
         step);
@@ -508,7 +509,7 @@ private:
         0, 3, (upperBound - lowerBound + step).floorDiv(step));
     auto genericUpperBound = rewriter.create<mlir::AffineApplyOp>(
         op.getLoc(), upperBoundMap,
-        ValueRange({op.lowerBound(), op.upperBound(), op.step()}));
+        ValueRange({op.getLowerBound(), op.getUpperBound(), op.getStep()}));
     auto actualIndexMap = mlir::AffineMap::get(
         1, 2,
         (lowerBound + mlir::getAffineDimExpr(0, op.getContext())) *
@@ -524,7 +525,8 @@ private:
     rewriter.setInsertionPointToStart(affineFor.getBody());
     auto actualIndex = rewriter.create<mlir::AffineApplyOp>(
         op.getLoc(), actualIndexMap,
-        ValueRange({affineFor.getInductionVar(), op.lowerBound(), op.step()}));
+        ValueRange(
+            {affineFor.getInductionVar(), op.getLowerBound(), op.getStep()}));
     return std::make_pair(affineFor, actualIndex.getResult());
   }
 
@@ -542,8 +544,8 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     LLVM_DEBUG(llvm::dbgs() << "AffineIfConversion: rewriting if:\n";
                op.dump(););
-    auto &ifOps = op.thenRegion().front().getOperations();
-    auto affineCondition = AffineIfCondition(op.condition());
+    auto &ifOps = op.getThenRegion().front().getOperations();
+    auto affineCondition = AffineIfCondition(op.getCondition());
     if (!affineCondition.hasIntegerSet()) {
       LLVM_DEBUG(
           llvm::dbgs()
@@ -552,13 +554,13 @@ public:
     }
     auto affineIf = rewriter.create<mlir::AffineIfOp>(
         op.getLoc(), affineCondition.getIntegerSet(),
-        affineCondition.getAffineArgs(), !op.elseRegion().empty());
+        affineCondition.getAffineArgs(), !op.getElseRegion().empty());
     rewriter.startRootUpdate(affineIf);
     affineIf.getThenBlock()->getOperations().splice(
         std::prev(affineIf.getThenBlock()->end()), ifOps, ifOps.begin(),
         std::prev(ifOps.end()));
-    if (!op.elseRegion().empty()) {
-      auto &otherOps = op.elseRegion().front().getOperations();
+    if (!op.getElseRegion().empty()) {
+      auto &otherOps = op.getElseRegion().front().getOperations();
       affineIf.getElseBlock()->getOperations().splice(
           std::prev(affineIf.getElseBlock()->end()), otherOps, otherOps.begin(),
           std::prev(otherOps.end()));

--- a/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CharacterConversion.cpp
@@ -46,7 +46,7 @@ public:
     auto zero = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
     auto one = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
     auto idxTy = rewriter.getIndexType();
-    auto castCnt = rewriter.create<fir::ConvertOp>(loc, idxTy, conv.count());
+    auto castCnt = rewriter.create<fir::ConvertOp>(loc, idxTy, conv.getCount());
     auto countm1 = rewriter.create<mlir::arith::SubIOp>(loc, castCnt, one);
     auto loop = rewriter.create<fir::DoLoopOp>(loc, zero, countm1, one);
     auto insPt = rewriter.saveInsertionPoint();
@@ -59,8 +59,8 @@ public:
                        .cast<fir::CharacterType>();
       return kindMap.getCharacterBitsize(chrTy.getFKind());
     };
-    auto fromBits = getCharBits(conv.from().getType());
-    auto toBits = getCharBits(conv.to().getType());
+    auto fromBits = getCharBits(conv.getFrom().getType());
+    auto toBits = getCharBits(conv.getTo().getType());
     auto pointerType = [&](unsigned bits) {
       return fir::ReferenceType::get(fir::SequenceType::get(
           fir::SequenceType::ShapeRef{fir::SequenceType::getUnknownExtent()},
@@ -69,8 +69,9 @@ public:
     auto fromPtrTy = pointerType(fromBits);
     auto toTy = rewriter.getIntegerType(toBits);
     auto toPtrTy = pointerType(toBits);
-    auto fromPtr = rewriter.create<fir::ConvertOp>(loc, fromPtrTy, conv.from());
-    auto toPtr = rewriter.create<fir::ConvertOp>(loc, toPtrTy, conv.to());
+    auto fromPtr =
+        rewriter.create<fir::ConvertOp>(loc, fromPtrTy, conv.getFrom());
+    auto toPtr = rewriter.create<fir::ConvertOp>(loc, toPtrTy, conv.getTo());
     auto getEleTy = [&](unsigned bits) {
       return fir::ReferenceType::get(rewriter.getIntegerType(bits));
     };

--- a/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
@@ -46,12 +46,12 @@ public:
   matchAndRewrite(fir::CallOp op,
                   mlir::PatternRewriter &rewriter) const override {
     rewriter.startRootUpdate(op);
-    auto callee = op.callee();
+    auto callee = op.getCallee();
     if (callee.hasValue()) {
       auto result = fir::NameUniquer::deconstruct(
           callee.getValue().getRootReference().getValue());
       if (fir::NameUniquer::isExternalFacingUniquedName(result))
-        op.calleeAttr(
+        op.setCalleeAttr(
             SymbolRefAttr::get(op.getContext(), mangleExternalName(result)));
     }
     rewriter.finalizeRootUpdate(op);
@@ -87,10 +87,10 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     rewriter.startRootUpdate(op);
     auto result = fir::NameUniquer::deconstruct(
-        op.symref().getRootReference().getValue());
+        op.getSymref().getRootReference().getValue());
     if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
       auto newName = mangleExternalName(result);
-      op.symrefAttr(mlir::SymbolRefAttr::get(op.getContext(), newName));
+      op.setSymrefAttr(mlir::SymbolRefAttr::get(op.getContext(), newName));
       SymbolTable::setSymbolName(op, newName);
     }
     rewriter.finalizeRootUpdate(op);
@@ -106,11 +106,11 @@ public:
   matchAndRewrite(fir::AddrOfOp op,
                   mlir::PatternRewriter &rewriter) const override {
     auto result = fir::NameUniquer::deconstruct(
-        op.symbol().getRootReference().getValue());
+        op.getSymbol().getRootReference().getValue());
     if (fir::NameUniquer::isExternalFacingUniquedName(result)) {
       auto newName =
           SymbolRefAttr::get(op.getContext(), mangleExternalName(result));
-      rewriter.replaceOpWithNewOp<fir::AddrOfOp>(op, op.resTy().getType(),
+      rewriter.replaceOpWithNewOp<fir::AddrOfOp>(op, op.getResTy().getType(),
                                                  newName);
     }
     return success();
@@ -138,9 +138,9 @@ void ExternalNameConversionPass::runOnOperation() {
                          acc::OpenACCDialect, omp::OpenMPDialect>();
 
   target.addDynamicallyLegalOp<fir::CallOp>([](fir::CallOp op) {
-    if (op.callee().hasValue())
+    if (op.getCallee().hasValue())
       return !fir::NameUniquer::needExternalNameMangling(
-          op.callee().getValue().getRootReference().getValue());
+          op.getCallee().getValue().getRootReference().getValue());
     return true;
   });
 
@@ -150,12 +150,12 @@ void ExternalNameConversionPass::runOnOperation() {
 
   target.addDynamicallyLegalOp<fir::GlobalOp>([](fir::GlobalOp op) {
     return !fir::NameUniquer::needExternalNameMangling(
-        op.symref().getRootReference().getValue());
+        op.getSymref().getRootReference().getValue());
   });
 
   target.addDynamicallyLegalOp<fir::AddrOfOp>([](fir::AddrOfOp op) {
     return !fir::NameUniquer::needExternalNameMangling(
-        op.symbol().getRootReference().getValue());
+        op.getSymbol().getRootReference().getValue());
   });
 
   if (failed(applyPartialConversion(op, target, std::move(patterns))))

--- a/flang/lib/Optimizer/Transforms/MemoryAllocation.cpp
+++ b/flang/lib/Optimizer/Transforms/MemoryAllocation.cpp
@@ -115,10 +115,11 @@ public:
         return *opt;
       return {};
     };
-    auto uniqName = unpackName(alloca.uniq_name());
-    auto bindcName = unpackName(alloca.bindc_name());
+    auto uniqName = unpackName(alloca.getUniqName());
+    auto bindcName = unpackName(alloca.getBindcName());
     auto heap = rewriter.create<fir::AllocMemOp>(
-        loc, varTy, uniqName, bindcName, alloca.typeparams(), alloca.shape());
+        loc, varTy, uniqName, bindcName, alloca.getTypeparams(),
+        alloca.getShape());
     auto insPt = rewriter.saveInsertionPoint();
     for (mlir::Operation *retOp : returnOps) {
       rewriter.setInsertionPoint(retOp);

--- a/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
+++ b/flang/lib/Optimizer/Transforms/RewriteLoop.cpp
@@ -48,20 +48,20 @@ public:
     // Split the first DoLoopOp block in two parts. The part before will be the
     // conditional block since it already has the induction variable and
     // loop-carried values as arguments.
-    auto *conditionalBlock = &loop.region().front();
+    auto *conditionalBlock = &loop.getRegion().front();
     conditionalBlock->addArgument(rewriter.getIndexType());
     auto *firstBlock =
         rewriter.splitBlock(conditionalBlock, conditionalBlock->begin());
-    auto *lastBlock = &loop.region().back();
+    auto *lastBlock = &loop.getRegion().back();
 
     // Move the blocks from the DoLoopOp between initBlock and endBlock
-    rewriter.inlineRegionBefore(loop.region(), endBlock);
+    rewriter.inlineRegionBefore(loop.getRegion(), endBlock);
 
     // Get loop values from the DoLoopOp
-    auto low = loop.lowerBound();
-    auto high = loop.upperBound();
+    auto low = loop.getLowerBound();
+    auto high = loop.getUpperBound();
     assert(low && high && "must be a Value");
-    auto step = loop.step();
+    auto step = loop.getStep();
 
     // Initalization block
     rewriter.setInsertionPointToEnd(initBlock);
@@ -101,8 +101,8 @@ public:
 
     llvm::SmallVector<mlir::Value> loopCarried;
     loopCarried.push_back(steppedIndex);
-    auto begin = loop.finalValue() ? std::next(terminator->operand_begin())
-                                   : terminator->operand_begin();
+    auto begin = loop.getFinalValue() ? std::next(terminator->operand_begin())
+                                      : terminator->operand_begin();
     loopCarried.append(begin, terminator->operand_end());
     loopCarried.push_back(itersMinusOne);
     rewriter.create<mlir::BranchOp>(loc, conditionalBlock, loopCarried);
@@ -120,7 +120,7 @@ public:
 
     // The result of the loop operation is the values of the condition block
     // arguments except the induction variable on the last iteration.
-    auto args = loop.finalValue()
+    auto args = loop.getFinalValue()
                     ? conditionalBlock->getArguments()
                     : conditionalBlock->getArguments().drop_front();
     rewriter.replaceOp(loop, args.drop_back());
@@ -160,7 +160,7 @@ public:
 
     // Move blocks from the "then" region to the region containing 'fir.if',
     // place it before the continuation block, and branch to it.
-    auto &ifOpRegion = ifOp.thenRegion();
+    auto &ifOpRegion = ifOp.getThenRegion();
     auto *ifOpBlock = &ifOpRegion.front();
     auto *ifOpTerminator = ifOpRegion.back().getTerminator();
     auto ifOpTerminatorOperands = ifOpTerminator->getOperands();
@@ -173,7 +173,7 @@ public:
     // 'fir.if', place it before the continuation block and branch to it.  It
     // will be placed after the "then" regions.
     auto *otherwiseBlock = continueBlock;
-    auto &otherwiseRegion = ifOp.elseRegion();
+    auto &otherwiseRegion = ifOp.getElseRegion();
     if (!otherwiseRegion.empty()) {
       otherwiseBlock = &otherwiseRegion.front();
       auto *otherwiseTerm = otherwiseRegion.back().getTerminator();
@@ -187,7 +187,7 @@ public:
 
     rewriter.setInsertionPointToEnd(condBlock);
     rewriter.create<mlir::CondBranchOp>(
-        loc, ifOp.condition(), ifOpBlock, llvm::ArrayRef<mlir::Value>(),
+        loc, ifOp.getCondition(), ifOpBlock, llvm::ArrayRef<mlir::Value>(),
         otherwiseBlock, llvm::ArrayRef<mlir::Value>());
     rewriter.replaceOp(ifOp, continueBlock->getArguments());
     return success();
@@ -219,11 +219,11 @@ public:
     // arguments. Split out all operations from the first block into a new
     // block. Move all body blocks from the loop body region to the region
     // containing the loop.
-    auto *conditionBlock = &whileOp.region().front();
+    auto *conditionBlock = &whileOp.getRegion().front();
     auto *firstBodyBlock =
         rewriter.splitBlock(conditionBlock, conditionBlock->begin());
-    auto *lastBodyBlock = &whileOp.region().back();
-    rewriter.inlineRegionBefore(whileOp.region(), endBlock);
+    auto *lastBodyBlock = &whileOp.getRegion().back();
+    rewriter.inlineRegionBefore(whileOp.getRegion(), endBlock);
     auto iv = conditionBlock->getArgument(0);
     auto iterateVar = conditionBlock->getArgument(1);
 
@@ -232,13 +232,13 @@ public:
     // operands of the loop terminator.
     auto *terminator = lastBodyBlock->getTerminator();
     rewriter.setInsertionPointToEnd(lastBodyBlock);
-    auto step = whileOp.step();
+    auto step = whileOp.getStep();
     mlir::Value stepped = rewriter.create<mlir::arith::AddIOp>(loc, iv, step);
     assert(stepped && "must be a Value");
 
     llvm::SmallVector<mlir::Value> loopCarried;
     loopCarried.push_back(stepped);
-    auto begin = whileOp.finalValue() ? std::next(terminator->operand_begin())
+    auto begin = whileOp.getFinalValue() ? std::next(terminator->operand_begin())
                                       : terminator->operand_begin();
     loopCarried.append(begin, terminator->operand_end());
     rewriter.create<mlir::BranchOp>(loc, conditionBlock, loopCarried);
@@ -246,8 +246,8 @@ public:
 
     // Compute loop bounds before branching to the condition.
     rewriter.setInsertionPointToEnd(initBlock);
-    auto lowerBound = whileOp.lowerBound();
-    auto upperBound = whileOp.upperBound();
+    auto lowerBound = whileOp.getLowerBound();
+    auto upperBound = whileOp.getUpperBound();
     assert(lowerBound && upperBound && "must be a Value");
 
     // The initial values of loop-carried values is obtained from the operands
@@ -283,7 +283,7 @@ public:
                                         llvm::ArrayRef<mlir::Value>());
     // The result of the loop operation is the values of the condition block
     // arguments except the induction variable on the last iteration.
-    auto args = whileOp.finalValue()
+    auto args = whileOp.getFinalValue()
                     ? conditionBlock->getArguments()
                     : conditionBlock->getArguments().drop_front();
     rewriter.replaceOp(whileOp, args);

--- a/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
+++ b/flang/unittests/Optimizer/Builder/DoLoopHelperTest.cpp
@@ -44,10 +44,10 @@ TEST_F(DoLoopHelperTest, createLoopWithCountTest) {
       firBuilder.getUnknownLoc(), firBuilder.getIndexType(), 10);
   auto loop =
       helper.createLoop(c10, [&](fir::FirOpBuilder &, mlir::Value index) {});
-  checkConstantValue(loop.lowerBound(), 0);
+  checkConstantValue(loop.getLowerBound(), 0);
   EXPECT_TRUE(
-      mlir::isa<mlir::arith::SubIOp>(loop.upperBound().getDefiningOp()));
-  auto subOp = dyn_cast<mlir::arith::SubIOp>(loop.upperBound().getDefiningOp());
+      mlir::isa<mlir::arith::SubIOp>(loop.getUpperBound().getDefiningOp()));
+  auto subOp = dyn_cast<mlir::arith::SubIOp>(loop.getUpperBound().getDefiningOp());
   EXPECT_EQ(c10, subOp.lhs());
   checkConstantValue(subOp.rhs(), 1);
   checkConstantValue(loop.getStep(), 1);

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -185,13 +185,13 @@ TEST_F(FIRBuilderTest, createGlobal1) {
   auto global = builder.createGlobal(
       loc, i64Type, "global1", builder.createInternalLinkage(), {}, true);
   EXPECT_TRUE(mlir::isa<fir::GlobalOp>(global));
-  EXPECT_EQ("global1", global.sym_name());
-  EXPECT_TRUE(global.constant().hasValue());
+  EXPECT_EQ("global1", global.getSymName());
+  EXPECT_TRUE(global.getConstant().hasValue());
   EXPECT_EQ(i64Type, global.type());
-  EXPECT_TRUE(global.linkName().hasValue());
-  EXPECT_EQ(
-      builder.createInternalLinkage().getValue(), global.linkName().getValue());
-  EXPECT_FALSE(global.initVal().hasValue());
+  EXPECT_TRUE(global.getLinkName().hasValue());
+  EXPECT_EQ(builder.createInternalLinkage().getValue(),
+      global.getLinkName().getValue());
+  EXPECT_FALSE(global.getInitVal().hasValue());
 
   auto g1 = builder.getNamedGlobal("global1");
   EXPECT_EQ(global, g1);
@@ -209,16 +209,16 @@ TEST_F(FIRBuilderTest, createGlobal2) {
   auto global = builder.createGlobal(
       loc, i32Type, "global2", builder.createLinkOnceLinkage(), attr, false);
   EXPECT_TRUE(mlir::isa<fir::GlobalOp>(global));
-  EXPECT_EQ("global2", global.sym_name());
-  EXPECT_FALSE(global.constant().hasValue());
+  EXPECT_EQ("global2", global.getSymName());
+  EXPECT_FALSE(global.getConstant().hasValue());
   EXPECT_EQ(i32Type, global.type());
-  EXPECT_TRUE(global.initVal().hasValue());
-  EXPECT_TRUE(global.initVal().getValue().isa<mlir::IntegerAttr>());
+  EXPECT_TRUE(global.getInitVal().hasValue());
+  EXPECT_TRUE(global.getInitVal().getValue().isa<mlir::IntegerAttr>());
   EXPECT_EQ(
-      16, global.initVal().getValue().cast<mlir::IntegerAttr>().getValue());
-  EXPECT_TRUE(global.linkName().hasValue());
-  EXPECT_EQ(
-      builder.createLinkOnceLinkage().getValue(), global.linkName().getValue());
+      16, global.getInitVal().getValue().cast<mlir::IntegerAttr>().getValue());
+  EXPECT_TRUE(global.getLinkName().hasValue());
+  EXPECT_EQ(builder.createLinkOnceLinkage().getValue(),
+      global.getLinkName().getValue());
 }
 
 TEST_F(FIRBuilderTest, uniqueCFIdent) {
@@ -263,7 +263,7 @@ TEST_F(FIRBuilderTest, locationToFilename) {
       mlir::FileLineColLoc::get(builder.getIdentifier("file1.f90"), 10, 5);
   mlir::Value locToFile = fir::factory::locationToFilename(builder, loc);
   auto addrOp = dyn_cast<fir::AddrOfOp>(locToFile.getDefiningOp());
-  auto symbol = addrOp.symbol().getRootReference().getValue();
+  auto symbol = addrOp.getSymbol().getRootReference().getValue();
   auto global = builder.getNamedGlobal(symbol);
   auto stringLitOps = global.getRegion().front().getOps<fir::StringLitOp>();
   EXPECT_TRUE(llvm::hasSingleElement(stringLitOps));
@@ -305,10 +305,10 @@ TEST_F(FIRBuilderTest, createStringLiteral) {
   auto addr = charBox->getBuffer();
   EXPECT_TRUE(mlir::isa<fir::AddrOfOp>(addr.getDefiningOp()));
   auto addrOp = dyn_cast<fir::AddrOfOp>(addr.getDefiningOp());
-  auto symbol = addrOp.symbol().getRootReference().getValue();
+  auto symbol = addrOp.getSymbol().getRootReference().getValue();
   auto global = builder.getNamedGlobal(symbol);
-  EXPECT_EQ(
-      builder.createLinkOnceLinkage().getValue(), global.linkName().getValue());
+  EXPECT_EQ(builder.createLinkOnceLinkage().getValue(),
+      global.getLinkName().getValue());
   EXPECT_EQ(fir::CharacterType::get(builder.getContext(), 1, strValue.size()),
       global.type());
 
@@ -329,13 +329,13 @@ TEST_F(FIRBuilderTest, allocateLocal) {
       loc, builder.getI64Type(), "", varName, {}, {}, false);
   EXPECT_TRUE(mlir::isa<fir::AllocaOp>(var.getDefiningOp()));
   auto allocaOp = dyn_cast<fir::AllocaOp>(var.getDefiningOp());
-  EXPECT_EQ(builder.getI64Type(), allocaOp.in_type());
-  EXPECT_TRUE(allocaOp.bindc_name().hasValue());
-  EXPECT_EQ(varName, allocaOp.bindc_name().getValue());
-  EXPECT_FALSE(allocaOp.uniq_name().hasValue());
-  EXPECT_FALSE(allocaOp.pinned());
-  EXPECT_EQ(0u, allocaOp.typeparams().size());
-  EXPECT_EQ(0u, allocaOp.shape().size());
+  EXPECT_EQ(builder.getI64Type(), allocaOp.getInType());
+  EXPECT_TRUE(allocaOp.getBindcName().hasValue());
+  EXPECT_EQ(varName, allocaOp.getBindcName().getValue());
+  EXPECT_FALSE(allocaOp.getUniqName().hasValue());
+  EXPECT_FALSE(allocaOp.getPinned());
+  EXPECT_EQ(0u, allocaOp.getTypeparams().size());
+  EXPECT_EQ(0u, allocaOp.getShape().size());
 }
 
 static void checkShapeOp(mlir::Value shape, mlir::Value c10, mlir::Value c100) {

--- a/flang/unittests/Optimizer/Builder/Runtime/RuntimeCallTestBase.h
+++ b/flang/unittests/Optimizer/Builder/Runtime/RuntimeCallTestBase.h
@@ -83,13 +83,13 @@ static inline void checkCallOp(mlir::Operation *op, llvm::StringRef fctName,
     unsigned nbArgs, bool addLocArgs = true) {
   EXPECT_TRUE(mlir::isa<fir::CallOp>(*op));
   auto callOp = mlir::dyn_cast<fir::CallOp>(*op);
-  EXPECT_TRUE(callOp.callee().hasValue());
-  mlir::SymbolRefAttr callee = *callOp.callee();
+  EXPECT_TRUE(callOp.getCallee().hasValue());
+  mlir::SymbolRefAttr callee = *callOp.getCallee();
   EXPECT_EQ(fctName, callee.getRootReference().getValue());
   // sourceFile and sourceLine are added arguments.
   if (addLocArgs)
     nbArgs += 2;
-  EXPECT_EQ(nbArgs, callOp.args().size());
+  EXPECT_EQ(nbArgs, callOp.getArgs().size());
 }
 
 /// Check the call operation from the \p result value. In some cases the


### PR DESCRIPTION
Cherry-pick: https://reviews.llvm.org/rG149ad3d554c6e901a57c7e34e29fba334dcd283c
Differential: https://reviews.llvm.org/D119812

`emitAccessorPrefix` is still `kEmitAccessorPrefix_Both` to avoid breaking the compilation here. While upstreaming, the change that is being upstreamed should be refactored with appropriate accessors. This patch will make sure there are minimal unnecessary conflicts while upstreaming.