### PR TITLE
Catch unit number out of range in I/O and fix temp I/O item clean-up spots

### DIFF
--- a/flang/include/flang/Runtime/io-api.h
+++ b/flang/include/flang/Runtime/io-api.h
@@ -111,6 +111,24 @@ Cookie IONAME(BeginInternalFormattedInput)(const char *internal,
     void **scratchArea = nullptr, std::size_t scratchBytes = 0,
     const char *sourceFile = nullptr, int sourceLine = 0);
 
+// External unit numbers must fit in default integers. When the integer
+// provided as UNIT is of a wider type than the default integer, it could
+// overflow when converted to a default integer.
+// CheckUnitNumberInRange should be called to verify that a unit number of a
+// wide integer type can fit in a default integer. Since it should be called
+// before the BeginXXX(unit, ...) call, it has its own error handling interface.
+// If handleError is false, and the unit number is out of range, the program
+// will be terminated. Otherwise, if unit is out of range, a nonzero Iostat
+// code is returned and ioMsg is set if it is not a nullptr.
+enum Iostat IONAME(CheckUnitNumberInRange64)(std::int64_t unit,
+    bool handleError, char *ioMsg = nullptr, std::size_t ioMsgLength = 0,
+    const char *sourceFile = nullptr, int sourceLine = 0);
+#ifdef __SIZEOF_INT128__
+enum Iostat IONAME(CheckUnitNumberInRange128)(common::int128_t unit,
+    bool handleError, char *ioMsg = nullptr, std::size_t ioMsgLength = 0,
+    const char *sourceFile = nullptr, int sourceLine = 0);
+#endif
+
 // External synchronous I/O initiation
 Cookie IONAME(BeginExternalListOutput)(ExternalUnit = DefaultUnit,
     const char *sourceFile = nullptr, int sourceLine = 0);

--- a/flang/include/flang/Runtime/iostat.h
+++ b/flang/include/flang/Runtime/iostat.h
@@ -67,6 +67,7 @@ enum Iostat {
   IostatMissingTerminator,
   IostatBadUnformattedRecord,
   IostatUTF8Decoding,
+  IostatUnitOverflow,
 };
 
 const char *IostatErrorString(int);

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -81,6 +81,7 @@ static constexpr std::tuple<
     mkIOKey(BeginEndfile), mkIOKey(BeginRewind), mkIOKey(BeginOpenUnit),
     mkIOKey(BeginOpenNewUnit), mkIOKey(BeginInquireUnit),
     mkIOKey(BeginInquireFile), mkIOKey(BeginInquireIoLength),
+    mkIOKey(CheckUnitNumberInRange64), mkIOKey(CheckUnitNumberInRange128),
     mkIOKey(EnableHandlers), mkIOKey(SetAdvance), mkIOKey(SetBlank),
     mkIOKey(SetDecimal), mkIOKey(SetDelim), mkIOKey(SetPad), mkIOKey(SetPos),
     mkIOKey(SetRec), mkIOKey(SetRound), mkIOKey(SetSign),
@@ -111,10 +112,11 @@ namespace {
 /// and an IOMSG specifier variable may be set to a description of a condition.
 struct ConditionSpecInfo {
   const Fortran::lower::SomeExpr *ioStatExpr{};
-  const Fortran::lower::SomeExpr *ioMsgExpr{};
+  llvm::Optional<fir::ExtendedValue> ioMsg;
   bool hasErr{};
   bool hasEnd{};
   bool hasEor{};
+  fir::IfOp bigUnitIfOp;
 
   /// Check for any condition specifier that applies to specifier processing.
   bool hasErrorConditionSpec() const { return ioStatExpr != nullptr || hasErr; }
@@ -127,7 +129,7 @@ struct ConditionSpecInfo {
 
   /// Check for any condition specifier, including IOMSG.
   bool hasAnyConditionSpec() const {
-    return hasTransferConditionSpec() || ioMsgExpr != nullptr;
+    return hasTransferConditionSpec() || ioMsg;
   }
 };
 } // namespace
@@ -174,34 +176,39 @@ static mlir::FuncOp getIORuntimeFunc(mlir::Location loc,
 /// It is the caller's responsibility to generate branches on that value.
 static mlir::Value genEndIO(Fortran::lower::AbstractConverter &converter,
                             mlir::Location loc, mlir::Value cookie,
-                            const ConditionSpecInfo &csi,
+                            ConditionSpecInfo &csi,
                             Fortran::lower::StatementContext &stmtCtx) {
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
-  if (csi.ioMsgExpr) {
+  if (csi.ioMsg) {
     mlir::FuncOp getIoMsg = getIORuntimeFunc<mkIOKey(GetIoMsg)>(loc, builder);
-    fir::ExtendedValue ioMsgVar =
-        converter.genExprAddr(csi.ioMsgExpr, stmtCtx, loc);
     builder.create<fir::CallOp>(
         loc, getIoMsg,
         mlir::ValueRange{
             cookie,
             builder.createConvert(loc, getIoMsg.getType().getInput(1),
-                                  fir::getBase(ioMsgVar)),
+                                  fir::getBase(*csi.ioMsg)),
             builder.createConvert(loc, getIoMsg.getType().getInput(2),
-                                  fir::getLen(ioMsgVar))});
+                                  fir::getLen(*csi.ioMsg))});
   }
   mlir::FuncOp endIoStatement =
       getIORuntimeFunc<mkIOKey(EndIoStatement)>(loc, builder);
   auto call = builder.create<fir::CallOp>(loc, endIoStatement,
                                           mlir::ValueRange{cookie});
