### PR TITLE
Fix allocatable assignment with vector subscripts in RHS

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -193,19 +193,6 @@ translateFloatRelational(Fortran::common::RelationalOperator rop) {
   llvm_unreachable("unhandled REAL relational operator");
 }
 
-/// Lower `opt` (from front-end shape analysis) to MLIR. If `opt` is `nullopt`
-/// then issue an error.
-static mlir::Value
-convertOptExtentExpr(Fortran::lower::AbstractConverter &converter,
-                     Fortran::lower::StatementContext &stmtCtx,
-                     const Fortran::evaluate::MaybeExtentExpr &opt) {
-  mlir::Location loc = converter.getCurrentLocation();
-  if (!opt.has_value())
-    fir::emitFatalError(loc, "shape analysis failed to return an expression");
-  Fortran::lower::SomeExpr e = toEvExpr(*opt);
-  return fir::getBase(converter.genExprValue(&e, stmtCtx, loc));
-}
-
 static mlir::Value genActualIsPresentTest(fir::FirOpBuilder &builder,
                                           mlir::Location loc,
                                           fir::ExtendedValue actual) {
@@ -3268,12 +3255,12 @@ public:
     fir::MutableBoxValue mutableBox =
         createMutableBox(loc, converter, lhs, symMap);
     mlir::Type resultTy = converter.genType(rhs);
+    if (rhs.Rank() > 0)
+      determineShapeOfDest(rhs);
     auto rhsCC = [&]() {
       PushSemantics(ConstituentSemantics::RefTransparent);
       return genarr(rhs);
     }();
-    if (!arrayOperands.empty())
-      destShape = getShape(getInducingShapeArrayOperand());
 
     llvm::SmallVector<mlir::Value> lengthParams;
     // Currently no safe way to gather length from rhs (at least for
@@ -3629,9 +3616,13 @@ private:
       return;
     if (explicitSpaceIsActive() && determineShapeWithSlice(lhs))
       return;
-    if (std::optional<Fortran::evaluate::Shape> shape =
-            Fortran::evaluate::GetShape(converter.getFoldingContext(), lhs))
-      convertFEShape(shape.value(), destShape);
+    mlir::Type idxTy = builder.getIndexType();
+    mlir::Location loc = getLoc();
+    if (std::optional<Fortran::evaluate::ConstantSubscripts> constantShape =
+            Fortran::evaluate::GetConstantExtents(converter.getFoldingContext(),
+                                                  lhs))
+      for (Fortran::common::ConstantSubscript extent : *constantShape)
+        destShape.push_back(builder.createIntegerConstant(loc, idxTy, extent));
   }
 
   bool genShapeFromDataRef(const Fortran::semantics::Symbol &x) {
@@ -3705,26 +3696,6 @@ private:
     std::optional<Fortran::evaluate::DataRef> dref =
         Fortran::evaluate::ExtractDataRef(lhs);
     return dref.has_value() ? genShapeFromDataRef(*dref) : false;
-  }
-
-  /// Returns true iff the Ev::Shape is constant.
-  static bool evalShapeIsConstant(const Fortran::evaluate::Shape &shape) {
-    for (const auto &s : shape)
-      if (!s || !Fortran::evaluate::IsConstantExpr(*s))
-        return false;
-    return true;
-  }
-
-  /// Convert an Ev::Shape to IR values.
-  void convertFEShape(const Fortran::evaluate::Shape &shape,
-                      llvm::SmallVectorImpl<mlir::Value> &result) {
-    if (evalShapeIsConstant(shape)) {
-      mlir::IndexType idxTy = builder.getIndexType();
-      mlir::Location loc = getLoc();
-      for (const auto &s : shape)
-        result.emplace_back(builder.createConvert(
-            loc, idxTy, convertOptExtentExpr(converter, stmtCtx, s)));
-    }
   }
 
   /// CHARACTER and derived type elements are treated as memory references. The
@@ -5282,27 +5253,6 @@ private:
     }
     return result;
   }
