### PR TITLE
Fix bugs relating to support for characters of different kinds. Lowering

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1364,7 +1364,7 @@ public:
     auto consLit = [&]() -> fir::StringLitOp {
       mlir::MLIRContext *context = builder.getContext();
       std::int64_t size = static_cast<std::int64_t>(value.size());
-      mlir::ShapedType shape = mlir::VectorType::get(
+      mlir::ShapedType shape = mlir::RankedTensorType::get(
           llvm::ArrayRef<std::int64_t>{size},
           mlir::IntegerType::get(builder.getContext(), sizeof(ET) * 8));
       auto denseAttr = mlir::DenseElementsAttr::get(

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -343,19 +343,6 @@ createGlobalInitialization(fir::FirOpBuilder &builder, fir::GlobalOp global,
   builder.restoreInsertionPoint(insertPt);
 }
 
-template <int KIND>
-static mlir::DenseElementsAttr genWideCharLit(fir::FirOpBuilder &builder,
-                                              void *ptr, unsigned len) {
-  auto *ctx = builder.getContext();
-  llvm::ArrayRef<std::int64_t> lenVec = {len};
-  using ET = typename Fortran::evaluate::Scalar<Fortran::evaluate::Type<
-      Fortran::common::TypeCategory::Character, KIND>>::value_type;
-  auto ty = mlir::RankedTensorType::get(
-      lenVec, mlir::IntegerType::get(ctx, sizeof(ET) * 8));
-  return mlir::DenseElementsAttr::get(
-      ty, llvm::ArrayRef<ET>{static_cast<const ET *>(ptr), len});
-}
-
 /// Create the global op and its init if it has one
 static fir::GlobalOp defineGlobal(Fortran::lower::AbstractConverter &converter,
                                   const Fortran::lower::pft::Variable &var,

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -620,31 +620,36 @@ struct StringLitOpConversion : public FIROpConversion<fir::StringLitOp> {
     if (attr.isa<mlir::StringAttr>()) {
       rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(constop, ty, attr);
     } else {
-      // FIXME: As of llvm head 85bf221f204eafc1142a064f1650ffa9d9e03dad, using
-      // a dense elements attr causes llvm ir verification error:
-      //   %0 = llvm.mlir.constant(dense<[234, 456]> : vector<2xi16>) :
-      //   !llvm.array<2 x i16> creates a vector type constant instead of an
-      //   array, later conflicting with its usage. It is likely an MLIR bug
-      //   that should be investigated. In the meantime, do a dumb chain of
-      //   inserts.
-      auto arr = attr.cast<mlir::ArrayAttr>();
       auto charTy = constop.getType().cast<fir::CharacterType>();
       auto bits = lowerTy().characterBitsize(charTy);
       auto intTy = rewriter.getIntegerType(bits);
       auto loc = constop.getLoc();
-
       mlir::Value cst = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-      for (auto a : llvm::enumerate(arr.getValue())) {
-        // convert each character to a precise bitsize
-        auto elemAttr = mlir::IntegerAttr::get(
-            intTy,
-            a.value().cast<mlir::IntegerAttr>().getValue().sextOrTrunc(bits));
-        auto elemCst =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, intTy, elemAttr);
-        auto index = mlir::ArrayAttr::get(
-            constop.getContext(), rewriter.getI32IntegerAttr(a.index()));
-        cst = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, cst, elemCst,
-                                                         index);
+      if (auto arr = attr.dyn_cast<mlir::DenseElementsAttr>()) {
+        for (auto a : llvm::enumerate(arr.getValues<llvm::APInt>())) {
+          // convert each character to a precise bitsize
+          auto elemAttr =
+              mlir::IntegerAttr::get(intTy, a.value().zextOrTrunc(bits));
+          auto elemCst =
+              rewriter.create<mlir::LLVM::ConstantOp>(loc, intTy, elemAttr);
+          auto index = mlir::ArrayAttr::get(
+              constop.getContext(), rewriter.getI32IntegerAttr(a.index()));
+          cst = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, cst,
+                                                           elemCst, index);
+        }
+      } else if (auto arr = attr.dyn_cast<mlir::ArrayAttr>()) {
+        for (auto a : llvm::enumerate(arr.getValue())) {
+          // convert each character to a precise bitsize
+          auto elemAttr = mlir::IntegerAttr::get(
+              intTy,
+              a.value().cast<mlir::IntegerAttr>().getValue().zextOrTrunc(bits));
+          auto elemCst =
+              rewriter.create<mlir::LLVM::ConstantOp>(loc, intTy, elemAttr);
+          auto index = mlir::ArrayAttr::get(
+              constop.getContext(), rewriter.getI32IntegerAttr(a.index()));
+          cst = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, cst,
+                                                           elemCst, index);
+        }
       }
       rewriter.replaceOp(constop, cst);
     }
@@ -1181,14 +1186,14 @@ struct EmboxCommonConversion : public FIROpConversion<OP> {
               this->genConstantOffset(loc, rewriter, typeCode)};
     };
     auto doCharacter =
-        [&](unsigned width,
+        [&](unsigned bitWidth,
             mlir::Value len) -> std::tuple<mlir::Value, mlir::Value> {
-      auto typeCode = fir::characterBitsToTypeCode(width);
+      auto typeCode = fir::characterBitsToTypeCode(bitWidth);
       auto typeCodeVal = this->genConstantOffset(loc, rewriter, typeCode);
-      if (width == 8)
+      if (bitWidth == 8)
         return {len, typeCodeVal};
-      auto byteWidth = this->genConstantOffset(loc, rewriter, width / 8);
       auto i64Ty = mlir::IntegerType::get(&this->lowerTy().getContext(), 64);
+      auto byteWidth = genConstantIndex(loc, i64Ty, rewriter, bitWidth / 8);
       auto size =
           rewriter.create<mlir::LLVM::MulOp>(loc, i64Ty, byteWidth, len);
       return {size, typeCodeVal};
@@ -1868,10 +1873,10 @@ struct EmboxProcOpConversion : public FIROpConversion<fir::EmboxProcOp> {
     auto c0 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(0));
     auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
     auto un = rewriter.create<mlir::LLVM::UndefOp>(loc, ty);
-    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(loc, ty, un,
-                                                        adaptor.getOperands()[0], c0);
-    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(emboxproc, ty, r,
-                                                           adaptor.getOperands()[1], c1);
+    auto r = rewriter.create<mlir::LLVM::InsertValueOp>(
+        loc, ty, un, adaptor.getOperands()[0], c0);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(
+        emboxproc, ty, r, adaptor.getOperands()[1], c1);
     return success();
   }
 };
@@ -2588,17 +2593,17 @@ struct GlobalOpConversion : public FIROpConversion<fir::GlobalOp> {
   mlir::LogicalResult
   matchAndRewrite(fir::GlobalOp global, OperandTy operands,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto tyAttr = convertType(global.getType());
+    auto objTy = convertType(global.getType());
     if (global.getType().isa<fir::BoxType>())
-      tyAttr = tyAttr.cast<mlir::LLVM::LLVMPointerType>().getElementType();
+      objTy = objTy.cast<mlir::LLVM::LLVMPointerType>().getElementType();
     auto loc = global.getLoc();
-    mlir::Attribute initAttr{};
+    mlir::Attribute initAttr;
     if (global.initVal())
       initAttr = global.initVal().getValue();
     auto linkage = convertLinkage(global.linkName());
     auto isConst = global.constant().hasValue();
-    auto g = rewriter.create<mlir::LLVM::GlobalOp>(
-        loc, tyAttr, isConst, linkage, global.sym_name(), initAttr);
+    auto g = rewriter.create<mlir::LLVM::GlobalOp>(loc, objTy, isConst, linkage,
+                                                   global.sym_name(), initAttr);
     auto &gr = g.getInitializerRegion();
     rewriter.inlineRegionBefore(global.region(), gr, gr.end());
     if (!gr.empty()) {

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -12,7 +12,7 @@
 
 // -----
 
-// expected-error@+1{{'fir.string_lit' op values in list must be integers}}
+// expected-error@+1{{'fir.string_lit' op values in initializer must be integers}}
 %2 = fir.string_lit [158, 2.0](2) : !fir.char<2>
 
 // -----

--- a/flang/test/Lower/array-wide-char.f90
+++ b/flang/test/Lower/array-wide-char.f90
@@ -1,0 +1,31 @@
+  ! RUN: bbc %s -o - | tco | FileCheck %s
+
+  character(LEN=128, KIND=4), PARAMETER :: conarr(3) = &
+       [ character(128,4) :: "now is the time", "for all good men to come", &
+       "to the aid of the country" ]       
+  character(LEN=10, KIND=4) :: arr(3) = &
+       [ character(10,4) :: "good buddy", "best buddy", " " ]
+  call action_on_char4(conarr)
+  call action_on_char4(arr)
+  end program
+
+  subroutine sub1
+    integer, parameter :: k = 4
+    character(63,k), parameter :: wiggle = k_"wiggle"
+    call sub2(wiggle)
+  end subroutine sub1
+
+! CHECK-LABEL: @_QFEarr = internal global [3 x [10 x i32]] [
+! CHECK-SAME: [10 x i32] [i32 103, i32 111, i32 111, i32 100, i32 32, i32 98, i32 117, i32 100, i32 100, i32 121],
+! CHECK-SAME: [10 x i32] [i32 98, i32 101, i32 115, i32 116, i32 32, i32 98, i32 117, i32 100, i32 100, i32 121],
+! CHECK-SAME: [10 x i32] [i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32]]
+! CHECK-LABEL: @_QFsub1ECwiggle = internal constant [63 x i32] [i32 119,
+! CHECK-SAME: i32 105, i32 103, i32 103, i32 108, i32 101, i32 32, i32 32,
+! CHECK: @_QQcl[[inline:.*]] = linkonce constant [63 x i32] [i32 119, i32 105, i32 103, i32 103, i32 108, i32 101, i32 32,
+
+! CHECK-LABEL: define void @_QQmain()
+! CHECK: call void @_QPaction_on_char4(i32* getelementptr inbounds ([3 x [10 x
+! CHECK-SAME: i32]], [3 x [10 x i32]]* @_QFEarr, i32 0, i32 0, i32 0), i64 10)
+
+! CHECK-LABEL: define void @_QPsub1(
+! CHECK: call void @_QPsub2(i32* getelementptr inbounds ([63 x i32], [63 x i32]* @_QQcl[[inline]], i32 0, i32 0), i64 63)

--- a/flang/test/Lower/derived-type-descriptor.f90
+++ b/flang/test/Lower/derived-type-descriptor.f90
@@ -10,10 +10,16 @@ subroutine foo()
   type(sometype), allocatable, save :: x(:)
 end subroutine
 
-! CHECK-DAG: fir.global internal @_QFfooE.n.num("num") constant : !fir.char<1,3>
-! CHECK-DAG: fir.global internal @_QFfooE.n.values("values") constant : !fir.char<1,6>
-! CHECK-DAG: fir.global internal @_QFfooE.di.sometype.num constant : i32
-! CHECK-DAG: fir.global internal @_QFfooE.n.sometype("sometype") constant : !fir.char<1,8>
+! CHECK-LABEL: fir.global internal @_QFfooE.n.num constant : !fir.char<1,3> {
+! CHECK: %[[res:.*]] = fir.string_lit "num"(3) : !fir.char<1,3>
+! CHECK: fir.has_value %[[res]] : !fir.char<1,3>
+! CHECK-LABEL: fir.global internal @_QFfooE.di.sometype.num constant : i32
+! CHECK-LABEL: fir.global internal @_QFfooE.n.values constant : !fir.char<1,6> {
+! CHECK: %[[res:.*]] = fir.string_lit "values"(6) : !fir.char<1,6>
+! CHECK: fir.has_value %[[res]] : !fir.char<1,6>
+! CHECK-LABEL: fir.global internal @_QFfooE.n.sometype constant : !fir.char<1,8> {
+! CHECK: %[[res:.*]] = fir.string_lit "sometype"(8) : !fir.char<1,8>
+! CHECK: fir.has_value %[[res]] : !fir.char<1,8>
 
 ! CHECK-LABEL: fir.global internal @_QFfooE.di.sometype.values constant : !fir.type<_QFfooT.dp.sometype.values{values:!fir.box<!fir.ptr<!fir.array<?x?xf32>>>}> {
   ! CHECK: fir.address_of(@_QFfooEinit_values)
@@ -39,7 +45,10 @@ subroutine char_comp_init()
   type(t) :: a
 end subroutine
 
-! CHECK-LABEL: fir.global internal @_QFchar_comp_initE.di.t.name("Empty   ") constant : !fir.char<1,8>
+! CHECK-LABEL: fir.global internal @_QFchar_comp_initE.di.t.name constant : !fir.char<1,8> {
+! CHECK: %[[res:.*]] = fir.string_lit "Empty   "(8) : !fir.char<1,8>
+! CHECK: fir.has_value %[[res]] : !fir.char<1,8>
+
 ! CHECK-LABEL: fir.global internal @_QFchar_comp_initE.c.t constant : {{.*}} {
   ! CHECK: fir.address_of(@_QFchar_comp_initE.di.t.name) : !fir.ref<!fir.char<1,8>>
 ! CHECK: }


### PR DESCRIPTION
was creating bad FIR and MLIR that crashed in conversion to LLVM IR.

Includes some clang-format diffs.  Add regression test.