### PR TITLE
system_clock intrinsic calls with dynamically optional arguments

### DIFF
--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -371,10 +371,10 @@ public:
   }
 
   /// Generate code testing \p addr is not a null address.
-  mlir::Value genIsNotNull(mlir::Location loc, mlir::Value addr);
+  mlir::Value genIsNotNullAddr(mlir::Location loc, mlir::Value addr);
 
   /// Generate code testing \p addr is a null address.
-  mlir::Value genIsNull(mlir::Location loc, mlir::Value addr);
+  mlir::Value genIsNullAddr(mlir::Location loc, mlir::Value addr);
 
   /// Compute the extent of (lb:ub:step) as max((ub-lb+step)/step, 0). See
   /// Fortran 2018 9.5.3.3.2 section for more details.

--- a/flang/lib/Lower/CustomIntrinsicCall.cpp
+++ b/flang/lib/Lower/CustomIntrinsicCall.cpp
@@ -52,14 +52,14 @@ static bool isIshftcWithDynamicallyOptionalArg(
          Fortran::evaluate::MayBePassedAsAbsentOptional(*expr, foldingContex);
 }
 
-/// Is this a call to SYSTEM_CLOCK or RANDOM_SEED intrinsic with arguments that
-/// may be absent at runtime? This are special cases because that aspect cannot
+/// Is this a call to the RANDOM_SEED intrinsic with arguments that may be
+/// absent at runtime? This is a special case because that aspect cannot
 /// be delegated to the runtime via a null fir.box or address given the current
 /// runtime entry point.