+  mlir::Value iostat = call.getResult(0);
+  if (csi.bigUnitIfOp) {
+    stmtCtx.finalize(/*popScope=*/true);
+    builder.create<fir::ResultOp>(loc, iostat);
+    builder.setInsertionPointAfter(csi.bigUnitIfOp);
+    iostat = csi.bigUnitIfOp.getResult(0);
+  }
   if (csi.ioStatExpr) {
     mlir::Value ioStatVar =
         fir::getBase(converter.genExprAddr(csi.ioStatExpr, stmtCtx, loc));
-    mlir::Value ioStatResult = builder.createConvert(
-        loc, converter.genType(*csi.ioStatExpr), call.getResult(0));
+    mlir::Value ioStatResult =
+        builder.createConvert(loc, converter.genType(*csi.ioStatExpr), iostat);
     builder.create<fir::StoreOp>(loc, ioStatResult, ioStatVar);
   }
-  return csi.hasTransferConditionSpec() ? call.getResult(0) : mlir::Value{};
+  return csi.hasTransferConditionSpec() ? iostat : mlir::Value{};
 }
 
 /// Make the next call in the IO statement conditional on runtime result `ok`.
@@ -1159,10 +1166,10 @@ static void threadSpecs(Fortran::lower::AbstractConverter &converter,
 /// information from the runtime, via a variable, about the nature of the
 /// condition that occurred. These condition specifiers are handled here.
 template <typename A>
-static void
-genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
-                        mlir::Location loc, mlir::Value cookie,
-                        const A &specList, ConditionSpecInfo &csi) {
+ConditionSpecInfo lowerErrorSpec(Fortran::lower::AbstractConverter &converter,
+                                 mlir::Location loc, const A &specList) {
+  ConditionSpecInfo csi;
+  const Fortran::lower::SomeExpr *ioMsgExpr = nullptr;
   for (const auto &spec : specList) {
     std::visit(
         Fortran::common::visitors{
@@ -1176,13 +1183,13 @@ genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
                     std::get<Fortran::parser::ScalarIntVariable>(var.t));
             },
             [&](const Fortran::parser::MsgVariable &var) {
-              csi.ioMsgExpr = Fortran::semantics::GetExpr(var);
+              ioMsgExpr = Fortran::semantics::GetExpr(var);
             },
             [&](const Fortran::parser::InquireSpec::CharVar &var) {
               if (std::get<Fortran::parser::InquireSpec::CharVar::Kind>(
                       var.t) ==
                   Fortran::parser::InquireSpec::CharVar::Kind::Iomsg)
-                csi.ioMsgExpr = Fortran::semantics::GetExpr(
+                ioMsgExpr = Fortran::semantics::GetExpr(
                     std::get<Fortran::parser::ScalarDefaultCharVariable>(
                         var.t));
             },
@@ -1192,6 +1199,20 @@ genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
             [](const auto &) {}},
         spec.u);
   }
+  if (ioMsgExpr) {
+    // iomsg is a variable, its evaluation may require temps, but it cannot
+    // itself be a temp, and it is ok to us a local statement context here.
+    Fortran::lower::StatementContext stmtCtx;
+    csi.ioMsg = converter.genExprAddr(ioMsgExpr, stmtCtx, loc);
+  }
+
+  return csi;
+}
+template <typename A>
+static void
+genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
+                        mlir::Location loc, mlir::Value cookie,
+                        const A &specList, ConditionSpecInfo &csi) {
   if (!csi.hasAnyConditionSpec())
     return;
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
@@ -1207,7 +1228,7 @@ genConditionHandlerCall(Fortran::lower::AbstractConverter &converter,
                                            boolValue(csi.hasErr),
                                            boolValue(csi.hasEnd),
                                            boolValue(csi.hasEor),
-                                           boolValue(csi.ioMsgExpr != nullptr)};
+                                           boolValue(csi.ioMsg.hasValue())};
   builder.create<fir::CallOp>(loc, enableHandlers, ioArgs);
 }
 
@@ -1513,34 +1534,84 @@ getBuffer(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
   llvm::report_fatal_error("failed to get IoUnit expr in lowering");
 }
 
