### PR TITLE
[Sync][flang][CodeGen] Transform `fir.boxchar_len` to a sequence of L…

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -423,6 +423,17 @@ struct AllocaOpConversion : public FIROpConversion<fir::AllocaOp> {
 };
 } // namespace
 
+/// Construct an `llvm.extractvalue` instruction. It will return value at
+/// element \p x from  \p tuple.
+static mlir::LLVM::ExtractValueOp
+genExtractValueWithIndex(mlir::Location loc, mlir::Value tuple, mlir::Type ty,
+                         mlir::ConversionPatternRewriter &rewriter,
+                         mlir::MLIRContext *ctx, int x) {
+  auto cx = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(x));
+  auto xty = ty.cast<mlir::LLVM::LLVMStructType>().getBody()[x];
+  return rewriter.create<mlir::LLVM::ExtractValueOp>(loc, xty, tuple, cx);
+}
+
 namespace {
 /// Lower `fir.box_addr` to the sequence of operations to extract the first
 /// element of the box.
@@ -447,18 +458,25 @@ struct BoxAddrOpConversion : public FIROpConversion<fir::BoxAddrOp> {
   }
 };
 
-/// convert to an extractvalue for the 2nd part of the boxchar
+/// Convert `!fir.boxchar_len` to  `!llvm.extractvalue` for the 2nd part of the
+/// boxchar.
 struct BoxCharLenOpConversion : public FIROpConversion<fir::BoxCharLenOp> {
   using FIROpConversion::FIROpConversion;
 
   mlir::LogicalResult
-  matchAndRewrite(fir::BoxCharLenOp boxchar, OperandTy operands,
+  matchAndRewrite(fir::BoxCharLenOp boxCharLen, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto a = operands[0];
-    auto ty = convertType(boxchar.getType());
-    auto *ctx = boxchar.getContext();
-    auto c1 = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(1));
-    rewriter.replaceOpWithNewOp<mlir::LLVM::ExtractValueOp>(boxchar, ty, a, c1);
+    mlir::Value boxChar = adaptor.getOperands()[0];
+    mlir::Location loc = boxChar.getLoc();
+    mlir::MLIRContext *ctx = boxChar.getContext();
+    mlir::Type returnValTy = boxCharLen.getResult().getType();
+
+    constexpr int boxcharLenIdx = 1;
+    mlir::LLVM::ExtractValueOp len = genExtractValueWithIndex(
+        loc, boxChar, boxChar.getType(), rewriter, ctx, boxcharLenIdx);
+    mlir::Value lenAfterCast = integerCast(loc, rewriter, returnValTy, len);
+    rewriter.replaceOp(boxCharLen, lenAfterCast);
+
     return success();
   }
 };
@@ -2934,16 +2952,6 @@ struct StoreOpConversion : public FIROpConversion<fir::StoreOp> {
     return success();
   }
 };
-
-// cons an extractvalue on a tuple value, returning value at element `x`
-mlir::LLVM::ExtractValueOp
-genExtractValueWithIndex(mlir::Location loc, mlir::Value tuple, mlir::Type ty,
-                         mlir::ConversionPatternRewriter &rewriter,
-                         mlir::MLIRContext *ctx, int x) {
-  auto cx = mlir::ArrayAttr::get(ctx, rewriter.getI32IntegerAttr(x));
-  auto xty = ty.cast<mlir::LLVM::LLVMStructType>().getBody()[x];
-  return rewriter.create<mlir::LLVM::ExtractValueOp>(loc, xty, tuple, cx);
-}
 
 /// Convert `fir.unboxchar` into two `llvm.extractvalue` instructions. One for
 /// the character buffer and one for the buffer length.

