### PR TITLE
[flang] Make not yet implemented messages more consistent

### DIFF
--- a/flang/docs/tutorials/addingIntrinsics.md
+++ b/flang/docs/tutorials/addingIntrinsics.md
@@ -163,7 +163,7 @@ The categories are:
 - `fir::CharArrayBoxValue` contiguous character arrays.
 - `fir::MutableBoxValue` for allocatable and pointers of all types.
 - `fir::ProcBoxValue` for procedure pointers.
-- `fir::BoxValue` for all the rest (e.g. non-contiguous arrays, polymorphic or parametrized derived types).
+- `fir::BoxValue` for all the rest (e.g. non-contiguous arrays, polymorphic or parameterized derived types).
 See `include/flang/Support/BoxValue.h` for more details.
 
 If the intrinsic has a runtime implementation, the actual binding should be done in another helper function called

--- a/flang/include/flang/Lower/Todo.h
+++ b/flang/include/flang/Lower/Todo.h
@@ -34,16 +34,16 @@
 // In a release build, just give a message and exit.
 #define TODO_NOLOC(ToDoMsg)                                                    \
   do {                                                                         \
-    llvm::errs() << __FILE__ << ':' << __LINE__ << ": not yet implemented "    \
-                 << ToDoMsg << '\n';                                           \
+    llvm::errs() << __FILE__ << ':' << __LINE__                                \
+                 << ": not yet implemented: " << ToDoMsg << '\n';              \
     std::exit(1);                                                              \
   } while (false)
 
 #undef TODO_DEFN
 #define TODO_DEFN(MlirLoc, ToDoMsg, ToDoFile, ToDoLine)                        \
   do {                                                                         \
-    mlir::emitError(MlirLoc, ToDoFile                                          \
-                    ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg); \
+    mlir::emitError(MlirLoc, ToDoFile ":" TODOQUOTE(                           \
+                                 ToDoLine) ": not yet implemented: " ToDoMsg); \
     std::exit(1);                                                              \
   } while (false)
 
@@ -56,7 +56,7 @@
 #define TODO_NOLOCDEFN(ToDoMsg, ToDoFile, ToDoLine)                            \
   do {                                                                         \
     llvm::report_fatal_error(                                                  \
-        ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg);    \
+        ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented: " ToDoMsg);   \
   } while (false)
 
 #define TODO_NOLOC(ToDoMsg) TODO_NOLOCDEFN(ToDoMsg, __FILE__, __LINE__)
@@ -66,7 +66,7 @@
   do {                                                                         \
     fir::emitFatalError(                                                       \
         MlirLoc,                                                               \
-        ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented " ToDoMsg);    \
+        ToDoFile ":" TODOQUOTE(ToDoLine) ": not yet implemented: " ToDoMsg);   \
   } while (false)
 
 #define TODO(MlirLoc, ToDoMsg) TODO_DEFN(MlirLoc, ToDoMsg, __FILE__, __LINE__)

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -429,7 +429,7 @@ private:
     if (const Fortran::semantics::DerivedTypeSpec *derived =
             typeSpec->AsDerived())
       if (Fortran::semantics::CountLenParameters(*derived) > 0)
-        TODO(loc, "TODO: setting derived type params in allocation");
+        TODO(loc, "setting derived type params in allocation");
     if (typeSpec->category() ==
         Fortran::semantics::DeclTypeSpec::Category::Character) {
       Fortran::semantics::ParamValue lenParam =
@@ -467,7 +467,7 @@ private:
     TODO(loc, "MOLD allocation lowering");
   }
   void genSetType(const Allocation &, const fir::MutableBoxValue &) {
-    TODO(loc, "Polymorphic entity allocation lowering");
+    TODO(loc, "polymorphic entity allocation lowering");
   }
 
   /// Returns a pointer to the DeclTypeSpec if a type-spec is provided in the

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2815,7 +2815,7 @@ private:
       const Fortran::semantics::Symbol &procSymbol =
           funit.getSubprogramSymbol();
       if (procSymbol.owner().IsSubmodule()) {
-        TODO(toLocation(), "support submodules");
+        TODO(toLocation(), "support for submodules");
         return;
       }
     }

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -804,13 +804,13 @@ private:
     if (obj.attrs.test(Attrs::Optional))
       addMLIRAttr(fir::getOptionalAttrName());
     if (obj.attrs.test(Attrs::Asynchronous))
-      TODO(loc, "Asynchronous in procedure interface");
+      TODO(loc, "ASYNCHRONOUS in procedure interface");
     if (obj.attrs.test(Attrs::Contiguous))
       addMLIRAttr(fir::getContiguousAttrName());
     if (obj.attrs.test(Attrs::Value))
       isValueAttr = true; // TODO: do we want an mlir::Attribute as well?
     if (obj.attrs.test(Attrs::Volatile))
-      TODO(loc, "Volatile in procedure interface");
+      TODO(loc, "VOLATILE in procedure interface");
     if (obj.attrs.test(Attrs::Target))
       addMLIRAttr(fir::getTargetAttrName());
 
@@ -820,9 +820,9 @@ private:
     const Fortran::evaluate::characteristics::TypeAndShape::Attrs &shapeAttrs =
         obj.type.attrs();
     if (shapeAttrs.test(ShapeAttr::AssumedRank))
-      TODO(loc, "Assumed Rank in procedure interface");
+      TODO(loc, "assumed rank in procedure interface");
     if (shapeAttrs.test(ShapeAttr::Coarray))
-      TODO(loc, "Coarray in procedure interface");
+      TODO(loc, "coarray in procedure interface");
 
     // So far assume that if the argument cannot be passed by implicit interface
     // it must be by box. That may no be always true (e.g for simple optionals)

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1036,7 +1036,7 @@ public:
       TODO(loc, "rank inquiry on assumed rank");
     case Fortran::evaluate::DescriptorInquiry::Field::Stride:
       // So far the front end does not generate this inquiry.
-      TODO(loc, "Stride inquiry");
+      TODO(loc, "stride inquiry");
     }
     llvm_unreachable("unknown descriptor inquiry");
   }
