### PR TITLE
Change the symbol map to map ultimate symbols rather than whatever

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -76,11 +76,9 @@ public:
   /// Copy the binding of src to target symbol.
   virtual void copySymbolBinding(SymbolRef src, SymbolRef target) = 0;
 
-  /// Binds the symbol to an fir extended value and returns true if the symbol
-  /// has no existing binding. If there is an existing binding this function
-  /// does nothing and returns false.
-  virtual bool bindSymbol(const SymbolRef sym,
-                          const fir::ExtendedValue &exval) = 0;
+  /// Binds the symbol to an fir extended value. The symbol binding will be
+  /// added or replaced at the inner-most level of the local symbol map.
+  virtual void bindSymbol(SymbolRef sym, const fir::ExtendedValue &exval) = 0;
 
   /// Get the label set associated with a symbol.
   virtual bool lookupLabelSet(SymbolRef sym, pft::LabelSet &labelSet) = 0;

--- a/flang/include/flang/Lower/SymbolMap.h
+++ b/flang/include/flang/Lower/SymbolMap.h
@@ -295,6 +295,13 @@ public:
     return lookupSymbol(*sym);
   }
 
+  /// Find `symbol` and return its value if it appears in the inner-most level
+  /// map.
+  SymbolBox shallowLookupSymbol(semantics::SymbolRef sym);
+  SymbolBox shallowLookupSymbol(const semantics::Symbol *sym) {
+    return shallowLookupSymbol(*sym);
+  }
+
   /// Add a new binding from the ac-do-variable `var` to `value`.
   void pushImpliedDoBinding(AcDoVar var, mlir::Value value) {
     impliedDoStack.emplace_back(var, value);
@@ -326,12 +333,13 @@ public:
 
 private:
   /// Add `symbol` to the current map and bind a `box`.
-  void makeSym(semantics::SymbolRef sym, const SymbolBox &box,
+  void makeSym(semantics::SymbolRef symRef, const SymbolBox &box,
                bool force = false) {
+    const auto *sym = &symRef.get().GetUltimate();
     if (force)
-      symbolMapStack.back().erase(&*sym);
+      symbolMapStack.back().erase(sym);
     assert(box && "cannot add an undefined symbol box");
-    symbolMapStack.back().try_emplace(&*sym, box);
+    symbolMapStack.back().try_emplace(sym, box);
   }
 
   llvm::SmallVector<llvm::DenseMap<const semantics::Symbol *, SymbolBox>>

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -32,13 +32,23 @@ void Fortran::lower::SymMap::addSymbol(Fortran::semantics::SymbolRef sym,
 }
 
 Fortran::lower::SymbolBox
-Fortran::lower::SymMap::lookupSymbol(Fortran::semantics::SymbolRef sym) {
+Fortran::lower::SymMap::lookupSymbol(Fortran::semantics::SymbolRef symRef) {
+  Fortran::semantics::SymbolRef sym = symRef.get().GetUltimate();
   for (auto jmap = symbolMapStack.rbegin(), jend = symbolMapStack.rend();
        jmap != jend; ++jmap) {
     auto iter = jmap->find(&*sym);
     if (iter != jmap->end())
       return iter->second;
   }
+  return SymbolBox::None{};
+}
+
+Fortran::lower::SymbolBox Fortran::lower::SymMap::shallowLookupSymbol(
+    Fortran::semantics::SymbolRef symRef) {
+  auto &map = symbolMapStack.back();
+  auto iter = map.find(&symRef.get().GetUltimate());
+  if (iter != map.end())
+    return iter->second;
   return SymbolBox::None{};
 }
 

--- a/flang/test/Lower/OpenMP/omp-parallel-private-clause-fixes.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-private-clause-fixes.f90
@@ -8,7 +8,7 @@
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFmultiple_private_fixEj"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFmultiple_private_fixEx"}
 ! CHECK:         omp.parallel {
-! CHECK:           %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "j", pinned}
+! CHECK:           %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "j", pinned
 ! CHECK:           %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFmultiple_private_fixEx"}
 ! CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_4:.*]] : !fir.ref<i32>

