### PR TITLE
Handle boxed characters that are values when doing a conversion.

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -1246,10 +1246,20 @@ public:
             // to "0xE2 0x82 0xAC" : UTF-8.
             mlir::Value bufferSize = boxchar.getLen();
             auto kindMap = builder.getKindMap();
-            auto fromBits = kindMap.getCharacterBitsize(
-                fir::unwrapRefType(boxchar.getAddr().getType())
-                    .cast<fir::CharacterType>()
-                    .getFKind());
+            mlir::Value boxCharAddr = boxchar.getAddr();
+            auto fromTy = boxCharAddr.getType();
+            if (auto charTy = fromTy.dyn_cast<fir::CharacterType>()) {
+              // boxchar is a value, not a variable. Turn it into a temporary.
+              // As a value, it ought to have a constant LEN value.
+              assert(charTy.hasConstantLen() && "must have constant length");
+              mlir::Value tmp = builder.createTemporary(loc, charTy);
+              builder.create<fir::StoreOp>(loc, boxCharAddr, tmp);
+              boxCharAddr = tmp;
+            }
+            auto fromBits =
+                kindMap.getCharacterBitsize(fir::unwrapRefType(fromTy)
+                                                .cast<fir::CharacterType>()
+                                                .getFKind());
             auto toBits = kindMap.getCharacterBitsize(
                 ty.cast<fir::CharacterType>().getFKind());
             if (toBits < fromBits) {
@@ -1261,7 +1271,7 @@ public:
             }
             auto dest = builder.create<fir::AllocaOp>(
                 loc, ty, mlir::ValueRange{bufferSize});
-            builder.create<fir::CharConvertOp>(loc, boxchar.getAddr(),
+            builder.create<fir::CharConvertOp>(loc, boxCharAddr,
                                                boxchar.getLen(), dest);
             return fir::CharBoxValue{dest, boxchar.getLen()};
           } else {

--- a/flang/test/Lower/intrinsic-procedures/achar.f90
+++ b/flang/test/Lower/intrinsic-procedures/achar.f90
@@ -1,0 +1,24 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Tests ACHAR lowering (converting an INTEGER to a CHARACTER (singleton, LEN=1)
+! along with conversion of CHARACTER to another KIND.
+subroutine achar_test1(a)
+  integer, parameter :: ckind = 2
+  integer, intent(in) :: a
+  character(kind=ckind, len=1) :: ch
+
+  ch = achar(a)
+  call achar_test1_foo(ch)
+end subroutine achar_test1
+
+! CHECK-LABEL: func @_QPachar_test1(
+! CHECK-SAME: %[[arg:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) {
+! CHECK: %[[VAL_0:.*]] = fir.alloca !fir.char<1>
+! CHECK: %[[VAL_1:.*]] = fir.alloca !fir.char<2> {bindc_name = "ch", uniq_name = "_QFachar_test1Ech"}
+! CHECK: %[[VAL_2:.*]] = fir.load %[[arg]] : !fir.ref<i32>
+! CHECK: %[[VAL_5:.*]] = fir.undefined !fir.char<1>
+! CHECK: %[[VAL_6:.*]] = fir.insert_value %[[VAL_5]], %{{.*}}, [0 : index] : (!fir.char<1>, i8) -> !fir.char<1>
+! CHECK: fir.store %[[VAL_6]] to %[[VAL_0]] : !fir.ref<!fir.char<1>>
+! CHECK: %[[VAL_7:.*]] = fir.alloca !fir.char<2,?>(%{{.*}} : index)
+! CHECK: fir.char_convert %[[VAL_0]] for %{{.*}} to %[[VAL_7]] : !fir.ref<!fir.char<1>>, index, !fir.ref<!fir.char<2,?>>
+! CHECK: fir.call @_QPachar_test1_foo(%{{.*}}) : (!fir.boxchar<2>) -> ()


### PR DESCRIPTION
Character conversion requires memory storage as it operates on a
sequence of code points.

Add test.