### PR TITLE
[flang] Validate DIM argument for reduction intrinsics that return a …

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/Reduction.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/Reduction.h
@@ -93,9 +93,10 @@ void genMinlocDim(fir::FirOpBuilder &builder, mlir::Location loc,
                   mlir::Value maskBox, mlir::Value kind, mlir::Value back);
 
 /// Generate call to `Maxval` intrinsic runtime routine. This is the version
-/// that does not take a dim argument.
+/// that returns a scalar.
 mlir::Value genMaxval(fir::FirOpBuilder &builder, mlir::Location loc,
-                      mlir::Value arrayBox, mlir::Value maskBox);
+                      mlir::Value arrayBox, bool absentDim, mlir::Value dim,
+                      mlir::Value maskBox);
 
 /// Generate call to `MaxvalCharacter` intrinsic runtime routine. This is the
 /// version hat that handles 1 dimensional character arrays  with no DIM
@@ -111,9 +112,10 @@ void genMaxvalDim(fir::FirOpBuilder &builder, mlir::Location loc,
                   mlir::Value maskBox);
 
 /// Generate call to `Minval` intrinsic runtime routine. This is the version
-/// that does not take a dim argument.
+/// that returns a scalar.
 mlir::Value genMinval(fir::FirOpBuilder &builder, mlir::Location loc,
-                      mlir::Value arrayBox, mlir::Value maskBox);
+                      mlir::Value arrayBox, bool absentDim,
+                      const mlir::Value dim, mlir::Value maskBox);
 
 /// Generate call to `MinvalCharacter` intrinsic runtime routine. This is the
 /// version that that handles 1 dimensional character arrays with no DIM

