### PR TITLE
[sync] Add some semantic checks for allocatable argument association

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -417,6 +417,27 @@ const Symbol *UnwrapWholeSymbolOrComponentDataRef(const A &x) {
   return nullptr;
 }
 
+// If an expression is a whole symbol or a whole component designator,
+// potentially followed by an image selector, extract and return that symbol,
+// else null.
+template <typename A>
+const Symbol *UnwrapWholeSymbolOrComponentOrCoarrayRef(const A &x) {
+  if (auto dataRef{ExtractDataRef(x)}) {
+    if (const SymbolRef * p{std::get_if<SymbolRef>(&dataRef->u)}) {
+      return &p->get();
+    } else if (const Component * c{std::get_if<Component>(&dataRef->u)}) {
+      if (c->base().Rank() == 0) {
+        return &c->GetLastSymbol();
+      }
+    } else if (const CoarrayRef * c{std::get_if<CoarrayRef>(&dataRef->u)}) {
+      if (c->subscript().empty()) {
+        return &c->GetLastSymbol();
+      }
+    }
+  }
+  return nullptr;
+}
+
 // GetFirstSymbol(A%B%C[I]%D) -> A
 template <typename A> const Symbol *GetFirstSymbol(const A &x) {
   if (auto dataRef{ExtractDataRef(x, true)}) {
@@ -892,6 +913,8 @@ template <typename A> bool IsAllocatableOrPointer(const A &x) {
 // Like IsAllocatableOrPointer, but accepts pointer function results as being
 // pointers.
 bool IsAllocatableOrPointerObject(const Expr<SomeType> &, FoldingContext &);
+
+bool IsAllocatableDesignator(const Expr<SomeType> &);
 
 // Procedure and pointer detection predicates
 bool IsProcedure(const Expr<SomeType> &);

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2307,9 +2307,7 @@ static bool ApplySpecificChecks(SpecificCall &call, FoldingContext &context) {
     const auto &arg{call.arguments[0]};
     if (arg) {
       if (const auto *expr{arg->UnwrapExpr()}) {
-        if (const Symbol * symbol{GetLastSymbol(*expr)}) {
-          ok = symbol->attrs().test(semantics::Attr::ALLOCATABLE);
-        }
+        ok = evaluate::IsAllocatableDesignator(*expr);
       }
     }
     if (!ok) {

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1094,6 +1094,15 @@ bool IsAllocatableOrPointerObject(
       evaluate::IsObjectPointer(expr, context);
 }
 
+bool IsAllocatableDesignator(const Expr<SomeType> &expr) {
+  // Allocatable sub-objects are not themselves allocatable (9.5.3.1 NOTE 2).
+  if (const semantics::Symbol *
+      sym{UnwrapWholeSymbolOrComponentOrCoarrayRef(expr)}) {
+    return semantics::IsAllocatable(*sym);
+  }
+  return false;
+}
+
 bool MayBePassedAsAbsentOptional(
     const Expr<SomeType> &expr, FoldingContext &context) {
   const semantics::Symbol *sym{UnwrapWholeSymbolOrComponentDataRef(expr)};

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -401,8 +401,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
   // 15.5.2.6 -- dummy is ALLOCATABLE
   bool dummyIsAllocatable{
       dummy.attrs.test(characteristics::DummyDataObject::Attr::Allocatable)};
-  bool actualIsAllocatable{
-      actualLastSymbol && IsAllocatable(*actualLastSymbol)};
+  bool actualIsAllocatable{evaluate::IsAllocatableDesignator(actual)};
   if (dummyIsAllocatable) {
     if (!actualIsAllocatable) {
       messages.Say(

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -471,6 +471,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
               "POINTER or ALLOCATABLE dummy and actual arguments must have the same declared type and kind"_err_en_US);
         }
       }
+      // 15.5.2.5(4)
       if (const auto *derived{
               evaluate::GetDerivedTypeSpec(actualType.type())}) {
         if (!DefersSameTypeParameters(
@@ -478,6 +479,10 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           messages.Say(
               "Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE"_err_en_US);
         }
+      } else if (dummy.type.type().HasDeferredTypeParameter() !=
+          actualType.type().HasDeferredTypeParameter()) {
+        messages.Say(
+            "Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE"_err_en_US);
       }
     }
   }

--- a/flang/test/Lower/allocatable-caller.f90
+++ b/flang/test/Lower/allocatable-caller.f90
@@ -37,25 +37,21 @@ subroutine test_char_scalar_deferred_call()
   end subroutine
   end interface
   character(:), allocatable :: x
-  character(10), allocatable :: x2
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx2"}
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx"}
   call test_char_scalar_deferred(x)
   ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
-  call test_char_scalar_deferred(x2)
-  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
-  ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_explicit_call(
-subroutine test_char_scalar_explicit_call()
+subroutine test_char_scalar_explicit_call(n)
+  integer :: n
   interface
   subroutine test_char_scalar_explicit(x)
     character(10), allocatable :: x
   end subroutine
   end interface
   character(10), allocatable :: x
-  character(:), allocatable :: x2
+  character(n), allocatable :: x2
   ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx"}
   ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx2"}
   call test_char_scalar_explicit(x)
@@ -74,25 +70,21 @@ subroutine test_char_array_deferred_call()
   end subroutine
   end interface
   character(:), allocatable :: x(:)
-  character(10), allocatable :: x2(:)
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx2"}
+  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx"}
   call test_char_array_deferred(x)
   ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
-  call test_char_array_deferred(x2)
-  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-  ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box2cast]]) : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_array_explicit_call(
-subroutine test_char_array_explicit_call()
+subroutine test_char_array_explicit_call(n)
+  integer :: n
   interface
   subroutine test_char_array_explicit(x)
     character(10), allocatable :: x(:)
   end subroutine
   end interface
   character(10), allocatable :: x(:)
-  character(:), allocatable :: x2(:)
+  character(n), allocatable :: x2(:)
   ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx"}
   ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx2"}
   call test_char_array_explicit(x)

--- a/flang/test/Lower/pointer-args-caller.f90
+++ b/flang/test/Lower/pointer-args-caller.f90
@@ -46,9 +46,10 @@ subroutine test_ptr_to_char_array_ptr(p)
 end subroutine
 
 ! CHECK-LABEL: func @_QMcall_defsPtest_ptr_to_non_deferred_char_array_ptr(
-! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "p"}) {
-subroutine test_ptr_to_non_deferred_char_array_ptr(p)
-  character(:), pointer :: p(:)
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "p"}
+subroutine test_ptr_to_non_deferred_char_array_ptr(p, n)
+  integer :: n
+  character(n), pointer :: p(:)
 ! CHECK:  %[[VAL_1:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,10>>>>>
 ! CHECK:  fir.call @_QPnon_deferred_char_array_ptr(%[[VAL_1]]) : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.char<1,10>>>>>) -> ()
   call non_deferred_char_array_ptr(p)

--- a/flang/test/Semantics/allocated.f90
+++ b/flang/test/Semantics/allocated.f90
@@ -1,0 +1,66 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Tests for the ALLOCATED() intrinsic
+subroutine alloc(coarray_alloc, coarray_not_alloc, t2_not_alloc)
+
+  interface
+    function return_allocatable()
+      integer, allocatable :: return_allocatable(:)
+    end function
+  end interface
+
+  type :: t1
+    integer, allocatable :: alloc(:)
+    integer :: not_alloc
+  end type
+
+  type :: t2
+    real, allocatable :: coarray_alloc[:]
+    real, allocatable :: coarray_alloc_array(:)[:]
+  end type
+
+
+  integer :: not_alloc(100)
+  real, allocatable :: x_alloc
+  character(:), allocatable :: char_alloc(:)
+  type(t1) :: dt_not_alloc(100)
+  type(t1), allocatable :: dt_alloc(:)
+
+  real, allocatable :: coarray_alloc[:, :]
+  real, allocatable :: coarray_alloc_array(:)[:, :]
+  real :: coarray_not_alloc(:)[*]
+
+  type(t2) :: t2_not_alloc
+
+
+  ! OK
+  print *, allocated(x_alloc)
+  print *, allocated(char_alloc)
+  print *, allocated(dt_alloc)
+  print *, allocated(dt_not_alloc(3)%alloc)
+  print *, allocated(dt_alloc(3)%alloc)
+  print *, allocated(coarray_alloc)
+  print *, allocated(coarray_alloc[2,3])
+  print *, allocated(t2_not_alloc%coarray_alloc)
+  print *, allocated(t2_not_alloc%coarray_alloc[2])
+
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(not_alloc)
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(dt_not_alloc)
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(dt_alloc%not_alloc)
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(char_alloc(:))
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(char_alloc(1)(1:10))
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(coarray_alloc_array(1:10))
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(coarray_alloc_array(1:10)[2,2])
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(t2_not_alloc%coarray_alloc_array(1))
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(t2_not_alloc%coarray_alloc_array(1)[2])
+  !ERROR: Argument of ALLOCATED() must be an ALLOCATABLE object or component
+  print *, allocated(return_allocatable())
+end subroutine

--- a/flang/test/Semantics/call05.f90
+++ b/flang/test/Semantics/call05.f90
@@ -118,3 +118,79 @@ module m
   end subroutine
 
 end module
+
+module m2
+
+  character(len=10), allocatable :: t1, t2, t3, t4
+  character(len=:), allocatable :: t5, t6, t7, t8(:)
+
+  character(len=10), pointer :: p1
+  character(len=:), pointer :: p2
+
+  integer, allocatable :: x(:)
+
+ contains
+
+  subroutine sma(a)
+    character(len=:), allocatable, intent(in) :: a
+  end
+
+  subroutine sma2(a)
+    character(len=10), allocatable, intent(in) :: a
+  end
+
+  subroutine smp(p)
+    character(len=:), pointer, intent(in) :: p
+  end
+
+  subroutine smp2(p)
+    character(len=10), pointer, intent(in) :: p
+  end
+
+  subroutine smb(b)
+    integer, allocatable, intent(in) :: b(:)
+  end
+
+  subroutine test()
+
+    call sma2(t1) ! ok
+
+    call smp2(p1) ! ok
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t2(:))
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t3(1))
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t4(1:2))
+
+    call sma(t5) ! ok
+
+    call smp(p2) ! ok
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t5(:))
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t6(1))
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t7(1:2))
+
+    !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
+    call sma(t8(1))
+
+    !ERROR: ALLOCATABLE dummy argument 'b=' must be associated with an ALLOCATABLE actual argument
+    call smb(x(:))
+
+    !ERROR: ALLOCATABLE dummy argument 'b=' must be associated with an ALLOCATABLE actual argument
+    call smb(x(2))
+
+    !ERROR: ALLOCATABLE dummy argument 'b=' must be associated with an ALLOCATABLE actual argument
+    call smb(x(1:2))
+
+  end subroutine
+
+end module