-  llvm::SmallVector<mlir::Value>
-  getShape(const Fortran::semantics::SymbolRef &x) {
-    if (x.get().Rank() == 0)
-      return {};
-    return getFrontEndShape(x);
-  }
-  template <typename A>
-  llvm::SmallVector<mlir::Value> getShape(const A &x) {
-    if (x.Rank() == 0)
-      return {};
-    return getFrontEndShape(x);
-  }
-  template <typename A>
-  llvm::SmallVector<mlir::Value> getFrontEndShape(const A &x) {
-    if (auto optShape = Fortran::evaluate::GetShape(x)) {
-      llvm::SmallVector<mlir::Value> result;
-      convertFEShape(*optShape, result);
-      return result;
-    }
-    return {};
-  }
 
   CC genarr(const Fortran::semantics::SymbolRef &sym,
             ComponentPath &components) {
@@ -5325,17 +5275,6 @@ private:
     mlir::Type arrTy = fir::dyn_cast_ptrOrBoxEleTy(memref.getType());
     assert(arrTy.isa<fir::SequenceType>() && "memory ref must be an array");
     mlir::Value shape = builder.createShape(loc, extMemref);
-    if (destShape.empty()) {
-      if (shape) {
-        std::vector<mlir::Value, std::allocator<mlir::Value>> extents =
-            fir::factory::getExtents(shape);
-        destShape.assign(extents.begin(), extents.end());
-      } else {
-        llvm::SmallVector<mlir::Value> extents =
-            fir::factory::getExtents(builder, loc, extMemref);
-        destShape.assign(extents.begin(), extents.end());
-      }
-    }
     mlir::Value slice;
     if (components.isSlice()) {
       if (isBoxValue() && components.substring) {
@@ -5401,6 +5340,8 @@ private:
       }
     }
     arrayOperands.push_back(ArrayOperand{memref, shape, slice});
+    if (destShape.empty())
+      destShape = getShape(arrayOperands.back());
     if (isBoxValue()) {
       // Semantics are a reference to a boxed array.
       // This case just requires that an embox operation be created to box the

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -268,6 +268,8 @@ end subroutine
 subroutine test_from_cst_shape_array(x, y)
   real, allocatable  :: x(:, :)
   real :: y(2, 3)
+! CHECK:  %[[VAL_2_0:.*]] = arith.constant 2 : index
+! CHECK:  %[[VAL_3_0:.*]] = arith.constant 3 : index
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 2 : index
 ! CHECK:  %[[VAL_3:.*]] = arith.constant 3 : index
 ! CHECK:  %[[VAL_6:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
@@ -444,11 +446,11 @@ subroutine test_runtime_shape(x)
 ! CHECK:  %[[VAL_6:.*]] = arith.constant 1 : index
 ! CHECK:  %[[VAL_7:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_6]] : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, index) -> (index, index, index)
 ! CHECK:  %[[VAL_8:.*]] = fir.shift %[[VAL_5]]#0, %[[VAL_7]]#0 : (index, index) -> !fir.shift<2>
-! CHECK:  %[[VAL_9:.*]] = fir.array_load %[[VAL_3]](%[[VAL_8]]) : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, !fir.shift<2>) -> !fir.array<?x?xf32>
 ! CHECK:  %[[VAL_10:.*]] = arith.constant 0 : index
 ! CHECK:  %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_10]] : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, index) -> (index, index, index)
 ! CHECK:  %[[VAL_12:.*]] = arith.constant 1 : index
 ! CHECK:  %[[VAL_13:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_12]] : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, index) -> (index, index, index)
