### PR TITLE
Add TODO for assumed shape arrays with VALUE attribute

### DIFF
--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -836,6 +836,8 @@ private:
       addPassedArg(PassEntityBy::MutableBox, entity, characteristics);
     } else if (dummyRequiresBox(obj)) {
       // Pass as fir.box
+      if (isValueAttr)
+        TODO(loc, "assumed shape dummy argument with VALUE attribute");
       addFirOperand(boxType, nextPassedArgPosition(), Property::Box, attrs);
       addPassedArg(PassEntityBy::Box, entity, characteristics);
     } else if (dynamicType.category() ==


### PR DESCRIPTION
Currently, the VALUE attribute was simply ignored for assumed shapes.
This caused programs like the following to compile without making a copy
of actual arguments that are variables:

```
  interface
    subroutine foo(x)
      integer, value :: x(:)
    end subroutine
  end interface
  integer :: x(100)
  call foo(x)
end
```

Since gfortran and nvfortran do not support assumed shape with VALUE
attribute yet, simply add a TODO for now to prioritize more important
bugs.