### PR TITLE
Fixes several bugs relating to initialization expressions. An

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -47,12 +47,16 @@ fir::ExtendedValue createSomeExtendedExpression(mlir::Location loc,
                                                 SymMap &symMap,
                                                 StatementContext &stmtCtx);
 
+/// Create a global array symbol with the Dense attribute
 fir::GlobalOp createDenseGlobal(mlir::Location loc, mlir::Type symTy,
                                 llvm::StringRef globalName,
                                 mlir::StringAttr linkage, bool isConst,
                                 const SomeExpr &expr,
                                 Fortran::lower::AbstractConverter &converter);
 
+/// Create the IR for the expression \p expr in an initialization context.
+/// Expressions that appear in initializers may not allocate temporaries, do not
+/// have a stack, etc.
 fir::ExtendedValue createSomeInitializerExpression(mlir::Location loc,
                                                    AbstractConverter &converter,
                                                    const SomeExpr &expr,
@@ -65,6 +69,15 @@ fir::ExtendedValue createSomeExtendedAddress(mlir::Location loc,
                                              const SomeExpr &expr,
                                              SymMap &symMap,
                                              StatementContext &stmtCtx);
+
+/// Create an address in an initializer context. Must be a constant or a symbol
+/// to be resolved at link-time. Expressions that appear in initializers may not
+/// allocate temporaries, do not have a stack, etc.
+fir::ExtendedValue createInitializerAddress(mlir::Location loc,
+                                            AbstractConverter &converter,
+                                            const SomeExpr &expr,
+                                            SymMap &symMap,
+                                            StatementContext &stmtCtx);
 
 /// Create the address of the box.
 /// \p expr must be the designator of an allocatable/pointer entity.

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -854,24 +854,34 @@ public:
       if (isBuiltinCPtr(sym)) {
         // Builtin c_ptr and c_funptr have special handling because initial
         // value are handled for them as an extension.
-        ExtValue addr = Fortran::lower::genExtAddrInInitializer(converter, loc,
-                                                                expr.value());
-        mlir::Value baseAddr = fir::getBase(addr);
-        auto undef = builder.create<fir::UndefOp>(loc, componentTy);
-        auto cPtrRecTy = componentTy.dyn_cast<fir::RecordType>();
-        assert(cPtrRecTy && "c_ptr and c_funptr must be derived types");
-        llvm::StringRef addrFieldName = Fortran::lower::builtin::cptrFieldName;
-        mlir::Type addrFieldTy = cPtrRecTy.getType(addrFieldName);
-        auto addrField = builder.create<fir::FieldIndexOp>(
-            loc, fieldTy, addrFieldName, componentTy,
-            /*typeParams=*/mlir::ValueRange{});
-        mlir::Value castAddr =
-            builder.createConvert(loc, addrFieldTy, baseAddr);
-        auto val = builder.create<fir::InsertValueOp>(
-            loc, componentTy, undef, castAddr,
-            builder.getArrayAttr(addrField.getAttributes()));
+        mlir::Value addr = fir::getBase(Fortran::lower::genExtAddrInInitializer(
+            converter, loc, expr.value()));
+        if (addr.getType() == componentTy) {
+          // Do nothing. The Ev::Expr was returned as a value that can be
+          // inserted directly to the component without an intermediary.
+        } else {
+          // The Ev::Expr returned is an initializer that is a pointer (null)
+          // that must be inserted into an intermediate cptr record value's
+          // address field, which ought to be an intptr_t on the target.
+          assert(fir::isa_ref_type(addr.getType()) &&
+                 "expect reference type for address field");
+          assert(fir::isa_derived(componentTy) &&
+                 "expect CPTR, C_FUNPTR to be a record");
+          auto cPtrRecTy = componentTy.cast<fir::RecordType>();
+          llvm::StringRef addrFieldName =
+              Fortran::lower::builtin::cptrFieldName;
+          mlir::Type addrFieldTy = cPtrRecTy.getType(addrFieldName);
+          auto addrField = builder.create<fir::FieldIndexOp>(
+              loc, fieldTy, addrFieldName, componentTy,
+              /*typeParams=*/mlir::ValueRange{});
+          mlir::Value castAddr = builder.createConvert(loc, addrFieldTy, addr);
+          auto undef = builder.create<fir::UndefOp>(loc, componentTy);
+          addr = builder.create<fir::InsertValueOp>(
+              loc, componentTy, undef, castAddr,
+              builder.getArrayAttr(addrField.getAttributes()));
+        }
         res = builder.create<fir::InsertValueOp>(
-            loc, recTy, res, val, builder.getArrayAttr(field.getAttributes()));
+            loc, recTy, res, addr, builder.getArrayAttr(field.getAttributes()));
         continue;
       }
 
