### PR TITLE
[NFC] Thread source location information for reporting unsupported co…

### DIFF
--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -12,6 +12,7 @@
 
 #include "Target.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Optimizer/Support/KindMapping.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeRange.h"
@@ -79,7 +80,7 @@ struct TargetI386 : public GenericTarget<TargetI386> {
   static constexpr int defaultWidth = 32;
 
   CodeGenSpecifics::Marshalling
-  complexArgumentType(mlir::Type eleTy) const override {
+  complexArgumentType(mlir::Location, mlir::Type eleTy) const override {
     assert(fir::isa_real(eleTy));
     CodeGenSpecifics::Marshalling marshal;
     // Use a type that will be translated into LLVM as:
@@ -92,7 +93,7 @@ struct TargetI386 : public GenericTarget<TargetI386> {
   }
 
   CodeGenSpecifics::Marshalling
-  complexReturnType(mlir::Type eleTy) const override {
+  complexReturnType(mlir::Location loc, mlir::Type eleTy) const override {
     assert(fir::isa_real(eleTy));
     CodeGenSpecifics::Marshalling marshal;
     const auto *sem = &floatToSemantics(kindMap, eleTy);
@@ -108,7 +109,7 @@ struct TargetI386 : public GenericTarget<TargetI386> {
       marshal.emplace_back(fir::ReferenceType::get(structTy),
                            AT{/*alignment=*/4, /*byval=*/false, /*sret=*/true});
     } else {
-      llvm::report_fatal_error("complex for this precision not implemented");
+      fir::emitFatalError(loc, "complex for this precision not implemented");
     }
     return marshal;
   }
@@ -126,7 +127,7 @@ struct TargetX86_64 : public GenericTarget<TargetX86_64> {
   static constexpr int defaultWidth = 64;
 
   CodeGenSpecifics::Marshalling
-  complexArgumentType(mlir::Type eleTy) const override {
+  complexArgumentType(mlir::Location loc, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     const auto *sem = &floatToSemantics(kindMap, eleTy);
     if (sem == &llvm::APFloat::IEEEsingle()) {
@@ -144,13 +145,13 @@ struct TargetX86_64 : public GenericTarget<TargetX86_64> {
                                mlir::TupleType::get(eleTy.getContext(), range)),
                            AT{/*align=*/16, /*byval=*/true});
     } else {
-      llvm::report_fatal_error("complex for this precision not implemented");
+      fir::emitFatalError(loc, "complex for this precision not implemented");
     }
     return marshal;
   }
 
   CodeGenSpecifics::Marshalling
-  complexReturnType(mlir::Type eleTy) const override {
+  complexReturnType(mlir::Location loc, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     const auto *sem = &floatToSemantics(kindMap, eleTy);
     if (sem == &llvm::APFloat::IEEEsingle()) {
@@ -170,7 +171,7 @@ struct TargetX86_64 : public GenericTarget<TargetX86_64> {
                                mlir::TupleType::get(eleTy.getContext(), range)),
                            AT{/*align=*/16, /*byval=*/false, /*sret=*/true});
     } else {
-      llvm::report_fatal_error("complex for this precision not implemented");
+      fir::emitFatalError(loc, "complex for this precision not implemented");
     }
     return marshal;
   }
@@ -188,7 +189,7 @@ struct TargetAArch64 : public GenericTarget<TargetAArch64> {
   static constexpr int defaultWidth = 64;
 
   CodeGenSpecifics::Marshalling
-  complexArgumentType(mlir::Type eleTy) const override {
+  complexArgumentType(mlir::Location loc, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     const auto *sem = &floatToSemantics(kindMap, eleTy);
     if (sem == &llvm::APFloat::IEEEsingle() ||
@@ -196,13 +197,13 @@ struct TargetAArch64 : public GenericTarget<TargetAArch64> {
       // [2 x t]   array of 2 eleTy
       marshal.emplace_back(fir::SequenceType::get({2}, eleTy), AT{});
     } else {
-      llvm::report_fatal_error("complex for this precision not implemented");
+      fir::emitFatalError(loc, "complex for this precision not implemented");
     }
     return marshal;
   }
 
   CodeGenSpecifics::Marshalling
-  complexReturnType(mlir::Type eleTy) const override {
+  complexReturnType(mlir::Location loc, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     const auto *sem = &floatToSemantics(kindMap, eleTy);
     if (sem == &llvm::APFloat::IEEEsingle() ||
@@ -213,7 +214,7 @@ struct TargetAArch64 : public GenericTarget<TargetAArch64> {
       marshal.emplace_back(mlir::TupleType::get(eleTy.getContext(), range),
                            AT{});
     } else {
-      llvm::report_fatal_error("complex for this precision not implemented");
+      fir::emitFatalError(loc, "complex for this precision not implemented");
     }
     return marshal;
   }
@@ -231,7 +232,7 @@ struct TargetPPC64le : public GenericTarget<TargetPPC64le> {
   static constexpr int defaultWidth = 64;
 
   CodeGenSpecifics::Marshalling
-  complexArgumentType(mlir::Type eleTy) const override {
+  complexArgumentType(mlir::Location, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     // two distinct element type arguments (re, im)
     marshal.emplace_back(eleTy, AT{});
@@ -240,7 +241,7 @@ struct TargetPPC64le : public GenericTarget<TargetPPC64le> {
   }
 
   CodeGenSpecifics::Marshalling
-  complexReturnType(mlir::Type eleTy) const override {
+  complexReturnType(mlir::Location, mlir::Type eleTy) const override {
     CodeGenSpecifics::Marshalling marshal;
     // Use a type that will be translated into LLVM as:
     // { t, t }   struct of 2 element type
@@ -303,5 +304,5 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &&trp,
     }
     break;
   }
-  llvm::report_fatal_error("target not implemented");
+  fir::emitFatalError(mlir::UnknownLoc::get(ctx), "target not implemented");
 }

--- a/flang/lib/Optimizer/CodeGen/Target.h
+++ b/flang/lib/Optimizer/CodeGen/Target.h
@@ -72,11 +72,13 @@ public:
   /// Type representation of a `complex<eleTy>` type argument when passed by
   /// value. An argument value may need to be passed as a (safe) reference
   /// argument.
-  virtual Marshalling complexArgumentType(mlir::Type eleTy) const = 0;
+  virtual Marshalling complexArgumentType(mlir::Location loc,
+                                          mlir::Type eleTy) const = 0;
 
   /// Type representation of a `complex<eleTy>` type return value. Such a return
   /// value may need to be converted to a hidden reference argument.
-  virtual Marshalling complexReturnType(mlir::Type eleTy) const = 0;
+  virtual Marshalling complexReturnType(mlir::Location loc,
+                                        mlir::Type eleTy) const = 0;
 
   /// Type presentation of a `boxchar<n>` type value in memory.
   virtual mlir::Type boxcharMemoryType(mlir::Type eleTy) const = 0;

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -116,14 +116,14 @@ public:
 
   template <typename A, typename B, typename C>
   std::function<mlir::Value(mlir::Operation *)>
-  rewriteCallComplexResultType(A ty, B &newResTys, B &newInTys, C &newOpers) {
-    auto m = specifics->complexReturnType(ty.getElementType());
+  rewriteCallComplexResultType(mlir::Location loc, A ty, B &newResTys,
+                               B &newInTys, C &newOpers) {
+    auto m = specifics->complexReturnType(loc, ty.getElementType());
     // Currently targets mandate COMPLEX is a single aggregate or packed
     // scalar, including the sret case.
     assert(m.size() == 1 && "target lowering of complex return not supported");
     auto resTy = std::get<mlir::Type>(m[0]);
     auto attr = std::get<CodeGenSpecifics::Attributes>(m[0]);
-    auto loc = mlir::UnknownLoc::get(resTy.getContext());
     if (attr.isSRet()) {
       assert(isa_ref_type(resTy));
       mlir::Value stack =
@@ -149,9 +149,11 @@ public:
   template <typename A, typename B, typename C>
   void rewriteCallComplexInputType(A ty, mlir::Value oper, B &newInTys,
                                    C &newOpers) {
-    auto m = specifics->complexArgumentType(ty.getElementType());
     auto *ctx = ty.getContext();
-    auto loc = mlir::UnknownLoc::get(ctx);
+    mlir::Location loc = mlir::UnknownLoc::get(ctx);
+    if (auto *op = oper.getDefiningOp())
+      loc = op->getLoc();
+    auto m = specifics->complexArgumentType(loc, ty.getElementType());
     if (m.size() == 1) {
       // COMPLEX is a single aggregate
       auto resTy = std::get<mlir::Type>(m[0]);
@@ -212,11 +214,11 @@ public:
       mlir::Type ty = fnTy.getResult(0);
       llvm::TypeSwitch<mlir::Type>(ty)
           .template Case<fir::ComplexType>([&](fir::ComplexType cmplx) {
-            wrap = rewriteCallComplexResultType(cmplx, newResTys, newInTys,
+            wrap = rewriteCallComplexResultType(loc, cmplx, newResTys, newInTys,
                                                 newOpers);
           })
           .template Case<mlir::ComplexType>([&](mlir::ComplexType cmplx) {
-            wrap = rewriteCallComplexResultType(cmplx, newResTys, newInTys,
+            wrap = rewriteCallComplexResultType(loc, cmplx, newResTys, newInTys,
                                                 newOpers);
           })
           .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
@@ -337,11 +339,13 @@ public:
 
   // Result type fixup for fir::ComplexType and mlir::ComplexType
   template <typename A, typename B>
-  void lowerComplexSignatureRes(A cmplx, B &newResTys, B &newInTys) {
+  void lowerComplexSignatureRes(mlir::Location loc, A cmplx, B &newResTys,
+                                B &newInTys) {
     if (noComplexConversion) {
       newResTys.push_back(cmplx);
     } else {
-      for (auto &tup : specifics->complexReturnType(cmplx.getElementType())) {
+      for (auto &tup :
+           specifics->complexReturnType(loc, cmplx.getElementType())) {
         auto argTy = std::get<mlir::Type>(tup);
         if (std::get<CodeGenSpecifics::Attributes>(tup).isSRet())
           newInTys.push_back(argTy);
@@ -353,11 +357,12 @@ public:
 
   // Argument type fixup for fir::ComplexType and mlir::ComplexType
   template <typename A, typename B>
-  void lowerComplexSignatureArg(A cmplx, B &newInTys) {
+  void lowerComplexSignatureArg(mlir::Location loc, A cmplx, B &newInTys) {
     if (noComplexConversion)
       newInTys.push_back(cmplx);
     else
-      for (auto &tup : specifics->complexArgumentType(cmplx.getElementType()))
+      for (auto &tup :
+           specifics->complexArgumentType(loc, cmplx.getElementType()))
         newInTys.push_back(std::get<mlir::Type>(tup));
   }
 
@@ -367,13 +372,14 @@ public:
     auto addrTy = addrOp.getType().cast<mlir::FunctionType>();
     llvm::SmallVector<mlir::Type> newResTys;
     llvm::SmallVector<mlir::Type> newInTys;
+    auto loc = addrOp.getLoc();
     for (mlir::Type ty : addrTy.getResults()) {
       llvm::TypeSwitch<mlir::Type>(ty)
           .Case<fir::ComplexType>([&](fir::ComplexType ty) {
-            lowerComplexSignatureRes(ty, newResTys, newInTys);
+            lowerComplexSignatureRes(loc, ty, newResTys, newInTys);
           })
           .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
-            lowerComplexSignatureRes(ty, newResTys, newInTys);
+            lowerComplexSignatureRes(loc, ty, newResTys, newInTys);
           })
           .Default([&](mlir::Type ty) { newResTys.push_back(ty); });
     }
@@ -394,10 +400,10 @@ public:
             }
           })
           .Case<fir::ComplexType>([&](fir::ComplexType ty) {
-            lowerComplexSignatureArg(ty, newInTys);
+            lowerComplexSignatureArg(loc, ty, newInTys);
           })
           .Case<mlir::ComplexType>([&](mlir::ComplexType ty) {
-            lowerComplexSignatureArg(ty, newInTys);
+            lowerComplexSignatureArg(loc, ty, newInTys);
           })
           .Case<mlir::TupleType>([&](mlir::TupleType tuple) {
             if (isCharacterProcedureTuple(tuple)) {
@@ -727,7 +733,8 @@ public:
       newResTys.push_back(cmplx);
       return;
     }
-    auto m = specifics->complexReturnType(cmplx.getElementType());
+    auto m =
+        specifics->complexReturnType(func.getLoc(), cmplx.getElementType());
     assert(m.size() == 1);
     auto &tup = m[0];
     auto attr = std::get<CodeGenSpecifics::Attributes>(tup);
@@ -773,7 +780,8 @@ public:
       newInTys.push_back(cmplx);
       return;
     }
-    auto m = specifics->complexArgumentType(cmplx.getElementType());
+    auto m =
+        specifics->complexArgumentType(func.getLoc(), cmplx.getElementType());
     const auto fixupCode =
         m.size() > 1 ? FixupTy::Codes::Split : FixupTy::Codes::ArgumentType;
     for (auto e : llvm::enumerate(m)) {


### PR DESCRIPTION
…mplex types.

Purely cosmetic change to the output of a hard error: some complex
precisions are not yet supported by LLVM, clang, etc.