--- a/flang/test/Semantics/call05.f90
+++ b/flang/test/Semantics/call05.f90
@@ -153,7 +153,13 @@ module m2
 
   subroutine test()
 
+    !ERROR: Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE
+    call sma(t1)
+
     call sma2(t1) ! ok
+
+    !ERROR: Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE
+    call smp(p1)
 
     call smp2(p1) ! ok
 
@@ -168,7 +174,13 @@ module m2
 
     call sma(t5) ! ok
 
+    !ERROR: Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE
+    call sma2(t5)
+
     call smp(p2) ! ok
+
+    !ERROR: Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE
+    call smp2(p2)
 
     !ERROR: ALLOCATABLE dummy argument 'a=' must be associated with an ALLOCATABLE actual argument
     call sma(t5(:))
@@ -190,6 +202,28 @@ module m2
 
     !ERROR: ALLOCATABLE dummy argument 'b=' must be associated with an ALLOCATABLE actual argument
     call smb(x(1:2))
+
+  end subroutine
+
+end module
+
+module test
+  type t(l)
+    integer, len :: l
+    character(l) :: c
+  end type
+
+ contains
+
+  subroutine bar(p)
+    type(t(:)), allocatable :: p(:)
+  end subroutine
+
+  subroutine foo
+    type(t(10)), allocatable :: p(:)
+
+    !ERROR: Dummy and actual arguments must defer the same type parameters when POINTER or ALLOCATABLE
+    call bar(p)
 
   end subroutine
 


### PR DESCRIPTION
Allocatable sub-objects are not themselves allocatable (9.5.3.1 NOTE 2). The actual argument shall have deferred the same type parameters as the dummy argument if the argument is allocatable or pointer variable. Currently programs not following these get one crash during lowering or execution.

Cherry-pick https://reviews.llvm.org/D122899 and https://reviews.llvm.org/D122779.
