### PR TITLE
Lower a NULL() being passed in the position of a mutable box argument as

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -594,6 +594,25 @@ public:
     fir::emitFatalError(getLoc(), "NULL() must be lowered in its context");
   }
 
+  /// A `NULL()` in a position where a mutable box is expected has the same
+  /// semantics as an absent optional box value.
+  ExtValue genMutableBoxValueImpl(const Fortran::evaluate::NullPointer &) {
+    mlir::Location loc = getLoc();
+    auto nullConst = builder.createNullConstant(loc);
+    auto noneTy = mlir::NoneType::get(builder.getContext());
+    auto polyRefTy = fir::LLVMPointerType::get(noneTy);
+    // MutableBoxValue will dereference the box, so create a bogus temporary for
+    // the `nullptr`. The LLVM optimizer will garbage collect the temp.
+    auto temp =
+        builder.createTemporary(loc, polyRefTy, /*shape=*/mlir::ValueRange{});
+    auto nullPtr = builder.createConvert(loc, polyRefTy, nullConst);
+    builder.create<fir::StoreOp>(loc, nullPtr, temp);
+    auto nullBoxTy = builder.getRefType(fir::BoxType::get(noneTy));
+    return fir::MutableBoxValue(builder.createConvert(loc, nullBoxTy, temp),
+                                /*lenParameters=*/mlir::ValueRange{},
+                                /*mutableProperties=*/{});
+  }
+
   template <typename T>
   ExtValue
   genMutableBoxValueImpl(const Fortran::evaluate::FunctionRef<T> &funRef) {

--- a/flang/test/Lower/dummy-argument-optional.f90
+++ b/flang/test/Lower/dummy-argument-optional.f90
@@ -145,4 +145,13 @@ subroutine alloc_component_eval_only_once(x)
   call assumed_shape(x(ifoo())%p)
 end subroutine
 
+! CHECK-LABEL: func @_QMoptPnull_as_optional() {
+subroutine null_as_optional
+  ! CHECK: %[[temp:.*]] = fir.alloca !fir.llvm_ptr<none>
+  ! CHECK: %[[null:.*]] = fir.zero_bits !fir.ref<none>
+  ! CHECK: fir.store %{{.*}} to %[[temp]] : !fir.ref<!fir.llvm_ptr<none>>
+  ! CHECK: fir.call @_QMoptPassumed_shape(%{{.*}}) : (!fir.box<!fir.array<?xf32>>) -> ()
+ call assumed_shape(null())
+end subroutine null_as_optional
+
 end module


### PR DESCRIPTION
an absent optional.

Add test.