### PR TITLE
Handle TARGET that are OPTIONAL in ASSOCIATED 

### DIFF
--- a/flang/include/flang/Runtime/pointer.h
+++ b/flang/include/flang/Runtime/pointer.h
@@ -105,7 +105,7 @@ bool RTNAME(PointerIsAssociated)(const Descriptor &);
 
 // True when the pointer is associated with a specific target.
 bool RTNAME(PointerIsAssociatedWith)(
-    const Descriptor &, const Descriptor &target);
+    const Descriptor &, const Descriptor *target);
 
 } // extern "C"
 } // namespace Fortran::runtime

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -33,6 +33,7 @@
 #include "flang/Optimizer/Builder/Runtime/Reduction.h"
 #include "flang/Optimizer/Builder/Runtime/Stop.h"
 #include "flang/Optimizer/Builder/Runtime/Transformational.h"
+#include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "llvm/Support/CommandLine.h"
@@ -674,7 +675,7 @@ static constexpr IntrinsicHandler handlers[]{
      /*isElemental=*/false},
     {"associated",
      &I::genAssociated,
-     {{{"pointer", asInquired}, {"target", asBox}}},
+     {{{"pointer", asInquired}, {"target", asInquired}}},
      /*isElemental=*/false},
     {"btest", &I::genBtest},
     {"ceiling", &I::genCeiling},
@@ -1991,13 +1992,32 @@ IntrinsicLibrary::genAssociated(mlir::Type resultType,
                     [&](const auto &) -> const fir::MutableBoxValue * {
                       fir::emitFatalError(loc, "pointer not a MutableBoxValue");
                     });
-  if (isAbsent(args[1]))
+  const fir::ExtendedValue &target = args[1];
+  if (isAbsent(target))
     return fir::factory::genIsAllocatedOrAssociatedTest(builder, loc, *pointer);
+
+  mlir::Value targetBox = builder.createBox(loc, target);
+  if (fir::valueHasFirAttribute(fir::getBase(target),
+                                fir::getOptionalAttrName())) {
+    // Subtle: contrary to other intrinsic optional arguments, disassociated
+    // POINTER and unallocated ALLOCATABLE actual argument are not considered
+    // absent here. This is because ASSOCIATED has special requirements for
+    // TARGET actual arguments that are POINTERs. There is no precise
+    // requirements for ALLOCATABLEs, but all existing Fortran compilers treat
+    // them similarly to POINTERs. That is: unallocated TARGETs cause ASSOCIATED
+    // to rerun false.  The runtime deals with the disassociated/unallocated
+    // case. Simply ensures that TARGET that are OPTIONAL get conditionally
+    // emboxed here to convey the optional aspect to the runtime.
+    auto isPresent = builder.create<fir::IsPresentOp>(loc, builder.getI1Type(),
+                                                      fir::getBase(target));
+    auto absentBox = builder.create<fir::AbsentOp>(loc, targetBox.getType());
+    targetBox =
+        builder.create<mlir::SelectOp>(loc, isPresent, targetBox, absentBox);
+  }
   mlir::Value pointerBoxRef =
       fir::factory::getMutableIRBox(builder, loc, *pointer);
   auto pointerBox = builder.create<fir::LoadOp>(loc, pointerBoxRef);
-  return Fortran::lower::genAssociated(builder, loc, pointerBox,
-                                       fir::getBase(args[1]));
+  return Fortran::lower::genAssociated(builder, loc, pointerBox, targetBox);
 }
 
 // AINT

