### PR TITLE
[sync] Fix lowering OpenMP/OpenACC declarative constructs

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1170,8 +1170,9 @@ public:
   void dumpModuleLikeUnit(llvm::raw_ostream &outputStream,
                           const lower::pft::ModuleLikeUnit &moduleLikeUnit) {
     outputStream << getNodeIndex(moduleLikeUnit) << " ";
-    outputStream << "ModuleLike: ";
-    outputStream << "\nContains\n";
+    outputStream << "ModuleLike:\n";
+    dumpEvaluationList(outputStream, moduleLikeUnit.evaluationList);
+    outputStream << "Contains\n";
     for (const lower::pft::FunctionLikeUnit &func :
          moduleLikeUnit.nestedFunctions)
       dumpFunctionLikeUnit(outputStream, func);

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -167,8 +167,6 @@ public:
       exitFunction();
     } else if constexpr (lower::pft::isConstruct<A> ||
                          lower::pft::isDirective<A>) {
-      if constexpr (lower::pft::isDeclConstruct<A>)
-        return;
       exitConstructOrDirective();
     }
   }
@@ -252,11 +250,6 @@ private:
     if (evaluationListStack.empty())
       return;
     auto evaluationList = evaluationListStack.back();
-    if (evaluationList->empty() &&
-        pftParentStack.back().getIf<lower::pft::ModuleLikeUnit>()) {
-      popEvaluationList();
-      return;
-    }
     if (evaluationList->empty() || !evaluationList->back().isEndStmt()) {
       const auto &endStmt =
           pftParentStack.back().get<lower::pft::FunctionLikeUnit>().endStmt;
@@ -286,10 +279,20 @@ private:
     lastLexicalEvaluation = nullptr;
   }
 
+  /// Pop the ModuleLikeUnit evaluationList when entering the first module
+  /// procedure.
+  void cleanModuleEvaluationList() {
+    if (evaluationListStack.empty())
+      return;
+    if (pftParentStack.back().isA<lower::pft::ModuleLikeUnit>())
+      popEvaluationList();
+  }
+
   /// Initialize a new function-like unit and make it the builder's focus.
   template <typename A>
   bool enterFunction(const A &func,
                      const semantics::SemanticsContext &semanticsContext) {
+    cleanModuleEvaluationList();
     endFunctionBody(); // enclosing host subprogram body, if any
     Fortran::lower::pft::FunctionLikeUnit &unit =
         addFunction(lower::pft::FunctionLikeUnit{func, pftParentStack.back(),
@@ -323,12 +326,6 @@ private:
     pushEvaluationList(eval.evaluationList.get());
     pftParentStack.emplace_back(eval);
     constructAndDirectiveStack.emplace_back(&eval);
-    if constexpr (lower::pft::isDeclConstruct<A>) {
-      popEvaluationList();
-      pftParentStack.pop_back();
-      constructAndDirectiveStack.pop_back();
-      popEvaluationList();
-    }
     return true;
   }
 

--- a/flang/test/Lower/pre-fir-tree06.f90
+++ b/flang/test/Lower/pre-fir-tree06.f90
@@ -1,0 +1,12 @@
+! RUN: %flang_fc1 -fdebug-pre-fir-tree -fopenmp %s | FileCheck %s
+
+! Test structure of the Pre-FIR tree with OpenMP declarative construct
+
+! CHECK: ModuleLike
+module m
+  real, dimension(10) :: x
+  ! CHECK-NEXT: OpenMPDeclarativeConstruct
+  !$omp threadprivate(x)
+end
+! CHECK: End ModuleLike
+

--- a/flang/test/Lower/pre-fir-tree06.f90
+++ b/flang/test/Lower/pre-fir-tree06.f90
@@ -10,3 +10,45 @@ module m
 end
 ! CHECK: End ModuleLike
 
+! CHECK: ModuleLike
+module m2
+  integer, save :: i
+  ! CHECK-NEXT: OpenMPDeclarativeConstruct
+  !$omp threadprivate(i)
+contains
+  subroutine sub()
+    i = 1;
+  end
+  subroutine sub2()
+    i = 2;
+  end
+end
+! CHECK: End ModuleLike
+
+! CHECK: Program main
+program main
+  real :: y
+  ! CHECK-NEXT: OpenMPDeclarativeConstruct
+  !$omp threadprivate(y)
+end
+! CHECK: End Program main
+
+! CHECK: Subroutine sub1
+subroutine sub1()
+  real, save :: p
+  ! CHECK-NEXT: OpenMPDeclarativeConstruct
+  !$omp threadprivate(p)
+end
+! CHECK: End Subroutine sub1
+
+! CHECK: Subroutine sub2
+subroutine sub2()
+  real, save :: q
+  ! CHECK-NEXT: OpenMPDeclarativeConstruct
+  !$omp threadprivate(q)
+contains
+  subroutine sub()
+  end
+end
+! CHECK: End Subroutine sub2
+

--- a/flang/test/Lower/pre-fir-tree07.f90
+++ b/flang/test/Lower/pre-fir-tree07.f90
@@ -1,0 +1,12 @@
+! RUN: %flang_fc1 -fdebug-pre-fir-tree -fopenacc %s | FileCheck %s
+
+! Test structure of the Pre-FIR tree with OpenACC declarative construct
+
+! CHECK: ModuleLike
+module m
+  real, dimension(10) :: x
+  ! CHECK-NEXT: OpenACCDeclarativeConstruct
+  !$acc declare create(x)
+end
+! CHECK: End ModuleLike
+


### PR DESCRIPTION
The previous design for lowering OpenMP/OpenACC declarative constructs in module is dirty. Refactor the code as follows:
```
EnterModule (push ModuleLikeUnit evalutionList)
  [Enter OpenMP/OpenACC decl constructs] (push declconstruct ... as other directives)
  [Exit OpenMP/OpenACC decl constructs] (pop declconstruct ... as other directives)
  [Enter module procedure] (pop ModuleLikeUnit evalutionList)
  [Exit module procedure]
ExitModule (pop ModuleLikeUnit evalutionList if there is no module procedure)
```