### PR TITLE
[flang] Avoid lowering functions in submodules

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2688,6 +2688,14 @@ private:
 
   /// Lower a procedure (nest).
   void lowerFunc(Fortran::lower::pft::FunctionLikeUnit &funit) {
+    if (!funit.isMainProgram()) {
+      const Fortran::semantics::Symbol &procSymbol =
+          funit.getSubprogramSymbol();
+      if (procSymbol.owner().IsSubmodule()) {
+        TODO(toLocation(), "support submodules");
+        return;
+      }
+    }
     setCurrentPosition(funit.getStartingSourceLoc());
     for (int entryIndex = 0, last = funit.entryPointList.size();
          entryIndex < last; ++entryIndex) {

--- a/flang/test/Lower/program-units-fir-mangling.f90
+++ b/flang/test/Lower/program-units-fir-mangling.f90
@@ -92,32 +92,34 @@ module color_points
   end interface
 end module color_points
 
-submodule (color_points) color_points_a
-contains
-  ! CHECK-LABEL: func @_QMcolor_pointsScolor_points_aPsub() {
-  subroutine sub
-  end subroutine
-  ! CHECK: }
-end submodule
-
-submodule (color_points:color_points_a) impl
-contains
-  ! CHECK-LABEL: func @_QMcolor_pointsScolor_points_aSimplPfoo()
-  subroutine foo
-    contains
-    ! CHECK-LABEL: func @_QMcolor_pointsScolor_points_aSimplFfooPbar() {
-    subroutine bar
-    ! CHECK: }
-    end subroutine
-  end subroutine
-  ! CHECK-LABEL: func @_QMcolor_pointsPdraw() {
-  module subroutine draw()
-  end subroutine
-  !FIXME func @_QMcolor_pointsPerase() -> i32 {
-  module procedure erase
-  ! CHECK: }
-  end procedure
-end submodule
+! We don't handle lowering of submodules yet.  The following tests are
+! commented out and "CHECK" is changed to "xHECK" to not trigger FileCheck.
+!submodule (color_points) color_points_a
+!contains
+!  ! xHECK-LABEL: func @_QMcolor_pointsScolor_points_aPsub() {
+!  subroutine sub
+!  end subroutine
+!  ! xHECK: }
+!end submodule
+!
+!submodule (color_points:color_points_a) impl
+!contains
+!  ! xHECK-LABEL: func @_QMcolor_pointsScolor_points_aSimplPfoo()
+!  subroutine foo
+!    contains
+!    ! xHECK-LABEL: func @_QMcolor_pointsScolor_points_aSimplFfooPbar() {
+!    subroutine bar
+!    ! xHECK: }
+!    end subroutine
+!  end subroutine
+!  ! xHECK-LABEL: func @_QMcolor_pointsPdraw() {
+!  module subroutine draw()
+!  end subroutine
+!  !FIXME func @_QMcolor_pointsPerase() -> i32 {
+!  module procedure erase
+!  ! xHECK: }
+!  end procedure
+!end submodule
 
 ! CHECK-LABEL: func @_QPshould_not_collide() {
 subroutine should_not_collide()


### PR DESCRIPTION
We don't currently update the symbol map with names declared in the
parent module.  So errors happen when a function that's defined in a
submodule references such names.

This change detects functions defined in submodules and avoids lowering
them with a "TODO".