### PR TITLE
[Flang] Fix issues with double and re-privatisation

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -49,7 +49,9 @@ static void createPrivateVarSyms(Fortran::lower::AbstractConverter &converter,
         ompObject.u);
 
     // Privatization for symbols which are pre-determined (like loop index
-    // variables) happen separately, for everything else privatize here
+    // variables) happen separately, for everything else privatize here.
+    if (sym->test(Fortran::semantics::Symbol::Flag::OmpPreDetermined))
+      continue;
     if constexpr (std::is_same_v<T, Fortran::parser::OmpClause::Firstprivate>) {
       converter.copyHostAssociateVar(*sym);
     } else {

--- a/flang/test/Lower/OpenMP/omp-parallel-private-clause-fixes.f90
+++ b/flang/test/Lower/OpenMP/omp-parallel-private-clause-fixes.f90
@@ -8,13 +8,14 @@
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFmultiple_private_fixEj"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFmultiple_private_fixEx"}
 ! CHECK:         omp.parallel {
-! CHECK:           %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "j", pinned
-! CHECK:           %[[VAL_1:.*]] = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFmultiple_private_fixEx"}
-! CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+! CHECK:           %[[PRIV_J:.*]] = fir.alloca i32 {bindc_name = "j", pinned
+! CHECK:           %[[PRIV_X:.*]] = fir.alloca i32 {bindc_name = "x", pinned
+! CHECK:           %[[PRIV_I:.*]] = fir.alloca i32 {{{.*}}, pinned
+! CHECK:           %[[ONE:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_4:.*]] : !fir.ref<i32>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
-! CHECK:           omp.wsloop (%[[VAL_6:.*]]) : i32 = (%[[VAL_2]]) to (%[[VAL_3]]) inclusive step (%[[VAL_5]]) {
-! CHECK:             fir.store %[[VAL_6]] to %[[STORE:.*]] : !fir.ref<i32>
+! CHECK:           omp.wsloop (%[[VAL_6:.*]]) : i32 = (%[[ONE]]) to (%[[VAL_3]]) inclusive step (%[[VAL_5]]) {
+! CHECK:             fir.store %[[VAL_6]] to %[[PRIV_I]] : !fir.ref<i32>
 ! CHECK:             %[[VAL_7:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i32) -> index
 ! CHECK:             %[[VAL_9:.*]] = fir.load %[[VAL_4]] : !fir.ref<i32>
@@ -22,16 +23,16 @@
 ! CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 ! CHECK:             %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_8]] to %[[VAL_10]] step %[[VAL_11]] -> index {
 ! CHECK:               %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (index) -> i32
-! CHECK:               fir.store %[[VAL_14]] to %[[VAL_0]] : !fir.ref<i32>
-! CHECK:               %[[LOAD:.*]] = fir.load %[[STORE]] : !fir.ref<i32>
-! CHECK:               %[[VAL_15:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:               fir.store %[[VAL_14]] to %[[PRIV_J]] : !fir.ref<i32>
+! CHECK:               %[[LOAD:.*]] = fir.load %[[PRIV_I]] : !fir.ref<i32>
+! CHECK:               %[[VAL_15:.*]] = fir.load %[[PRIV_J]] : !fir.ref<i32>
 ! CHECK:               %[[VAL_16:.*]] = arith.addi %[[LOAD]], %[[VAL_15]] : i32
-! CHECK:               fir.store %[[VAL_16]] to %[[VAL_1]] : !fir.ref<i32>
+! CHECK:               fir.store %[[VAL_16]] to %[[PRIV_X]] : !fir.ref<i32>
 ! CHECK:               %[[VAL_17:.*]] = arith.addi %[[VAL_13]], %[[VAL_11]] : index
 ! CHECK:               fir.result %[[VAL_17]] : index
 ! CHECK:             }
 ! CHECK:             %[[VAL_18:.*]] = fir.convert %[[VAL_19:.*]] : (index) -> i32
-! CHECK:             fir.store %[[VAL_18]] to %[[VAL_0]] : !fir.ref<i32>
+! CHECK:             fir.store %[[VAL_18]] to %[[PRIV_J]] : !fir.ref<i32>
 ! CHECK:             omp.yield
 ! CHECK:           }
 ! CHECK:           omp.terminator
@@ -46,4 +47,32 @@ subroutine multiple_private_fix(gama)
           end do
         end do
 !$OMP END PARALLEL DO
+end subroutine
+
+! CHECK-LABEL: multiple_private_fix2
+! CHECK:  %[[X1:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFmultiple_private_fix2Ex"}
+! CHECK:  omp.parallel  {
+! CHECK:    %[[X2:.*]] = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFmultiple_private_fix2Ex"}
+! CHECK:    omp.parallel  {
+! CHECK:      %[[X3:.*]] = fir.alloca i32 {bindc_name = "x", pinned, uniq_name = "_QFmultiple_private_fix2Ex"}
+! CHECK:      %[[C3:.*]] = arith.constant 1 : i32
+! CHECK:      fir.store %[[C3]] to %[[X3]] : !fir.ref<i32>
+! CHECK:      omp.terminator
+! CHECK:    }
+! CHECK:      %[[C2:.*]] = arith.constant 1 : i32
+! CHECK:      fir.store %[[C2]] to %[[X2]] : !fir.ref<i32>
+! CHECK:    omp.terminator
+! CHECK:  }
+! CHECK:      %[[C1:.*]] = arith.constant 1 : i32
+! CHECK:      fir.store %[[C1]] to %[[X1]] : !fir.ref<i32>
+! CHECK:  return
+subroutine multiple_private_fix2()
+   integer :: x
+   !$omp parallel private(x)
+   !$omp parallel private(x)
+      x = 1
+   !$omp end parallel
+      x = 1
+   !$omp end parallel
+      x = 1
 end subroutine

--- a/flang/test/Lower/OpenMP/omp-sections.f90
+++ b/flang/test/Lower/OpenMP/omp-sections.f90
@@ -73,9 +73,9 @@ program sample
 end program sample
 
 !FIRDialect: func @_QPfirstprivate(%[[ARG:.*]]: !fir.ref<f32> {fir.bindc_name = "alpha"}) {
-!FIRDialect: %[[ALPHA:.*]] = fir.alloca f32 {bindc_name = "alpha", pinned, uniq_name = "_QFfirstprivateEalpha"}
-!FIRDialect: %[[ALPHA_STORE:.*]] = fir.load %[[ARG]] : !fir.ref<f32>
-!FIRDialect: fir.store %[[ALPHA_STORE]] to %[[ALPHA]] : !fir.ref<f32>
+!FIRDialect: %[[ALPHA_PRIVATE:.*]] = fir.alloca f32 {bindc_name = "alpha", pinned, uniq_name = "_QFfirstprivateEalpha"}
+!FIRDialect: %[[ALPHA_VAL:.*]] = fir.load %[[ARG]] : !fir.ref<f32>
+!FIRDialect: fir.store %[[ALPHA_VAL]] to %[[ALPHA_PRIVATE]] : !fir.ref<f32>
 !FIRDialect: omp.sections {
 !FIRDialect: omp.section  {
 !FIRDialect: omp.terminator
@@ -84,10 +84,10 @@ end program sample
 !FIRDialect: }
 !FIRDialect: omp.sections {
 !FIRDialect: omp.section  {
-!FIRDialect: %[[PRIVATE_VAR:.*]] = fir.load %[[ARG]] : !fir.ref<f32>
+!FIRDialect: %[[PRIVATE_VAR:.*]] = fir.load %[[ALPHA_PRIVATE]] : !fir.ref<f32>
 !FIRDialect: %[[CONSTANT:.*]] = arith.constant 5.000000e+00 : f32
 !FIRDialect: %[[PRIVATE_VAR_2:.*]] = arith.mulf %[[PRIVATE_VAR]], %[[CONSTANT]] : f32
-!FIRDialect: fir.store %[[PRIVATE_VAR_2]] to %[[ARG]] : !fir.ref<f32>
+!FIRDialect: fir.store %[[PRIVATE_VAR_2]] to %[[ALPHA_PRIVATE]] : !fir.ref<f32>
 !FIRDialect: omp.terminator
 !FIRDialect: }
 !FIRDialect: omp.terminator

--- a/flang/test/Lower/OpenMP/omp-unstructured.f90
+++ b/flang/test/Lower/OpenMP/omp-unstructured.f90
@@ -61,8 +61,9 @@ end
 ! CHECK-LABEL: func @_QPss3{{.*}} {
 ! CHECK:   omp.parallel {
 ! CHECK:     fir.alloca i32 {pinned}
-! CHECK-NEXT: %[[ALLOCA_1:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
-! CHECK-NEXT: %[[ALLOCA_2:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
+! CHECK: %[[ALLOCA_0:.*]] = fir.alloca i32 {bindc_name = "k", pinned}
+! CHECK: %[[ALLOCA_1:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
+! CHECK: %[[ALLOCA_2:.*]] = fir.alloca i32 {adapt.valuebyref, pinned}
 ! CHECK:     br ^bb1
 ! CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
 ! CHECK:     cond_br %{{[0-9]*}}, ^bb2, ^bb3
@@ -83,8 +84,8 @@ end
 ! CHECK:       cond_br %{{[0-9]*}}, ^bb4, ^bb3
 ! CHECK:     ^bb3:  // pred: ^bb2
 ! CHECK:       @_FortranAioBeginExternalListOutput
-! CHECK:       %[[LOAD_2:.*]] = fir.load %[[ALLOCA_2]] : !fir.ref<i32>
-! CHECK:     @_FortranAioOutputInteger32(%{{.*}}, %[[LOAD_2]])
+! CHECK:       %[[LOAD_0:.*]] = fir.load %[[ALLOCA_0]] : !fir.ref<i32>
+! CHECK:     @_FortranAioOutputInteger32(%{{.*}}, %[[LOAD_0]])
 ! CHECK:       br ^bb1
 ! CHECK:     ^bb4:  // 2 preds: ^bb1, ^bb2
 ! CHECK:       omp.yield


### PR DESCRIPTION
-> Loop index variables are separately privatised in Flang. If these
variables occur as part of a privatisation clause then do not double
privatise them.

-> Allow the privatisation of an already privatised variable. This
requires that we always push SymbolStack in an OpenMPConstruct.

-> If we do a shallow lookup and not find a symbol then it is OK to
add a new binding at the topmost level. For this purpose use
`bindIfNewSymbol` instead of `bindSymbol`.

-> Adds a testcase and corrects a few testcases.

This fixes a few issues seen in SNAP and Spec OMP 2012
(https://github.com/llvm/llvm-project/issues/54473).