### PR TITLE
Address performance issue from unneeded array copy.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -2132,7 +2132,9 @@ class region_Op<string mnemonic, list<OpTrait> traits = []> :
 }
 
 def fir_DoLoopOp : region_Op<"do_loop",
-    [DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
+    [DeclareOpInterfaceMethods<LoopLikeOpInterface>,
+     DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+     RecursiveSideEffects]> {
   let summary = "generalized loop operation";
   let description = [{
     Generalized high-level looping construct. This operation is similar to
@@ -2227,7 +2229,9 @@ def fir_DoLoopOp : region_Op<"do_loop",
   }];
 }
 
-def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
+def fir_IfOp : region_Op<"if",
+      [DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+       RecursiveSideEffects, NoRegionArguments]> {
   let summary = "if-then-else conditional operation";
   let description = [{
     Used to conditionally execute operations. This operation is the FIR
@@ -2277,7 +2281,9 @@ def fir_IfOp : region_Op<"if", [NoRegionArguments]> {
 }
 
 def fir_IterWhileOp : region_Op<"iterate_while",
-    [DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
+    [DeclareOpInterfaceMethods<LoopLikeOpInterface>,
+     DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+     RecursiveSideEffects]> {
   let summary = "DO loop with early exit condition";
   let description = [{
     This single-entry, single-exit looping construct is useful for lowering

--- a/flang/test/Fir/array-value-copy-3.fir
+++ b/flang/test/Fir/array-value-copy-3.fir
@@ -53,3 +53,48 @@ func @test_overlap_with_alloc_components(%arg0: !fir.ref<!fir.array<10x!t_with_a
 // CHECK:   %[[VAL_72:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.ref<!fir.array<10x!fir.type<t{i:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>>>) -> !fir.box<none>
 // CHECK:   %[[VAL_73:.*]] = fir.call @_FortranADestroy(%[[VAL_72]]) : (!fir.box<none>) -> none
 // CHECK:   fir.freemem %[[VAL_11]]
+
+func @_QMtestPissue() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 4.200000e+01 : f32
+  %0 = fir.alloca !fir.array<1xf32> {bindc_name = "a", uniq_name = "_QMtestFissueEa"}
+  %1 = fir.shape %c1 : (index) -> !fir.shape<1>
+  %2 = fir.array_load %0(%1) : (!fir.ref<!fir.array<1xf32>>, !fir.shape<1>) -> !fir.array<1xf32>
+  %3 = fir.do_loop %arg0 = %c0 to %c0 step %c1 unordered iter_args(%arg1 = %2) -> (!fir.array<1xf32>) {
+    %13 = fir.array_update %arg1, %cst, %arg0 : (!fir.array<1xf32>, f32, index) -> !fir.array<1xf32>
+    fir.result %13 : !fir.array<1xf32>
+  }
+  fir.array_merge_store %2, %3 to %0 : !fir.array<1xf32>, !fir.array<1xf32>, !fir.ref<!fir.array<1xf32>>
+  %4 = fir.array_load %0(%1) : (!fir.ref<!fir.array<1xf32>>, !fir.shape<1>) -> !fir.array<1xf32>
+  %5 = fir.embox %0(%1) : (!fir.ref<!fir.array<1xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<1xf32>>
+  %6:3 = fir.box_dims %5, %c0 : (!fir.box<!fir.array<1xf32>>, index) -> (index, index, index)
+  %7 = fir.alloca !fir.array<?xf32>, %c1 {bindc_name = ".result"}
+  %8 = fir.shape %6#1 : (index) -> !fir.shape<1>
+  %9 = fir.convert %5 : (!fir.box<!fir.array<1xf32>>) -> !fir.box<!fir.array<?xf32>>
+  %10 = fir.call @_QMtestPfoo(%9) : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
+  fir.save_result %10 to %7(%8) : !fir.array<?xf32>, !fir.ref<!fir.array<?xf32>>, !fir.shape<1>
+  %11 = fir.array_load %7(%8) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
+  %12 = fir.do_loop %arg0 = %c0 to %c0 step %c1 unordered iter_args(%arg1 = %4) -> (!fir.array<1xf32>) {
+    %13 = fir.array_fetch %11, %arg0 : (!fir.array<?xf32>, index) -> f32
+    %14 = fir.array_update %arg1, %13, %arg0 : (!fir.array<1xf32>, f32, index) -> !fir.array<1xf32>
+    fir.result %14 : !fir.array<1xf32>
+  }
+  fir.array_merge_store %4, %12 to %0 : !fir.array<1xf32>, !fir.array<1xf32>, !fir.ref<!fir.array<1xf32>>
+  return
+}
+
+// CHECK-LABEL: func @_QMtestPissue() {
+// CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%{{.*}} = %{{.*}}) -> (!fir.array<1xf32>) {
+// CHECK: fir.result %{{.*}} : !fir.array<1xf32>
+// CHECK-NOT: fir.do_loop
+// CHECK: fir.call @_QMtestPfoo
+// CHECK: fir.do_loop %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} unordered iter_args(%{{.*}} = %{{.*}}) -> (!fir.array<1xf32>) {
+// CHECK: fir.result %{{.*}} : !fir.array<1xf32>
+// CHECK-NOT: fir.do_loop
+// CHECK: return
+
+func private @_QMtestPfoo(!fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> !fir.array<?xf32>
+func private @llvm.stacksave() -> !fir.ref<i8>
+func private @llvm.stackrestore(!fir.ref<i8>)
+


### PR DESCRIPTION
An array copy is made when the array is an argument to an elemental
function. If the function is applied to the entire array value, then the
copy-in/copy-out is elided and any aliasing issues are the user's
responsibility.

Also augments structured FIR ops with newer MLIR interfaces and uses
dependence analysis instead of assuming a particular high-level control
flow structure must be present.

Add regression test.