--- a/flang/runtime/pointer.cpp
+++ b/flang/runtime/pointer.cpp
@@ -147,16 +147,22 @@ bool RTNAME(PointerIsAssociated)(const Descriptor &pointer) {
 }
 
 bool RTNAME(PointerIsAssociatedWith)(
-    const Descriptor &pointer, const Descriptor &target) {
+    const Descriptor &pointer, const Descriptor *target) {
+  if (!target) {
+    return pointer.raw().base_addr != nullptr;
+  }
+  if (!target->raw().base_addr || target->ElementBytes() == 0) {
+    return false;
+  }
   int rank{pointer.rank()};
-  if (pointer.raw().base_addr != target.raw().base_addr ||
-      pointer.ElementBytes() != target.ElementBytes() ||
-      rank != target.rank()) {
+  if (pointer.raw().base_addr != target->raw().base_addr ||
+      pointer.ElementBytes() != target->ElementBytes() ||
+      rank != target->rank()) {
     return false;
   }
   for (int j{0}; j < rank; ++j) {
     const Dimension &pDim{pointer.GetDimension(j)};
-    const Dimension &tDim{target.GetDimension(j)};
+    const Dimension &tDim{target->GetDimension(j)};
     if (pDim.Extent() != tDim.Extent() ||
         pDim.ByteStride() != tDim.ByteStride()) {
       return false;

--- a/flang/test/Lower/intrinsic-procedures/associated.f90
+++ b/flang/test/Lower/intrinsic-procedures/associated.f90
@@ -38,3 +38,100 @@ subroutine test_func_results()
   ! CHECK:  arith.cmpi ne, %[[addr_cast]], %c0{{.*}} : i64
   print *, associated(get_pointer())
 end subroutine
+
+! CHECK-LABEL: func @_QPtest_optional_target_1(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.array<10xf32>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
+subroutine test_optional_target_1(p, optionales_ziel)
+  real, pointer :: p(:)
+  real, optional, target :: optionales_ziel(10)
+  print *, associated(p, optionales_ziel)
+! CHECK:  %[[VAL_2:.*]] = arith.constant 10 : index
+! CHECK:  %[[VAL_8:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:  %[[VAL_9:.*]] = fir.embox %[[VAL_1]](%[[VAL_8]]) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
+! CHECK:  %[[VAL_10:.*]] = fir.is_present %[[VAL_1]] : (!fir.ref<!fir.array<10xf32>>) -> i1
+! CHECK:  %[[VAL_11:.*]] = fir.absent !fir.box<!fir.array<10xf32>>
+! CHECK:  %[[VAL_12:.*]] = select %[[VAL_10]], %[[VAL_9]], %[[VAL_11]] : !fir.box<!fir.array<10xf32>>
+! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.array<10xf32>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_14]], %[[VAL_15]]) : (!fir.box<none>, !fir.box<none>) -> i1
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_optional_target_2(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
+subroutine test_optional_target_2(p, optionales_ziel)
+  real, pointer :: p(:)
+  real, optional, target :: optionales_ziel(:)
+  print *, associated(p, optionales_ziel)
+! CHECK:  %[[VAL_7:.*]] = fir.is_present %[[VAL_1]] : (!fir.box<!fir.array<?xf32>>) -> i1
+! CHECK:  %[[VAL_8:.*]] = fir.absent !fir.box<!fir.array<?xf32>>
+! CHECK:  %[[VAL_9:.*]] = select %[[VAL_7]], %[[VAL_1]], %[[VAL_8]] : !fir.box<!fir.array<?xf32>>
+! CHECK:  %[[VAL_10:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_11]], %[[VAL_12]]) : (!fir.box<none>, !fir.box<none>) -> i1
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_optional_target_3(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "optionales_ziel", fir.optional}) {
+subroutine test_optional_target_3(p, optionales_ziel)
+  real, pointer :: p(:)
+  real, optional, pointer :: optionales_ziel(:)
+  print *, associated(p, optionales_ziel)
+! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_8:.*]] = fir.is_present %[[VAL_1]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> i1
+! CHECK:  %[[VAL_9:.*]] = fir.absent !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:  %[[VAL_10:.*]] = select %[[VAL_8]], %[[VAL_7]], %[[VAL_9]] : !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:  %[[VAL_11:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_12]], %[[VAL_13]]) : (!fir.box<none>, !fir.box<none>) -> i1
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_optional_target_4(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "optionales_ziel", fir.optional, fir.target}) {
+subroutine test_optional_target_4(p, optionales_ziel)
+  real, pointer :: p(:)
+  real, optional, allocatable, target :: optionales_ziel(:)
+  print *, associated(p, optionales_ziel)
+! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_8:.*]] = fir.is_present %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> i1
+! CHECK:  %[[VAL_9:.*]] = fir.absent !fir.box<!fir.heap<!fir.array<?xf32>>>
+! CHECK:  %[[VAL_10:.*]] = select %[[VAL_8]], %[[VAL_7]], %[[VAL_9]] : !fir.box<!fir.heap<!fir.array<?xf32>>>
+! CHECK:  %[[VAL_11:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_12]], %[[VAL_13]]) : (!fir.box<none>, !fir.box<none>) -> i1
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_pointer_target(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "pointer_ziel"}) {
+subroutine test_pointer_target(p, pointer_ziel)
+  real, pointer :: p(:)
+  real, pointer :: pointer_ziel(:)
+  print *, associated(p, pointer_ziel)
+! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_9]], %[[VAL_10]]) : (!fir.box<none>, !fir.box<none>) -> i1
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_allocatable_target(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {fir.bindc_name = "allocatable_ziel", fir.target}) {
+subroutine test_allocatable_target(p, allocatable_ziel)
+  real, pointer :: p(:)
+  real, allocatable, target :: allocatable_ziel(:)
+! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_8:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.box<none>
+! CHECK:  fir.call @_FortranAPointerIsAssociatedWith(%[[VAL_9]], %[[VAL_10]]) : (!fir.box<none>, !fir.box<none>) -> i1
+  print *, associated(p, allocatable_ziel)
+end subroutine


### PR DESCRIPTION
Handle OPTIONAL target in ASSOCIATED TARGET actual arguments that
are absent OPTIONAL dummy arguments must be considered as being
absent in TARGET. However, contrary to other intrinsic optional arguments,
TARGETs that are disassociated POINTERs or unallocated ALLOCATABLE
must not be considered as being absent (ASSOCIATED must return false in
that case, which the runtime deals with).

Cherry picks related runtime change https://reviews.llvm.org/D120835
 