### PR TITLE
[mlir][ods] Allow type attribute/operand for 0 result ops prefixed

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2823,11 +2823,6 @@ def fir_GlobalOp : fir_Op<"global", [IsolatedFromAbove, Symbol]> {
     static constexpr llvm::StringRef getLinkageAttrNameStr() { return "linkName"; }
     static constexpr llvm::StringRef getTypeAttrNameStr() { return "type"; }
 
-    /// The printable type of the global
-    mlir::Type getTypeAttrType() {
-      return (*this)->getAttrOfType<TypeAttr>(getTypeAttrName()).getValue();
-    }
-
     /// The semantic type of the global
     mlir::Type resultType();
 

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -1175,7 +1175,7 @@ static ParseResult parseGlobalOp(OpAsmParser &parser, OperationState &result) {
   if (parser.parseColonType(globalType))
     return mlir::failure();
 
-  result.addAttribute(fir::GlobalOp::getTypeAttrNameStr(),
+  result.addAttribute(fir::GlobalOp::getTypeAttrName(result.name),
                       mlir::TypeAttr::get(globalType));
 
   if (simpleInitializer) {
@@ -1218,7 +1218,7 @@ void fir::GlobalOp::build(mlir::OpBuilder &builder, OperationState &result,
                           Attribute initialVal, StringAttr linkage,
                           ArrayRef<NamedAttribute> attrs) {
   result.addRegion();
-  result.addAttribute(getTypeAttrNameStr(), mlir::TypeAttr::get(type));
+  result.addAttribute(getTypeAttrName(result.name), mlir::TypeAttr::get(type));
   result.addAttribute(mlir::SymbolTable::getSymbolAttrName(),
                       builder.getStringAttr(name));
   result.addAttribute(getSymbolAttrNameStr(),

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -187,7 +187,7 @@ TEST_F(FIRBuilderTest, createGlobal1) {
   EXPECT_TRUE(mlir::isa<fir::GlobalOp>(global));
   EXPECT_EQ("global1", global.sym_name());
   EXPECT_TRUE(global.constant().hasValue());
-  EXPECT_EQ(i64Type, global.type());
+  EXPECT_EQ(i64Type, global.getType());
   EXPECT_TRUE(global.linkName().hasValue());
   EXPECT_EQ(
       builder.createInternalLinkage().getValue(), global.linkName().getValue());
@@ -211,7 +211,7 @@ TEST_F(FIRBuilderTest, createGlobal2) {
   EXPECT_TRUE(mlir::isa<fir::GlobalOp>(global));
   EXPECT_EQ("global2", global.sym_name());
   EXPECT_FALSE(global.constant().hasValue());
-  EXPECT_EQ(i32Type, global.type());
+  EXPECT_EQ(i32Type, global.getType());
   EXPECT_TRUE(global.initVal().hasValue());
   EXPECT_TRUE(global.initVal().getValue().isa<mlir::IntegerAttr>());
   EXPECT_EQ(
@@ -310,7 +310,7 @@ TEST_F(FIRBuilderTest, createStringLiteral) {
   EXPECT_EQ(
       builder.createLinkOnceLinkage().getValue(), global.linkName().getValue());
   EXPECT_EQ(fir::CharacterType::get(builder.getContext(), 1, strValue.size()),
-      global.type());
+      global.getType());
 
   auto stringLitOps = global.getRegion().front().getOps<fir::StringLitOp>();
   EXPECT_TRUE(llvm::hasSingleElement(stringLitOps));

--- a/mlir/lib/TableGen/Operator.cpp
+++ b/mlir/lib/TableGen/Operator.cpp
@@ -656,7 +656,25 @@ getGetterOrSetterNames(bool isGetter, const Operator &op, StringRef name) {
   bool rawToo = prefixType == Dialect::EmitPrefix::Both;
 
   auto skip = [&](StringRef newName) {
-    bool shouldSkip = newName == "getOperands";
+    bool shouldSkip = newName == "getAttributeNames" ||
+                      newName == "getAttributes" || newName == "getOperation";
+    if (newName == "getOperands") {
+      // To reduce noise, skip generating the prefixed form and the warning if
+      // $operands correspond to single variadic argument.
+      if (op.getNumOperands() == 1 && op.getNumVariableLengthOperands() == 1)
+        return true;
+      shouldSkip = true;
+    }
+    if (newName == "getRegions") {
+      if (op.getNumRegions() == 1 && op.getNumVariadicRegions() == 1)
+        return true;
+      shouldSkip = true;
+    }
+    if (newName == "getType") {
+      if (op.getNumResults() == 0)
+        return false;
+      shouldSkip = true;
+    }
     if (!shouldSkip)
       return false;
 


### PR DESCRIPTION
Without results, there is no getType injected and so generating one in prefixed form doesn't result in any failures during C++ compilation.

Differential Revision: https://reviews.llvm.org/D119871

Cherry-pick this change since it touches FIR. Trying to not fall too much behind MLIR. 