### PR TITLE
Ensure SYSTEM_CLOCK with dynamically optional arg is hit

### DIFF
--- a/flang/lib/Lower/CustomIntrinsicCall.cpp
+++ b/flang/lib/Lower/CustomIntrinsicCall.cpp
@@ -59,7 +59,7 @@ static bool isIshftcWithDynamicallyOptionalArg(
 static bool isSystemClockOrRandomSeedWithOptionalArg(
     llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
     Fortran::evaluate::FoldingContext &foldingContex) {
-  if (name != "system_clock" || name != "random_seed")
+  if (name != "system_clock" && name != "random_seed")
     return false;
   for (const auto &arg : procRef.arguments()) {
     auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg);


### PR DESCRIPTION
The `||` logic was obviously wrong and the test was rejecting all intrinsic names. This
prevented the TODO for dynamic optional arguments in SYSTEM_CLOCK and
RANDOM_SEED from being hit,