--- a/flang/test/Fir/convert-to-llvm-target.fir
+++ b/flang/test/Fir/convert-to-llvm-target.fir
@@ -1,0 +1,149 @@
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix INT64
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT64
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT32
+// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s --check-prefixes INT64
+
+//=============================================================================
+// SUMMARY: Tests for FIR --> LLVM MLIR conversion that *depend* on the target
+//=============================================================================
+
+// Test fir.emboxchar
+
+func @test_embox(%char_array : !fir.ref<!fir.char<1,?>>) -> () {
+  %c10 = arith.constant 10 : i64
+  %box_char = fir.emboxchar %char_array, %c10 : (!fir.ref<!fir.char<1,?>>, i64) -> !fir.boxchar<1>
+  return
+}
+
+// INT64-LABEL: test_embox
+// INT64-SAME: (%[[char_array:.*]]: !llvm.ptr<i8>)
+// INT64:    %[[c10:.*]] = llvm.mlir.constant(10 : i64) : i64
+// INT64:    %[[empty_struct:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<i8>, i{{.*}})>
+// INT64:    %[[struct_with_buffer:.*]] = llvm.insertvalue %[[char_array]], %[[empty_struct]][0 : i32] : !llvm.struct<(ptr<i8>, i{{.*}})>
+// INT64:    %{{.*}} = llvm.insertvalue %[[c10]], %[[struct_with_buffer]][1 : i32] : !llvm.struct<(ptr<i8>, i{{.*}})>
+// INT64-NEXT:    llvm.return
+
+// INT32-LABEL:  llvm.func @test_embox
+// INT32-SAME: %[[char_array:.*]]: !llvm.ptr<i8>)
+// INT32:    %[[c10:.*]] = llvm.mlir.constant(10 : i64) : i64
+// INT32:    %[[empty_struct:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<i8>, i32)>
+// INT32:    %[[c10_truncated:.*]] = llvm.trunc %[[c10]] : i64 to i32
+// INT32:    %[[struct_with_buffer:.*]] = llvm.insertvalue %[[char_array]], %[[empty_struct]][0 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32:    %{{.*}} = llvm.insertvalue %[[c10_truncated:.*]], %[[struct_with_buffer]][1 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32-NEXT:    llvm.return
+
+// -----
+
+// Test fir.unboxchar
+
+func @unboxchar_i8(%arg0 : !fir.boxchar<1>) -> () {
+  %0:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1>>, i64)
+  return
+}
+
+// INT64-LABEL: llvm.func @unboxchar_i8
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][0 : i32] : !llvm.struct<(ptr<i8>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i64)>
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @unboxchar_i8
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %{{.*}} = llvm.extractvalue %[[box_char]][0 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %[[len_unextended:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %{{.*}} = llvm.sext %[[len_unextended]] : i32 to i64
+// INT32-NEXT:  llvm.return
+
+func @unboxchar_i32(%arg0 : !fir.boxchar<4>) -> () {
+  fir.unboxchar %arg0 : (!fir.boxchar<4>) -> (!fir.ref<!fir.char<4>>, i64)
+  return
+}
+
+// INT64-LABEL: llvm.func @unboxchar_i32
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][0 : i32] : !llvm.struct<(ptr<i32>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i64)>
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @unboxchar_i32
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %{{.*}} = llvm.extractvalue %[[box_char]][0 : i32] : !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %[[len_unextended:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %{{.*}} = llvm.sext %[[len_unextended]] : i32 to i64
+// INT32-NEXT:  llvm.return
+
+// -----
+
+// Test fir.boxchar_len
+
+func @boxchar_len_i8_i32(%arg0 : !fir.boxchar<1>) -> () {
+  fir.boxchar_len %arg0 : (!fir.boxchar<1>) -> i32
+  return
+}
+
+// INT64-LABEL: llvm.func @boxchar_len_i8_i32
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i64)>
+// INT64:  %[[len:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i64)>
+// INT64: %{{.*}} = llvm.trunc %[[len]] : i64 to i32
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @boxchar_len_i8_i32
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32-NOT:  llvm.trunc
+// INT32-NOT:  llvm.sext
+// INT32-NEXT:  llvm.return
+
+func @boxchar_len_i8_i64(%arg0 : !fir.boxchar<1>) -> () {
+  fir.boxchar_len %arg0 : (!fir.boxchar<1>) -> i64
+  return
+}
+
+// INT64-LABEL: llvm.func @boxchar_len_i8_i64
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i64)>
+// INT64-NOT:  llvm.trunc
+// INT64-NOT:  llvm.sext
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @boxchar_len_i8_i64
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %[[len:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i8>, i32)>
+// INT32:  %{{.*}} = llvm.sext %0 : i32 to i64
+// INT32-NEXT:  llvm.return
+
+func @boxchar_len_i32_i32(%arg0 : !fir.boxchar<4>) -> () {
+  fir.boxchar_len %arg0 : (!fir.boxchar<4>) -> i32
+  return
+}
+
+// INT64-LABEL: llvm.func @boxchar_len_i32_i32
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i64)>
+// INT64:  %[[len:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i64)>
+// INT64: %{{.*}} = llvm.trunc %[[len]] : i64 to i32
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @boxchar_len_i32_i32
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i32)>
+// INT32-NOT:  llvm.trunc
+// INT32-NOT:  llvm.sext
+// INT32-NEXT:  llvm.return
+
+func @boxchar_len_i32_i64(%arg0 : !fir.boxchar<4>) -> (i64) {
+  %0 = fir.boxchar_len %arg0 : (!fir.boxchar<4>) -> i64
+  return %0 : i64
+}
+
+// INT64-LABEL: llvm.func @boxchar_len_i32_i64
+// INT64-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i64)>
+// INT64:  %{{.*}} = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i64)>
+// INT64-NOT:  llvm.trunc
+// INT64-NOT:  llvm.sext
+// INT64-NEXT:  llvm.return
+
+// INT32-LABEL: llvm.func @boxchar_len_i32_i64
+// INT32-SAME: %[[box_char:.*]]: !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %[[len:.*]] = llvm.extractvalue %[[box_char]][1 : i32] : !llvm.struct<(ptr<i32>, i32)>
+// INT32:  %{{.*}} = llvm.sext %0 : i32 to i64
+// INT32-NEXT:  llvm.return


### PR DESCRIPTION
…LVM MLIR

This patch extends the `FIRToLLVMLowering` pass in Flang by adding a
hook to transform `fir.boxchar_len` to a sequence of LLVM MLIR
instructions.

This is part of the upstreaming effort from the `fir-dev` branch in [1].

Note: Also brings in the test file `convert-to-llvm-target.fir`.

[1] https://github.com/flang-compiler/f18-llvm-project

Differential Revision: https://reviews.llvm.org/D113763

Originally written by:
Co-authored-by: Eric Schweitz <eschweitz@nvidia.com>