### PR TITLE
Remove unused variable

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -303,7 +303,6 @@ private:
   void lowerAllocation(const Allocation &alloc) {
     fir::MutableBoxValue boxAddr =
         genMutableBoxValue(converter, loc, alloc.getAllocObj());
-    mlir::Value backupBox;
 
     if (sourceExpr) {
       genSourceAllocation(alloc, boxAddr);


### PR DESCRIPTION
This was triggering a buildbot failure upstream.