### PR TITLE
[sync] Fix CI fail for check-mlir

### DIFF
--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1697,7 +1697,7 @@ module {
 // CHECK:   call void @qux
 
 llvm.func @duplicate_block_in_switch(%cond : i32, %arg1: f32, %arg2: f32) {
-  llvm.switch %cond : i32, ^bb1(%arg1: f32) [
+  llvm.switch %cond, ^bb1(%arg1: f32) [
     105: ^bb2,
     108: ^bb3(%arg2: f32),
     106: ^bb2
@@ -1745,7 +1745,7 @@ llvm.func @duplicate_block_in_switch(%cond : i32, %arg1: f32, %arg2: f32) {
 // CHECK:   br label %[[DUPLICATE]]
 
 llvm.func @duplicate_block_with_args_in_switch(%cond : i32, %arg1: f32, %arg2: f32) {
-  llvm.switch %cond : i32, ^bb1(%arg1: f32) [
+  llvm.switch %cond, ^bb1(%arg1: f32) [
     106: ^bb3(%arg1: f32),
     105: ^bb2,
     108: ^bb3(%arg2: f32)

--- a/mlir/test/Transforms/test-legalize-type-conversion.mlir
+++ b/mlir/test/Transforms/test-legalize-type-conversion.mlir
@@ -116,20 +116,6 @@ func @test_block_argument_not_converted() {
 
 // -----
 
-// Make sure argument type changes aren't implicitly forwarded.
-func @test_signature_conversion_no_converter() {
-  "test.signature_conversion_no_converter"() ({
-  // expected-error@below {{failed to materialize conversion for block argument #0 that remained live after conversion}}
-  ^bb0(%arg0: f32):
-    // expected-note@below {{see existing live user here}}
-    "test.type_consumer"(%arg0) : (f32) -> ()
-    "test.return"(%arg0) : (f32) -> ()
-  }) : () -> ()
-  return
-}
-
-// -----
-
 // CHECK-LABEL: @recursive_type_conversion
 func @recursive_type_conversion() {
   // CHECK:  !test.test_rec<outer_converted_type, smpla>


### PR DESCRIPTION
The test case in llvmir.mlir uses the format in llvm-main instead of that
in fir-dev.

The test case in test-legalize-type-conversion.mlir is added in commit
4e25ec65c1451 incorrectly. The original PR in llvm-main is
https://reviews.llvm.org/D113579. The test case is added in llvm-main by
https://reviews.llvm.org/D113233.