### PR TITLE
[NFC][flang] Remove unused code in lowerExplicitLowerBounds

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1062,9 +1062,6 @@ static void lowerExplicitLowerBounds(
       mlir::Value lb = builder.createConvert(
           loc, idxTy, genScalarValue(converter, loc, expr, symMap, stmtCtx));
       result.emplace_back(lb);
-    } else if (!spec->lbound().isColon()) {
-      // Implicit lower bound is 1 (Fortran 2018 section 8.5.8.3 point 3.)
-      result.emplace_back(builder.createIntegerConstant(loc, idxTy, 1));
     }
   }
   assert(result.empty() || result.size() == box.dynamicBound().size());


### PR DESCRIPTION
There is no need to lower the implicit lower bounds for assumed-shape
array in lowerExplicitLowerBounds. Remove the unused code.