+static mlir::Value genIOUnitNumber(Fortran::lower::AbstractConverter &converter,
+                                   mlir::Location loc,
+                                   const Fortran::lower::SomeExpr *iounit,
+                                   mlir::Type ty, ConditionSpecInfo &csi,
+                                   Fortran::lower::StatementContext &stmtCtx) {
+  auto &builder = converter.getFirOpBuilder();
+  auto rawUnit = fir::getBase(converter.genExprValue(iounit, stmtCtx, loc));
+  unsigned rawUnitWidth = rawUnit.getType().cast<IntegerType>().getWidth();
+  unsigned runtimeArgWidth = ty.cast<IntegerType>().getWidth();
+  // The IO runtime supports `int` unit numbers, if the unit number may
+  // overflow when passed to the IO runtime, check that the unit number is
+  // in range before calling the BeginXXX.
+  if (rawUnitWidth > runtimeArgWidth) {
+    mlir::FuncOp check =
+        rawUnitWidth <= 64
+            ? getIORuntimeFunc<mkIOKey(CheckUnitNumberInRange64)>(loc, builder)
+            : getIORuntimeFunc<mkIOKey(CheckUnitNumberInRange128)>(loc,
+                                                                   builder);
+    mlir::FunctionType funcTy = check.getType();
+    llvm::SmallVector<mlir::Value> args;
+    args.push_back(builder.createConvert(loc, funcTy.getInput(0), rawUnit));
+    args.push_back(builder.createBool(loc, csi.hasErrorConditionSpec()));
+    if (csi.ioMsg) {
+      args.push_back(builder.createConvert(loc, funcTy.getInput(2),
+                                           fir::getBase(*csi.ioMsg)));
+      args.push_back(builder.createConvert(loc, funcTy.getInput(3),
+                                           fir::getLen(*csi.ioMsg)));
+    } else {
+      args.push_back(builder.createNullConstant(loc, funcTy.getInput(2)));
+      args.push_back(
+          fir::factory::createZeroValue(builder, loc, funcTy.getInput(3)));
+    }
+    mlir::Value file = locToFilename(converter, loc, funcTy.getInput(4));
+    mlir::Value line = locToLineNo(converter, loc, funcTy.getInput(5));
+    args.push_back(file);
+    args.push_back(line);
+    auto checkCall = builder.create<fir::CallOp>(loc, check, args);
+    if (csi.hasErrorConditionSpec()) {
+      mlir::Value iostat = checkCall.getResult(0);
+      mlir::Type iostatTy = iostat.getType();
+      mlir::Value zero = fir::factory::createZeroValue(builder, loc, iostatTy);
+      mlir::Value unitIsOK = builder.create<mlir::arith::CmpIOp>(
+          loc, mlir::arith::CmpIPredicate::eq, iostat, zero);
+      auto ifOp = builder.create<fir::IfOp>(loc, iostatTy, unitIsOK,
+                                            /*withElseRegion=*/true);
+      builder.setInsertionPointToStart(&ifOp.elseRegion().front());
+      builder.create<fir::ResultOp>(loc, iostat);
+      builder.setInsertionPointToStart(&ifOp.thenRegion().front());
+      stmtCtx.pushScope();
+      csi.bigUnitIfOp = ifOp;
+    }
+  }
+  return builder.createConvert(loc, ty, rawUnit);
+}
+
 static mlir::Value genIOUnit(Fortran::lower::AbstractConverter &converter,
                              mlir::Location loc,
-                             const Fortran::parser::IoUnit &iounit,
-                             mlir::Type ty,
+                             const Fortran::parser::IoUnit *iounit,
+                             mlir::Type ty, ConditionSpecInfo &csi,
                              Fortran::lower::StatementContext &stmtCtx) {
   auto &builder = converter.getFirOpBuilder();
-  if (auto *e = std::get_if<Fortran::parser::FileUnitNumber>(&iounit.u)) {
-    auto ex = fir::getBase(
-        converter.genExprValue(Fortran::semantics::GetExpr(*e), stmtCtx, loc));
-    return builder.createConvert(loc, ty, ex);
-  }
+  if (iounit)
+    if (auto *e = std::get_if<Fortran::parser::FileUnitNumber>(&iounit->u))
+      return genIOUnitNumber(converter, loc, Fortran::semantics::GetExpr(*e),
+                             ty, csi, stmtCtx);
   return builder.create<mlir::arith::ConstantOp>(
       loc, builder.getIntegerAttr(ty, Fortran::runtime::io::DefaultUnit));
 }
 
 template <typename A>