-static bool isSystemClockOrRandomSeedWithOptionalArg(
+static bool isRandomSeedWithDynamicallyOptionalArg(
     llvm::StringRef name, const Fortran::evaluate::ProcedureRef &procRef,
     Fortran::evaluate::FoldingContext &foldingContex) {
-  if (name != "system_clock" && name != "random_seed")
+  if (name != "random_seed")
     return false;
   for (const auto &arg : procRef.arguments()) {
     auto *expr = Fortran::evaluate::UnwrapExpr<Fortran::lower::SomeExpr>(arg);
@@ -78,7 +78,7 @@ bool Fortran::lower::intrinsicRequiresCustomOptionalHandling(
   Fortran::evaluate::FoldingContext &fldCtx = converter.getFoldingContext();
   return isMinOrMaxWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
          isIshftcWithDynamicallyOptionalArg(name, procRef, fldCtx) ||
-         isSystemClockOrRandomSeedWithOptionalArg(name, procRef, fldCtx);
+         isRandomSeedWithDynamicallyOptionalArg(name, procRef, fldCtx);
 }
 
 static void prepareMinOrMaxArguments(

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -402,7 +402,7 @@ public:
         if (!fir::isa_ref_type(eleTy))
           eleTy = builder.getRefType(eleTy);
         auto addr = builder.create<fir::BoxAddrOp>(loc, eleTy, box);
-        mlir::Value isPresent = builder.genIsNotNull(loc, addr);
+        mlir::Value isPresent = builder.genIsNotNullAddr(loc, addr);
         auto absentBox = builder.create<fir::AbsentOp>(loc, boxTy);
         box = builder.create<mlir::SelectOp>(loc, isPresent, box, absentBox);
       }

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -3269,7 +3269,7 @@ IntrinsicLibrary::genSize(mlir::Type resultType,
     return builder.createConvert(
         loc, resultType, fir::runtime::genSizeDim(builder, loc, array, dim));
 
-  mlir::Value isDynamicallyAbsent = builder.genIsNull(loc, dim);
+  mlir::Value isDynamicallyAbsent = builder.genIsNullAddr(loc, dim);
   return builder
       .genIfOp(loc, {resultType}, isDynamicallyAbsent,
                /*withElseRegion=*/true)

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -499,13 +499,14 @@ genNullPointerComparison(fir::FirOpBuilder &builder, mlir::Location loc,
   return builder.create<mlir::arith::CmpIOp>(loc, condition, ptrToInt, c0);
 }
 
-mlir::Value fir::FirOpBuilder::genIsNotNull(mlir::Location loc,
-                                            mlir::Value addr) {
+mlir::Value fir::FirOpBuilder::genIsNotNullAddr(mlir::Location loc,
+                                                mlir::Value addr) {
   return genNullPointerComparison(*this, loc, addr,
                                   mlir::arith::CmpIPredicate::ne);
 }
 
-mlir::Value fir::FirOpBuilder::genIsNull(mlir::Location loc, mlir::Value addr) {
+mlir::Value fir::FirOpBuilder::genIsNullAddr(mlir::Location loc,
+                                             mlir::Value addr) {
   return genNullPointerComparison(*this, loc, addr,
                                   mlir::arith::CmpIPredicate::eq);
 }

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -427,7 +427,7 @@ fir::factory::genIsAllocatedOrAssociatedTest(fir::FirOpBuilder &builder,
                                              mlir::Location loc,
                                              const fir::MutableBoxValue &box) {
   auto addr = MutablePropertyReader(builder, loc, box).readBaseAddress();
-  return builder.genIsNotNull(loc, addr);
+  return builder.genIsNotNullAddr(loc, addr);
 }
 
 /// Generate finalizer call and inlined free. This does not check that the
@@ -447,7 +447,7 @@ void fir::factory::genFinalization(fir::FirOpBuilder &builder,
                                    mlir::Location loc,
                                    const fir::MutableBoxValue &box) {
   auto addr = MutablePropertyReader(builder, loc, box).readBaseAddress();
-  auto isAllocated = builder.genIsNotNull(loc, addr);
+  auto isAllocated = builder.genIsNotNullAddr(loc, addr);
   auto ifOp = builder.create<fir::IfOp>(loc, isAllocated,
                                         /*withElseRegion=*/false);
   auto insPt = builder.saveInsertionPoint();
@@ -714,7 +714,7 @@ fir::factory::genReallocIfNeeded(fir::FirOpBuilder &builder, mlir::Location loc,
   auto addr = reader.readBaseAddress();
   auto i1Type = builder.getI1Type();
   auto addrType = addr.getType();
-  auto isAllocated = builder.genIsNotNull(loc, addr);
+  auto isAllocated = builder.genIsNotNullAddr(loc, addr);
   auto ifOp =
       builder
           .genIfOp(loc, {i1Type, addrType}, isAllocated,

--- a/flang/lib/Optimizer/Builder/Runtime/Ragged.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Ragged.cpp
@@ -35,7 +35,7 @@ void fir::runtime::genRaggedArrayAllocate(mlir::Location loc,
   auto ptrTy = builder.getRefType(eleTy.cast<mlir::TupleType>().getType(1));
   auto ptr = builder.create<fir::CoordinateOp>(loc, ptrTy, header, one);
   auto heap = builder.create<fir::LoadOp>(loc, ptr);
-  auto cmp = builder.genIsNull(loc, heap);
+  auto cmp = builder.genIsNullAddr(loc, heap);
   builder.genIfThen(loc, cmp)
       .genThen([&]() {
         auto asHeadersVal = builder.createIntegerConstant(loc, i1Ty, asHeaders);

--- a/flang/test/Lower/intrinsic-procedures/system_clock.f90
+++ b/flang/test/Lower/intrinsic-procedures/system_clock.f90
@@ -30,62 +30,136 @@ subroutine system_clock_test()
 ! print*, m
 end subroutine
 
-! CHECK-LABEL: system_clock_optional_test
-subroutine system_clock_optional_test()
-  ! CHECK-DAG: %[[VAL_0:[0-9]*]] = fir.alloca i64 {bindc_name = "count", uniq_name = "_QFsystem_clock_optional_testEcount"}
-  ! CHECK-DAG: %[[VAL_1:[0-9]*]] = fir.alloca !fir.box<!fir.heap<i64>> {bindc_name = "count_max", uniq_name = "_QFsystem_clock_optional_testEcount_max"}
-  ! CHECK-DAG: %[[VAL_2:[0-9]*]] = fir.alloca !fir.heap<i64> {uniq_name = "_QFsystem_clock_optional_testEcount_max.addr"}
-  ! CHECK-DAG: %[[VAL_4:[0-9]*]] = fir.alloca !fir.box<!fir.ptr<i64>> {bindc_name = "count_rate", uniq_name = "_QFsystem_clock_optional_testEcount_rate"}
-  ! CHECK-DAG: %[[VAL_5:[0-9]*]] = fir.alloca !fir.ptr<i64> {uniq_name = "_QFsystem_clock_optional_testEcount_rate.addr"}
-  ! CHECK-DAG: %[[VAL_7:[0-9]*]] = fir.alloca i64 {bindc_name = "count_rate_", fir.target, uniq_name = "_QFsystem_clock_optional_testEcount_rate_"}
-  ! CHECK-DAG: %[[VAL_9:[0-9]*]] = fir.allocmem i64 {uniq_name = "_QFsystem_clock_optional_testEcount_max.alloc"}
-  ! CHECK: fir.store %[[VAL_9]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
-  integer(8) :: count
+! CHECK-LABEL: @_QPss
+subroutine ss(count)
+  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.box<!fir.heap<i64>> {bindc_name = "count_max", uniq_name = "_QFssEcount_max"}
+  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.heap<i64> {uniq_name = "_QFssEcount_max.addr"}
+  ! CHECK:   %[[V_2:[0-9]+]] = fir.zero_bits !fir.heap<i64>
+  ! CHECK:   fir.store %[[V_2]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.box<!fir.ptr<i64>> {bindc_name = "count_rate", uniq_name = "_QFssEcount_rate"}
+  ! CHECK:   %[[V_4:[0-9]+]] = fir.alloca !fir.ptr<i64> {uniq_name = "_QFssEcount_rate.addr"}
+  ! CHECK:   %[[V_5:[0-9]+]] = fir.zero_bits !fir.ptr<i64>
+  ! CHECK:   fir.store %[[V_5]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:   %[[V_6:[0-9]+]] = fir.alloca i64 {bindc_name = "count_rate_", fir.target, uniq_name = "_QFssEcount_rate_"}
+  ! CHECK:   %[[V_7:[0-9]+]] = fir.convert %[[V_6]] : (!fir.ref<i64>) -> !fir.ptr<i64>
+  ! CHECK:   fir.store %[[V_7]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:   %[[V_8:[0-9]+]] = fir.allocmem i64 {uniq_name = "_QFssEcount_max.alloc"}
+  ! CHECK:   fir.store %[[V_8]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   %[[V_9:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:   %[[V_10:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   %[[V_11:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  ! CHECK:   fir.if %[[V_11]] {
+  ! CHECK:     %[[V_29:[0-9]+]] = fir.call @_FortranASystemClockCount(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %[[V_9]] : (!fir.ptr<i64>) -> i64
+  ! CHECK:   %[[V_13:[0-9]+]] = arith.cmpi ne, %[[V_12]], %c0{{.*}}_i64 : i64
+  ! CHECK:   fir.if %[[V_13]] {
+  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %[[V_9]] : !fir.ptr<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_14:[0-9]+]] = fir.convert %[[V_10]] : (!fir.heap<i64>) -> i64
+  ! CHECK:   %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_14]], %c0{{.*}}_i64_0 : i64
+  ! CHECK:   fir.if %[[V_15]] {
+  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %[[V_10]] : !fir.heap<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_16:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  ! CHECK:   fir.if %[[V_16]] {
+  ! CHECK:     %[[V_31:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK:     %[[V_32:[0-9]+]] = fir.load %arg0 : !fir.ref<i64>
+  ! CHECK:     %[[V_33:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_32]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_34:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:     %[[V_35:[0-9]+]] = fir.load %[[V_34]] : !fir.ptr<i64>
+  ! CHECK:     %[[V_36:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_35]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_37:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:     %[[V_38:[0-9]+]] = fir.load %[[V_37]] : !fir.heap<i64>
+  ! CHECK:     %[[V_39:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_38]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_40:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_31]]) : (!fir.ref<i8>) -> i32
+  ! CHECK:   } else {
+  ! CHECK:     %[[V_29]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:     %[[V_30:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:     %[[V_31]] = fir.convert %[[V_29]] : (!fir.ptr<i64>) -> i64
+  ! CHECK:     %[[V_32]] = arith.cmpi ne, %[[V_31]], %c0{{.*}}_i64_3 : i64
+  ! CHECK:     fir.if %[[V_32]] {
+  ! CHECK:       %[[V_45:[0-9]+]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:       fir.store %[[V_45]] to %[[V_29]] : !fir.ptr<i64>
+  ! CHECK:     }
+  ! CHECK:     %[[V_33]] = fir.convert %[[V_30]] : (!fir.heap<i64>) -> i64
+  ! CHECK:     %[[V_34]] = arith.cmpi ne, %[[V_33]], %c0{{.*}}_i64_4 : i64
+  ! CHECK:     fir.if %[[V_34]] {
+  ! CHECK:       %[[V_45]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:       fir.store %[[V_45]] to %[[V_30]] : !fir.heap<i64>
+  ! CHECK:     }
+  ! CHECK:     %[[V_37]] = fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK:     %[[V_38]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:     %[[V_39]] = fir.load %[[V_38]] : !fir.ptr<i64>
+  ! CHECK:     %[[V_40]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_39]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_41:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:     %[[V_42:[0-9]+]] = fir.load %[[V_41]] : !fir.heap<i64>
+  ! CHECK:     %[[V_43:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_42]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_44:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_37]]) : (!fir.ref<i8>) -> i32
+  ! CHECK:   }
+  ! CHECK:   %[[V_17:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  ! CHECK:   fir.if %[[V_17]] {
+  ! CHECK:     %[[V_29]] = fir.convert %c0{{.*}}_i32 : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
+  ! CHECK:   } else {
+  ! CHECK:   }
+  ! CHECK:   %[[V_18:[0-9]+]] = fir.zero_bits !fir.ptr<i64>
+  ! CHECK:   fir.store %[[V_18]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:   %[[V_19:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   fir.freemem %[[V_19]] : !fir.heap<i64>
+  ! CHECK:   %[[V_20:[0-9]+]] = fir.zero_bits !fir.heap<i64>
+  ! CHECK:   fir.store %[[V_20]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   %[[V_21:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:   %[[V_22:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK:   %[[V_23:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  ! CHECK:   fir.if %[[V_23]] {
+  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCount(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_24:[0-9]+]] = fir.convert %[[V_21]] : (!fir.ptr<i64>) -> i64
+  ! CHECK:   %[[V_25:[0-9]+]] = arith.cmpi ne, %[[V_24]], %c0{{.*}}_i64_1 : i64
+  ! CHECK:   fir.if %[[V_25]] {
+  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %[[V_21]] : !fir.ptr<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_26:[0-9]+]] = fir.convert %[[V_22]] : (!fir.heap<i64>) -> i64
+  ! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi ne, %[[V_26]], %c0{{.*}}_i64_2 : i64
+  ! CHECK:   fir.if %[[V_27]] {
+  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) : (i32) -> i64
+  ! CHECK:     fir.store %[[V_29]] to %[[V_22]] : !fir.heap<i64>
+  ! CHECK:   }
+  ! CHECK:   %[[V_28:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
+  ! CHECK:   fir.if %[[V_28]] {
+  ! CHECK:     %[[V_31]] = fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK:     %[[V_32]] = fir.load %arg0 : !fir.ref<i64>
+  ! CHECK:     %[[V_33]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_32]]) : (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_34]] = fir.call @_FortranAioEndIoStatement(%[[V_31]]) : (!fir.ref<i8>) -> i32
+  ! CHECK:   } else {
+  ! CHECK:   }
+  ! CHECK:   return
+  ! CHECK: }
+
+  integer(8), optional :: count
   integer(8), target :: count_rate_
   integer(8), pointer :: count_rate
   integer(8), allocatable :: count_max
 
-  ! CHECK: %[[VAL_10:[0-9]*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK: %[[VAL_11:[0-9]*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK: %[[VAL_12:[0-9]*]] = fir.call @_FortranASystemClockCount(%c8{{.*}}) : (i32) -> i64
-  ! CHECK: fir.store %[[VAL_12]] to %[[VAL_0]] : !fir.ref<i64>
-  ! CHECK: %[[VAL_13:[0-9]*]] = fir.convert %[[VAL_10]] : (!fir.ptr<i64>) -> i64
-  ! CHECK: %[[VAL_14:[0-9]*]] = arith.cmpi ne, %[[VAL_13]], %c0{{.*}} : i64
-  ! CHECK: fir.if %[[VAL_14]] {
-  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}) : (i32) -> i64
-  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_10]] : !fir.ptr<i64>
-  ! CHECK: }
-  ! CHECK: %[[VAL_15:[0-9]*]] = fir.convert %[[VAL_11]] : (!fir.heap<i64>) -> i64
-  ! CHECK: %[[VAL_16:[0-9]*]] = arith.cmpi ne, %[[VAL_15]], %c0{{.*}} : i64
-  ! CHECK: fir.if %[[VAL_16]] {
-  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}) : (i32) -> i64
-  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_11]] : !fir.heap<i64>
-  ! CHECK: }
   count_rate => count_rate_
   allocate(count_max)
   call system_clock(count, count_rate, count_max)
-  print*, count, count_rate, count_max
+  if (present(count)) then
+    print*, count, count_rate, count_max
+  else
+    call system_clock(count_rate=count_rate, count_max=count_max)
+    print*, count_rate, count_max
+  endif
 
-  ! CHECK:                    = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK: %[[VAL_33:[0-9]*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK: %[[VAL_34:[0-9]*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK: %[[VAL_35:[0-9]*]] = fir.call @_FortranASystemClockCount(%c8{{.*}}) : (i32) -> i64
-  ! CHECK: fir.store %[[VAL_35]] to %[[VAL_0]] : !fir.ref<i64>
-  ! CHECK: %[[VAL_36:[0-9]*]] = fir.convert %[[VAL_33]] : (!fir.ptr<i64>) -> i64
-  ! CHECK: %[[VAL_37:[0-9]*]] = arith.cmpi ne, %[[VAL_36]], %c0{{.*}} : i64
-  ! CHECK: fir.if %[[VAL_37]] {
-  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}) : (i32) -> i64
-  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_33]] : !fir.ptr<i64>
-  ! CHECK: }
-  ! CHECK: %[[VAL_38:[0-9]*]] = fir.convert %[[VAL_34]] : (!fir.heap<i64>) -> i64
-  ! CHECK: %[[VAL_39:[0-9]*]] = arith.cmpi ne, %[[VAL_38]], %c0{{.*}} : i64
-  ! CHECK: fir.if %[[VAL_39]] {
-  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}) : (i32) -> i64
-  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_34]] : !fir.heap<i64>
-  ! CHECK: }
-  count = 0
+  if (present(count)) count = 0
   count_rate => null()
   deallocate(count_max)
   call system_clock(count, count_rate, count_max)
-  print*, count
+  if (present(count)) print*, count
 end

--- a/flang/test/Lower/intrinsic-procedures/system_clock.f90
+++ b/flang/test/Lower/intrinsic-procedures/system_clock.f90
@@ -29,3 +29,63 @@ subroutine system_clock_test()
   ! CHECK-NOT: fir.call
 ! print*, m
 end subroutine
+
+! CHECK-LABEL: system_clock_optional_test
+subroutine system_clock_optional_test()
+  ! CHECK-DAG: %[[VAL_0:[0-9]*]] = fir.alloca i64 {bindc_name = "count", uniq_name = "_QFsystem_clock_optional_testEcount"}
+  ! CHECK-DAG: %[[VAL_1:[0-9]*]] = fir.alloca !fir.box<!fir.heap<i64>> {bindc_name = "count_max", uniq_name = "_QFsystem_clock_optional_testEcount_max"}
+  ! CHECK-DAG: %[[VAL_2:[0-9]*]] = fir.alloca !fir.heap<i64> {uniq_name = "_QFsystem_clock_optional_testEcount_max.addr"}
+  ! CHECK-DAG: %[[VAL_4:[0-9]*]] = fir.alloca !fir.box<!fir.ptr<i64>> {bindc_name = "count_rate", uniq_name = "_QFsystem_clock_optional_testEcount_rate"}
+  ! CHECK-DAG: %[[VAL_5:[0-9]*]] = fir.alloca !fir.ptr<i64> {uniq_name = "_QFsystem_clock_optional_testEcount_rate.addr"}
+  ! CHECK-DAG: %[[VAL_7:[0-9]*]] = fir.alloca i64 {bindc_name = "count_rate_", fir.target, uniq_name = "_QFsystem_clock_optional_testEcount_rate_"}
+  ! CHECK-DAG: %[[VAL_9:[0-9]*]] = fir.allocmem i64 {uniq_name = "_QFsystem_clock_optional_testEcount_max.alloc"}
+  ! CHECK: fir.store %[[VAL_9]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+  integer(8) :: count
+  integer(8), target :: count_rate_
+  integer(8), pointer :: count_rate
+  integer(8), allocatable :: count_max
+
+  ! CHECK: %[[VAL_10:[0-9]*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK: %[[VAL_11:[0-9]*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK: %[[VAL_12:[0-9]*]] = fir.call @_FortranASystemClockCount(%c8{{.*}}) : (i32) -> i64
+  ! CHECK: fir.store %[[VAL_12]] to %[[VAL_0]] : !fir.ref<i64>
+  ! CHECK: %[[VAL_13:[0-9]*]] = fir.convert %[[VAL_10]] : (!fir.ptr<i64>) -> i64
+  ! CHECK: %[[VAL_14:[0-9]*]] = arith.cmpi ne, %[[VAL_13]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[VAL_14]] {
+  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}) : (i32) -> i64
+  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_10]] : !fir.ptr<i64>
+  ! CHECK: }
+  ! CHECK: %[[VAL_15:[0-9]*]] = fir.convert %[[VAL_11]] : (!fir.heap<i64>) -> i64
+  ! CHECK: %[[VAL_16:[0-9]*]] = arith.cmpi ne, %[[VAL_15]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[VAL_16]] {
+  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}) : (i32) -> i64
+  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_11]] : !fir.heap<i64>
+  ! CHECK: }
+  count_rate => count_rate_
+  allocate(count_max)
+  call system_clock(count, count_rate, count_max)
+  print*, count, count_rate, count_max
+
+  ! CHECK:                    = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK: %[[VAL_33:[0-9]*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK: %[[VAL_34:[0-9]*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+  ! CHECK: %[[VAL_35:[0-9]*]] = fir.call @_FortranASystemClockCount(%c8{{.*}}) : (i32) -> i64
+  ! CHECK: fir.store %[[VAL_35]] to %[[VAL_0]] : !fir.ref<i64>
+  ! CHECK: %[[VAL_36:[0-9]*]] = fir.convert %[[VAL_33]] : (!fir.ptr<i64>) -> i64
+  ! CHECK: %[[VAL_37:[0-9]*]] = arith.cmpi ne, %[[VAL_36]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[VAL_37]] {
+  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}) : (i32) -> i64
+  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_33]] : !fir.ptr<i64>
+  ! CHECK: }
+  ! CHECK: %[[VAL_38:[0-9]*]] = fir.convert %[[VAL_34]] : (!fir.heap<i64>) -> i64
+  ! CHECK: %[[VAL_39:[0-9]*]] = arith.cmpi ne, %[[VAL_38]], %c0{{.*}} : i64
+  ! CHECK: fir.if %[[VAL_39]] {
+  ! CHECK:   %[[VAL_46:[0-9]*]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}) : (i32) -> i64
+  ! CHECK:   fir.store %[[VAL_46]] to %[[VAL_34]] : !fir.heap<i64>
+  ! CHECK: }
+  count = 0
+  count_rate => null()
+  deallocate(count_max)
+  call system_clock(count, count_rate, count_max)
+  print*, count
+end

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -99,23 +99,23 @@ TEST_F(FIRBuilderTest, genIfWithThenAndElse) {
 // Helper functions tests
 //===----------------------------------------------------------------------===//
 
-TEST_F(FIRBuilderTest, genIsNotNull) {
+TEST_F(FIRBuilderTest, genIsNotNullAddr) {
   auto builder = getBuilder();
   auto loc = builder.getUnknownLoc();
   auto dummyValue =
       builder.createIntegerConstant(loc, builder.getIndexType(), 0);
-  auto res = builder.genIsNotNull(loc, dummyValue);
+  auto res = builder.genIsNotNullAddr(loc, dummyValue);
   EXPECT_TRUE(mlir::isa<arith::CmpIOp>(res.getDefiningOp()));
   auto cmpOp = dyn_cast<arith::CmpIOp>(res.getDefiningOp());
   EXPECT_EQ(arith::CmpIPredicate::ne, cmpOp.getPredicate());
 }
 
-TEST_F(FIRBuilderTest, genIsNull) {
+TEST_F(FIRBuilderTest, genIsNullAddr) {
   auto builder = getBuilder();
   auto loc = builder.getUnknownLoc();
   auto dummyValue =
       builder.createIntegerConstant(loc, builder.getIndexType(), 0);
-  auto res = builder.genIsNull(loc, dummyValue);
+  auto res = builder.genIsNullAddr(loc, dummyValue);
   EXPECT_TRUE(mlir::isa<arith::CmpIOp>(res.getDefiningOp()));
   auto cmpOp = dyn_cast<arith::CmpIOp>(res.getDefiningOp());
   EXPECT_EQ(arith::CmpIPredicate::eq, cmpOp.getPredicate());
@@ -147,8 +147,7 @@ TEST_F(FIRBuilderTest, createRealZeroConstant) {
   EXPECT_TRUE(mlir::isa<mlir::arith::ConstantOp>(cst.getDefiningOp()));
   auto cstOp = dyn_cast<mlir::arith::ConstantOp>(cst.getDefiningOp());
   EXPECT_EQ(realTy, cstOp.getType());
-  EXPECT_EQ(
-      0u, cstOp.value().cast<FloatAttr>().getValue().convertToDouble());
+  EXPECT_EQ(0u, cstOp.value().cast<FloatAttr>().getValue().convertToDouble());
 }
 
 TEST_F(FIRBuilderTest, createBool) {


### PR DESCRIPTION
Modify intrinsic system_clock calls to allow for an argument that is a
disassociated pointer or an unallocated allocatable.  A call with such
an argument is the same as a call that does not specify that argument.