### PR TITLE
Add hard TODO for pointer procedures

### DIFF
--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -228,6 +228,8 @@ struct TypeBuilder {
     // links, the fir type is built based on the ultimate symbol. This relies
     // on the fact volatile and asynchronous are not reflected in fir types.
     const Fortran::semantics::Symbol &ultimate = symbol.GetUltimate();
+    if (Fortran::semantics::IsProcedurePointer(ultimate))
+      TODO(loc, "procedure pointers");
     if (const Fortran::semantics::DeclTypeSpec *type = ultimate.GetType()) {
       if (const Fortran::semantics::IntrinsicTypeSpec *tySpec =
               type->AsIntrinsic()) {

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1405,7 +1405,7 @@ struct SymbolDependenceDepth {
     LLVM_DEBUG(llvm::dbgs() << "analyze symbol: " << sym << '\n');
     if (!done.second)
       return 0;
-    if (semantics::IsProcedure(sym)) {
+    if (semantics::IsProcedure(sym) && !semantics::IsProcedurePointer(sym)) {
       // TODO: add declaration?
       return 0;
     }
@@ -1426,15 +1426,14 @@ struct SymbolDependenceDepth {
 
     // Symbol must be something lowering will have to allocate.
     int depth = 0;
-    const semantics::DeclTypeSpec *symTy = sym.GetType();
-    assert(symTy && "symbol must have a type");
-
     // Analyze symbols appearing in object entity specification expression. This
     // ensures these symbols will be instantiated before the current one.
     // This is not done for object entities that are host associated because
     // they must be instantiated from the value of the host symbols (the
     // specification expressions should not be re-evaluated).
     if (const auto *details = sym.detailsIf<semantics::ObjectEntityDetails>()) {
+      const semantics::DeclTypeSpec *symTy = sym.GetType();
+      assert(symTy && "symbol must have a type");
       // check CHARACTER's length
       if (symTy->category() == semantics::DeclTypeSpec::Character)
         if (auto e = symTy->characterTypeSpec().length().GetExplicit())


### PR DESCRIPTION
Currently, procedure pointer symbols were just dropped in the PFT,
causing error "failed to find indirect call symbol address".

Add procedure pointers to the PFT variables and add a hard TODO in
type conversion for now.