+! CHECK:  %[[VAL_9:.*]] = fir.array_load %[[VAL_3]](%[[VAL_8]]) : (!fir.box<!fir.ptr<!fir.array<?x?xf32>>>, !fir.shift<2>) -> !fir.array<?x?xf32>
 ! CHECK:  %[[VAL_14:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
 ! CHECK:  %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.heap<!fir.array<?x?xf32>>
 ! CHECK:  %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.heap<!fir.array<?x?xf32>>) -> i64
@@ -565,8 +567,9 @@ subroutine test_cst_char(x, c)
   character(12) :: c(20)
 ! CHECK:  %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<20x!fir.char<1,12>>>
+! CHECK:  %[[VAL_4_0:.*]] = arith.constant 20 : index
 ! CHECK:  %[[VAL_4:.*]] = arith.constant 20 : index
-! CHECK:  %[[VAL_5:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
+! CHECK:  %[[VAL_5:.*]] = fir.shape %[[VAL_4_0]] : (index) -> !fir.shape<1>
 ! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
 ! CHECK:  %[[VAL_8:.*]] = fir.box_addr %[[VAL_7]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
 ! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.heap<!fir.array<?x!fir.char<1,10>>>) -> i64
@@ -613,9 +616,10 @@ subroutine test_dyn_char(x, n, c)
   character(*) :: c(20)
 ! CHECK:  %[[VAL_3:.*]]:2 = fir.unboxchar %[[VAL_2]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<20x!fir.char<1,?>>>
-! CHECK:  %[[VAL_5:.*]] = arith.constant 20 : index
+! CHECK:  %[[VAL_5_0:.*]] = arith.constant 20 : index
 ! CHECK:  %[[VAL_6:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-! CHECK:  %[[VAL_7:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:  %[[VAL_5:.*]] = arith.constant 20 : index
+! CHECK:  %[[VAL_7:.*]] = fir.shape %[[VAL_5_0]] : (index) -> !fir.shape<1>
 ! CHECK:  %[[VAL_9:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
 ! CHECK:  %[[VAL_10:.*]] = fir.box_addr %[[VAL_9]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
 ! CHECK:  %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> i64
@@ -679,6 +683,50 @@ subroutine test_derived_with_init(x, y)
 ! CHECK:  } else {
 ! CHECK:    fir.result %{{.*}} : !fir.heap<!fir.type<_QMalloc_assignFtest_derived_with_initTt{a:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>
 ! CHECK:  }
+end subroutine
+
+! CHECK-LABEL: func @_QMalloc_assignPtest_vector_subscript(
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "x"},
+! CHECK-SAME: %[[VAL_1:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "y"},
+! CHECK-SAME: %[[VAL_2:.*]]: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "v"}) {
+subroutine test_vector_subscript(x, y, v)
+  ! Test that the new shape is computed correctly in presence of
+  ! vector subscripts on the RHS and that it is used to allocate
+  ! the new storage and to drive the implicit loop.
+  integer, allocatable :: x(:)
+  integer :: y(:), v(:)
+  x = y(v)
+! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_4:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_5:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_4]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_7:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_6]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+! CHECK:         %[[VAL_8:.*]] = fir.array_load %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_9:.*]] = arith.cmpi sgt, %[[VAL_7]]#1, %[[VAL_5]]#1 : index
+! CHECK:         %[[VAL_10:.*]] = select %[[VAL_9]], %[[VAL_5]]#1, %[[VAL_7]]#1 : index
+! CHECK:         fir.if {{.*}} {
+! CHECK:           %[[VAL_18:.*]] = arith.constant false
+! CHECK:           %[[VAL_20:.*]]:3 = fir.box_dims %{{.*}}, %{{.*}} : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_20]]#1, %[[VAL_10]] : index
+! CHECK:           %[[VAL_22:.*]] = select %[[VAL_21]], %[[VAL_21]], %[[VAL_18]] : i1
+! CHECK:           fir.if %[[VAL_22]] {{.*}} {
+! CHECK:             %[[VAL_24:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_10]] {uniq_name = ".auto.alloc"}
+! CHECK:             fir.result %[[VAL_24]] : !fir.heap<!fir.array<?xi32>>
+! CHECK:           } else {
+! CHECK:             fir.result %{{.*}} : !fir.heap<!fir.array<?xi32>>
+! CHECK:           }
+! CHECK:           fir.result %{{.*}}, %{{.*}}
+! CHECK:         } else {
+! CHECK:           %[[VAL_27:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_10]] {uniq_name = ".auto.alloc"}
+! CHECK:           fir.result %{{.*}}, %[[VAL_27]] : i1, !fir.heap<!fir.array<?xi32>>
+! CHECK:         }
+! CHECK:         %[[VAL_28:.*]] = fir.shape %[[VAL_10]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_29:.*]] = fir.array_load %[[VAL_30:.*]]#1(%[[VAL_28]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.array<?xi32>
+! CHECK:         %[[VAL_31:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_32:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_33:.*]] = arith.subi %[[VAL_10]], %[[VAL_31]] : index
+! CHECK:         %[[VAL_34:.*]] = fir.do_loop %[[VAL_35:.*]] = %[[VAL_32]] to %[[VAL_33]] step %[[VAL_31]] {{.*}} {
+! CHECK:         }
 end subroutine
 
 ! CHECK: fir.global linkonce @[[error_message]] constant : !fir.char<1,76> {

--- a/flang/test/Lower/array-derived.f90
+++ b/flang/test/Lower/array-derived.f90
@@ -43,12 +43,14 @@ contains
 ! CHECK:         %[[VAL_7:.*]] = fir.field_index d, !fir.type<_QMcsTr{n:i32,d:i32}>
 ! CHECK:         %[[VAL_8:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_4]] : (!fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_9:.*]] = fir.slice %[[VAL_5]], %[[VAL_8]]#1, %[[VAL_5]] path %[[VAL_6]], %[[VAL_7]] : (index, index, index, !fir.field, !fir.field) -> !fir.slice<1>
+! CHECK:         %[[VAL_8_2:.*]] = arith.cmpi sgt, %[[VAL_8]]#1, %[[VAL_4]] : index
+! CHECK:         %[[VAL_8_3:.*]] = select %[[VAL_8_2]], %[[VAL_8]]#1, %[[VAL_4]] : index
 ! CHECK:         %[[VAL_10:.*]] = fir.field_index f1, !fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>
 ! CHECK:         %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_4]] : (!fir.box<!fir.array<?x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_12:.*]] = fir.slice %[[VAL_5]], %[[VAL_11]]#1, %[[VAL_5]] path %[[VAL_10]], %[[VAL_4]] : (index, index, index, !fir.field, index) -> !fir.slice<1>
 ! CHECK:         %[[VAL_13:.*]] = fir.slice %[[VAL_5]], %[[VAL_11]]#1, %[[VAL_5]] path %[[VAL_10]], %[[VAL_3]] : (index, index, index, !fir.field, index) -> !fir.slice<1>
 ! CHECK:         %[[VAL_14:.*]] = fir.slice %[[VAL_5]], %[[VAL_11]]#1, %[[VAL_5]] path %[[VAL_10]], %[[VAL_2]] : (index, index, index, !fir.field, index) -> !fir.slice<1>
-! CHECK:         br ^bb1(%[[VAL_4]], %[[VAL_8]]#1 : index, index)
+! CHECK:         br ^bb1(%[[VAL_4]], %[[VAL_8_3]] : index, index)
 ! CHECK:       ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
 ! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_4]] : index
 ! CHECK:         cond_br %[[VAL_17]], ^bb2, ^bb3
