### PR TITLE
Don't assert for a procedure pointer

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1169,6 +1169,8 @@ void Fortran::lower::mapSymbolAttributes(
           loc, builder.getRefType(converter.genType(var)));
       symMap.addSymbol(sym, undefOp);
     }
+    if (Fortran::semantics::IsPointer(sym))
+      TODO(loc, "procedure pointers");
     return;
   }
 

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -1156,14 +1156,14 @@ void Fortran::lower::mapSymbolAttributes(
   const bool isDeclaredDummy = Fortran::semantics::IsDummy(sym);
   // An active dummy from the current entry point.
   const bool isDummy = isDeclaredDummy && symMap.lookupSymbol(sym).getAddr();
+  // An unused dummy from another entry point.
+  const bool isUnusedEntryDummy = isDeclaredDummy && !isDummy;
   const bool isResult = Fortran::semantics::IsFunctionResult(sym);
   const bool replace = isDummy || isResult;
   fir::factory::CharacterExprHelper charHelp{builder, loc};
 
   if (Fortran::semantics::IsProcedure(sym)) {
-    assert(isDeclaredDummy && "expected a dummy procedure argument");
-    if (!isDummy) {
-      // This is an unused dummy procedure argument from another entry point.
+    if (isUnusedEntryDummy) {
       // Additional discussion below.
       mlir::Value undefOp = builder.create<fir::UndefOp>(
           loc, builder.getRefType(converter.genType(var)));
@@ -1253,7 +1253,7 @@ void Fortran::lower::mapSymbolAttributes(
   //    for dynamic objects via calls to genUnusedEntryPointBox.
 
   auto genUnusedEntryPointBox = [&]() {
-    if (isDeclaredDummy && !isDummy) { // dummy from another entry point
+    if (isUnusedEntryDummy) {
       symMap.addSymbol(sym, fir::factory::createTempMutableBox(
                                 builder, loc, converter.genType(var)));
       return true;

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -67,7 +67,6 @@ subroutine ss(n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   integer n17, n2
-  procedure(), pointer :: procptr1
   nx = 100
   n1 = nx + 10
   return
@@ -125,7 +124,7 @@ end
 
 ! CHECK-LABEL: func @_QPchar_array()
 function char_array()
-  character(10) c(5)
+  character(10), c(5)
 ! CHECK-LABEL: func @_QPchar_array_entry(
 ! CHECK-SAME: %{{.*}}: !fir.boxchar<1>{{.*}}) -> f32 {
 entry char_array_entry(c)

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -67,6 +67,7 @@ subroutine ss(n1)
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Enx"}
   ! CHECK: fir.alloca i32 {{{.*}}uniq_name = "{{.*}}Eny"}
   integer n17, n2
+  procedure(), pointer :: procptr1
   nx = 100
   n1 = nx + 10
   return
@@ -124,7 +125,7 @@ end
 
 ! CHECK-LABEL: func @_QPchar_array()
 function char_array()
-  character(10), c(5)
+  character(10) c(5)
 ! CHECK-LABEL: func @_QPchar_array_entry(
 ! CHECK-SAME: %{{.*}}: !fir.boxchar<1>{{.*}}) -> f32 {
 entry char_array_entry(c)


### PR DESCRIPTION
A procedure pointer does not yet have code to map it to fir.
Do not prematurely assert attempting to map one, as that masks a
later more user friendly "unimplemented" message.