@@ -2988,6 +2998,10 @@ public:
   }
   template <typename A>
   ExtValue genref(const A &a) {
+    if (inInitializer) {
+      // Initialization expressions can never allocate memory.
+      return genval(a);
+    }
     mlir::Type storageType = converter.genType(toEvExpr(a));
     return placeScalarValueInMemory(builder, getLoc(), genval(a), storageType);
   }
@@ -6744,7 +6758,7 @@ fir::ExtendedValue Fortran::lower::createSomeExtendedExpression(
   LLVM_DEBUG(expr.AsFortran(llvm::dbgs() << "expr: ") << '\n');
   return ScalarExprLowering{loc, converter, symMap, stmtCtx}.genval(expr);
 }
-/// Create a global array symbol with the Dense attribute
+
 fir::GlobalOp Fortran::lower::createDenseGlobal(
     mlir::Location loc, mlir::Type symTy, llvm::StringRef globalName,
     mlir::StringAttr linkage, bool isConst,
@@ -6787,7 +6801,16 @@ fir::ExtendedValue Fortran::lower::createSomeExtendedAddress(
     const Fortran::lower::SomeExpr &expr, Fortran::lower::SymMap &symMap,
     Fortran::lower::StatementContext &stmtCtx) {
   LLVM_DEBUG(expr.AsFortran(llvm::dbgs() << "address: ") << '\n');
-  return ScalarExprLowering{loc, converter, symMap, stmtCtx}.gen(expr);
+  return ScalarExprLowering(loc, converter, symMap, stmtCtx).gen(expr);
+}
+
+fir::ExtendedValue Fortran::lower::createInitializerAddress(
+    mlir::Location loc, Fortran::lower::AbstractConverter &converter,
+    const Fortran::lower::SomeExpr &expr, Fortran::lower::SymMap &symMap,
+    Fortran::lower::StatementContext &stmtCtx) {
+  LLVM_DEBUG(expr.AsFortran(llvm::dbgs() << "address: ") << '\n');
+  InitializerData init;
+  return ScalarExprLowering(loc, converter, symMap, stmtCtx, &init).gen(expr);
 }
 
 void Fortran::lower::createSomeArrayAssignment(

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -866,7 +866,7 @@ public:
           assert(fir::isa_ref_type(addr.getType()) &&
                  "expect reference type for address field");
           assert(fir::isa_derived(componentTy) &&
-                 "expect CPTR, C_FUNPTR to be a record");
+                 "expect C_PTR, C_FUNPTR to be a record");
           auto cPtrRecTy = componentTy.cast<fir::RecordType>();
           llvm::StringRef addrFieldName =
               Fortran::lower::builtin::cptrFieldName;

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -180,8 +180,8 @@ fir::ExtendedValue Fortran::lower::genExtAddrInInitializer(
     Fortran::lower::instantiateVariable(converter, var, globalOpSymMap,
                                         storeMap);
   }
-  return Fortran::lower::createSomeExtendedAddress(loc, converter, addr,
-                                                   globalOpSymMap, stmtCtx);
+  return Fortran::lower::createInitializerAddress(loc, converter, addr,
+                                                  globalOpSymMap, stmtCtx);
 }
 
 /// create initial-data-target fir.box in a global initializer region.