@@ -88,10 +90,12 @@ contains
 ! CHECK:         %[[VAL_9:.*]] = fir.field_index n, !fir.type<_QMcsTr{n:i32,d:i32}>
 ! CHECK:         %[[VAL_10:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_6]] : (!fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_11:.*]] = fir.slice %[[VAL_5]], %[[VAL_10]]#1, %[[VAL_5]] path %[[VAL_7]], %[[VAL_6]], %[[VAL_6]], %[[VAL_8]], %[[VAL_9]] : (index, index, index, !fir.field, index, index, !fir.field, !fir.field) -> !fir.slice<1>
+! CHECK:         %[[VAL_10_2:.*]] = arith.cmpi sgt, %[[VAL_10]]#1, %[[VAL_6]] : index
+! CHECK:         %[[VAL_10_3:.*]] = select %[[VAL_10_2]], %[[VAL_10]]#1, %[[VAL_6]] : index
 ! CHECK:         %[[VAL_12:.*]] = fir.field_index f1, !fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>
 ! CHECK:         %[[VAL_13:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_6]] : (!fir.box<!fir.array<?x!fir.type<_QMcsTt3{f:!fir.array<3x3x!fir.type<_QMcsTt2{f1:!fir.array<5xi32>,f2:!fir.type<_QMcsTr{n:i32,d:i32}>}>>}>>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_14:.*]] = fir.slice %[[VAL_5]], %[[VAL_13]]#1, %[[VAL_5]] path %[[VAL_7]], %[[VAL_5]], %[[VAL_5]], %[[VAL_12]], %[[VAL_3]] : (index, index, index, !fir.field, index, index, !fir.field, index) -> !fir.slice<1>
-! CHECK:         br ^bb1(%[[VAL_6]], %[[VAL_10]]#1 : index, index)
+! CHECK:         br ^bb1(%[[VAL_6]], %[[VAL_10_3]] : index, index)
 ! CHECK:       ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
 ! CHECK:         %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_6]] : index
 ! CHECK:         cond_br %[[VAL_17]], ^bb2, ^bb3
