### PR TITLE
[NFC] Remove the use of pointer (meant in a generic sense) as it is

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -64,8 +64,8 @@ def TargetRewrite : Pass<"target-rewrite", "mlir::ModuleOp"> {
   ];
 }
 
-def ProcedurePointerPass : Pass<"procedure-pointer", "mlir::ModuleOp"> {
-  let constructor = "::fir::createProcedurePointerPass()";
+def BoxedProcedurePass : Pass<"boxed-procedure", "mlir::ModuleOp"> {
+  let constructor = "::fir::createBoxedProcedurePass()";
   let options = [
     Option<"useThunks", "use-thunks",
            "bool", /*default=*/"true",

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -40,14 +40,17 @@ std::unique_ptr<mlir::Pass> createFIRToLLVMPass();
 
 using LLVMIRLoweringPrinter =
     std::function<void(llvm::Module &, llvm::raw_ostream &)>;
+
 /// Convert the LLVM IR dialect to LLVM-IR proper
 std::unique_ptr<mlir::Pass> createLLVMDialectToLLVMPass(
     llvm::raw_ostream &output,
     LLVMIRLoweringPrinter printer =
         [](llvm::Module &m, llvm::raw_ostream &out) { m.print(out, nullptr); });
 
-std::unique_ptr<mlir::Pass> createProcedurePointerPass();
-std::unique_ptr<mlir::Pass> createProcedurePointerPass(bool useThunks);
+/// Convert boxproc values to a lower level representation. The default is to
+/// use function pointers and thunks.
+std::unique_ptr<mlir::Pass> createBoxedProcedurePass();
+std::unique_ptr<mlir::Pass> createBoxedProcedurePass(bool useThunks);
 
 // declarative passes
 #define GEN_PASS_REGISTRATION

--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -51,8 +51,8 @@ DisableOption(CodeGenRewrite, "codegen-rewrite", "rewrite FIR for codegen");
 DisableOption(TargetRewrite, "target-rewrite", "rewrite FIR for target");
 DisableOption(FirToLlvmIr, "fir-to-llvmir", "FIR to LLVM-IR dialect");
 DisableOption(LlvmIrToLlvm, "llvm", "conversion to LLVM");
-DisableOption(ProcedurePointerRewrite, "procedure-pointer-rewrite",
-    "rewrite abstract procedure pointers");
+DisableOption(BoxedProcedureRewrite, "boxed-procedure-rewrite",
+    "rewrite boxed procedures");
 #endif
 
 /// Generic for adding a pass to the pass manager if it is not disabled.
@@ -124,9 +124,9 @@ inline void addLLVMDialectToLLVMPass(
       [&]() { return fir::createLLVMDialectToLLVMPass(output); });
 }
 
-inline void addProcedurePointerPass(mlir::PassManager &pm) {
-  addPassConditionally(pm, disableProcedurePointerRewrite,
-      [&]() { return fir::createProcedurePointerPass(); });
+inline void addBoxedProcedurePass(mlir::PassManager &pm) {
+  addPassConditionally(pm, disableBoxedProcedureRewrite,
+      [&]() { return fir::createBoxedProcedurePass(); });
 }
 #endif
 
@@ -165,7 +165,7 @@ inline void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm) {
 
 #if !defined(FLANG_EXCLUDE_CODEGEN)
 inline void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm) {
-  fir::addProcedurePointerPass(pm);
+  fir::addBoxedProcedurePass(pm);
   pm.addNestedPass<mlir::FuncOp>(fir::createAbstractResultOptPass());
   fir::addCodeGenRewritePass(pm);
   fir::addTargetRewritePass(pm);

--- a/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
+++ b/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
@@ -1,4 +1,4 @@
-//===-- ProcedurePointer.cpp ----------------------------------------------===//
+//===-- BoxedProcedure.cpp ------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -24,7 +24,7 @@ using namespace fir;
 
 namespace {
 /// Options to the procedure pointer pass.
-struct ProcedurePointerOptions {
+struct BoxedProcedureOptions {
   // Lower the boxproc abstraction to function pointers and thunks where
   // required.
   bool useThunks = true;
@@ -230,11 +230,11 @@ public:
 /// the frame pointer during execution. In LLVM IR, the frame pointer is
 /// designated with the `nest` attribute. The thunk's address will then be used
 /// as the call target instead of the original function's address directly.
-class ProcedurePointerPass
-    : public ProcedurePointerPassBase<ProcedurePointerPass> {
+class BoxedProcedurePass
+    : public BoxedProcedurePassBase<BoxedProcedurePass> {
 public:
-  ProcedurePointerPass() { options = {true}; }
-  ProcedurePointerPass(bool useThunks) { options = {useThunks}; }
+  BoxedProcedurePass() { options = {true}; }
+  BoxedProcedurePass(bool useThunks) { options = {useThunks}; }
 
   inline mlir::ModuleOp getModule() { return getOperation(); }
 
@@ -289,14 +289,14 @@ public:
   }
 
 private:
-  ProcedurePointerOptions options;
+  BoxedProcedureOptions options;
 };
 } // namespace
 
-std::unique_ptr<mlir::Pass> fir::createProcedurePointerPass() {
-  return std::make_unique<ProcedurePointerPass>();
+std::unique_ptr<mlir::Pass> fir::createBoxedProcedurePass() {
+  return std::make_unique<BoxedProcedurePass>();
 }
 
-std::unique_ptr<mlir::Pass> fir::createProcedurePointerPass(bool useThunks) {
-  return std::make_unique<ProcedurePointerPass>(useThunks);
+std::unique_ptr<mlir::Pass> fir::createBoxedProcedurePass(bool useThunks) {
+  return std::make_unique<BoxedProcedurePass>(useThunks);
 }

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 add_flang_library(FIRCodeGen
+  BoxedProcedure.cpp
   CGOps.cpp
   CodeGen.cpp
   PreCGRewrite.cpp
-  ProcedurePointer.cpp
   Target.cpp
   TargetRewrite.cpp
 


### PR DESCRIPTION
overloaded with the Fortran POINTER attribute and may be unintentionally
confusing.