### PR TITLE
Zero size character array constructors

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -6136,8 +6136,11 @@ private:
 
     // Return the continuation.
     if (fir::isa_char(seqTy.getEleTy())) {
-      auto len = builder.create<fir::LoadOp>(loc, charLen.getValue());
-      return genarr(fir::CharArrayBoxValue{mem, len, extents});
+      if (charLen.hasValue()) {
+        auto len = builder.create<fir::LoadOp>(loc, charLen.getValue());
+        return genarr(fir::CharArrayBoxValue{mem, len, extents});
+      }
+      return genarr(fir::CharArrayBoxValue{mem, zero, extents});
     }
     return genarr(fir::ArrayBoxValue{mem, extents});
   }


### PR DESCRIPTION
    subroutine s(n)
      character(n), allocatable :: a(:)
      a = [character(n)::]
      print*, '[', a, ']', len(a) ! expect: [] 4
    end
    call s(4)
    end