@@ -106,9 +110,11 @@ contains
 ! CHECK:         br ^bb1(%[[VAL_18]], %[[VAL_23]] : index, index)
 ! CHECK:       ^bb3:
 ! CHECK:         %[[VAL_24:.*]] = fir.slice %[[VAL_5]], %[[VAL_13]]#1, %[[VAL_5]] path %[[VAL_7]], %[[VAL_2]], %[[VAL_2]], %[[VAL_12]], %[[VAL_5]] : (index, index, index, !fir.field, index, index, !fir.field, index) -> !fir.slice<1>
+! CHECK:         %[[VAL_13_2:.*]] = arith.cmpi sgt, %[[VAL_13]]#1, %[[VAL_6]] : index
+! CHECK:         %[[VAL_13_3:.*]] = select %[[VAL_13_2]], %[[VAL_13]]#1, %[[VAL_6]] : index
 ! CHECK:         %[[VAL_25:.*]] = fir.field_index d, !fir.type<_QMcsTr{n:i32,d:i32}>
 ! CHECK:         %[[VAL_26:.*]] = fir.slice %[[VAL_5]], %[[VAL_10]]#1, %[[VAL_5]] path %[[VAL_7]], %[[VAL_6]], %[[VAL_5]], %[[VAL_8]], %[[VAL_25]] : (index, index, index, !fir.field, index, index, !fir.field, !fir.field) -> !fir.slice<1>
-! CHECK:         br ^bb4(%[[VAL_6]], %[[VAL_13]]#1 : index, index)
+! CHECK:         br ^bb4(%[[VAL_6]], %[[VAL_13_3]] : index, index)
 ! CHECK:       ^bb4(%[[VAL_27:.*]]: index, %[[VAL_28:.*]]: index):
 ! CHECK:         %[[VAL_29:.*]] = arith.cmpi sgt, %[[VAL_28]], %[[VAL_6]] : index
 ! CHECK:         cond_br %[[VAL_29]], ^bb5, ^bb6

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -336,18 +336,17 @@ end subroutine test10
 ! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_0]](%[[VAL_8]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
 ! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_11:.*]] = fir.array_load %[[VAL_1]](%[[VAL_10]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
-! CHECK:         %[[VAL_12:.*]] = arith.constant 100 : i64
-! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
+! CHECK:         %[[VAL_12:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_14:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_15:.*]] = fir.array_load %[[VAL_2]](%[[VAL_14]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
 ! CHECK:         %[[VAL_16:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_17:.*]] = fir.array_load %[[VAL_3]](%[[VAL_16]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
 ! CHECK:         %[[VAL_18:.*]] = fir.allocmem !fir.array<100xf32>
-! CHECK:         %[[VAL_19:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_19:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_20:.*]] = fir.array_load %[[VAL_18]](%[[VAL_19]]) : (!fir.heap<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.array<100xf32>
 ! CHECK:         %[[VAL_21:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_22:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_23:.*]] = arith.subi %[[VAL_13]], %[[VAL_21]] : index
+! CHECK:         %[[VAL_23:.*]] = arith.subi %[[VAL_12]], %[[VAL_21]] : index
 ! CHECK:         %[[VAL_24:.*]] = fir.do_loop %[[VAL_25:.*]] = %[[VAL_22]] to %[[VAL_23]] step %[[VAL_21]] unordered iter_args(%[[VAL_26:.*]] = %[[VAL_20]]) -> (!fir.array<100xf32>) {
 ! CHECK:           %[[VAL_27:.*]] = fir.array_fetch %[[VAL_15]], %[[VAL_25]] : (!fir.array<100xf32>, index) -> f32
 ! CHECK:           %[[VAL_28:.*]] = fir.array_fetch %[[VAL_17]], %[[VAL_25]] : (!fir.array<100xf32>, index) -> f32
@@ -1120,8 +1119,7 @@ end subroutine test19h
 ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_12:.*]] = arith.constant {{.*}} : i32
 ! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_9]], %[[VAL_11]], %[[VAL_12]]) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_14:.*]] = arith.constant 10 : i64
-! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i64) -> index
+! CHECK:         %[[VAL_15:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_16:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_17:.*]] = fir.shape_shift %[[VAL_7]], %[[VAL_8]] : (index, index) -> !fir.shapeshift<1>
 ! CHECK:         %[[VAL_18:.*]] = fir.allocmem !fir.array<10xi32>

