### PR TITLE
[lowering] Ensure lowering does not assume the fir.logical implementation

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -763,8 +763,10 @@ struct ConvertOpConversion : public FIROpConversion<fir::ConvertOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::ConvertOp convert, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto fromTy = convertType(convert.getValue().getType());
-    auto toTy = convertType(convert.getRes().getType());
+    auto fromFirTy = convert.getValue().getType();
+    auto toFirTy = convert.getRes().getType();
+    auto fromTy = convertType(fromFirTy);
+    auto toTy = convertType(toFirTy);
     mlir::Value op0 = adaptor.getOperands()[0];
     if (fromTy == toTy) {
       rewriter.replaceOp(convert, op0);
@@ -786,8 +788,7 @@ struct ConvertOpConversion : public FIROpConversion<fir::ConvertOp> {
       return rewriter.create<mlir::LLVM::FPExtOp>(loc, toTy, val);
     };
     // Complex to complex conversion.
-    if (fir::isa_complex(convert.getValue().getType()) &&
-        fir::isa_complex(convert.getRes().getType())) {
+    if (fir::isa_complex(fromFirTy) && fir::isa_complex(toFirTy)) {
       // Special case: handle the conversion of a complex such that both the
       // real and imaginary parts are converted together.
       auto zero = mlir::ArrayAttr::get(convert.getContext(),
@@ -809,6 +810,22 @@ struct ConvertOpConversion : public FIROpConversion<fir::ConvertOp> {
                                                              ic, one);
       return mlir::success();
     }
+
+    // Follow UNIX F77 convention for logicals:
+    // 1. underlying integer is not zero => logical is .TRUE.
+    // 2. logical is .TRUE. => set underlying integer to 1.
+    auto i1Type = mlir::IntegerType::get(convert.getContext(), 1);
+    if (fromFirTy.isa<fir::LogicalType>() && toFirTy == i1Type) {
+      mlir::Value zero = genConstantIndex(loc, fromTy, rewriter, 0);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::ICmpOp>(
+          convert, mlir::LLVM::ICmpPredicate::ne, op0, zero);
+      return mlir::success();
+    }
+    if (fromFirTy == i1Type && toFirTy.isa<fir::LogicalType>()) {
+      rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(convert, toTy, op0);
+      return mlir::success();
+    }
+
     // Floating point to floating point conversion.
     if (isFloatingPointTy(fromTy)) {
       if (isFloatingPointTy(toTy)) {
@@ -1868,10 +1885,10 @@ struct EmboxProcOpConversion : public FIROpConversion<fir::EmboxProcOp> {
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
     auto un = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, un,
-                                                        adaptor.getOperands()[0], c0);
-    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(emboxproc, ty, r,
-                                                           adaptor.getOperands()[1], c1);
+    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(
+        loc, ty, un, adaptor.getOperands()[0], c0);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(
+        emboxproc, ty, r, adaptor.getOperands()[1], c1);
     return success();
   }
 };

--- a/flang/test/Fir/constant.fir
+++ b/flang/test/Fir/constant.fir
@@ -20,7 +20,6 @@ func @y() -> !fir.real<10> {
 func @z() -> !fir.logical<2> {
   %1 = arith.constant true
   %0 = fir.convert %1 : (i1) -> !fir.logical<2>
- // CHECK-LABEL: ret i16 -1
- // TODO: Why is it -1?
+ // CHECK-LABEL: ret i16 1
   return %0 : !fir.logical<2>
 }

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -658,7 +658,8 @@ func @select_case_logical(%arg0: !fir.ref<!fir.logical<4>>) {
 // CHECK-LABEL: llvm.func @select_case_logical(
 // CHECK-SAME:                                 %[[ARG0:.*]]: !llvm.ptr<i32>
 // CHECK:         %[[LOAD_ARG0:.*]] = llvm.load %[[ARG0]] : !llvm.ptr<i32>
-// CHECK:         %[[SELECT_VALUE:.*]] = llvm.trunc %[[LOAD_ARG0]] : i32 to i1
+// CHECK:         %[[CST_ZERO:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:         %[[SELECT_VALUE:.*]] = llvm.icmp "ne" %[[LOAD_ARG0]], %[[CST_ZERO]] : i32
 // CHECK:         %[[CST_FALSE:.*]] = llvm.mlir.constant(false) : i1
 // CHECK:         %[[CST_TRUE:.*]] = llvm.mlir.constant(true) : i1
 // CHECK:         %[[CMPEQ:.*]] = llvm.icmp "eq" %[[SELECT_VALUE]], %[[CST_FALSE]] : i1

--- a/flang/test/Fir/global-initialization.fir
+++ b/flang/test/Fir/global-initialization.fir
@@ -39,7 +39,7 @@ fir.global internal @_QEmasklogical : !fir.array<32768x!fir.logical<4>> {
 // CHECK: llvm.mlir.global internal @_QEmasklogical() : !llvm.array<32768 x i32> {
 // CHECK:   [[VAL0:%.*]] = llvm.mlir.constant(true) : i1
 // CHECK:   [[VAL1:%.*]] = llvm.mlir.undef : !llvm.array<32768 x i32>
-// CHECK:   [[VAL2:%.*]] = llvm.sext [[VAL0]] : i1 to i32
+// CHECK:   [[VAL2:%.*]] = llvm.zext [[VAL0]] : i1 to i32
 // CHECK:   [[VAL3:%.*]] = llvm.mlir.constant(dense<true> : vector<32768xi1>) : !llvm.array<32768 x i32>
 // CHECK:   llvm.return [[VAL3]] : !llvm.array<32768 x i32>
 // CHECK: }

--- a/flang/test/Lower/array-elemental-calls-char-byval.f90
+++ b/flang/test/Lower/array-elemental-calls-char-byval.f90
@@ -125,18 +125,18 @@ subroutine foo4(i, j)
 ! CHECK-DAG:   %[[VAL_69:.*]] = arith.constant 10 : index
 ! CHECK-DAG:   %[[VAL_70:.*]] = arith.constant 0 : index
 ! CHECK-DAG:   %[[VAL_71:.*]] = arith.constant 1 : index
+! CHECK:   %[[VAL_66:.*]] = fir.alloca !fir.char<1> {adapt.valuebyref}
 ! CHECK:   %[[VAL_72:.*]] = fir.shape %[[VAL_69]] : (index) -> !fir.shape<1>
 ! CHECK:   %[[VAL_73:.*]] = fir.coordinate_of %[[VAL_74]], %[[VAL_67]] : (!fir.ref<!fir.array<10xi32>>, i64) -> !fir.ref<i32>
 ! CHECK:   %[[VAL_75:.*]] = fir.load %[[VAL_73]] : !fir.ref<i32>
 ! CHECK:   %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (i32) -> i8
 ! CHECK:   %[[VAL_77:.*]] = fir.undefined !fir.char<1>
 ! CHECK:   %[[VAL_78:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_76]], [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
-! CHECK:   %[[VAL_79:.*]] = fir.alloca !fir.char<1>
-! CHECK:   fir.store %[[VAL_78]] to %[[VAL_79]] : !fir.ref<!fir.char<1>>
+! CHECK:   fir.store %[[VAL_78]] to %[[VAL_66]] : !fir.ref<!fir.char<1>>
 ! CHECK:   %[[VAL_80:.*]] = fir.alloca !fir.char<1> {bindc_name = ".chrtmp"}
 ! CHECK:   %[[VAL_81:.*]] = fir.convert %[[VAL_71]] : (index) -> i64
 ! CHECK:   %[[VAL_82:.*]] = fir.convert %[[VAL_80]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
-! CHECK:   %[[VAL_83:.*]] = fir.convert %[[VAL_79]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
+! CHECK:   %[[VAL_83:.*]] = fir.convert %[[VAL_66]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
 ! CHECK:   fir.call @llvm.memmove.p0i8.p0i8.i64(%[[VAL_82]], %[[VAL_83]], %[[VAL_81]], %[[VAL_68]]) : (!fir.ref<i8>, !fir.ref<i8>, i64, i1) -> ()
 ! CHECK:   br ^bb1(%[[VAL_70]], %[[VAL_69]] : index, index)
 ! CHECK: ^bb1(%[[VAL_84:.*]]: index, %[[VAL_85:.*]]: index):

--- a/flang/test/Lower/call.f90
+++ b/flang/test/Lower/call.f90
@@ -12,8 +12,8 @@ subroutine test_nested_calls()
     integer function bar()
     end function
   end interface
+  ! CHECK: %[[result_storage:.*]] = fir.alloca i32 {adapt.valuebyref}
   ! CHECK: %[[result:.*]] = fir.call @_QPbar() : () -> i32
-  ! CHECK: %[[result_storage:.*]] = fir.alloca i32
   ! CHECK: fir.store %[[result]] to %[[result_storage]] : !fir.ref<i32>
   ! CHECK: fir.call @_QPfoo(%[[result_storage]]) : (!fir.ref<i32>) -> ()
   call foo(bar())

--- a/flang/test/Lower/intrinsic-procedures/count.f90
+++ b/flang/test/Lower/intrinsic-procedures/count.f90
@@ -39,7 +39,7 @@ subroutine test_count3(rslt, mask)
 ! CHECK-DAG:  %[[a1:.*]] = fir.convert %[[arg1]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
 ! CHECK:  %[[a3:.*]] = fir.convert %[[c0]] : (index) -> i32
   call bar(count(mask, kind=2))
-! CHECK:  %[[a4:.*]] = fir.call @_FortranACount(%[[a1]], %{{.*}}, %{{.*}}, %3) : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64
+! CHECK:  %[[a4:.*]] = fir.call @_FortranACount(%[[a1]], %{{.*}}, %{{.*}}, %[[a3]]) : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64
 ! CHECK:  %{{.*}} = fir.convert %[[a4]] : (i64) -> i16
 end subroutine
 

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -26,9 +26,9 @@ end function
 real(4) function test_stmt_only_eval_arg_once()
   real(4) :: only_once, x1
   func(x1) = x1 + x1
+  ! CHECK: %[[x2:.*]] = fir.alloca f32 {adapt.valuebyref}
   ! CHECK: %[[x1:.*]] = fir.call @_QPonly_once()
   ! Note: using -emit-fir, so the faked pass-by-reference is exposed
-  ! CHECK: %[[x2:.*]] = fir.alloca f32
   ! CHECK: fir.store %[[x1]] to %[[x2]]
   ! CHECK: addf %{{.*}}, %{{.*}}
   test_stmt_only_eval_arg_once = func(only_once())


### PR DESCRIPTION
Codegen part of the change is cherry-picked here but is up for review in https://reviews.llvm.org/D121200. The lowering part is in the second commit.

The fir.logical implementation should only be defined by the LLVM
implementation of fir.convert between `i1` and `fir.logical`.

Two spots in lowering currently only happened to work because the test for truth
was implemented to be "lowest bit is one" only in codegen.
This broke with the codegen change. This patch makes lowering independent of
the actual fir.logical implementation.

The first issue was the interface with the runtime where fir.ref<fir.logical> are
passed as `&bool` to the runtime in order to be set.
Since the `&bool` only refers to the lowest bits part of the logical
storage, the upper bits remains umodified/undefined by the runtime.
This is not an issue if the implementation for truth only tests the
lowest bit, but it leads to undefined behaviors/errors if the
implementation tests all the bits and some upper bit happened
to have been `1` before the runtime call (a value set to `.false.` by the
runtime could be read as `.true.` by inlined code).

To solve this first issue, interpret the `&bool` as a `fir.ref<i1>` right
after the runtime call and use a `fir.convert i1 -> fir.logical` before
storing the value into the logical to ensure the resulting `fir.logical`
respects the logical implementation, whatever that is.

The second issue was that `foo(intrinsics_returns_logical())` was storing the
value result of `intrinsics_returns_logical()` into a `fir.ref<i1>` instead
of a `fir.ref<fir.logical>`. To solve the issue, use the actual expression type
of `FunctionRef<T>` to store the intermediate result. Also add the
`adapt.byvalref` attribute to this case.