--- a/flang/test/Lower/OpenMP/omp-seqloop.f90
+++ b/flang/test/Lower/OpenMP/omp-seqloop.f90
@@ -9,7 +9,7 @@ program wsloop
 
 !FIRDialect:  omp.parallel {
         !$OMP PARALLEL
-!FIRDialect:    %[[PRIVATE_INDX:.*]] = fir.alloca i32 {bindc_name = "i", pinned}
+!FIRDialect:    %[[PRIVATE_INDX:.*]] = fir.alloca i32 {bindc_name = "i", pinned
 !FIRDialect:    %[[FINAL_INDX:.*]] = fir.do_loop %[[INDX:.*]] = {{.*}} {
         do i=1, 9
         print*, i
@@ -24,11 +24,11 @@ end
 
 !FIRDialect: func @_QPsub1() {
 subroutine sub1
-!FIRDialect:   {{.*}} = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub1Ei"}
+!FIRDialect:   = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub1Ei"}
   integer :: i
   integer :: arr(10)
 !FIRDialect:   omp.parallel {
-!FIRDialect:     {{.*}} = fir.alloca i32 {bindc_name = "i", pinned}
+!FIRDialect:     = fir.alloca i32 {bindc_name = "i", pinned
   !$OMP PARALLEL
   do i=1, 10
     arr(i) = i
@@ -40,11 +40,11 @@ end subroutine
 
 !FIRDialect: func @_QPsub2() {
 subroutine sub2
-!FIRDialect:   {{.*}} = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub2Ei"}
+!FIRDialect:   = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub2Ei"}
   integer :: i
   integer :: arr(10)
 !FIRDialect:   omp.parallel {
-!FIRDialect:     {{.*}} = fir.alloca i32 {bindc_name = "i", pinned}
+!FIRDialect:     = fir.alloca i32 {bindc_name = "i", pinned
   !$OMP PARALLEL
 !FIRDialect:     omp.master  {
   !$OMP MASTER
@@ -62,12 +62,12 @@ end subroutine
 
 !FIRDialect: func @_QPsub3() {
 subroutine sub3
-!FIRDialect:   {{.*}} = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub3Ei"}
-!FIRDialect:   {{.*}} = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFsub3Ej"}
+!FIRDialect:   = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFsub3Ei"}
+!FIRDialect:   = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFsub3Ej"}
   integer :: i,j
   integer :: arr(10)
 !FIRDialect:   omp.parallel {
-!FIRDialect:     {{.*}} = fir.alloca i32 {bindc_name = "i", pinned}
+!FIRDialect:     = fir.alloca i32 {bindc_name = "i", pinned
   !$OMP PARALLEL
   do i=1, 10
     arr(i) = i
@@ -75,7 +75,7 @@ subroutine sub3
 !FIRDialect:     omp.master  {
   !$OMP MASTER
 !FIRDialect:       omp.parallel {
-!FIRDialect:         {{.*}} = fir.alloca i32 {bindc_name = "j", pinned}
+!FIRDialect:         = fir.alloca i32 {bindc_name = "j", pinned
   !$OMP PARALLEL
   do j=1, 10
     arr(j) = j

--- a/flang/test/Lower/OpenMP/omp-unstructured.f90
+++ b/flang/test/Lower/OpenMP/omp-unstructured.f90
@@ -60,9 +60,9 @@ end
 
 ! CHECK-LABEL: func @_QPss3{{.*}} {
 ! CHECK:   omp.parallel {
-! CHECK:     %[[ALLOCA_K:.*]] = fir.alloca i32 {bindc_name = "k", pinned}
-! CHECK:     %[[ALLOCA_1:.*]] = fir.alloca i32 {{{.*}}, pinned}
-! CHECK:     %[[ALLOCA_2:.*]] = fir.alloca i32 {{{.*}}, pinned}
+! CHECK:     fir.alloca i32 {pinned}
+! CHECK-NEXT: %[[ALLOCA_1:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
+! CHECK-NEXT: %[[ALLOCA_2:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
 ! CHECK:     br ^bb1
 ! CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
 ! CHECK:     cond_br %{{[0-9]*}}, ^bb2, ^bb3
@@ -83,7 +83,7 @@ end
 ! CHECK:       cond_br %{{[0-9]*}}, ^bb4, ^bb3
 ! CHECK:     ^bb3:  // pred: ^bb2
 ! CHECK:       @_FortranAioBeginExternalListOutput
-! CHECK:       %[[LOAD_2:.*]] = fir.load %[[ALLOCA_K]] : !fir.ref<i32>
+! CHECK:       %[[LOAD_2:.*]] = fir.load %[[ALLOCA_2]] : !fir.ref<i32>
 ! CHECK:     @_FortranAioOutputInteger32(%{{.*}}, %[[LOAD_2]])
 ! CHECK:       br ^bb1
 ! CHECK:     ^bb4:  // 2 preds: ^bb1, ^bb2


### PR DESCRIPTION
symbol the client supplies.  Specifically, this changes how host and
use associated placeholder symbols are inserted and fetched from the
symbol table.

This should help eliminate the class of "symbol not found" assertions
such as when the front-end symbol has multiple identities for the same
variable.

The change mostly impacts OpenMP lowering, which deals with associated
symbols.