### PR TITLE
[flang][cmake] Make CMake copy "omp_lib.h" into the build directory

### DIFF
--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -365,6 +365,15 @@ static std::string getIntrinsicDir() {
   return std::string(driverPath);
 }
 
+// Generate the path to look for OpenMP headers
+static std::string getOpenMPHeadersDir() {
+  llvm::SmallString<128> includePath;
+  includePath.assign(llvm::sys::fs::getMainExecutable(nullptr, nullptr));
+  llvm::sys::path::remove_filename(includePath);
+  includePath.append("/../include/flang/OpenMP/");
+  return std::string(includePath);
+}
+
 /// Parses all preprocessor input arguments and populates the preprocessor
 /// options accordingly.
 ///
@@ -609,6 +618,11 @@ void CompilerInvocation::SetDefaultFortranOpts() {
 
   std::vector<std::string> searchDirectories{"."s};
   fortranOptions.searchDirectories = searchDirectories;
+
+  // Add the location of omp_lib.h to the search directories. Currently this is
+  // identical to the modules' directory.
+  fortranOptions.searchDirectories.emplace_back(getOpenMPHeadersDir());
+
   fortranOptions.isFixedForm = false;
 }
 

--- a/flang/test/Driver/include-omp-header.f90
+++ b/flang/test/Driver/include-omp-header.f90
@@ -1,0 +1,34 @@
+! Verify that the omp_lib.h header is found and included correctly. This header file should be available at a path:
+!   * relative to the driver, that's
+!   * known the driver.
+! This is taken care of at the CMake and the driver levels. Note that when searching for header files, the directory of the current
+! source file takes precedence over other search paths. Hence adding omp_lib.h in the current directory will make Flang use that
+! header file instead of the one shipped with Flang.
+
+!----------
+! RUN LINES
+!----------
+! This should just work
+! RUN: not rm omp_lib.h
+! RUN: %flang -fsyntax-only -fopenmp %s  2>&1
+
+! Create an empty omp_lib.h header that _does not_ define omp_default_mem_alloc - this should lead to semantic errors
+! RUN: touch omp_lib.h
+! RUN: not %flang -fsyntax-only -fopenmp %s  2>&1 | FileCheck %s
+! RUN: rm omp_lib.h
+
+!--------------------------
+! EXPECTED OUTPUT
+!--------------------------
+! CHECK: error: Must have INTEGER type, but is REAL(4)
+
+!-------
+! INPUT
+!-------
+include "omp_lib.h"
+
+integer :: x, y
+
+!$omp allocate(x, y) allocator(omp_default_mem_alloc)
+
+end

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -69,3 +69,6 @@ if (NOT WIN32)
     FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE)
   install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/flang DESTINATION bin)
 endif()
+
+# TODO Move this to a more suitable location
+file(COPY ${FLANG_SOURCE_DIR}/module/omp_lib.h DESTINATION "${CMAKE_BINARY_DIR}/include/flang/OpenMP/" FILE_PERMISSIONS OWNER_READ OWNER_WRITE)


### PR DESCRIPTION
Any header or module file in the Flang source directory is of no use to
the compiler unless it is copied into the build directory. Indeed, all
compiler search paths are relative to the compiler executable (flang-new
in our case). Hence, "omp_lib.h" should be copied into the build
directory alongside other compiler-provided files that can be "included"
(header files) or "used" (module files).

For now, "omp_lib.h" is copied into "<build-dir>/include/flang/OpenMP".
We may decide to change this in future. For example, Clang copies a
bunch of runtime headers into “<build-dir>/lib/clang/<version-number>”.
We could also consider using a similar header from a different
sub-project.

Flang's driver search path is updated accordingly. A rule for
"installing" the "omp_lib.h" header is _yet to be added_ (we will also
need to determine the suitable location for this).

Differential Revision: https://reviews.llvm.org/D122015