### PR TITLE
Sync back after upstreaming - add missing test for `iachar`

### DIFF
--- a/flang/test/Lower/intrinsic-procedures/ichar.f90
+++ b/flang/test/Lower/intrinsic-procedures/ichar.f90
@@ -23,4 +23,10 @@ subroutine ichar_test(c)
   ! CHECK: fir.call @{{.*}}OutputInteger32{{.*}}%[[ARG]]
   ! CHECK: fir.call @{{.*}}EndIoStatement
   print *, ichar(str(J))
+
+  ! "Magic" 88 below is the value returned by IACHAR (’X’)
+  ! CHECK: %[[c88:.*]] = arith.constant 88 : i32
+  ! CHECK-NEXT: fir.call @{{.*}}OutputInteger32({{.*}}, %[[c88]])
+  ! CHECK-NEXT: fir.call @{{.*}}EndIoStatement
+  print *, iachar('X')
 end subroutine

--- a/flang/test/Lower/intrinsic-procedures/ichar.f90
+++ b/flang/test/Lower/intrinsic-procedures/ichar.f90
@@ -24,7 +24,7 @@ subroutine ichar_test(c)
   ! CHECK: fir.call @{{.*}}EndIoStatement
   print *, ichar(str(J))
 
-  ! "Magic" 88 below is the value returned by IACHAR (’X’)
+  ! "Magic" 88 below is the ASCII code for `X` and the value returned by IACHAR (’X’)
   ! CHECK: %[[c88:.*]] = arith.constant 88 : i32
   ! CHECK-NEXT: fir.call @{{.*}}OutputInteger32({{.*}}, %[[c88]])
   ! CHECK-NEXT: fir.call @{{.*}}EndIoStatement


### PR DESCRIPTION
Upstream patch: https://reviews.llvm.org/D121790