### PR TITLE
Fix linkage issue of uninitialized module equivalence

### DIFF
--- a/flang/test/Lower/equivalence-static-init.f90
+++ b/flang/test/Lower/equivalence-static-init.f90
@@ -2,6 +2,17 @@
 
 ! Test explicit static initialization of equivalence storage
 
+module module_without_init
+  real :: x(2)
+  integer :: i(2)
+  equivalence(i(1), x)
+end module
+! CHECK-LABEL: fir.global @_QMmodule_without_initEi : !fir.array<8xi8> {
+  ! CHECK: %0 = fir.undefined !fir.array<8xi8>
+  ! CHECK: fir.has_value %0 : !fir.array<8xi8>
+! CHECK}
+
+
 subroutine test_eqv_init
   integer, save :: link(3)
   integer :: i = 5


### PR DESCRIPTION
Code using module equivalence whose members have no initial values
was hitting ` undefined reference to _QMxxxEyyy` like errors.

When lowering a module file definition, an IR initial value must be created
for the defined globals with "external" linkage. Otherwise, the variables will be
expected to be defined in other compilation units, triggering linkage errors.

Add a `fir.undef` FIR initial value when defining the storage of an equivalence
without a Fortran initial value.