--- a/flang/test/Lower/array-user-def-assignments.f90
+++ b/flang/test/Lower/array-user-def-assignments.f90
@@ -281,8 +281,7 @@ end subroutine
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_7:.*]] = arith.constant 10 : i64
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
+! CHECK:         %[[VAL_8:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_9:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_10:.*]] = fir.array_load %[[VAL_2]](%[[VAL_9]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
 ! CHECK:         %[[VAL_11:.*]] = fir.allocmem !fir.array<10x!fir.logical<4>>
@@ -332,8 +331,7 @@ end subroutine
 ! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.logical<4>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_6:.*]] = arith.constant 10 : i64
-! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
+! CHECK:         %[[VAL_7:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_8:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_2]](%[[VAL_8]]) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.array<10x!fir.logical<4>>
 ! CHECK:         %[[VAL_10:.*]] = fir.allocmem !fir.array<10x!fir.logical<4>>

--- a/flang/test/Lower/call-parenthesized-arg.f90
+++ b/flang/test/Lower/call-parenthesized-arg.f90
@@ -52,8 +52,7 @@ subroutine foo_num_array(x)
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
 ! CHECK:         fir.call @_QPbar_num_array(%[[VAL_0]]) : (!fir.ref<!fir.array<100xi32>>) -> ()
   call bar_num_array((x))
-! CHECK:         %[[VAL_2:.*]] = arith.constant 100 : i64
-! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (i64) -> index
+! CHECK:         %[[VAL_3:.*]] = arith.constant 100 : index
 ! CHECK:         %[[VAL_4:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_5:.*]] = fir.array_load %[[VAL_0]](%[[VAL_4]]) : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.array<100xi32>
 ! CHECK:         %[[VAL_6:.*]] = fir.allocmem !fir.array<100xi32>
@@ -86,8 +85,7 @@ subroutine foo_char_array(x)
   ! CHECK: %[[VAL_5:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.array<100x!fir.char<1,10>>>) -> !fir.ref<!fir.char<1,?>>
   ! CHECK: %[[VAL_6:.*]] = fir.emboxchar %[[VAL_5]], %[[VAL_2]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPbar_char_array(%[[VAL_6]]) : (!fir.boxchar<1>) -> ()
-  ! CHECK: %[[VAL_7:.*]] = arith.constant 100 : i64
-  ! CHECK: %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
+  ! CHECK: %[[VAL_8:.*]] = arith.constant 100 : index
   ! CHECK: %[[VAL_9:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_10:.*]] = fir.array_load %[[VAL_3]](%[[VAL_9]]) : (!fir.ref<!fir.array<100x!fir.char<1,10>>>, !fir.shape<1>) -> !fir.array<100x!fir.char<1,10>>
   ! CHECK: %[[VAL_11:.*]] = fir.allocmem !fir.array<100x!fir.char<1,10>>
@@ -133,8 +131,7 @@ subroutine foo_num_array_box(x)
   ! CHECK: %[[VAL_3:.*]] = fir.embox %[[VAL_0]](%[[VAL_2]]) : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<100xi32>>
   ! CHECK: %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.array<100xi32>>) -> !fir.box<!fir.array<?xi32>>
   ! CHECK: fir.call @_QPbar_num_array_box(%[[VAL_4]]) : (!fir.box<!fir.array<?xi32>>) -> ()
-  ! CHECK: %[[VAL_5:.*]] = arith.constant 100 : i64
-  ! CHECK: %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i64) -> index
+  ! CHECK: %[[VAL_6:.*]] = arith.constant 100 : index
   ! CHECK: %[[VAL_7:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_8:.*]] = fir.array_load %[[VAL_0]](%[[VAL_7]]) : (!fir.ref<!fir.array<100xi32>>, !fir.shape<1>) -> !fir.array<100xi32>
   ! CHECK: %[[VAL_9:.*]] = fir.allocmem !fir.array<100xi32>