@@ -2289,7 +2289,7 @@ public:
       if (charType.hasDynamicLen() && allocMemTypeParams.empty())
         allocMemTypeParams.push_back(charLen);
     } else if (fir::hasDynamicSize(elementType)) {
-      TODO(loc, "Creating temporary for derived type with length parameters");
+      TODO(loc, "creating temporary for derived type with length parameters");
     }
 
     mlir::Value temp = builder.create<fir::AllocMemOp>(
@@ -4496,8 +4496,9 @@ private:
       const Fortran::evaluate::ProcedureRef &procRef,
       llvm::Optional<mlir::Type> retTy,
       const Fortran::evaluate::SpecificIntrinsic &intrinsic) {
+
     llvm::SmallVector<CC> operands;
-    llvm::StringRef name = intrinsic.name;
+    std::string name = intrinsic.name;
     const Fortran::lower::IntrinsicArgumentLoweringRules *argLowering =
         Fortran::lower::getIntrinsicArgumentLowering(name);
     mlir::Location loc = getLoc();
@@ -4529,7 +4530,6 @@ private:
           converter);
 
       fir::FirOpBuilder *bldr = &converter.getFirOpBuilder();
-      llvm::StringRef name = intrinsic.name;
       return [=](IterSpace iters) -> ExtValue {
         auto getArgument = [&](std::size_t i) -> ExtValue {
           return operands[i].first(iters);
@@ -5320,6 +5320,7 @@ private:
                   // vector subscript with replicated values.
                   assert(!isBoxValue() &&
                          "fir.box cannot be created with vector subscripts");
+                  // TODO: Avoid creating a new evaluate::Expr here
                   auto arrExpr = ignoreEvConvert(e);
                   if (createDestShape) {
                     destShape.push_back(fir::getExtentAtDimension(
@@ -5957,7 +5958,6 @@ private:
 
     if (fir::isRecordWithAllocatableMember(eleTy))
       TODO(loc, "deep copy on allocatable members");
-
     if (!eleSz) {
       // Compute the element size at runtime.
       assert(fir::hasDynamicSize(eleTy));

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -164,7 +164,7 @@ struct TypeBuilder {
       int rank = expr.Rank();
       if (rank < 0)
         TODO(converter.getCurrentLocation(),
-             "Assumed rank expression type lowering");
+             "assumed rank expression type lowering");
       for (int dim = 0; dim < rank; ++dim)
         shape.emplace_back(fir::SequenceType::getUnknownExtent());
     }
@@ -331,7 +331,7 @@ struct TypeBuilder {
     if (!ps.empty()) {
       // This type is a PDT (parametric derived type). Create the functions to
       // use for allocation, dereferencing, and address arithmetic here.
-      TODO(loc, "parametrized derived types lowering");
+      TODO(loc, "parameterized derived types lowering");
     }
     LLVM_DEBUG(llvm::dbgs() << "derived type: " << rec << '\n');
 

--- a/flang/lib/Lower/VectorSubscripts.cpp
+++ b/flang/lib/Lower/VectorSubscripts.cpp
@@ -111,7 +111,7 @@ private:
     // Parent components will not be found here, they are not part
     // of the FIR type and cannot be used in the path yet.
     if (componentSymbol.test(Fortran::semantics::Symbol::Flag::ParentComp))
-      TODO(loc, "Reference to parent component");
+      TODO(loc, "reference to parent component");
     mlir::Type fldTy = fir::FieldType::get(&converter.getMLIRContext());
     llvm::StringRef componentName = toStringRef(componentSymbol.name());
     // Parameters threading in field_index is not yet very clear. We only
@@ -212,7 +212,7 @@ private:
 
   mlir::Type gen(const Fortran::evaluate::CoarrayRef &) {
     // Is this possible/legal ?
-    TODO(loc, "Coarray ref with vector subscript in IO input");
+    TODO(loc, "coarray ref with vector subscript in IO input");
   }
 
   template <typename A>

--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/BoxValue.h"
+#include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/Support/Debug.h"
@@ -55,15 +56,13 @@ llvm::SmallVector<mlir::Value> fir::getTypeParams(const ExtendedValue &exv) {
       [](const fir::CharBoxValue &x) -> RT { return {x.getLen()}; },
       [](const fir::CharArrayBoxValue &x) -> RT { return {x.getLen()}; },
       [&](const fir::BoxValue &) -> RT {
-        LLVM_DEBUG(mlir::emitWarning(
-            loc, "TODO: box value is missing type parameters"));
+        TODO(loc, "box value is missing type parameters");
         return {};
       },
       [&](const fir::MutableBoxValue &) -> RT {
         // In this case, the type params may be bound to the variable in an
         // ALLOCATE statement as part of a type-spec.
-        LLVM_DEBUG(mlir::emitWarning(
-            loc, "TODO: mutable box value is missing type parameters"));
+        TODO(loc, "mutable box value is missing type parameters");
         return {};
       },
       [](const auto &) -> RT { return {}; });

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -396,7 +396,7 @@ fir::factory::genMutableBoxRead(fir::FirOpBuilder &builder, mlir::Location loc,
                                 const fir::MutableBoxValue &box,
                                 bool mayBePolymorphic) {
   if (box.hasAssumedRank())
-    TODO(loc, "Assumed rank allocatables or pointers");
+    TODO(loc, "assumed rank allocatables or pointers");
   llvm::SmallVector<mlir::Value> lbounds;
   llvm::SmallVector<mlir::Value> extents;
   llvm::SmallVector<mlir::Value> lengths;
@@ -526,7 +526,7 @@ void fir::factory::associateMutableBox(fir::FirOpBuilder &builder,
                             "Cannot write MutableBox to another MutableBox");
       },
       [&](const fir::ProcBoxValue &) {
-        TODO(loc, "Procedure pointer assignment");
+        TODO(loc, "procedure pointer assignment");
       });
 }
 
@@ -623,7 +623,7 @@ void fir::factory::associateMutableBoxWithRemap(
                             "Cannot write MutableBox to another MutableBox");
       },
       [&](const fir::ProcBoxValue &) {
-        TODO(loc, "Procedure pointer assignment");
+        TODO(loc, "procedure pointer assignment");
       });
 }
 

--- a/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Reduction.h"
-#include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"

--- a/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/Runtime/Transformational.h"
-#include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -15,7 +15,6 @@
 
 #include "DescriptorModel.h"
 #include "Target.h"
-#include "flang/Lower/Todo.h" // remove when TODO's are done
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/FIRContext.h"
 #include "flang/Optimizer/Support/KindMapping.h"

--- a/flang/lib/Optimizer/Transforms/AbstractResult.cpp
+++ b/flang/lib/Optimizer/Transforms/AbstractResult.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "flang/Lower/Todo.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
@@ -264,8 +265,7 @@ public:
         return true;
       auto resultType = dispatch->getResult(0).getType();
       if (resultType.isa<fir::SequenceType, fir::BoxType, fir::RecordType>()) {
-        mlir::emitError(dispatch.getLoc(),
-                        "TODO: dispatchOp with abstract results");
+        TODO(dispatch.getLoc(), "dispatchOp with abstract results");
         return false;
       }
       return true;

--- a/flang/test/Fir/Todo/allocmem.fir
+++ b/flang/test/Fir/Todo/allocmem.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 func @allocmem_test(%arg0 : i32, %arg1 : i16) {
-// CHECK: not yet implemented fir.allocmem codegen of derived type with length parameters
+// CHECK: not yet implemented: fir.allocmem codegen of derived type with length parameters
   %0 = fir.allocmem !fir.type<_QTt(p1:i32,p2:i16){f1:i32,f2:f32}>(%arg0, %arg1 : i32, i16) {name = "_QEvar"}
   return
 }

--- a/flang/test/Fir/Todo/cordinate_of_1.fir
+++ b/flang/test/Fir/Todo/cordinate_of_1.fir
@@ -5,7 +5,7 @@
 // currently being generated (this error is generated before trying to convert
 // `fir.coordinate_of`)
 func @coordinate_box_derived_with_fir_len(%arg0: !fir.box<!fir.type<derived_2{len1:i32}>>) {
-// CHECK: not yet implemented fir.len_param_index codegen
+// CHECK: not yet implemented: fir.len_param_index codegen
   %e = fir.len_param_index len1, !fir.type<derived_2{len1:i32}>
   %q = fir.coordinate_of %arg0, %e : (!fir.box<!fir.type<derived_2{len1:i32}>>, !fir.len) -> !fir.ref<i32>
   return

--- a/flang/test/Fir/Todo/cordinate_of_2.fir
+++ b/flang/test/Fir/Todo/cordinate_of_2.fir
@@ -1,6 +1,6 @@
 // RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
-// CHECK: not yet implemented fir.array nested inside other array and/or derived type
+// CHECK: not yet implemented: fir.array nested inside other array and/or derived type
 
 // `!fir.coordinate_of` - `!fir.array` inside "boxed" `!fir.type`
 func @coordinate_box_array_inside_derived(%arg0: !fir.box<!fir.type<derived_2{field_1:!fir.array<10 x i32>, field_2:i32}>>, %arg1 : index) {

--- a/flang/test/Fir/Todo/cordinate_of_3.fir
+++ b/flang/test/Fir/Todo/cordinate_of_3.fir
@@ -1,6 +1,6 @@
 // RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
-// CHECK: not yet implemented fir.array nested inside other array and/or derived type
+// CHECK: not yet implemented: fir.array nested inside other array and/or derived type
 
 // `fir.coordinate_of` - `fir.array` inside "boxed" `!fir.type<derived_1{!fir.type<derived_2{}>}` (i.e. nested `!fir.type`)
 func @coordinate_box_array_inside_derived(%arg0: !fir.box<!fir.type<derived_1{field_1:!fir.type<derived_2{field_2:!fir.array<10 x i32>}>}>>, %arg1 : index) {

--- a/flang/test/Fir/Todo/cordinate_of_4.fir
+++ b/flang/test/Fir/Todo/cordinate_of_4.fir
@@ -4,7 +4,7 @@
 // `!fir.len_param_index` is not implemented yet, the error that we hit is
 // related to `!fir.len_param_index` rather than `!fir.coordinate_of`.
 func @coordinate_box_derived_with_fir_len(%arg0: !fir.box<!fir.type<derived_2{len1:i32}>>) {
-// CHECK: not yet implemented fir.len_param_index codegen
+// CHECK: not yet implemented: fir.len_param_index codegen
   %e = fir.len_param_index len1, !fir.type<derived_2{len1:i32}>
   %q = fir.coordinate_of %arg0, %e : (!fir.box<!fir.type<derived_2{len1:i32}>>, !fir.len) -> !fir.ref<i32>
   return

--- a/flang/test/Fir/Todo/dispatch.fir
+++ b/flang/test/Fir/Todo/dispatch.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 func @dispatch(%arg0: !fir.box<!fir.type<derived3{f:f32}>>) {
-// CHECK: not yet implemented fir.dispatch codegen
+// CHECK: not yet implemented: fir.dispatch codegen
   %0 = fir.dispatch "method"(%arg0) : (!fir.box<!fir.type<derived3{f:f32}>>) -> i32
   return
 }

--- a/flang/test/Fir/Todo/dispatch_table.fir
+++ b/flang/test/Fir/Todo/dispatch_table.fir
@@ -3,7 +3,7 @@
 // Test fir.dispatch_table conversion to llvm.
 // Not implemented yet.
 
-// CHECK: not yet implemented fir.dispatch_table codegen
+// CHECK: not yet implemented: fir.dispatch_table codegen
 fir.dispatch_table @dispatch_tbl {
   fir.dt_entry "method", @method_impl
 }

--- a/flang/test/Fir/Todo/gentypedesc.fir
+++ b/flang/test/Fir/Todo/gentypedesc.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 func @gentypedesc() {
-// CHECK: not yet implemented fir.gentypedesc codegen
+// CHECK: not yet implemented: fir.gentypedesc codegen
   %0 = fir.gentypedesc !fir.type<derived3>
   return
 }

--- a/flang/test/Fir/Todo/global_len.fir
+++ b/flang/test/Fir/Todo/global_len.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 fir.global @global_derived : !fir.type<minez(f:i32)> {
-// CHECK: not yet implemented fir.global_len codegen
+// CHECK: not yet implemented: fir.global_len codegen
   fir.global_len f, 1 : i32
   %0 = fir.undefined !fir.type<minez>
   fir.has_value %0 : !fir.type<minez>

--- a/flang/test/Fir/Todo/len_param_index.fir
+++ b/flang/test/Fir/Todo/len_param_index.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 func @lenparamindex() {
-  // CHECK: not yet implemented fir.len_param_index codegen
+  // CHECK: not yet implemented: fir.len_param_index codegen
   %0 = fir.len_param_index l1, !fir.type<twolens(l1:i32, l2:i32){i:i32, f:f32, l:i64}>
   return
 }

--- a/flang/test/Fir/Todo/select_case_with_character.fir
+++ b/flang/test/Fir/Todo/select_case_with_character.fir
@@ -4,7 +4,7 @@
 // Not implemented yet.
 
 func @select_case_charachter(%arg0: !fir.char<2, 10>, %arg1: !fir.char<2, 10>, %arg2: !fir.char<2, 10>) {
-// CHECK: not yet implemented fir.select_case codegen with character type
+// CHECK: not yet implemented: fir.select_case codegen with character type
   fir.select_case %arg0 : !fir.char<2, 10> [#fir.point, %arg1, ^bb1,
                                             #fir.point, %arg2, ^bb2,
                                             unit, ^bb3]

--- a/flang/test/Lower/derived-types.f90
+++ b/flang/test/Lower/derived-types.f90
@@ -1,7 +1,7 @@
 ! Test basic parts of derived type entities lowering
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
-! Note: only testing non parametrized derived type here.
+! Note: only testing non parameterized derived type here.
 
 module d
   type r


### PR DESCRIPTION
To make it easier to find things that are not yet implemented, I'm changing the
messages that appear in the compiler's output to all have the string "not yet
implemented:".

These changes apply to files in the lowering code.  I have another set of
changes to files in the front end.

In addition the changes related to the user messages, I fixed a bug
(with Jean's help) where we were incorrectly passing around the name of
an intrinsic.

I also fixed some places where we misspelled "parameterized".