--- a/flang/include/flang/Runtime/reduction.h
+++ b/flang/include/flang/Runtime/reduction.h
@@ -44,49 +44,49 @@ extern "C" {
 // SUM()
 
 std::int8_t RTNAME(SumInteger1)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(SumInteger2)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(SumInteger4)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(SumInteger8)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(SumInteger16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #endif
 
 // REAL/COMPLEX(2 & 3) return 32-bit float results for the caller to downconvert
 float RTNAME(SumReal2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(SumReal3)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(SumReal4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 double RTNAME(SumReal8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(SumReal10)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(SumReal16)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 
 void RTNAME(CppSumComplex2)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppSumComplex3)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppSumComplex4)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppSumComplex8)(std::complex<double> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppSumComplex10)(std::complex<long double> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppSumComplex16)(std::complex<long double> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 
 void RTNAME(SumDim)(Descriptor &result, const Descriptor &array, int dim,
@@ -95,50 +95,50 @@ void RTNAME(SumDim)(Descriptor &result, const Descriptor &array, int dim,
 // PRODUCT()
 
 std::int8_t RTNAME(ProductInteger1)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(ProductInteger2)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(ProductInteger4)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(ProductInteger8)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(ProductInteger16)(const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 #endif
 
 // REAL/COMPLEX(2 & 3) return 32-bit float results for the caller to downconvert
 float RTNAME(ProductReal2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(ProductReal3)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(ProductReal4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 double RTNAME(ProductReal8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(ProductReal10)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(ProductReal16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 
 void RTNAME(CppProductComplex2)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppProductComplex3)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppProductComplex4)(std::complex<float> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppProductComplex8)(std::complex<double> &, const Descriptor &,
-    const char *source, int line, int dim = 0,
+    const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppProductComplex10)(std::complex<long double> &,
-    const Descriptor &, const char *source, int line, int dim = 0,
+    const Descriptor &, const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 void RTNAME(CppProductComplex16)(std::complex<long double> &,
-    const Descriptor &, const char *source, int line, int dim = 0,
+    const Descriptor &, const char *source, int line, int dim = 1,
     const Descriptor *mask = nullptr);
 
 void RTNAME(ProductDim)(Descriptor &result, const Descriptor &array, int dim,
@@ -146,46 +146,46 @@ void RTNAME(ProductDim)(Descriptor &result, const Descriptor &array, int dim,
 
 // IALL, IANY, IPARITY
 std::int8_t RTNAME(IAll1)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(IAll2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(IAll4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(IAll8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(IAll16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #endif
 void RTNAME(IAllDim)(Descriptor &result, const Descriptor &array, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
 
 std::int8_t RTNAME(IAny1)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(IAny2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(IAny4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(IAny8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(IAny16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #endif
 void RTNAME(IAnyDim)(Descriptor &result, const Descriptor &array, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
 
 std::int8_t RTNAME(IParity1)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(IParity2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(IParity4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(IParity8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(IParity16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #endif
 void RTNAME(IParityDim)(Descriptor &result, const Descriptor &array, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
@@ -215,56 +215,63 @@ void RTNAME(MinlocDim)(Descriptor &, const Descriptor &x, int kind, int dim,
 
 // MAXVAL and MINVAL
 std::int8_t RTNAME(MaxvalInteger1)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int16_t RTNAME(MaxvalInteger2)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int32_t RTNAME(MaxvalInteger4)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 std::int64_t RTNAME(MaxvalInteger8)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(MaxvalInteger16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 #endif
 float RTNAME(MaxvalReal2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(MaxvalReal3)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(MaxvalReal4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 double RTNAME(MaxvalReal8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(MaxvalReal10)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(MaxvalReal16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, int dim = 1, const Descriptor *mask = nullptr);
 void RTNAME(MaxvalCharacter)(Descriptor &, const Descriptor &,
     const char *source, int line, const Descriptor *mask = nullptr);
 
 std::int8_t RTNAME(MinvalInteger1)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 std::int16_t RTNAME(MinvalInteger2)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 std::int32_t RTNAME(MinvalInteger4)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 std::int64_t RTNAME(MinvalInteger8)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 #ifdef __SIZEOF_INT128__
 common::int128_t RTNAME(MinvalInteger16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 #endif
 float RTNAME(MinvalReal2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    bool hasDim = false, int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(MinvalReal3)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    bool hasDim = false, int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(MinvalReal4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    bool hasDim = false, int dim = 1, const Descriptor *mask = nullptr);
 double RTNAME(MinvalReal8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    bool hasDim = false, int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(MinvalReal10)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 long double RTNAME(MinvalReal16)(const Descriptor &, const char *source,
-    int line, int dim = 0, const Descriptor *mask = nullptr);
+    int line, bool hasDim = false, int dim = 1,
+    const Descriptor *mask = nullptr);
 void RTNAME(MinvalCharacter)(Descriptor &, const Descriptor &,
     const char *source, int line, const Descriptor *mask = nullptr);
 
@@ -275,33 +282,33 @@ void RTNAME(MinvalDim)(Descriptor &, const Descriptor &, int dim,
 
 // NORM2
 float RTNAME(Norm2_2)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(Norm2_3)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 float RTNAME(Norm2_4)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 double RTNAME(Norm2_8)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(Norm2_10)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 long double RTNAME(Norm2_16)(const Descriptor &, const char *source, int line,
-    int dim = 0, const Descriptor *mask = nullptr);
+    int dim = 1, const Descriptor *mask = nullptr);
 void RTNAME(Norm2Dim)(Descriptor &, const Descriptor &, int dim,
     const char *source, int line, const Descriptor *mask = nullptr);
 
 // ALL, ANY, COUNT, & PARITY logical reductions
-bool RTNAME(All)(const Descriptor &, const char *source, int line, int dim = 0);
+bool RTNAME(All)(const Descriptor &, const char *source, int line, int dim = 1);
 void RTNAME(AllDim)(Descriptor &result, const Descriptor &, int dim,
     const char *source, int line);
-bool RTNAME(Any)(const Descriptor &, const char *source, int line, int dim = 0);
+bool RTNAME(Any)(const Descriptor &, const char *source, int line, int dim = 1);
 void RTNAME(AnyDim)(Descriptor &result, const Descriptor &, int dim,
     const char *source, int line);
 std::int64_t RTNAME(Count)(
-    const Descriptor &, const char *source, int line, int dim = 0);
+    const Descriptor &, const char *source, int line, int dim = 1);
 void RTNAME(CountDim)(Descriptor &result, const Descriptor &, int dim, int kind,
     const char *source, int line);
 bool RTNAME(Parity)(
-    const Descriptor &, const char *source, int line, int dim = 0);
+    const Descriptor &, const char *source, int line, int dim = 1);
 void RTNAME(ParityDim)(Descriptor &result, const Descriptor &, int dim,
     const char *source, int line);
 

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -268,8 +268,11 @@ genExtremumVal(FN func, FD funcDim, FC funcChar, mlir::Type resultType,
 
   // For Maxval/MinVal, we call the type specific versions of
   // Maxval/Minval because the result is scalar in the case below.
+  mlir::Value dim =
+      absentDim ? builder.createIntegerConstant(loc, builder.getIndexType(), 0)
+                : fir::getBase(args[1]);
   if (!hasCharacterResult && (absentDim || rank == 1))
-    return func(builder, loc, array, mask);
+    return func(builder, loc, array, absentDim, dim, mask);
 
   if (hasCharacterResult && (absentDim || rank == 1)) {
     // Create mutable fir.box to be passed to the runtime for the result.

--- a/flang/runtime/findloc.cpp
+++ b/flang/runtime/findloc.cpp
@@ -133,7 +133,8 @@ struct TotalNumericFindlocHelper {
       using Eq = Equality<XCAT, XKIND, TARGET_CAT, TARGET_KIND>;
       using Accumulator = LocationAccumulator<Eq>;
       Accumulator accumulator{x, target, back};
-      DoTotalReduction<void>(x, dim, mask, accumulator, "FINDLOC", terminator);
+      DoTotalReduction<void>(
+          x, /*hasDim=*/true, dim, mask, accumulator, "FINDLOC", terminator);
       ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor,
           void>(kind, terminator, accumulator, result);
     }
@@ -182,7 +183,8 @@ template <int KIND> struct CharacterFindlocHelper {
       Terminator &terminator) {
     using Accumulator = LocationAccumulator<CharacterEquality<KIND>>;
     Accumulator accumulator{x, target, back};
-    DoTotalReduction<void>(x, 0, mask, accumulator, "FINDLOC", terminator);
+    DoTotalReduction<void>(x, /*hasDim=*/false, /*dim=*/1, mask, accumulator,
+        "FINDLOC", terminator);
     ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor, void>(
         kind, terminator, accumulator, result);
   }
@@ -193,7 +195,8 @@ static void LogicalFindlocHelper(Descriptor &result, const Descriptor &x,
     Terminator &terminator) {
   using Accumulator = LocationAccumulator<LogicalEquivalence>;
   Accumulator accumulator{x, target, back};
-  DoTotalReduction<void>(x, 0, mask, accumulator, "FINDLOC", terminator);
+  DoTotalReduction<void>(
+      x, /*hasDim=*/false, /*dim=*/1, mask, accumulator, "FINDLOC", terminator);
   ApplyIntegerKind<LocationResultHelper<Accumulator>::template Functor, void>(
       kind, terminator, accumulator, result);
 }
@@ -221,19 +224,19 @@ void RTNAME(Findloc)(Descriptor &result, const Descriptor &x,
     ApplyIntegerKind<NumericFindlocHelper<TypeCategory::Integer,
                          TotalNumericFindlocHelper>::template Functor,
         void>(xType->second, terminator, targetType->first, targetType->second,
-        result, x, target, kind, 0, mask, back, terminator);
+        result, x, target, kind, /*dim=*/1, mask, back, terminator);
     break;
   case TypeCategory::Real:
     ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Real,
                                TotalNumericFindlocHelper>::template Functor,
         void>(xType->second, terminator, targetType->first, targetType->second,
-        result, x, target, kind, 0, mask, back, terminator);
+        result, x, target, kind, /*dim=*/1, mask, back, terminator);
     break;
   case TypeCategory::Complex:
     ApplyFloatingPointKind<NumericFindlocHelper<TypeCategory::Complex,
                                TotalNumericFindlocHelper>::template Functor,
         void>(xType->second, terminator, targetType->first, targetType->second,
-        result, x, target, kind, 0, mask, back, terminator);
+        result, x, target, kind, /*dim=*/1, mask, back, terminator);
     break;
   case TypeCategory::Character:
     RUNTIME_CHECK(terminator,

--- a/flang/runtime/product.cpp
+++ b/flang/runtime/product.cpp
@@ -56,28 +56,32 @@ extern "C" {
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(ProductInteger1)(
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "PRODUCT");
 }
 CppTypeFor<TypeCategory::Integer, 2> RTNAME(ProductInteger2)(
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "PRODUCT");
 }
 CppTypeFor<TypeCategory::Integer, 4> RTNAME(ProductInteger4)(
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "PRODUCT");
 }
 CppTypeFor<TypeCategory::Integer, 8> RTNAME(ProductInteger8)(
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x},
       "PRODUCT");
 }
@@ -85,8 +89,8 @@ CppTypeFor<TypeCategory::Integer, 8> RTNAME(ProductInteger8)(
 CppTypeFor<TypeCategory::Integer, 16> RTNAME(ProductInteger16)(
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
-      mask,
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
       "PRODUCT");
 }
@@ -95,27 +99,31 @@ CppTypeFor<TypeCategory::Integer, 16> RTNAME(ProductInteger16)(
 // TODO: real/complex(2 & 3)
 CppTypeFor<TypeCategory::Real, 4> RTNAME(ProductReal4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Real, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
       "PRODUCT");
 }
 CppTypeFor<TypeCategory::Real, 8> RTNAME(ProductReal8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Real, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
       "PRODUCT");
 }
 #if LONG_DOUBLE == 80
 CppTypeFor<TypeCategory::Real, 10> RTNAME(ProductReal10)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 10>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Real, 10>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 10>>{x},
       "PRODUCT");
 }
 #elif LONG_DOUBLE == 128
 CppTypeFor<TypeCategory::Real, 16> RTNAME(ProductReal16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 16>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Real, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       NonComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 16>>{x},
       "PRODUCT");
 }
@@ -124,31 +132,35 @@ CppTypeFor<TypeCategory::Real, 16> RTNAME(ProductReal16)(const Descriptor &x,
 void RTNAME(CppProductComplex4)(CppTypeFor<TypeCategory::Complex, 4> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 4>(x, source, line, dim,
-      mask, ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
+  result = GetTotalReduction<TypeCategory::Complex, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
       "PRODUCT");
 }
 void RTNAME(CppProductComplex8)(CppTypeFor<TypeCategory::Complex, 8> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 8>(x, source, line, dim,
-      mask, ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
+  result = GetTotalReduction<TypeCategory::Complex, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 8>>{x},
       "PRODUCT");
 }
 #if LONG_DOUBLE == 80
 void RTNAME(CppProductComplex10)(CppTypeFor<TypeCategory::Complex, 10> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 10>(x, source, line, dim,
-      mask, ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 10>>{x},
+  result = GetTotalReduction<TypeCategory::Complex, 10>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 10>>{x},
       "PRODUCT");
 }
 #elif LONG_DOUBLE == 128
 void RTNAME(CppProductComplex16)(CppTypeFor<TypeCategory::Complex, 16> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 16>(x, source, line, dim,
-      mask, ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 16>>{x},
+  result = GetTotalReduction<TypeCategory::Complex, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      ComplexProductAccumulator<CppTypeFor<TypeCategory::Real, 16>>{x},
       "PRODUCT");
 }
 #endif

--- a/flang/runtime/reduction.cpp
+++ b/flang/runtime/reduction.cpp
@@ -76,30 +76,34 @@ private:
 extern "C" {
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(IAll1)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IALL");
 }
 CppTypeFor<TypeCategory::Integer, 2> RTNAME(IAll2)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IALL");
 }
 CppTypeFor<TypeCategory::Integer, 4> RTNAME(IAll4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IALL");
 }
 CppTypeFor<TypeCategory::Integer, 8> RTNAME(IAll8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x}, "IALL");
 }
 #ifdef __SIZEOF_INT128__
 CppTypeFor<TypeCategory::Integer, 16> RTNAME(IAll16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
-      mask, IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
-      "IALL");
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      IntegerAndAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x}, "IALL");
 }
 #endif
 void RTNAME(IAllDim)(Descriptor &result, const Descriptor &x, int dim,
@@ -114,30 +118,34 @@ void RTNAME(IAllDim)(Descriptor &result, const Descriptor &x, int dim,
 
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(IAny1)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IANY");
 }
 CppTypeFor<TypeCategory::Integer, 2> RTNAME(IAny2)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IANY");
 }
 CppTypeFor<TypeCategory::Integer, 4> RTNAME(IAny4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "IANY");
 }
 CppTypeFor<TypeCategory::Integer, 8> RTNAME(IAny8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x}, "IANY");
 }
 #ifdef __SIZEOF_INT128__
 CppTypeFor<TypeCategory::Integer, 16> RTNAME(IAny16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
-      mask, IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
-      "IANY");
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      IntegerOrAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x}, "IANY");
 }
 #endif
 void RTNAME(IAnyDim)(Descriptor &result, const Descriptor &x, int dim,
@@ -152,33 +160,38 @@ void RTNAME(IAnyDim)(Descriptor &result, const Descriptor &x, int dim,
 
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(IParity1)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "IPARITY");
 }
 CppTypeFor<TypeCategory::Integer, 2> RTNAME(IParity2)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "IPARITY");
 }
 CppTypeFor<TypeCategory::Integer, 4> RTNAME(IParity4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x},
       "IPARITY");
 }
 CppTypeFor<TypeCategory::Integer, 8> RTNAME(IParity8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x},
       "IPARITY");
 }
 #ifdef __SIZEOF_INT128__
 CppTypeFor<TypeCategory::Integer, 16> RTNAME(IParity16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
-      mask, IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      IntegerXorAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
       "IPARITY");
 }
 #endif
@@ -222,13 +235,15 @@ private:
   bool result_{REDUCTION == LogicalReduction::All};
 };
 
+// This version is for when the MASK argument has rank 1
 template <typename ACCUMULATOR>
 inline auto GetTotalLogicalReduction(const Descriptor &x, const char *source,
     int line, int dim, ACCUMULATOR &&accumulator, const char *intrinsic) ->
     typename ACCUMULATOR::Type {
   Terminator terminator{source, line};
-  if (dim < 0 || dim > 1) {
-    terminator.Crash("%s: bad DIM=%d", intrinsic, dim);
+  if (dim != 1) {
+    terminator.Crash(
+        "In the intrinsic %s: invalid DIM=%d, must be 1", intrinsic, dim);
   }
   SubscriptValue xAt[maxRank];
   x.GetLowerBounds(xAt);

--- a/flang/runtime/sum.cpp
+++ b/flang/runtime/sum.cpp
@@ -91,83 +91,87 @@ private:
 extern "C" {
 CppTypeFor<TypeCategory::Integer, 1> RTNAME(SumInteger1)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 1>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "SUM");
 }
 CppTypeFor<TypeCategory::Integer, 2> RTNAME(SumInteger2)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 2>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "SUM");
 }
 CppTypeFor<TypeCategory::Integer, 4> RTNAME(SumInteger4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 4>>{x}, "SUM");
 }
 CppTypeFor<TypeCategory::Integer, 8> RTNAME(SumInteger8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line, dim, mask,
+  return GetTotalReduction<TypeCategory::Integer, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask,
       IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 8>>{x}, "SUM");
 }
 #ifdef __SIZEOF_INT128__
 CppTypeFor<TypeCategory::Integer, 16> RTNAME(SumInteger16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line, dim,
-      mask, IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x},
-      "SUM");
+  return GetTotalReduction<TypeCategory::Integer, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask,
+      IntegerSumAccumulator<CppTypeFor<TypeCategory::Integer, 16>>{x}, "SUM");
 }
 #endif
 
 // TODO: real/complex(2 & 3)
 CppTypeFor<TypeCategory::Real, 4> RTNAME(SumReal4)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 4>(
-      x, source, line, dim, mask, RealSumAccumulator<double>{x}, "SUM");
+  return GetTotalReduction<TypeCategory::Real, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask, RealSumAccumulator<double>{x}, "SUM");
 }
 CppTypeFor<TypeCategory::Real, 8> RTNAME(SumReal8)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 8>(
-      x, source, line, dim, mask, RealSumAccumulator<double>{x}, "SUM");
+  return GetTotalReduction<TypeCategory::Real, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask, RealSumAccumulator<double>{x}, "SUM");
 }
 #if LONG_DOUBLE == 80
 CppTypeFor<TypeCategory::Real, 10> RTNAME(SumReal10)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 10>(
-      x, source, line, dim, mask, RealSumAccumulator<long double>{x}, "SUM");
+  return GetTotalReduction<TypeCategory::Real, 10>(x, source, line,
+      /*hasDim=*/true, dim, mask, RealSumAccumulator<long double>{x}, "SUM");
 }
 #elif LONG_DOUBLE == 128
 CppTypeFor<TypeCategory::Real, 16> RTNAME(SumReal16)(const Descriptor &x,
     const char *source, int line, int dim, const Descriptor *mask) {
-  return GetTotalReduction<TypeCategory::Real, 16>(
-      x, source, line, dim, mask, RealSumAccumulator<long double>{x}, "SUM");
+  return GetTotalReduction<TypeCategory::Real, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask, RealSumAccumulator<long double>{x}, "SUM");
 }
 #endif
 
 void RTNAME(CppSumComplex4)(CppTypeFor<TypeCategory::Complex, 4> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 4>(
-      x, source, line, dim, mask, ComplexSumAccumulator<double>{x}, "SUM");
+  result = GetTotalReduction<TypeCategory::Complex, 4>(x, source, line,
+      /*hasDim=*/true, dim, mask, ComplexSumAccumulator<double>{x}, "SUM");
 }
 void RTNAME(CppSumComplex8)(CppTypeFor<TypeCategory::Complex, 8> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 8>(
-      x, source, line, dim, mask, ComplexSumAccumulator<double>{x}, "SUM");
+  result = GetTotalReduction<TypeCategory::Complex, 8>(x, source, line,
+      /*hasDim=*/true, dim, mask, ComplexSumAccumulator<double>{x}, "SUM");
 }
 #if LONG_DOUBLE == 80
 void RTNAME(CppSumComplex10)(CppTypeFor<TypeCategory::Complex, 10> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 10>(
-      x, source, line, dim, mask, ComplexSumAccumulator<long double>{x}, "SUM");
+  result = GetTotalReduction<TypeCategory::Complex, 10>(x, source, line,
+      /*hasDim=*/true, dim, mask, ComplexSumAccumulator<long double>{x}, "SUM");
 }
 #elif LONG_DOUBLE == 128
 void RTNAME(CppSumComplex16)(CppTypeFor<TypeCategory::Complex, 16> &result,
     const Descriptor &x, const char *source, int line, int dim,
     const Descriptor *mask) {
-  result = GetTotalReduction<TypeCategory::Complex, 16>(
-      x, source, line, dim, mask, ComplexSumAccumulator<long double>{x}, "SUM");
+  result = GetTotalReduction<TypeCategory::Complex, 16>(x, source, line,
+      /*hasDim=*/true, dim, mask, ComplexSumAccumulator<long double>{x}, "SUM");
 }
 #endif
 

