### PR TITLE
Fix compile crash with function interface used from modules

### DIFF
--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -270,7 +270,7 @@ public:
   }
 
   /// Get the SubprogramDetails that defines the interface of this call if it is
-  /// known at the call site. Return nullpt if it is not known.
+  /// known at the call site. Return nullptr if it is not known.
   const Fortran::semantics::SubprogramDetails *getInterfaceDetails() const;
 
   bool isMainProgram() const { return false; }

--- a/flang/include/flang/Lower/CallInterface.h
+++ b/flang/include/flang/Lower/CallInterface.h
@@ -269,6 +269,10 @@ public:
     return procRef;
   }
 
+  /// Get the SubprogramDetails that defines the interface of this call if it is
+  /// known at the call site. Return nullpt if it is not known.
+  const Fortran::semantics::SubprogramDetails *getInterfaceDetails() const;
+
   bool isMainProgram() const { return false; }
 
   /// Returns true if this is a call to a procedure pointer of a dummy

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -239,11 +239,10 @@ void Fortran::lower::CallerInterface::walkResultExtents(
     ExprVisitor visitor) const {
   // Walk directly the result symbol shape (the characteristic shape may contain
   // descriptor inquiries to it that would fail to lower on the caller side).
-  const Fortran::semantics::Symbol *interfaceSymbol =
-      procRef.proc().GetInterfaceSymbol();
-  if (interfaceSymbol) {
-    const Fortran::semantics::Symbol &result =
-        interfaceSymbol->get<Fortran::semantics::SubprogramDetails>().result();
+  const Fortran::semantics::SubprogramDetails *interfaceDetails =
+      getInterfaceDetails();
+  if (interfaceDetails) {
+    const Fortran::semantics::Symbol &result = interfaceDetails->result();
     if (const auto *objectDetails =
             result.detailsIf<Fortran::semantics::ObjectEntityDetails>())
       if (objectDetails->shape().IsExplicitShape())
@@ -263,7 +262,7 @@ bool Fortran::lower::CallerInterface::mustMapInterfaceSymbols() const {
   const std::optional<Fortran::evaluate::characteristics::FunctionResult>
       &result = characteristic->functionResult;
   if (!result || result->CanBeReturnedViaImplicitInterface() ||
-      !procRef.proc().GetInterfaceSymbol())
+      !getInterfaceDetails())
     return false;
   bool allResultSpecExprConstant = true;
   auto visitor = [&](const Fortran::lower::SomeExpr &e) {
@@ -277,12 +276,13 @@ bool Fortran::lower::CallerInterface::mustMapInterfaceSymbols() const {
 mlir::Value Fortran::lower::CallerInterface::getArgumentValue(
     const semantics::Symbol &sym) const {
   mlir::Location loc = converter.getCurrentLocation();
-  const Fortran::semantics::Symbol *iface = procRef.proc().GetInterfaceSymbol();
-  if (!iface)
+  const Fortran::semantics::SubprogramDetails *ifaceDetails =
+      getInterfaceDetails();
+  if (!ifaceDetails)
     fir::emitFatalError(
         loc, "mapping actual and dummy arguments requires an interface");
   const std::vector<Fortran::semantics::Symbol *> &dummies =
-      iface->get<semantics::SubprogramDetails>().dummyArgs();
+      ifaceDetails->dummyArgs();
   auto it = std::find(dummies.begin(), dummies.end(), &sym);
   if (it == dummies.end())
     fir::emitFatalError(loc, "symbol is not a dummy in this call");
@@ -300,11 +300,21 @@ mlir::Type Fortran::lower::CallerInterface::getResultStorageType() const {
 const Fortran::semantics::Symbol &
 Fortran::lower::CallerInterface::getResultSymbol() const {
   mlir::Location loc = converter.getCurrentLocation();
-  const Fortran::semantics::Symbol *iface = procRef.proc().GetInterfaceSymbol();
-  if (!iface)
+  const Fortran::semantics::SubprogramDetails *ifaceDetails =
+      getInterfaceDetails();
+  if (!ifaceDetails)
     fir::emitFatalError(
         loc, "mapping actual and dummy arguments requires an interface");
-  return iface->get<semantics::SubprogramDetails>().result();
+  return ifaceDetails->result();
+}
+
+const Fortran::semantics::SubprogramDetails *
+Fortran::lower::CallerInterface::getInterfaceDetails() const {
+  if (const Fortran::semantics::Symbol *iface =
+          procRef.proc().GetInterfaceSymbol())
+    return iface->GetUltimate()
+        .detailsIf<Fortran::semantics::SubprogramDetails>();
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/test/Lower/explicit-interface-results-2.f90
+++ b/flang/test/Lower/explicit-interface-results-2.f90
@@ -214,3 +214,31 @@ contains
     real :: return_array(n_common)
   end function
 end subroutine
+
+
+! Test call to a function returning an array where the interface is use
+! associated from a module.
+module define_interface
+contains
+function foo()
+  real :: foo(100)
+  foo = 42
+end function
+end module
+! CHECK-LABEL: func @_QPtest_call_to_used_interface(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.boxproc<() -> ()>) {
+subroutine test_call_to_used_interface(dummy_proc)
+  use define_interface
+  procedure(foo) :: dummy_proc
+  call takes_array(dummy_proc())
+! CHECK:  %[[VAL_1:.*]] = arith.constant 100 : index
+! CHECK:  %[[VAL_2:.*]] = fir.alloca !fir.array<100xf32> {bindc_name = ".result"}
+! CHECK:  %[[VAL_3:.*]] = fir.call @llvm.stacksave() : () -> !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
+! CHECK:  %[[VAL_5:.*]] = fir.box_addr %[[VAL_0]] : (!fir.boxproc<() -> ()>) -> (() -> !fir.array<100xf32>)
+! CHECK:  %[[VAL_6:.*]] = fir.call %[[VAL_5]]() : () -> !fir.array<100xf32>
+! CHECK:  fir.save_result %[[VAL_6]] to %[[VAL_2]](%[[VAL_4]]) : !fir.array<100xf32>, !fir.ref<!fir.array<100xf32>>, !fir.shape<1>
+! CHECK:  %[[VAL_7:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.array<100xf32>>) -> !fir.ref<!fir.array<?xf32>>
+! CHECK:  fir.call @_QPtakes_array(%[[VAL_7]]) : (!fir.ref<!fir.array<?xf32>>) -> ()
+! CHECK:  fir.call @llvm.stackrestore(%[[VAL_3]]) : (!fir.ref<i8>) -> ()
+end subroutine


### PR DESCRIPTION
The interfaceSymbol of an `evaluate::ProcedureDesignator` may be use
or host associated, therefore, it is wrong to directly assume it will
have SubprogramDetails like the previous code was doing in call interface
lowering. `GetUltimate()` must be called first. Add a `getInterfaceDetails`
helper to avoid making fatal assumptions and centralized the code accessing
the `SubprogramDetails` when lowering a caller interface.