### PR TITLE
Support passing vector subscripted arrays to assumed shape dummies

### DIFF
--- a/flang/include/flang/Lower/ConvertExpr.h
+++ b/flang/include/flang/Lower/ConvertExpr.h
@@ -85,6 +85,16 @@ fir::MutableBoxValue createMutableBox(mlir::Location loc,
                                       AbstractConverter &converter,
                                       const SomeExpr &expr, SymMap &symMap);
 
+/// Create a fir::BoxValue describing the value of \p expr.
+/// If \p expr is a variable without vector subscripts, the fir::BoxValue
+/// described the variable storage. Otherwise, the created fir::BoxValue
+/// describes a temporary storage containing \p expr evaluation, and clean-up
+/// for the temporary is added to the provided StatementContext \p stmtCtx.
+fir::ExtendedValue createBoxValue(mlir::Location loc,
+                                  AbstractConverter &converter,
+                                  const SomeExpr &expr, SymMap &symMap,
+                                  StatementContext &stmtCtx);
+
 /// Lower an array assignment expression.
 ///
 /// 1. Evaluate the lhs to determine the rank and how to form the ArrayLoad

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -308,12 +308,8 @@ public:
   fir::ExtendedValue genExprBox(const Fortran::lower::SomeExpr &expr,
                                 Fortran::lower::StatementContext &context,
                                 mlir::Location loc) override final {
-    if (expr.Rank() > 0 && Fortran::evaluate::IsVariable(expr) &&
-        !Fortran::evaluate::HasVectorSubscript(expr))
-      return Fortran::lower::createSomeArrayBox(*this, expr, localSymbols,
-                                                context);
-    return fir::BoxValue(
-        builder->createBox(loc, genExprAddr(expr, context, &loc)));
+    return Fortran::lower::createBoxValue(loc, *this, expr, localSymbols,
+                                          context);
   }
 
   Fortran::evaluate::FoldingContext &getFoldingContext() override final {

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2942,14 +2942,8 @@ public:
     // Designator is being passed as an argument to a procedure. Lower the
     // expression to a boxed value.
     auto someExpr = toEvExpr(x);
-    if (Fortran::evaluate::HasVectorSubscript(someExpr)) {
-      TODO(getLoc(), "boxing an expression with a vector subscript");
-      // Need to create a temporary, box the temporary, and add a cleanup of the
-      // temporary here.
-      return {};
-    }
-    return Fortran::lower::createSomeArrayBox(converter, someExpr, symMap,
-                                              stmtCtx);
+    return Fortran::lower::createBoxValue(getLoc(), converter, someExpr, symMap,
+                                          stmtCtx);
   }
   template <typename A, typename B>
   ExtValue asArrayArg(const A &, const B &x) {
@@ -6912,6 +6906,18 @@ fir::MutableBoxValue Fortran::lower::createMutableBox(
   Fortran::lower::StatementContext dummyStmtCtx;
   return ScalarExprLowering{loc, converter, symMap, dummyStmtCtx}
       .genMutableBoxValue(expr);
+}
+
+fir::ExtendedValue Fortran::lower::createBoxValue(
+    mlir::Location loc, Fortran::lower::AbstractConverter &converter,
+    const Fortran::lower::SomeExpr &expr, Fortran::lower::SymMap &symMap,
+    Fortran::lower::StatementContext &stmtCtx) {
+  if (expr.Rank() > 0 && Fortran::evaluate::IsVariable(expr) &&
+      !Fortran::evaluate::HasVectorSubscript(expr))
+    return Fortran::lower::createSomeArrayBox(converter, expr, symMap, stmtCtx);
+  fir::ExtendedValue addr = Fortran::lower::createSomeExtendedAddress(
+      loc, converter, expr, symMap, stmtCtx);
+  return fir::BoxValue(converter.getFirOpBuilder().createBox(loc, addr));
 }
 
 mlir::Value Fortran::lower::createSubroutineCall(


### PR DESCRIPTION
The current code was hitting a TODO when something like
`x(vector_subscript)` was passed to an assumed shape dummy.
Since this is an F95 feature and the implementation is easy
(just moving code around), do it.

Note that vector subscripted variables are not passed as variables
in non elemental calls. That is, there is no need to try copying out
the data from the temp.