--- a/flang/test/Lower/character-substrings.f90
+++ b/flang/test/Lower/character-substrings.f90
@@ -226,12 +226,18 @@ end subroutine array_substring_assignment
 ! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_5:.*]] = fir.slice %[[VAL_4]], %[[VAL_1]], %[[VAL_4]] path %[[VAL_2]] : (index, index, index, !fir.field) -> !fir.slice<1>
+! CHECK:         %[[c0:.*]] = arith.constant 0 : index
+! CHECK:         %[[sub:.*]] = arith.subi %[[VAL_1]], %[[VAL_4]] : index
+! CHECK:         %[[add:.*]] = arith.addi %[[sub]], %[[VAL_4]] : index
+! CHECK:         %[[div:.*]] = arith.divsi %4, %[[VAL_4]] : index
+! CHECK:         %[[cmp:.*]] = arith.cmpi sgt, %[[div]], %[[c0]] : index
+! CHECK:         %[[select:.*]] = select %[[cmp]], %[[div]], %[[c0]] : index
 ! CHECK:         %[[VAL_6:.*]] = fir.array_load %[[VAL_0]](%[[VAL_3]]) {{\[}}%[[VAL_5]]] : (!fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<8x!fir.char<1,7>>
 ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl.6E696365) : !fir.ref<!fir.char<1,4>>
 ! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : index
 ! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_10:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_1]], %[[VAL_9]] : index
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[select]], %[[VAL_9]] : index
 ! CHECK:         %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_10]] to %[[VAL_11]] step %[[VAL_9]] unordered iter_args(%[[VAL_14:.*]] = %[[VAL_6]]) -> (!fir.array<8x!fir.char<1,7>>) {
 ! CHECK:           %[[VAL_15:.*]] = fir.array_access %[[VAL_14]], %[[VAL_13]] : (!fir.array<8x!fir.char<1,7>>, index) -> !fir.ref<!fir.char<1,7>>
 ! CHECK:           %[[VAL_16:.*]] = arith.constant 4 : i64
@@ -312,6 +318,12 @@ end subroutine array_substring_assignment2
 ! CHECK:         %[[VAL_5:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_7:.*]] = fir.slice %[[VAL_6]], %[[VAL_2]], %[[VAL_6]] path %[[VAL_4]] : (index, index, index, !fir.field) -> !fir.slice<1>
+! CHECK:         %[[c0:.*]] = arith.constant 0 : index
+! CHECK:         %[[sub:.*]] = arith.subi %[[VAL_2]], %[[VAL_6]] : index
+! CHECK:         %[[add:.*]] = arith.addi %[[sub]], %[[VAL_6]] : index
+! CHECK:         %[[div:.*]] = arith.divsi %4, %[[VAL_6]] : index
+! CHECK:         %[[cmp:.*]] = arith.cmpi sgt, %[[div]], %[[c0]] : index
+! CHECK:         %[[select:.*]] = select %[[cmp]], %[[div]], %[[c0]] : index
 ! CHECK:         %[[VAL_8:.*]] = fir.array_load %[[VAL_0]](%[[VAL_5]]) {{\[}}%[[VAL_7]]] : (!fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<8x!fir.char<1,7>>
 ! CHECK:         %[[VAL_9:.*]] = fir.field_index ch, !fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>
 ! CHECK:         %[[VAL_10:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
@@ -320,7 +332,7 @@ end subroutine array_substring_assignment2
 ! CHECK:         %[[VAL_13:.*]] = fir.array_load %[[VAL_1]](%[[VAL_10]]) {{\[}}%[[VAL_12]]] : (!fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment3Tt{ch:!fir.char<1,7>}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<8x!fir.char<1,7>>
 ! CHECK:         %[[VAL_14:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_15:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_16:.*]] = arith.subi %[[VAL_2]], %[[VAL_14]] : index
+! CHECK:         %[[VAL_16:.*]] = arith.subi %[[select]], %[[VAL_14]] : index
 ! CHECK:         %[[VAL_17:.*]] = fir.do_loop %[[VAL_18:.*]] = %[[VAL_15]] to %[[VAL_16]] step %[[VAL_14]] unordered iter_args(%[[VAL_19:.*]] = %[[VAL_8]]) -> (!fir.array<8x!fir.char<1,7>>) {
 ! CHECK:           %[[VAL_20:.*]] = fir.array_access %[[VAL_13]], %[[VAL_18]] : (!fir.array<8x!fir.char<1,7>>, index) -> !fir.ref<!fir.char<1,7>>
 ! CHECK:           %[[VAL_21:.*]] = arith.constant 2 : i64

--- a/flang/test/Lower/forall/forall-array.f90
+++ b/flang/test/Lower/forall/forall-array.f90
@@ -41,8 +41,7 @@ end subroutine test_forall_with_array_assignment
 ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (i64) -> index
 ! CHECK:           %[[VAL_23:.*]] = arith.subi %[[VAL_22]], %[[VAL_19]] : index
 ! CHECK:           %[[VAL_24:.*]] = fir.field_index block1, !fir.type<_QFtest_forall_with_array_assignmentTt{block1:!fir.array<64xi64>,block2:!fir.array<64xi64>}>
-! CHECK:           %[[VAL_25:.*]] = arith.constant 64 : i64
-! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i64) -> index
+! CHECK:           %[[VAL_26:.*]] = arith.constant 64 : index
 ! CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
 ! CHECK-DAG:       %[[VAL_28:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
 ! CHECK-DAG:       %[[VAL_29:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/where.f90
+++ b/flang/test/Lower/where.f90
@@ -5,8 +5,7 @@
   ! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
   ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QFEb) : !fir.ref<!fir.array<10xf32>>
   ! CHECK:         %[[VAL_3:.*]] = arith.constant 10 : index
-  ! CHECK:         %[[VAL_4:.*]] = arith.constant 10 : i64
-  ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+  ! CHECK:         %[[VAL_5:.*]] = arith.constant 10 : index
   ! CHECK:         %[[VAL_6:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_7:.*]] = fir.array_load %[[VAL_0]](%[[VAL_6]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
   ! CHECK:         %[[VAL_8:.*]] = arith.constant 4.000000e+00 : f32
@@ -50,8 +49,7 @@
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_25]], %[[VAL_44:.*]] to %[[VAL_2]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>
   ! CHECK:         fir.freemem %[[VAL_9]] : !fir.heap<!fir.array<10x!fir.logical<4>>>
-  ! CHECK:         %[[VAL_45:.*]] = arith.constant 10 : i64
-  ! CHECK:         %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i64) -> index
+  ! CHECK:         %[[VAL_46:.*]] = arith.constant 10 : index
   ! CHECK:         %[[VAL_47:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_48:.*]] = fir.array_load %[[VAL_0]](%[[VAL_47]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
   ! CHECK:         %[[VAL_49:.*]] = arith.constant 1.000000e+02 : f32
@@ -95,8 +93,7 @@
   ! CHECK:           fir.result %[[VAL_85:.*]] : !fir.array<10xf32>
   ! CHECK:         }
   ! CHECK:         fir.array_merge_store %[[VAL_66]], %[[VAL_86:.*]] to %[[VAL_2]] : !fir.array<10xf32>, !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>
-  ! CHECK:         %[[VAL_87:.*]] = arith.constant 10 : i64
-  ! CHECK:         %[[VAL_88:.*]] = fir.convert %[[VAL_87]] : (i64) -> index
+  ! CHECK:         %[[VAL_88:.*]] = arith.constant 10 : index
   ! CHECK:         %[[VAL_89:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_90:.*]] = fir.array_load %[[VAL_0]](%[[VAL_89]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.array<10xf32>
   ! CHECK:         %[[VAL_91:.*]] = arith.constant 5.000000e+01 : f32


### PR DESCRIPTION
The shape computation of allocatable assignment diverged from normal
array assignment shape deduction. Merge that back.
This revealed that the destShape set up in genarr(exv, components) was
wrong in case the `shape` was a shiftOp and that it ignored the slice.
Use genShape(arrayOperand) to fix that. This actually ddresses at least
part of the TODO(expected vector to have an extent) errors too outside
of allocatable assignment.

Also, when looking at the code that computes array shape in lowering, I
noticed there was some dead code/opportunities to simplify the code
by using `GetConstantExtents`. So I did that too.

The lit test fallouts are of two kinds:
- some convert from i64 -> index were removed due to the usage of
  `GetConstantExtents`.
- some slice extent computation were introduced. The comes from the fact that
  destShape is now computed in genarr() in cases were the shape was previously
  actually left empty and later computed by other means (e.g. another
  operand). This slice extent compuation is usually foldable by MLIR
  given it involves c1 operands.