### PR TITLE
Handle dynamically optional DIM in SIZE intrinsic call

### DIFF
--- a/flang/test/Lower/intrinsic-procedures/size.f90
+++ b/flang/test/Lower/intrinsic-procedures/size.f90
@@ -27,13 +27,72 @@ subroutine size_test()
 ! CHECK:         %[[VAL_9:.*]] = fir.shape_shift %[[VAL_c1]], %[[VAL_c10]], %[[VAL_cneg10]], %[[VAL_c21]] : (index, index, index, index) -> !fir.shapeshift<2>
 ! CHECK:         %[[VAL_10:.*]] = fir.slice %[[VAL_3]], %[[VAL_5]], %[[VAL_4]], %[[VAL_6]], %[[VAL_8]], %[[VAL_7]] : (index, index, index, index, index, index) -> !fir.slice<2>
 ! CHECK:         %[[VAL_11:.*]] = fir.embox %[[VAL_0]](%[[VAL_9]]) [%[[VAL_10]]] : (!fir.ref<!fir.array<10x21xf32>>, !fir.shapeshift<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
-! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-! CHECK:         %[[VAL_13:.*]] = fir.address_of({{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
-! CHECK:         %[[VAL_c38_i32:.*]] = arith.constant 38 : i32
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
-! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_16:.*]] = fir.call @_FortranASizeDim(%[[VAL_14]], %[[VAL_12]], %[[VAL_15]], %[[VAL_c38_i32]]) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
-! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i64) -> i32
-! CHECK:         fir.store %[[VAL_17]] to %[[VAL_2]] : !fir.ref<i32>
+! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> i64
+! CHECK:         %[[c0_i64:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_13:.*]] = arith.cmpi eq, %[[VAL_12]], %[[c0_i64]] : i64
+! CHECK:         %[[VAL_14:.*]] = fir.if %[[VAL_13]] -> (i64) {
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_19:.*]] = fir.call @_FortranASize(%[[VAL_17]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_19]] : i64
+! CHECK:         } else {
+! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_11]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_20:.*]] = fir.call @_FortranASizeDim(%[[VAL_18]], %[[VAL_16]], %{{.*}}, %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_20]] : i64
+! CHECK:         }
+! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_14]] : (i64) -> i32
+! CHECK:         fir.store %[[VAL_21]] to %[[VAL_2]] : !fir.ref<i32>
   iSize = size(a(2:5, -1:1), dim, 8)
 end subroutine size_test
+
+! CHECK-LABEL: func @_QPsize_optional_dim_1(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>> {fir.bindc_name = "array"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<i32> {fir.bindc_name = "dim", fir.optional},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64> {fir.bindc_name = "isize"}) {
+subroutine size_optional_dim_1(array, dim, iSize)
+  real, dimension(:,:) :: array
+  integer, optional :: dim
+  integer(8) :: iSize
+  iSize = size(array, dim, 8)
+! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<i32>) -> i64
+! CHECK:         %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_5:.*]] = arith.cmpi eq, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:         %[[VAL_6:.*]] = fir.if %[[VAL_5]] -> (i64) {
+! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_11:.*]] = fir.call @_FortranASize(%[[VAL_9]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_11]] : i64
+! CHECK:         } else {
+! CHECK:           %[[VAL_12:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_17:.*]] = fir.call @_FortranASizeDim(%[[VAL_15]], %[[VAL_12]], %{{.*}}, %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_17]] : i64
+! CHECK:         }
+! CHECK:         fir.store %[[VAL_6]] to %[[VAL_2]] : !fir.ref<i64>
+end subroutine
+
+! CHECK-LABEL: func @_QPsize_optional_dim_2(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.box<!fir.array<?x?xf32>> {fir.bindc_name = "array"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "dim"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<i64> {fir.bindc_name = "isize"}) {
+subroutine size_optional_dim_2(array, dim, iSize)
+  real, dimension(:,:) :: array
+  integer, pointer :: dim
+  integer(8) :: iSize
+  iSize = size(array, dim, 8)
+! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK:         %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.ptr<i32>) -> i64
+! CHECK:         %[[VAL_6:.*]] = arith.constant 0 : i64
+! CHECK:         %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_6]] : i64
+! CHECK:         %[[VAL_8:.*]] = fir.if %[[VAL_7]] -> (i64) {
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_13:.*]] = fir.call @_FortranASize(%[[VAL_11]], %{{.*}}, %{{.*}}) : (!fir.box<none>, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_13]] : i64
+! CHECK:         } else {
+! CHECK:           %[[VAL_14:.*]] = fir.load %[[VAL_4]] : !fir.ptr<i32>
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_19:.*]] = fir.call @_FortranASizeDim(%[[VAL_17]], %[[VAL_14]], %{{.*}}, %{{.*}}) : (!fir.box<none>, i32, !fir.ref<i8>, i32) -> i64
+! CHECK:           fir.result %[[VAL_19]] : i64
+! CHECK:         }
+! CHECK:         fir.store %[[VAL_8]] to %[[VAL_2]] : !fir.ref<i64>
+end subroutine


### PR DESCRIPTION
Add support for dynamically optional DIM argument in SIZE.
This is done by lowering DIM to an address and dispatching to the
right runtime if DIM is absent.

This was eventually preferred to the alternative where the runtime
would have been modified to handle dynamically optional argument because
absent DIM cannot be encoded into zero without preventing possibility
for the runtime to check that 1<= DIM <=n when DIM is actually present,
and it is cumbersome to pass DIM by address since it can have any
integer kind.

Note that the if/then/else dispatching between the two runtime calls
is generated for all cases (see updated test), even when the argument is
not optional, but LLVM is good at getting rid of the branch for trivial cases.
For instance, `clang -O1` outputs of the LLVM IR generated for:

```
subroutine foo(array, iSize)
  integer :: dim
  integer(8) :: iSize
  real :: array(:, :)
  dim = 1
  iSize = size(array, dim, 8)
end subroutine

```

simply becomes (Clang -01 targeting X86-64):

```
    push    rbx
    .cfi_def_cfa_offset 16
    .cfi_offset rbx, -16
    mov     rbx, rsi
    mov     rdx, qword ptr [rip + _QQcl.2E2F746573742E66393000@GOTPCREL]
    mov     esi, 1
    mov     ecx, 6
    call    _FortranASizeDim@PLT
    mov     qword ptr [rbx], rax
    pop     rbx
    .cfi_def_cfa_offset 8
    ret
```