-mlir::Value getIOUnit(Fortran::lower::AbstractConverter &converter,
-                      mlir::Location loc, const A &stmt, mlir::Type ty,
-                      Fortran::lower::StatementContext &stmtCtx) {
-  if (stmt.iounit)
-    return genIOUnit(converter, loc, *stmt.iounit, ty, stmtCtx);
-  if (auto *iounit = getIOControl<Fortran::parser::IoUnit>(stmt))
-    return genIOUnit(converter, loc, *iounit, ty, stmtCtx);
-  fir::FirOpBuilder &builder = converter.getFirOpBuilder();
-  return builder.create<mlir::arith::ConstantOp>(
-      loc, builder.getIntegerAttr(ty, Fortran::runtime::io::DefaultUnit));
+static mlir::Value getIOUnit(Fortran::lower::AbstractConverter &converter,
+                             mlir::Location loc, const A &stmt, mlir::Type ty,
+                             ConditionSpecInfo &csi,
+                             Fortran::lower::StatementContext &stmtCtx) {
+  const Fortran::parser::IoUnit *iounit =
+      stmt.iounit ? &*stmt.iounit : getIOControl<Fortran::parser::IoUnit>(stmt);
+  return genIOUnit(converter, loc, iounit, ty, csi, stmtCtx);
 }
-
 //===----------------------------------------------------------------------===//
 // Generators for each IO statement type.
 //===----------------------------------------------------------------------===//
@@ -1551,17 +1622,18 @@ static mlir::Value genBasicIOStmt(Fortran::lower::AbstractConverter &converter,
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
   Fortran::lower::StatementContext stmtCtx;
   mlir::Location loc = converter.getCurrentLocation();
+  ConditionSpecInfo csi = lowerErrorSpec(converter, loc, stmt.v);
   mlir::FuncOp beginFunc = getIORuntimeFunc<K>(loc, builder);
   mlir::FunctionType beginFuncTy = beginFunc.getType();
-  mlir::Value unit = fir::getBase(converter.genExprValue(
-      getExpr<Fortran::parser::FileUnitNumber>(stmt), stmtCtx, loc));
+  mlir::Value unit = genIOUnitNumber(
+      converter, loc, getExpr<Fortran::parser::FileUnitNumber>(stmt),
+      beginFuncTy.getInput(0), csi, stmtCtx);
   mlir::Value un = builder.createConvert(loc, beginFuncTy.getInput(0), unit);
   mlir::Value file = locToFilename(converter, loc, beginFuncTy.getInput(1));
   mlir::Value line = locToLineNo(converter, loc, beginFuncTy.getInput(2));
   auto call = builder.create<fir::CallOp>(loc, beginFunc,
                                           mlir::ValueRange{un, file, line});
   mlir::Value cookie = call.getResult(0);
-  ConditionSpecInfo csi;
   genConditionHandlerCall(converter, loc, cookie, stmt.v, csi);
   mlir::Value ok;
   auto insertPt = builder.saveInsertionPoint();
@@ -1626,14 +1698,15 @@ Fortran::lower::genOpenStatement(Fortran::lower::AbstractConverter &converter,
   mlir::FuncOp beginFunc;
   llvm::SmallVector<mlir::Value> beginArgs;
   mlir::Location loc = converter.getCurrentLocation();
+  ConditionSpecInfo csi = lowerErrorSpec(converter, loc, stmt.v);
   bool hasNewunitSpec = false;
   if (hasSpec<Fortran::parser::FileUnitNumber>(stmt)) {
     beginFunc = getIORuntimeFunc<mkIOKey(BeginOpenUnit)>(loc, builder);
     mlir::FunctionType beginFuncTy = beginFunc.getType();
-    mlir::Value unit = fir::getBase(converter.genExprValue(
-        getExpr<Fortran::parser::FileUnitNumber>(stmt), stmtCtx, loc));
-    beginArgs.push_back(
-        builder.createConvert(loc, beginFuncTy.getInput(0), unit));
+    mlir::Value unit = genIOUnitNumber(
+        converter, loc, getExpr<Fortran::parser::FileUnitNumber>(stmt),
+        beginFuncTy.getInput(0), csi, stmtCtx);
+    beginArgs.push_back(unit);
     beginArgs.push_back(locToFilename(converter, loc, beginFuncTy.getInput(1)));
     beginArgs.push_back(locToLineNo(converter, loc, beginFuncTy.getInput(2)));
   } else {
@@ -1646,7 +1719,6 @@ Fortran::lower::genOpenStatement(Fortran::lower::AbstractConverter &converter,
   }
   auto cookie =
       builder.create<fir::CallOp>(loc, beginFunc, beginArgs).getResult(0);
-  ConditionSpecInfo csi;
   genConditionHandlerCall(converter, loc, cookie, stmt.v, csi);
   mlir::Value ok;
   auto insertPt = builder.saveInsertionPoint();
@@ -1669,22 +1741,22 @@ Fortran::lower::genWaitStatement(Fortran::lower::AbstractConverter &converter,
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
   Fortran::lower::StatementContext stmtCtx;
   mlir::Location loc = converter.getCurrentLocation();
+  ConditionSpecInfo csi = lowerErrorSpec(converter, loc, stmt.v);
   bool hasId = hasSpec<Fortran::parser::IdExpr>(stmt);
   mlir::FuncOp beginFunc =
       hasId ? getIORuntimeFunc<mkIOKey(BeginWait)>(loc, builder)
             : getIORuntimeFunc<mkIOKey(BeginWaitAll)>(loc, builder);
   mlir::FunctionType beginFuncTy = beginFunc.getType();
-  mlir::Value unit = fir::getBase(converter.genExprValue(
-      getExpr<Fortran::parser::FileUnitNumber>(stmt), stmtCtx, loc));
-  mlir::Value un = builder.createConvert(loc, beginFuncTy.getInput(0), unit);
-  llvm::SmallVector<mlir::Value> args{un};
+  mlir::Value unit = genIOUnitNumber(
+      converter, loc, getExpr<Fortran::parser::FileUnitNumber>(stmt),
+      beginFuncTy.getInput(0), csi, stmtCtx);
+  llvm::SmallVector<mlir::Value> args{unit};
   if (hasId) {
     mlir::Value id = fir::getBase(converter.genExprValue(
         getExpr<Fortran::parser::IdExpr>(stmt), stmtCtx, loc));
     args.push_back(builder.createConvert(loc, beginFuncTy.getInput(1), id));
   }
   auto cookie = builder.create<fir::CallOp>(loc, beginFunc, args).getResult(0);
-  ConditionSpecInfo csi;
   genConditionHandlerCall(converter, loc, cookie, stmt.v, csi);
   return genEndIO(converter, converter.getCurrentLocation(), cookie, csi,
                   stmtCtx);
@@ -1767,7 +1839,7 @@ void genBeginDataTransferCallArgs(
     const A &stmt, mlir::FunctionType ioFuncTy, bool isFormatted,
     bool isListOrNml, [[maybe_unused]] bool isInternal,
     [[maybe_unused]] bool isAsync,
-    const llvm::Optional<fir::ExtendedValue> &descRef,
+    const llvm::Optional<fir::ExtendedValue> &descRef, ConditionSpecInfo &csi,
     Fortran::lower::StatementContext &stmtCtx) {
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
   auto maybeGetFormatArgs = [&]() {
@@ -1800,12 +1872,14 @@ void genBeginDataTransferCallArgs(
           getDefaultScratchLen(builder, loc, ioFuncTy.getInput(ioArgs.size())));
     } else if (isAsync) { // unit; REC; buffer and length
       ioArgs.push_back(getIOUnit(converter, loc, stmt,
-                                 ioFuncTy.getInput(ioArgs.size()), stmtCtx));
+                                 ioFuncTy.getInput(ioArgs.size()), csi,
+                                 stmtCtx));
       TODO(loc, "asynchronous");
     } else { // external IO - maybe explicit format; unit
       maybeGetFormatArgs();
       ioArgs.push_back(getIOUnit(converter, loc, stmt,
-                                 ioFuncTy.getInput(ioArgs.size()), stmtCtx));
+                                 ioFuncTy.getInput(ioArgs.size()), csi,
+                                 stmtCtx));
     }
   } else { // PRINT - maybe explicit format; default unit
     maybeGetFormatArgs();
@@ -1837,6 +1911,12 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter,
   const bool isAsync = isDataTransferAsynchronous(loc, stmt);
   const bool isNml = isDataTransferNamelist(stmt);
 
+  // Generate an EnableHandlers call and remaining specifier calls.
+  ConditionSpecInfo csi;
+  if constexpr (hasIOCtrl) {
+    csi = lowerErrorSpec(converter, loc, stmt.controls);
+  }
+
   // Generate the begin data transfer function call.
   mlir::FuncOp ioFunc = getBeginDataTransferFunc<isInput>(
       loc, builder, isFormatted, isList || isNml, isInternal,
@@ -1844,12 +1924,10 @@ genDataTransferStmt(Fortran::lower::AbstractConverter &converter,
   llvm::SmallVector<mlir::Value> ioArgs;
   genBeginDataTransferCallArgs<hasIOCtrl>(
       ioArgs, converter, loc, stmt, ioFunc.getType(), isFormatted,
-      isList || isNml, isInternal, isAsync, descRef, stmtCtx);
+      isList || isNml, isInternal, isAsync, descRef, csi, stmtCtx);
   mlir::Value cookie =
       builder.create<fir::CallOp>(loc, ioFunc, ioArgs).getResult(0);
 
-  // Generate an EnableHandlers call and remaining specifier calls.
-  ConditionSpecInfo csi;
   auto insertPt = builder.saveInsertionPoint();
   mlir::Value ok;
   if constexpr (hasIOCtrl) {
@@ -2089,7 +2167,6 @@ mlir::Value Fortran::lower::genInquireStatement(
   Fortran::lower::StatementContext stmtCtx;
   mlir::Location loc = converter.getCurrentLocation();
   mlir::FuncOp beginFunc;
-  ConditionSpecInfo csi;
   llvm::SmallVector<mlir::Value> beginArgs;
   const auto *list =
       std::get_if<std::list<Fortran::parser::InquireSpec>>(&stmt.u);
@@ -2101,15 +2178,17 @@ mlir::Value Fortran::lower::genInquireStatement(
     return exprPair.first && exprPair.second;
   };
 
+  ConditionSpecInfo csi =
+      list ? lowerErrorSpec(converter, loc, *list) : ConditionSpecInfo{};
+
   // Make one of three BeginInquire calls.
   if (inquireFileUnit()) {
     // Inquire by unit -- [UNIT=]file-unit-number.
     beginFunc = getIORuntimeFunc<mkIOKey(BeginInquireUnit)>(loc, builder);
     mlir::FunctionType beginFuncTy = beginFunc.getType();
-    beginArgs = {builder.createConvert(loc, beginFuncTy.getInput(0),
-                                       fir::getBase(converter.genExprValue(
-                                           exprPair.first, stmtCtx, loc))),
-                 locToFilename(converter, loc, beginFuncTy.getInput(1)),
+    mlir::Value unit = genIOUnitNumber(converter, loc, exprPair.first,
+                                       beginFuncTy.getInput(0), csi, stmtCtx);
+    beginArgs = {unit, locToFilename(converter, loc, beginFuncTy.getInput(1)),
                  locToLineNo(converter, loc, beginFuncTy.getInput(2))};
   } else if (inquireFileName()) {
     // Inquire by file -- FILE=file-name-expr.

--- a/flang/runtime/iostat.cpp
+++ b/flang/runtime/iostat.cpp
@@ -77,6 +77,8 @@ const char *IostatErrorString(int iostat) {
     return "Erroneous unformatted sequential file record structure";
   case IostatUTF8Decoding:
     return "UTF-8 decoding error";
+  case IostatUnitOverflow:
+    return "UNIT number is out of range";
   default:
     return nullptr;
   }

--- a/flang/test/Lower/io-statement-big-unit-checks.f90
+++ b/flang/test/Lower/io-statement-big-unit-checks.f90
@@ -1,0 +1,315 @@
+! Test lowering of IO statement involving INTEGER(8) and INTEGER(16) external
+! unit number that may turn out at runtime to be too large to fit in a default
+! integer. Unit numbers must fit on default integers. This file tests that the
+! related generated runtime checks and error recovery code.
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+
+! -----------------------------------------------------------------------------
+!     Test that runtime checks are not emitted when not needed
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPopen_4
+subroutine open_4(n4)
+  integer(4) :: n4
+  ! CHECK-NOT: CheckUnitNumberInRange
+  ! CHECK-NOT: fir.if
+  open(n4)
+end subroutine
+
+! CHECK-LABEL: func @_QPwrite_4
+subroutine write_4(n4)
+  integer(4) :: n4
+  ! CHECK-NOT: CheckUnitNumberInRange
+  ! CHECK-NOT: fir.if
+  write(n4, *) "hello"
+end subroutine
+
+! CHECK-LABEL: func @_QPwrite_4_recovery
+subroutine write_4_recovery(n4, ios)
+  integer(4) :: n4, ios
+  ! CHECK-NOT: CheckUnitNumberInRange
+  write(n4, *, iostat=ios) "hello"
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test that runtime checks are emitted for integer(8/16) when there is
+!     no user error recovery.
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPopen_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine open_8(n)
+  integer(8) :: n
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_1]] : (i64) -> i32
+! CHECK:  %[[VAL_13:.*]] = fir.call @_FortranAioBeginOpenUnit(%[[VAL_9]], %{{.*}}, %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:  %[[VAL_14:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_13]]) : (!fir.ref<i8>) -> i32
+  open(n)
+end subroutine
+
+! CHECK-LABEL: func @_QPclose_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine close_8(n)
+  integer(8) :: n
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginClose
+  close(n)
+end subroutine
+
+! CHECK-LABEL: func @_QPrewind_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine rewind_8(n)
+  integer(8) :: n
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginRewind
+  rewind(n)
+end subroutine
+
+! CHECK-LABEL: func @_QPbackspace_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine backspace_8(n)
+  integer(8) :: n
+  backspace(n)
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginBackspace
+end subroutine
+
+! CHECK-LABEL: func @_QPinquire_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine inquire_8(n, fm)
+  integer(8) :: n
+  character(*), fm
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginInquire
+  inquire(n, formatted=fm)
+end subroutine
+
+! CHECK-LABEL: func @_QPwrite_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine write_8(n)
+  integer(8) :: n
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginExternalListOutput
+  write(n, *) "hello"
+end subroutine
+
+! CHECK-LABEL: func @_QPread_8(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+subroutine read_8(n, var)
+  integer(8) :: n
+  integer(4) :: var
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK-NOT: fir.if
+! CHECK: BeginExternalListInput
+  read(n, *) var
+end subroutine
+
+! CHECK-LABEL: func @_QPopen_16(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i128>
+subroutine open_16(n)
+  integer(16) :: n
+! CHECK:  %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<i128>
+! CHECK:  %[[VAL_2:.*]] = arith.constant false
+! CHECK:  %[[VAL_3:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_8:.*]] = fir.call @_FortranAioCheckUnitNumberInRange128(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %{{.*}}, %{{.*}}) : (i128, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+  open(n)
+end subroutine
+
+! -----------------------------------------------------------------------------
+!     Test generation of user error recovery if-nests with INTEGER(8/16)
+!     unit numbers.
+! -----------------------------------------------------------------------------
+
+! CHECK-LABEL: func @_QPopen_8_error_recovery_1(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+! CHECK-SAME:  , %[[VAL_1:.*]]: !fir.ref<i32>
+subroutine open_8_error_recovery_1(n, ios)
+  integer(8) :: n
+  integer(4) :: ios
+! CHECK:  %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_3:.*]] = arith.constant true
+! CHECK:  %[[VAL_4:.*]] = fir.zero_bits !fir.ref<i8>
+! CHECK:  %[[VAL_5:.*]] = arith.constant 0 : i64
+! CHECK:  %[[VAL_9:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK:  %[[VAL_10:.*]] = arith.constant 0 : i32
+! CHECK:  %[[VAL_11:.*]] = arith.cmpi eq, %[[VAL_9]], %[[VAL_10]] : i32
+! CHECK:  %[[VAL_12:.*]] = fir.if %[[VAL_11]] -> (i32) {
+! CHECK:    %[[VAL_13:.*]] = fir.convert %[[VAL_2]] : (i64) -> i32
+! CHECK:    %[[VAL_17:.*]] = fir.call @_FortranAioBeginOpenUnit(%[[VAL_13]], %{{.*}}, {{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:    %[[VAL_18:.*]] = arith.constant true
+! CHECK:    %[[VAL_19:.*]] = arith.constant false
+! CHECK:    %[[VAL_20:.*]] = arith.constant false
+! CHECK:    %[[VAL_21:.*]] = arith.constant false
+! CHECK:    %[[VAL_22:.*]] = arith.constant false
+! CHECK:    %[[VAL_23:.*]] = fir.call @_FortranAioEnableHandlers(%[[VAL_17]], %[[VAL_18]], %[[VAL_19]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]]) : (!fir.ref<i8>, i1, i1, i1, i1, i1) -> none
+! CHECK:    %[[VAL_24:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_17]]) : (!fir.ref<i8>) -> i32
+! CHECK:    fir.result %[[VAL_24]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_9]] : i32
+! CHECK:  }
+! CHECK:  fir.store %[[VAL_25:.*]] to %[[VAL_1]] : !fir.ref<i32>
+  open(n, iostat=ios)
+end subroutine
+
+! CHECK-LABEL: func @_QPopen_8_error_recovery_2(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>
+! CHECK-SAME:  , %[[VAL_1:.*]]: !fir.boxchar<1>
+subroutine open_8_error_recovery_2(n, msg)
+  integer(8) :: n
+  character(*) :: msg
+! CHECK:  %[[VAL_2:.*]]:2 = fir.unboxchar %[[VAL_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+! CHECK:  %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:  %[[VAL_4:.*]] = arith.constant true
+! CHECK:  %[[VAL_5:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:  %[[VAL_6:.*]] = fir.convert %[[VAL_2]]#1 : (index) -> i64
+! CHECK:  %[[VAL_10:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(%[[VAL_3]], %[[VAL_4]], %[[VAL_5]], %[[VAL_6]], %{{.*}}, %{{.*}}) : (i64, i1, !fir.ref<i8>, i64, !fir.ref<i8>, i32) -> i32
+! CHECK:  %[[VAL_11:.*]] = arith.constant 0 : i32
+! CHECK:  %[[VAL_12:.*]] = arith.cmpi eq, %[[VAL_10]], %[[VAL_11]] : i32
+! CHECK:  %[[VAL_13:.*]] = fir.if %[[VAL_12]] -> (i32) {
+! CHECK:    %[[VAL_14:.*]] = fir.convert %[[VAL_3]] : (i64) -> i32
+! CHECK:    %[[VAL_18:.*]] = fir.call @_FortranAioBeginOpenUnit(%[[VAL_14]], %{{.*}}, %{{.*}}) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:    %[[VAL_19:.*]] = arith.constant false
+! CHECK:    %[[VAL_20:.*]] = arith.constant true
+! CHECK:    %[[VAL_21:.*]] = arith.constant false
+! CHECK:    %[[VAL_22:.*]] = arith.constant false
+! CHECK:    %[[VAL_23:.*]] = arith.constant true
+! CHECK:    %[[VAL_24:.*]] = fir.call @_FortranAioEnableHandlers(%[[VAL_18]], %[[VAL_19]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]]) : (!fir.ref<i8>, i1, i1, i1, i1, i1) -> none
+! CHECK:    %[[VAL_25:.*]] = fir.convert %[[VAL_2]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<i8>
+! CHECK:    %[[VAL_26:.*]] = fir.convert %[[VAL_2]]#1 : (index) -> i64
+! CHECK:    %[[VAL_27:.*]] = fir.call @_FortranAioGetIoMsg(%[[VAL_18]], %[[VAL_25]], %[[VAL_26]]) : (!fir.ref<i8>, !fir.ref<i8>, i64) -> none
+! CHECK:    %[[VAL_28:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_18]]) : (!fir.ref<i8>) -> i32
+! CHECK:    fir.result %[[VAL_28]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_10]] : i32
+! CHECK:  }
+! CHECK:  %[[VAL_29:.*]] = fir.convert %[[VAL_30:.*]] : (i32) -> index
+! CHECK:  fir.select %[[VAL_29]] : index [0, ^bb1, unit, ^bb2]
+! CHECK:       ^bb1:
+! CHECK:  br ^bb3
+! CHECK:       ^bb2:
+! CHECK:  fir.call @_QPi_failed() : () -> ()
+! CHECK:  br ^bb3
+! CHECK:       ^bb3:
+! CHECK:  return
+  open(n, err=30, iomsg=msg)
+  return
+30 call i_failed()
+end subroutine
+
+! Torture test for temp clean-ups when user recovery is enabled.
+! Checks that temps are cleaned-up in the right nests.
+subroutine temp_cleanup(n, msg, ios)
+  interface
+    function make_temp0()
+      integer, allocatable :: make_temp0
+    end function
+    function make_temp1()
+      integer, allocatable :: make_temp1
+    end function
+    function make_temp2()
+      integer, allocatable :: make_temp2
+    end function
+    function make_temp3()
+      integer, allocatable :: make_temp3
+    end function
+    function make_temp4()
+      integer, allocatable :: make_temp4
+    end function
+    function make_temp5()
+      integer, allocatable :: make_temp5
+    end function
+  end interface
+  integer(8) :: n(2)
+  character(80) :: msg
+  Integer ios(2)
+  write(n(make_temp0()), iostat=ios(make_temp1()), iomsg=msg(make_temp2():make_temp3())) make_temp4(), make_temp5()
+! CHECK-LABEL: func @_QPtemp_cleanup(
+! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<!fir.array<2xi64>> {fir.bindc_name = "n"},
+! CHECK-SAME:  %[[VAL_1:.*]]: !fir.boxchar<1> {fir.bindc_name = "msg"},
+! CHECK-SAME:  %[[VAL_2:.*]]: !fir.ref<!fir.array<2xi32>> {fir.bindc_name = "ios"}) {
+! CHECK:  %[[VAL_10:.*]] = fir.call @_QPmake_temp2() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:  fir.save_result %[[VAL_10]] to %[[VAL_8:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_15:.*]] = fir.call @_QPmake_temp3() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:  fir.save_result %[[VAL_15]] to %[[VAL_7:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  fir.load %[[VAL_7]]
+! CHECK:  %[[VAL_32:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_33:.*]] = fir.box_addr %[[VAL_32]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[VAL_33]] : !fir.heap<i32>
+! CHECK:  %[[VAL_37:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_38:.*]] = fir.box_addr %[[VAL_37]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[VAL_38]] : !fir.heap<i32>
+! CHECK:  %[[VAL_42:.*]] = fir.call @_QPmake_temp0() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:  fir.save_result %[[VAL_42]] to %[[VAL_6:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_57:.*]] = fir.call @_FortranAioCheckUnitNumberInRange64(
+! CHECK:  %[[VAL_58:.*]] = arith.constant 0 : i32
+! CHECK:  %[[VAL_59:.*]] = arith.cmpi eq, %[[VAL_57]], %[[VAL_58]] : i32
+! CHECK:  %[[VAL_60:.*]] = fir.if %[[VAL_59]] -> (i32) {
+! CHECK:    fir.call @_FortranAioBeginUnformattedOutput(
+! CHECK:    fir.call @_FortranAioEnableHandlers(
+! CHECK:    %[[VAL_72:.*]] = fir.call @_QPmake_temp4() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:    fir.save_result %[[VAL_72]] to %[[VAL_5:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:    %[[VAL_77:.*]] = fir.call @_FortranAioOutputDescriptor(
+! CHECK:    %[[VAL_77_1:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:    %[[VAL_77_2:.*]] = fir.box_addr %[[VAL_77_1]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:    fir.freemem %[[VAL_77_2]] : !fir.heap<i32>
+! CHECK:    fir.if %[[VAL_77]] {
+! CHECK:      %[[VAL_78:.*]] = fir.call @_QPmake_temp5() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:      fir.save_result %[[VAL_78]] to %[[VAL_4:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:      fir.call @_FortranAioOutputDescriptor(
+! CHECK:      %[[VAL_84:.*]] = fir.load %[[VAL_4]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:      %[[VAL_85:.*]] = fir.box_addr %[[VAL_84]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:      fir.freemem %[[VAL_85]] : !fir.heap<i32>
+! CHECK:    }
+! CHECK-NOT: fir.call @_QPmake_temp3
+! CHECK:    fir.call @_FortranAioGetIoMsg(
+! CHECK:    %[[VAL_97:.*]] = fir.call @_FortranAioEndIoStatement(
+! CHECK:    fir.result %[[VAL_97]] : i32
+! CHECK:  } else {
+! CHECK:    fir.result %[[VAL_57]] : i32
+! CHECK:  }
+! CHECK:  %[[VAL_98:.*]] = fir.call @_QPmake_temp1() : () -> !fir.box<!fir.heap<i32>>
+! CHECK:  fir.save_result %[[VAL_98]] to %[[VAL_3:.*]] : !fir.box<!fir.heap<i32>>, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  fir.load %[[VAL_3]]
+! CHECK:  %[[VAL_107:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_108:.*]] = fir.box_addr %[[VAL_107]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[VAL_108]] : !fir.heap<i32>
+! CHECK:  %[[VAL_112:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:  %[[VAL_113:.*]] = fir.box_addr %[[VAL_112]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:  fir.freemem %[[VAL_113]] : !fir.heap<i32>
+end


### PR DESCRIPTION
External unit numbers may be provided by the user in wider types than INTEGER(4). In this case, it must be checked at runtime if the number can fit on an INTEGER(4). If not an I/O error must be raised before attempting to call the related BeginXXX. ("must" comes from the fact that all other compilers are doing it, and that it looks a sane thing to do. It is not a mandatory check from a standard point of view).

This PR cherry-pick the new CheckUnitNumberInRange runtime and use it in lowering. A new loop nest must be added around the IO calls in case of user error recovery.

While adding torture tests, I noticed that clean-up for IO item/output items was happening in the wrong spot in case of error recovery: it was done in the inner most if-nest (the nest of the last item), causing any previous temp to not be cleaned-up in case an I/O error is raised before the last item.