### PR TITLE
Alternate entry points with unused arguments

### DIFF
--- a/flang/include/flang/Lower/PFTBuilder.h
+++ b/flang/include/flang/Lower/PFTBuilder.h
@@ -667,8 +667,6 @@ struct FunctionLikeUnit : public ProgramUnit {
       entryPointList{std::pair{nullptr, nullptr}};
   /// Current index into entryPointList.  Index 0 is the primary entry point.
   int activeEntry = 0;
-  /// Dummy arguments that are not universal across entry points.
-  llvm::SmallVector<const semantics::Symbol *, 1> nonUniversalDummyArguments;
   /// Primary result for function subprograms with alternate entries.  This
   /// is one of the largest result values, not necessarily the first one.
   const semantics::Symbol *primaryResult{nullptr};

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1597,7 +1597,7 @@ private:
         auto insertPt = builder->saveInsertionPoint();
         // create a 'section' operation for every 'Section Block'
         genOpenMPSectionsBlock(*this, *curEval);
-        for (auto it = block.begin(); it != block.end(); it++) { 
+        for (auto it = block.begin(); it != block.end(); it++) {
           // generate FIR for every 'ExecutionPartConstruct' and encapsulate it
           // within the corresponding 'Section Block'
           genFIR(*sectionsBlockEvalIterator);
@@ -2564,19 +2564,6 @@ private:
     for (const Fortran::lower::CalleeInterface::PassedEntity &arg :
          callee.getPassedArguments())
       mapPassedEntity(arg);
-
-    // Allocate local skeleton instances of dummies from other entry points.
-    // Most of these locals will not survive into final generated code, but
-    // some will.  It is illegal to reference them at run time if they do.
-    for (const Fortran::semantics::Symbol *arg :
-         funit.nonUniversalDummyArguments) {
-      if (lookupSymbol(*arg))
-        continue;
-      mlir::Type type = genType(*arg);
-      // TODO: Account for VALUE arguments (and possibly other variants).
-      type = builder->getRefType(type);
-      addSymbol(*arg, builder->create<fir::UndefOp>(toLocation(), type));
-    }
     if (std::optional<Fortran::lower::CalleeInterface::PassedEntity>
             passedResult = callee.getPassedResult()) {
       mapPassedEntity(*passedResult);

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1141,11 +1141,10 @@ static mlir::Value genExtentValue(fir::FirOpBuilder &builder,
 }
 
 /// Lower specification expressions and attributes of variable \p var and
-/// add it to the symbol map.
-/// For global and aliases, the address must be pre-computed and provided
-/// in \p preAlloc.
-/// Dummy arguments must have already been mapped to mlir block arguments
-/// their mapping may be updated here.
+/// add it to the symbol map.  For a global or an alias, the address must be
+/// pre-computed and provided in \p preAlloc.  A dummy argument for the current
+/// entry point has already been mapped to an mlir block argument in
+/// mapDummiesAndResults.  Its mapping may be updated here.
 void Fortran::lower::mapSymbolAttributes(
     AbstractConverter &converter, const Fortran::lower::pft::Variable &var,
     Fortran::lower::SymMap &symMap, Fortran::lower::StatementContext &stmtCtx,
@@ -1154,14 +1153,29 @@ void Fortran::lower::mapSymbolAttributes(
   const Fortran::semantics::Symbol &sym = var.getSymbol();
   const mlir::Location loc = converter.genLocation(sym.name());
   mlir::IndexType idxTy = builder.getIndexType();
-  const bool isDummy = Fortran::semantics::IsDummy(sym);
+  const bool isDeclaredDummy = Fortran::semantics::IsDummy(sym);
+  // An active dummy from the current entry point.
+  const bool isDummy = isDeclaredDummy && symMap.lookupSymbol(sym).getAddr();
   const bool isResult = Fortran::semantics::IsFunctionResult(sym);
   const bool replace = isDummy || isResult;
   fir::factory::CharacterExprHelper charHelp{builder, loc};
+
+  if (Fortran::semantics::IsProcedure(sym)) {
+    assert(isDeclaredDummy && "expected a dummy procedure argument");
+    if (!isDummy) {
+      // This is an unused dummy procedure argument from another entry point.
+      // Additional discussion below.
+      mlir::Value undefOp = builder.create<fir::UndefOp>(
+          loc, builder.getRefType(converter.genType(var)));
+      symMap.addSymbol(sym, undefOp);
+    }
+    return;
+  }
+
   Fortran::lower::BoxAnalyzer ba;
   ba.analyze(sym);
 
-  // First deal with pointers an allocatables, because their handling here
+  // First deal with pointers and allocatables, because their handling here
   // is the same regardless of their rank.
   if (Fortran::semantics::IsAllocatableOrPointer(sym)) {
     // Get address of fir.box describing the entity.
@@ -1216,6 +1230,36 @@ void Fortran::lower::mapSymbolAttributes(
       return;
     }
   }
+
+  // A dummy from another entry point that is not declared in the current
+  // entry point requires a skeleton definition.  Most such "unused" dummies
+  // will not survive into final generated code, but some will.  It is illegal
+  // to reference one at run time if it does.  Such a dummy is mapped to a
+  // value in one of three ways:
+  //
+  //  - Generate a fir::UndefOp value.  This is lightweight, easy to clean up,
+  //    and often valid, but it may fail for a dummy with dynamic bounds,
+  //    or a dummy used to define another dummy.  Information to distinguish
+  //    valid cases is not generally available here, with the exception of
+  //    dummy procedures.  See the first function exit above.
+  //
+  //  - Allocate an uninitialized stack slot.  This is an intermediate-weight
+  //    solution that is harder to clean up.  It is often valid, but may fail
+  //    for an object with dynamic bounds.  This option is "automatically"
+  //    used by default for cases that do not use one of the other options.
+  //
+  //  - Allocate a heap box/descriptor, initialized to zero.  This always
+  //    works, but is more heavyweight and harder to clean up.  It is used
+  //    for dynamic objects via calls to genUnusedBox.
+
+  auto genUnusedBox = [&]() {
+    if (isDeclaredDummy && !isDummy) { // dummy from another entry point
+      symMap.addSymbol(sym, fir::factory::createTempMutableBox(
+                                builder, loc, converter.genType(var)));
+      return true;
+    }
+    return false;
+  };
 
   // Helper to generate scalars for the symbol properties.
   auto genValue = [&](const Fortran::lower::SomeExpr &expr) {
@@ -1366,6 +1410,8 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::ScalarDynamicChar &x) {
+        if (genUnusedBox())
+          return;
         // type is a CHARACTER, determine the LEN value
         auto charLen = x.charLen();
         if (replace) {
@@ -1373,17 +1419,8 @@ void Fortran::lower::mapSymbolAttributes(
           mlir::Value boxAddr = symBox.getAddr();
           mlir::Value len;
           mlir::Type addrTy = boxAddr.getType();
-          if (addrTy.isa<fir::BoxCharType>() || addrTy.isa<fir::BoxType>()) {
+          if (addrTy.isa<fir::BoxCharType>() || addrTy.isa<fir::BoxType>())
             std::tie(boxAddr, len) = charHelp.createUnboxChar(symBox.getAddr());
-          } else {
-            // dummy from an other entry case: we cannot get a dynamic length
-            // for it, it's illegal for the user program to use it. However,
-            // since we are lowering all function unit statements regardless
-            // of whether the execution will reach them or not, we need to
-            // fill a value for the length here.
-            len = builder.createIntegerConstant(
-                loc, builder.getCharacterLengthType(), 1);
-          }
           // Override LEN with an expression
           if (charLen)
             len = genExplicitCharLen(charLen);
@@ -1438,6 +1475,8 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArray &x) {
+        if (genUnusedBox())
+          return;
         // cast to the known constant parts from the declaration
         mlir::Type varType = converter.genType(var);
         mlir::Value addr = symMap.lookupSymbol(sym).getAddr();
@@ -1541,6 +1580,8 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::StaticArrayDynamicChar &x) {
+        if (genUnusedBox())
+          return;
         mlir::Value addr;
         mlir::Value len;
         [[maybe_unused]] bool mustBeDummy = false;
@@ -1610,6 +1651,8 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArrayStaticChar &x) {
+        if (genUnusedBox())
+          return;
         mlir::Value addr;
         mlir::Value len;
         mlir::Value argBox;
@@ -1668,6 +1711,8 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArrayDynamicChar &x) {
+        if (genUnusedBox())
+          return;
         mlir::Value addr;
         mlir::Value len;
         mlir::Value argBox;

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1250,9 +1250,9 @@ void Fortran::lower::mapSymbolAttributes(
   //
   //  - Allocate a heap box/descriptor, initialized to zero.  This always
   //    works, but is more heavyweight and harder to clean up.  It is used
-  //    for dynamic objects via calls to genUnusedBox.
+  //    for dynamic objects via calls to genUnusedEntryPointBox.
 
-  auto genUnusedBox = [&]() {
+  auto genUnusedEntryPointBox = [&]() {
     if (isDeclaredDummy && !isDummy) { // dummy from another entry point
       symMap.addSymbol(sym, fir::factory::createTempMutableBox(
                                 builder, loc, converter.genType(var)));
@@ -1410,7 +1410,7 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::ScalarDynamicChar &x) {
-        if (genUnusedBox())
+        if (genUnusedEntryPointBox())
           return;
         // type is a CHARACTER, determine the LEN value
         auto charLen = x.charLen();
@@ -1475,7 +1475,7 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArray &x) {
-        if (genUnusedBox())
+        if (genUnusedEntryPointBox())
           return;
         // cast to the known constant parts from the declaration
         mlir::Type varType = converter.genType(var);
@@ -1580,7 +1580,7 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::StaticArrayDynamicChar &x) {
-        if (genUnusedBox())
+        if (genUnusedEntryPointBox())
           return;
         mlir::Value addr;
         mlir::Value len;
@@ -1651,7 +1651,7 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArrayStaticChar &x) {
-        if (genUnusedBox())
+        if (genUnusedEntryPointBox())
           return;
         mlir::Value addr;
         mlir::Value len;
@@ -1711,7 +1711,7 @@ void Fortran::lower::mapSymbolAttributes(
       //===--------------------------------------------------------------===//
 
       [&](const Fortran::lower::details::DynamicArrayDynamicChar &x) {
-        if (genUnusedBox())
+        if (genUnusedEntryPointBox())
           return;
         mlir::Value addr;
         mlir::Value len;

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -976,30 +976,28 @@ private:
     }
   }
 
-  /// For multiple entry subprograms, build a list of the dummy arguments that
-  /// appear in some, but not all entry points.  For those that are functions,
-  /// also find one of the largest function results, since a single result
-  /// container holds the result for all entries.
+  /// Do processing specific to subprograms with multiple entry points.
   void processEntryPoints() {
     lower::pft::Evaluation *initialEval = &evaluationListStack.back()->front();
     lower::pft::FunctionLikeUnit *unit = initialEval->getOwningProcedure();
     int entryCount = unit->entryPointList.size();
     if (entryCount == 1)
       return;
-    llvm::DenseMap<semantics::Symbol *, int> dummyCountMap;
+
+    // The first executable statement in the subprogram is preceded by a
+    // branch to the entry point, so it starts a new block.
+    if (initialEval->hasNestedEvaluations())
+      initialEval = &initialEval->getFirstNestedEvaluation();
+    else if (initialEval->isA<Fortran::parser::EntryStmt>())
+      initialEval = initialEval->lexicalSuccessor;
+    initialEval->isNewBlock = true;
+
+    // All function entry points share a single result container.
+    // Find one of the largest results.
     for (int entryIndex = 0; entryIndex < entryCount; ++entryIndex) {
       unit->setActiveEntry(entryIndex);
       const auto &details =
           unit->getSubprogramSymbol().get<semantics::SubprogramDetails>();
-      for (semantics::Symbol *arg : details.dummyArgs()) {
-        if (!arg)
-          continue; // alternate return specifier (no actual argument)
-        const auto iter = dummyCountMap.find(arg);
-        if (iter == dummyCountMap.end())
-          dummyCountMap.try_emplace(arg, 1);
-        else
-          ++iter->second;
-      }
       if (details.isFunction()) {
         const semantics::Symbol *resultSym = &details.result();
         assert(resultSym && "missing result symbol");
@@ -1009,16 +1007,6 @@ private:
       }
     }
     unit->setActiveEntry(0);
-    for (auto arg : dummyCountMap)
-      if (arg.second < entryCount)
-        unit->nonUniversalDummyArguments.push_back(arg.first);
-    // The first executable statement in the subprogram is preceded by a
-    // branch to the entry point, so it starts a new block.
-    if (initialEval->hasNestedEvaluations())
-      initialEval = &initialEval->getFirstNestedEvaluation();
-    else if (initialEval->isA<Fortran::parser::EntryStmt>())
-      initialEval = initialEval->lexicalSuccessor;
-    initialEval->isNewBlock = true;
   }
 
   std::unique_ptr<lower::pft::Program> pgm;
@@ -1405,10 +1393,12 @@ struct SymbolDependenceDepth {
     LLVM_DEBUG(llvm::dbgs() << "analyze symbol: " << sym << '\n');
     if (!done.second)
       return 0;
-    if (semantics::IsProcedure(sym) && !semantics::IsProcedurePointer(sym)) {
-      // TODO: add declaration?
+    // A procedure argument in a subprogram with multiple entry points might
+    // need a vars list entry to trigger creation of a symbol map entry in
+    // some cases.  Non-dummy procedures don't.
+    if (semantics::IsProcedure(sym) && !semantics::IsProcedurePointer(sym) &&
+        !IsDummy(sym))
       return 0;
-    }
     semantics::Symbol ultimate = sym.GetUltimate();
     if (const auto *details =
             ultimate.detailsIf<semantics::NamelistDetails>()) {
@@ -1474,9 +1464,8 @@ struct SymbolDependenceDepth {
 
     // If there are alias sets, then link the participating variables to their
     // aggregate stores when constructing the new variable on the list.
-    if (lower::pft::Variable::AggregateStore *store = findStoreIfAlias(sym)) {
+    if (lower::pft::Variable::AggregateStore *store = findStoreIfAlias(sym))
       vars[depth].back().setAlias(store->getOffset());
-    }
     return depth;
   }
 

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -16,10 +16,25 @@ entry compare2(y, d2, d1)
 end
 
 program entries
+  character c(3)
   character(10) hh, qq, m
   character(len=4) s1, s2
-  integer mm
+  integer mm, x(3), y(5)
   logical r
+  complex xx(3)
+
+  interface
+    subroutine ashapec(asc)
+      character asc(:)
+    end subroutine
+    subroutine ashapei(asi)
+      integer asi(:)
+    end subroutine
+    subroutine ashapex(asx)
+      complex asx(:)
+    end subroutine
+  end interface
+
   s1 = 'a111'
   s2 = 'a222'
   call compare1(r, s1, s2); print*, r
@@ -37,6 +52,13 @@ program entries
   call dd2
   call dd3(6)
 6 continue
+  x = 5
+  y = 7
+  call level3a(x, y, 3)
+  call level3b(x, y, 3)
+  call ashapec(c); print*, c
+  call ashapei(x); print*, x
+  call ashapex(xx); print*, xx
 end
 
 ! CHECK-LABEL: func @_QPss(
@@ -110,49 +132,114 @@ end
 
 ! CHECK-LABEL: func @_QPdd1()
 subroutine dd1
-    ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name =
-    ! "_QFdd1Ekk"}
-    ! CHECK: br ^bb1
-    ! CHECK: ^bb1:  // pred: ^bb0
-    ! CHECK: %[[ten:.*]] = arith.constant 10 : i32
-    ! CHECK: fir.store %[[ten:.*]] to %[[kk]] : !fir.ref<i32>
-    ! CHECK: br ^bb2
-    ! CHECK: ^bb2:  // pred: ^bb1
-    ! CHECK: %[[twenty:.*]] = arith.constant 20 : i32
-    ! CHECK: fir.store %[[twenty:.*]] to %[[kk]] : !fir.ref<i32>
-    ! CHECK: br ^bb3
-    ! CHECK: ^bb3:  // pred: ^bb2
-    ! CHECK: return
-    kk = 10
+  ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name = "_QFdd1Ekk"}
+  ! CHECK: br ^bb1
+  ! CHECK: ^bb1:  // pred: ^bb0
+  ! CHECK: %[[ten:.*]] = arith.constant 10 : i32
+  ! CHECK: fir.store %[[ten:.*]] to %[[kk]] : !fir.ref<i32>
+  ! CHECK: br ^bb2
+  ! CHECK: ^bb2:  // pred: ^bb1
+  ! CHECK: %[[twenty:.*]] = arith.constant 20 : i32
+  ! CHECK: fir.store %[[twenty:.*]] to %[[kk]] : !fir.ref<i32>
+  ! CHECK: br ^bb3
+  ! CHECK: ^bb3:  // pred: ^bb2
+  ! CHECK: return
+  kk = 10
 
-    ! CHECK-LABEL: func @_QPdd2()
-    ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name =
-    ! "_QFdd1Ekk"}
-    ! CHECK: br ^bb1
-    ! CHECK: ^bb1:  // pred: ^bb0
-    ! CHECK: %[[twenty:.*]] = arith.constant 20 : i32
-    ! CHECK: fir.store %[[twenty:.*]] to %[[kk]] : !fir.ref<i32>
-    ! CHECK: br ^bb2
-    ! CHECK: ^bb2:  // pred: ^bb1
-    ! CHECK: return
-    entry dd2
-    kk = 20
-    return
+  ! CHECK-LABEL: func @_QPdd2()
+  ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name = "_QFdd1Ekk"}
+  ! CHECK: br ^bb1
+  ! CHECK: ^bb1:  // pred: ^bb0
+  ! CHECK: %[[twenty:.*]] = arith.constant 20 : i32
+  ! CHECK: fir.store %[[twenty:.*]] to %[[kk]] : !fir.ref<i32>
+  ! CHECK: br ^bb2
+  ! CHECK: ^bb2:  // pred: ^bb1
+  ! CHECK: return
+  entry dd2
+  kk = 20
+  return
 
-    ! CHECK-LABEL: func @_QPdd3
-    ! CHECK: %[[dd3:[0-9]*]] = fir.alloca index {bindc_name = "dd3"}
-    ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name =
-    ! "_QFdd1Ekk"}
-    ! CHECK: %[[zero:.*]] = arith.constant 0 : index
-    ! CHECK: fir.store %[[zero:.*]] to %[[dd3]] : !fir.ref<index>
-    ! CHECK: br ^bb1
-    ! CHECK: ^bb1:  // pred: ^bb0
-    ! CHECK: %[[thirty:.*]] = arith.constant 30 : i32
-    ! CHECK: fir.store %[[thirty:.*]] to %[[kk:[0-9]*]] : !fir.ref<i32>
-    ! CHECK: br ^bb2
-    ! CHECK: ^bb2:  // pred: ^bb1
-    ! CHECK: %[[altret:[0-9]*]] = fir.load %[[dd3]] : !fir.ref<index>
-    ! CHECK: return %[[altret:[0-9]*]] : index
-    entry dd3(*)
-    kk = 30
-  end
+  ! CHECK-LABEL: func @_QPdd3
+  ! CHECK: %[[dd3:[0-9]*]] = fir.alloca index {bindc_name = "dd3"}
+  ! CHECK: %[[kk:[0-9]*]] = fir.alloca i32 {bindc_name = "kk", uniq_name = "_QFdd1Ekk"}
+  ! CHECK: %[[zero:.*]] = arith.constant 0 : index
+  ! CHECK: fir.store %[[zero:.*]] to %[[dd3]] : !fir.ref<index>
+  ! CHECK: br ^bb1
+  ! CHECK: ^bb1:  // pred: ^bb0
+  ! CHECK: %[[thirty:.*]] = arith.constant 30 : i32
+  ! CHECK: fir.store %[[thirty:.*]] to %[[kk:[0-9]*]] : !fir.ref<i32>
+  ! CHECK: br ^bb2
+  ! CHECK: ^bb2:  // pred: ^bb1
+  ! CHECK: %[[altret:[0-9]*]] = fir.load %[[dd3]] : !fir.ref<index>
+  ! CHECK: return %[[altret:[0-9]*]] : index
+  entry dd3(*)
+  kk = 30
+end
+
+! CHECK-LABEL: func @_QPashapec(
+subroutine ashapec(asc)
+  ! CHECK: %[[asx:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>
+  ! CHECK: %[[asi:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: %[[zeroi:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+  ! CHECK: %[[shapei:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxi:[0-9]*]] = fir.embox %[[zeroi]](%[[shapei]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.store %[[boxi]] to %[[asi]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+  ! CHECK: %[[zerox:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.complex<4>>>
+  ! CHECK: %[[shapex:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxx:[0-9].*]] = fir.embox %[[zerox]](%[[shapex]]) : (!fir.heap<!fir.array<?x!fir.complex<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>
+  ! CHECK: fir.store %[[boxx]] to %[[asx]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>>
+  character asc(:)
+  integer asi(:)
+  complex asx(:)
+  asc = '?'
+  return
+! CHECK-LABEL: func @_QPashapei(
+entry ashapei(asi)
+  ! CHECK: %[[asx:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>
+  ! CHECK: %[[asc:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>
+  ! CHECK: %[[zeroc:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1>>>
+  ! CHECK: %[[shapec:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxc:[0-9]*]] = fir.embox %[[zeroc]](%[[shapec]]) : (!fir.heap<!fir.array<?x!fir.char<1>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>
+  ! CHECK: fir.store %[[boxc]] to %[[asc]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>>
+  ! CHECK: %[[zerox:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.complex<4>>>
+  ! CHECK: %[[shapex:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxx:[0-9].*]] = fir.embox %[[zerox]](%[[shapex]]) : (!fir.heap<!fir.array<?x!fir.complex<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>
+  ! CHECK: fir.store %[[boxx]] to %[[asx]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.complex<4>>>>>
+  asi = 3
+  return
+! CHECK-LABEL: func @_QPashapex(
+entry ashapex(asx)
+  ! CHECK: %[[asi:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: %[[asc:[0-9]*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>
+  ! CHECK: %[[zeroc:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1>>>
+  ! CHECK: %[[shapec:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxc:[0-9]*]] = fir.embox %[[zeroc]](%[[shapec]]) : (!fir.heap<!fir.array<?x!fir.char<1>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>
+  ! CHECK: fir.store %[[boxc]] to %[[asc]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1>>>>>
+  ! CHECK: %[[zeroi:[0-9]*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+  ! CHECK: %[[shapei:[0-9]*]] = fir.shape %c0{{.*}} : (index) -> !fir.shape<1>
+  ! CHECK: %[[boxi:[0-9].*]] = fir.embox %[[zeroi]](%[[shapei]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.store %[[boxi]] to %[[asi]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+  asx = (2.0,-2.0)
+end
+
+! CHECK-LABEL: func @_QPlevel3a(
+subroutine level3a(a, b, m)
+  ! CHECK: fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.alloca i32 {bindc_name = "n", uniq_name = "_QFlevel3aEn"}
+  integer :: a(m), b(a(m)), m
+  integer :: x(n), y(x(n)), n
+1 print*, m
+  print*, a
+  print*, b
+  if (m == 3) return
+! CHECK-LABEL: func @_QPlevel3b(
+entry level3b(x, y, n)
+  ! CHECK: fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+  ! CHECK: fir.alloca i32 {bindc_name = "m", uniq_name = "_QFlevel3aEm"}
+  print*, n
+  print*, x
+  print*, y
+  if (n /= 3) goto 1
+end


### PR DESCRIPTION
A dummy argument in an entry point of a subprogram with multiple
entry points need not be defined in other entry points.  It is only
legal to reference such an argument when calling an entry point that
does have a definition.  An entry point without such a definition
needs a local "substitute" definition sufficient to generate code.
It is nonconformant to reference such a definition at runtime.
Most such definitions and associated code will be deleted as dead
code at compile time.  However, that is not always possible, as in
the following code.  This code is conformant if all calls to entry
point `ss` set `m=3`, and all calls to entry point `ee` set `n=3`.
```
  subroutine ss(a, b, m, d, k) ! no x, y, n
    integer :: a(m), b(a(m)), m, d(k)
    integer :: x(n), y(x(n)), n
    integer :: k
  1 print*, m, k
    print*, a
    print*, b
    print*, d
    if (m == 3) return
  entry ee(x, y, n, d, k) ! no a, b, m
    print*, n, k
    print*, x
    print*, y
    print*, d
    if (n /= 3) goto 1
  end

    integer :: xx(3), yy(5), zz(3)
    xx = 5
    yy = 7
    zz = 9
    call ss(xx, yy, 3, zz, 3)
    call ss(xx, yy, 3, zz, 3)
  end
```
Lowering currently generates `fir::UndefOp's` for all unused arguments.
This is usually ok, but cases such as the one here incorrectly access
unused `UndefOp` arguments for m and n from an entry point that doesn't
have a proper definition.

The problem is addressed by creating a more complete definition of an
unused argument in most cases.  This is implemented in large part by
moving the definition of an unused argument from `mapDummiesAndResults`
to `mapSymbolAttributes`.  The code in `mapSymbolAttributes` then chooses
one of three code generation options, depending on information
available there.  The options vary in complexity from simple and
easy to remove when not needed, to more complex, but applicable
in more cases.