### PR TITLE
[flang] enable fir.is_present and fir.absent with function types

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -562,7 +562,7 @@ def AnyBoxLike : TypeConstraint<Or<[fir_BoxType.predicate,
     fir_BoxCharType.predicate, fir_BoxProcType.predicate]>, "any box">;
 
 def AnyRefOrBoxLike : TypeConstraint<Or<[AnyReferenceLike.predicate,
-    AnyBoxLike.predicate]>,
+    AnyBoxLike.predicate, FunctionType.predicate]>,
     "any reference or box like">;
 def AnyRefOrBox : TypeConstraint<Or<[fir_ReferenceType.predicate,
     fir_HeapType.predicate, fir_PointerType.predicate, fir_BoxType.predicate]>,

--- a/flang/test/Fir/optional.fir
+++ b/flang/test/Fir/optional.fir
@@ -50,3 +50,37 @@ func @bar3() -> i1 {
   %1 = fir.call @foo3(%0) : (!fir.boxchar<1>) -> i1
   return %1 : i1
 }
+
+// CHECK-LABEL: @foo4(
+// CHECK-SAME: i64 (i32)* %[[arg:.*]])
+func @foo4(%arg0: !fir.boxproc<(i32)->(i64)>) -> i1 {
+  // CHECK: %[[ptr:.*]] = ptrtoint i64 (i32)* %[[arg]] to i64
+  // CHECK: icmp ne i64 %[[ptr]], 0
+  %0 = fir.is_present %arg0 : (!fir.boxproc<(i32)->(i64)>) -> i1
+  return %0 : i1
+}
+
+// CHECK-LABEL: @bar4
+func @bar4() -> i1 {
+  %0 = fir.absent !fir.boxproc<(i32)->(i64)> 
+  // CHECK: call i1 @foo4(i64 (i32)* null)
+  %1 = fir.call @foo4(%0) : (!fir.boxproc<(i32)->(i64)>) -> i1
+  return %1 : i1
+}
+
+// CHECK-LABEL: @foo5(
+// CHECK-SAME: i64 (i32)* %[[arg:.*]])
+func @foo5(%arg0: (i32)->(i64)) -> i1 {
+  // CHECK: %[[ptr:.*]] = ptrtoint i64 (i32)* %[[arg]] to i64
+  // CHECK: icmp ne i64 %[[ptr]], 0
+  %0 = fir.is_present %arg0 : ((i32)->(i64)) -> i1
+  return %0 : i1
+}
+
+// CHECK-LABEL: @bar5
+func @bar5() -> i1 {
+  %0 = fir.absent (i32)->(i64)
+  // CHECK: call i1 @foo5(i64 (i32)* null)
+  %1 = fir.call @foo5(%0) : ((i32)->(i64)) -> i1
+  return %1 : i1
+}


### PR DESCRIPTION
Fortran dummy procedures and procedure pointer can be OPTIONAL, and
there is no technical reason to prevent fir.is_present and fir.absent from accepting function types.
Allow these types and add tests.