@@ -213,7 +213,7 @@ mlir::Value Fortran::lower::genInitialDataTarget(
     box = fir::getBase(Fortran::lower::createSomeArrayBox(
         converter, initialTarget, globalOpSymMap, stmtCtx));
   } else {
-    fir::ExtendedValue addr = Fortran::lower::createSomeExtendedAddress(
+    fir::ExtendedValue addr = Fortran::lower::createInitializerAddress(
         loc, converter, initialTarget, globalOpSymMap, stmtCtx);
     box = builder.createBox(loc, addr);
   }

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -30,6 +30,13 @@ static llvm::cl::opt<bool> nonRecursiveProcedures(
                    "default for all Fortran standards prior to 2018."),
     llvm::cl::init(/*2018 standard=*/false));
 
+static llvm::cl::opt<bool> mainProgramGlobals(
+    "main-program-globals",
+    llvm::cl::desc(
+        "Allocate all variables in the main program as global variables and "
+        "not on the stack regardless of type, kind, and rank."),
+    llvm::cl::init(/*2018 standard=*/false), llvm::cl::Hidden);
+
 using namespace Fortran;
 
 namespace {
@@ -1265,7 +1272,7 @@ bool Fortran::lower::definedInCommonBlock(const semantics::Symbol &sym) {
   return semantics::FindCommonBlockContaining(sym);
 }
 
-static bool isReEntrant(const Fortran::semantics::Scope &scope) {
+static bool isReentrant(const Fortran::semantics::Scope &scope) {
   if (scope.kind() == Fortran::semantics::Scope::Kind::MainProgram)
     return false;
   if (scope.kind() == Fortran::semantics::Scope::Kind::Subprogram) {
@@ -1285,7 +1292,7 @@ bool Fortran::lower::symbolIsGlobal(const semantics::Symbol &sym) {
   if (const auto *details = sym.detailsIf<semantics::ObjectEntityDetails>()) {
     if (details->init())
       return true;
-    if (!isReEntrant(sym.owner())) {
+    if (!isReentrant(sym.owner())) {
       // Turn array and character of non re-entrant programs (like the main
       // program) into global memory.
       if (const Fortran::semantics::DeclTypeSpec *symTy = sym.GetType())
@@ -1295,6 +1302,9 @@ bool Fortran::lower::symbolIsGlobal(const semantics::Symbol &sym) {
       if (!details->shape().empty() || !details->coshape().empty())
         return true;
     }
+    if (mainProgramGlobals &&
+        sym.owner().kind() == Fortran::semantics::Scope::Kind::MainProgram)
+      return true;
   }
   return semantics::IsSaved(sym) || lower::definedInCommonBlock(sym) ||
          semantics::IsNamedConstant(sym);

--- a/flang/test/Lower/c-interoperability.f90
+++ b/flang/test/Lower/c-interoperability.f90
@@ -1,24 +1,24 @@
 ! RUN: bbc %s -o - | FileCheck %s
 
-! CHECK-LABEL: fir.global @_QMm1Ethis_thing : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
+! CHECK-LABEL: fir.global @_QMc_interoperability_testEthis_thing : !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
 ! CHECK:         %[[VAL_0:.*]] = arith.constant 0 : i64
-! CHECK:         %[[VAL_1:.*]] = fir.undefined !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:         %[[VAL_1:.*]] = fir.undefined !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
 ! CHECK:         %[[VAL_2:.*]] = fir.undefined !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
 ! CHECK:         %[[VAL_3:.*]] = fir.insert_value %[[VAL_2]], %[[VAL_0]], ["__address", !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>] : (!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>, i64) -> !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK:         %[[VAL_4:.*]] = fir.insert_value %[[VAL_1]], %[[VAL_3]], ["cptr", !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>] : (!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>, !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>) -> !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
-! CHECK:         fir.has_value %[[VAL_4]] : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:         %[[VAL_4:.*]] = fir.insert_value %[[VAL_1]], %[[VAL_3]], ["cptr", !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>] : (!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>, !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>) -> !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:         fir.has_value %[[VAL_4]] : !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
 ! CHECK:       }
 
-! CHECK-LABEL: func @_QMm1Pget_a_thing() -> !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
-! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
-! CHECK:         %[[VAL_3:.*]] = fir.address_of(@_QMm1Ethis_thing) : !fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
-! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {bindc_name = "get_a_thing", uniq_name = "_QMm1Fget_a_thingEget_a_thing"}
-! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
-! CHECK:         %[[VAL_10:.*]] = fir.embox %[[VAL_3]] : (!fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
-! CHECK:         return %{{.*}} : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK-LABEL: func @_QMc_interoperability_testPget_a_thing() -> !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
+! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_3:.*]] = fir.address_of(@_QMc_interoperability_testEthis_thing) : !fir.ref<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {bindc_name = "get_a_thing", uniq_name = "_QMc_interoperability_testFget_a_thingEget_a_thing"}
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.ref<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_10:.*]] = fir.embox %[[VAL_3]] : (!fir.ref<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         return %{{.*}} : !fir.type<_QMc_interoperability_testTthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
 ! CHECK:       }
 
-module m1
+module c_interoperability_test
   use iso_c_binding, only: c_ptr, c_null_ptr
 
   type thing_with_pointer
@@ -32,4 +32,4 @@ contains
     type(thing_with_pointer) :: get_a_thing
     get_a_thing = this_thing
   end function get_a_thing
-end module m1
+end module c_interoperability_test

--- a/flang/test/Lower/c-interoperability.f90
+++ b/flang/test/Lower/c-interoperability.f90
@@ -1,4 +1,4 @@
-! RUN: bbc %s | FileCheck %s
+! RUN: bbc %s -o - | FileCheck %s
 
 ! CHECK-LABEL: fir.global @_QMm1Ethis_thing : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
 ! CHECK:         %[[VAL_0:.*]] = arith.constant 0 : i64

--- a/flang/test/Lower/c-interoperability.f90
+++ b/flang/test/Lower/c-interoperability.f90
@@ -1,0 +1,35 @@
+! RUN: bbc %s | FileCheck %s
+
+! CHECK-LABEL: fir.global @_QMm1Ethis_thing : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
+! CHECK:         %[[VAL_0:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_1:.*]] = fir.undefined !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:         %[[VAL_2:.*]] = fir.undefined !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_3:.*]] = fir.insert_value %[[VAL_2]], %[[VAL_0]], ["__address", !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>] : (!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>, i64) -> !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_4:.*]] = fir.insert_value %[[VAL_1]], %[[VAL_3]], ["cptr", !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>] : (!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>, !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>) -> !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:         fir.has_value %[[VAL_4]] : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:       }
+
+! CHECK-LABEL: func @_QMm1Pget_a_thing() -> !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {
+! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_3:.*]] = fir.address_of(@_QMm1Ethis_thing) : !fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_4:.*]] = fir.alloca !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}> {bindc_name = "get_a_thing", uniq_name = "_QMm1Fget_a_thingEget_a_thing"}
+! CHECK:         %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         %[[VAL_10:.*]] = fir.embox %[[VAL_3]] : (!fir.ref<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>) -> !fir.box<!fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>
+! CHECK:         return %{{.*}} : !fir.type<_QMm1Tthing_with_pointer{cptr:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>
+! CHECK:       }
+
+module m1
+  use iso_c_binding, only: c_ptr, c_null_ptr
+
+  type thing_with_pointer
+     type(c_ptr) :: cptr = c_null_ptr
+  end type thing_with_pointer
+
+  type(thing_with_pointer) :: this_thing
+  
+contains
+  function get_a_thing()
+    type(thing_with_pointer) :: get_a_thing
+    get_a_thing = this_thing
+  end function get_a_thing
+end module m1


### PR DESCRIPTION
initialization expression has no access to dynamic resources like the
stack or the heap. It must reduce to a relocatable expression that the
loader can complete at runtime.

To do: add regression tests.