--- a/flang/test/Lower/intrinsic-procedures/minval.f90
+++ b/flang/test/Lower/intrinsic-procedures/minval.f90
@@ -5,12 +5,14 @@
 integer function minval_test(a)
   integer :: a(:)
 ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-! CHECK-DAG:  %[[a2:.*]] = fir.absent !fir.box<i1>
-! CHECK-DAG:  %[[a4:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
-! CHECK:  %[[a6:.*]] = fir.convert %[[c0]] : (index) -> i32
-! CHECK:  %[[a7:.*]] = fir.convert %[[a2]] : (!fir.box<i1>) -> !fir.box<none>
+! CHECK-DAG:  %[[a1:.*]] = fir.absent !fir.box<i1>
+! CHECK:  %[[a2:.*]] = fir.address_of(
+! CHECK-DAG:  %[[a3:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
+! CHECK:  %[[a4:.*]] = fir.convert %[[a2]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:  %[[a5:.*]] = fir.convert %[[c0]] : (index) -> i32
+! CHECK:  %[[a6:.*]] = fir.convert %[[a1]] : (!fir.box<i1>) -> !fir.box<none>
   minval_test = minval(a)
-! CHECK:  %{{.*}} = fir.call @_FortranAMinvalInteger4(%[[a4]], %{{.*}}, %{{.*}}, %[[a6]], %[[a7]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
+! CHECK:  %{{.*}} = fir.call @_FortranAMinvalInteger4(%[[a3]], %{{.*}}, %{{.*}}, %{{.*}},  %[[a5]], %[[a6]]) : (!fir.box<none>, !fir.ref<i8>, i32, i1, i32, !fir.box<none>) -> i32
 end function
 
 ! CHECK-LABEL: func @_QPminval_test2(
@@ -55,7 +57,7 @@ subroutine test_minval_optional_scalar_mask(mask, array)
 ! CHECK:  %[[VAL_9:.*]] = fir.absent !fir.box<!fir.logical<4>>
 ! CHECK:  %[[VAL_10:.*]] = select %[[VAL_7]], %[[VAL_8]], %[[VAL_9]] : !fir.box<!fir.logical<4>>
 ! CHECK:  %[[VAL_17:.*]] = fir.convert %[[VAL_10]] : (!fir.box<!fir.logical<4>>) -> !fir.box<none>
-! CHECK: fir.call @_FortranAMinvalInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_17]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
+! CHECK: fir.call @_FortranAMinvalInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_17]]) : (!fir.box<none>, !fir.ref<i8>, i32, i1, i32, !fir.box<none>) -> i32
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_minval_optional_array_mask(
@@ -64,6 +66,6 @@ subroutine test_minval_optional_array_mask(mask, array)
   integer :: array(:)
   logical, optional :: mask(:)
   print *, minval(array, mask)
-! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
-! CHECK: fir.call @_FortranAMinvalInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_13]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32
+! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
+! CHECK: fir.call @_FortranAMinvalInteger4(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[VAL_8]]) : (!fir.box<none>, !fir.ref<i8>, i32, i1, i32, !fir.box<none>) -> i32
 end subroutine

--- a/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
@@ -90,10 +90,6 @@ TEST_F(RuntimeCallTest, genMaxValTest) {
 
 void testGenMinVal(
     fir::FirOpBuilder &builder, mlir::Type eleTy, llvm::StringRef fctName) {
-  FILE *file;
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In testGenMinVal\n");
-  fclose(file);
   mlir::Location loc = builder.getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), eleTy);
@@ -106,47 +102,16 @@ void testGenMinVal(
 }
 
 TEST_F(RuntimeCallTest, genMinValTest) {
-  FILE *file;
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest\n");
-  fclose(file);
   testGenMinVal(*firBuilder, f32Ty, "_FortranAMinvalReal4");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 1\n");
-  fclose(file);
   testGenMinVal(*firBuilder, f64Ty, "_FortranAMinvalReal8");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 2\n");
-  fclose(file);
   testGenMinVal(*firBuilder, f80Ty, "_FortranAMinvalReal10");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 3\n");
-  fclose(file);
-//  testGenMinVal(*firBuilder, f128Ty, "_FortranAMinvalReal16");
-//  file = fopen("/home/psteinfeld/log", "a");
-//  fprintf(file, "In genMinValTest 4\n");
-//  fclose(file);
+  testGenMinVal(*firBuilder, f128Ty, "_FortranAMinvalReal16");
 
   testGenMinVal(*firBuilder, i8Ty, "_FortranAMinvalInteger1");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 5\n");
-  fclose(file);
   testGenMinVal(*firBuilder, i16Ty, "_FortranAMinvalInteger2");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 6\n");
-  fclose(file);
   testGenMinVal(*firBuilder, i32Ty, "_FortranAMinvalInteger4");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 7\n");
-  fclose(file);
   testGenMinVal(*firBuilder, i64Ty, "_FortranAMinvalInteger8");
-  file = fopen("/home/psteinfeld/log", "a");
-  fprintf(file, "In genMinValTest 8\n");
-  fclose(file);
-//  testGenMinVal(*firBuilder, i128Ty, "_FortranAMinvalInteger16");
-//  file = fopen("/home/psteinfeld/log", "a");
-//  fprintf(file, "In genMinValTest 9\n");
-//  fclose(file);
+  testGenMinVal(*firBuilder, i128Ty, "_FortranAMinvalInteger16");
 }
 
 void testGenSum(

--- a/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
@@ -70,7 +70,8 @@ void testGenMaxVal(
   mlir::Type refSeqTy = fir::ReferenceType::get(seqTy);
   mlir::Value undef = builder.create<fir::UndefOp>(loc, refSeqTy);
   mlir::Value mask = builder.create<fir::UndefOp>(loc, seqTy);
-  mlir::Value max = fir::runtime::genMaxval(builder, loc, undef, mask);
+  mlir::Value max = fir::runtime::genMaxval(builder, loc, undef, false, undef, 
+      mask);
   checkCallOp(max.getDefiningOp(), fctName, 3);
 }
 
@@ -89,27 +90,63 @@ TEST_F(RuntimeCallTest, genMaxValTest) {
 
 void testGenMinVal(
     fir::FirOpBuilder &builder, mlir::Type eleTy, llvm::StringRef fctName) {
+  FILE *file;
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In testGenMinVal\n");
+  fclose(file);
   mlir::Location loc = builder.getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), eleTy);
   mlir::Type refSeqTy = fir::ReferenceType::get(seqTy);
   mlir::Value undef = builder.create<fir::UndefOp>(loc, refSeqTy);
   mlir::Value mask = builder.create<fir::UndefOp>(loc, seqTy);
-  mlir::Value min = fir::runtime::genMinval(builder, loc, undef, mask);
-  checkCallOp(min.getDefiningOp(), fctName, 3);
+  mlir::Value min = fir::runtime::genMinval(builder, loc, undef, false, undef,
+      mask);
+  checkCallOp(min.getDefiningOp(), fctName, 4);
 }
 
 TEST_F(RuntimeCallTest, genMinValTest) {
+  FILE *file;
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest\n");
+  fclose(file);
   testGenMinVal(*firBuilder, f32Ty, "_FortranAMinvalReal4");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 1\n");
+  fclose(file);
   testGenMinVal(*firBuilder, f64Ty, "_FortranAMinvalReal8");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 2\n");
+  fclose(file);
   testGenMinVal(*firBuilder, f80Ty, "_FortranAMinvalReal10");
-  testGenMinVal(*firBuilder, f128Ty, "_FortranAMinvalReal16");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 3\n");
+  fclose(file);
+//  testGenMinVal(*firBuilder, f128Ty, "_FortranAMinvalReal16");
+//  file = fopen("/home/psteinfeld/log", "a");
+//  fprintf(file, "In genMinValTest 4\n");
+//  fclose(file);
 
   testGenMinVal(*firBuilder, i8Ty, "_FortranAMinvalInteger1");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 5\n");
+  fclose(file);
   testGenMinVal(*firBuilder, i16Ty, "_FortranAMinvalInteger2");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 6\n");
+  fclose(file);
   testGenMinVal(*firBuilder, i32Ty, "_FortranAMinvalInteger4");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 7\n");
+  fclose(file);
   testGenMinVal(*firBuilder, i64Ty, "_FortranAMinvalInteger8");
-  testGenMinVal(*firBuilder, i128Ty, "_FortranAMinvalInteger16");
+  file = fopen("/home/psteinfeld/log", "a");
+  fprintf(file, "In genMinValTest 8\n");
+  fclose(file);
+//  testGenMinVal(*firBuilder, i128Ty, "_FortranAMinvalInteger16");
+//  file = fopen("/home/psteinfeld/log", "a");
+//  fprintf(file, "In genMinValTest 9\n");
+//  fclose(file);
 }
 
 void testGenSum(


### PR DESCRIPTION
…scalar

Reduction intrinsics that have an ARRAY argument of rank 1 can only accept a DIM argument whose value is 1.  We were not detecting cases where DIM was not equal to 1.  Here's a small program that illustrates the problem:
  program minval_test
    integer :: array(3) = [1,2,3]
    integer :: dim
    dim = 0
    print *, minval(array, dim)
  end program minval_test

Our implementation of reduction intrinsics has two sets of interfaces -- one set for intrinsics that return an array and another set for intrinsics that return a scalar.  Some of the intrinsics that return a scalar stem from calls without the DIM argument.  Others stem from calls with the DIM argument where the ARRAY argument has rank 1.  But for scalar-returning calls, we were not passing along the information of whether the call contained a DIM argument.

I fixed this by adding a boolean argument to the interface to the runtime that indicates whether the original source contained a DIM argument.  This small change propatated through a lot of the runtime resulting in several files changing.

This is an initial implementation that only implements this change for the MINVAL intrinsic.  If I receive initial comments validating this approach, I'll expand it to the other reduction intrinsics.