### PR TITLE
This fixes a number of issues.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -155,7 +155,7 @@ public:
   virtual mlir::Type genType(SymbolRef) = 0;
   /// Generate the type from a category
   virtual mlir::Type genType(Fortran::common::TypeCategory tc) = 0;
-  /// Generate the type from a category and kind and length parameters.
+  /// Generate the type from a category and kind and LEN parameters.
   virtual mlir::Type
   genType(Fortran::common::TypeCategory tc, int kind,
           llvm::ArrayRef<std::int64_t> lenParameters = llvm::None) = 0;

--- a/flang/include/flang/Lower/BoxAnalyzer.h
+++ b/flang/include/flang/Lower/BoxAnalyzer.h
@@ -484,7 +484,7 @@ private:
         sym.GetType()->characterTypeSpec().length();
     if (Fortran::semantics::MaybeIntExpr expr = lenParam.GetExplicit())
       return {Fortran::evaluate::AsGenericExpr(std::move(*expr))};
-    // For assumed length parameters, the length comes from the initialization
+    // For assumed LEN parameters, the length comes from the initialization
     // expression.
     if (sym.attrs().test(Fortran::semantics::Attr::PARAMETER))
       if (const auto *objectDetails =

--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -61,9 +61,9 @@ public:
   AbstractBox() = delete;
   AbstractBox(mlir::Value addr) : addr{addr} {}
 
-  /// FIXME: this comment is not true anymore since genLoad
-  /// is loading constant length characters. What is the impact  /// ?
-  /// An abstract box always contains a memory reference to a value.
+  /// An abstract box most often contains a memory reference to a value. Despite
+  /// the name here, it is possible that `addr` is a scalar value that is not a
+  /// memory reference.
   mlir::Value getAddr() const { return addr; }
 
 protected:
@@ -239,18 +239,20 @@ public:
       return seqTy.getDimension();
     return 0;
   }
-  /// Is this a character entity ?
-  bool isCharacter() const { return fir::isa_char(getEleTy()); };
-  /// Is this a derived type entity ?
-  bool isDerived() const { return getEleTy().isa<fir::RecordType>(); };
 
-  bool isDerivedWithLengthParameters() const {
-    auto record = getEleTy().dyn_cast<fir::RecordType>();
-    return record && record.getNumLenParams() != 0;
-  };
+  /// Is this a character entity ?
+  bool isCharacter() const { return fir::isa_char(getEleTy()); }
+
+  /// Is this a derived type entity ?
+  bool isDerived() const { return getEleTy().isa<fir::RecordType>(); }
+
+  bool isDerivedWithLenParameters() const {
+    return fir::isRecordWithTypeParameters(getEleTy());
+  }
+
   /// Is this a CLASS(*)/TYPE(*) ?
   bool isUnlimitedPolymorphic() const {
-    return getEleTy().isa<mlir::NoneType>();
+    return fir::isUnlimitedPolymorphicType(getBaseTy());
   }
 };
 
@@ -259,7 +261,7 @@ public:
 /// absent optional and we need to wait until the user is referencing it
 /// to read it, or because it contains important information that cannot
 /// be exposed in FIR (e.g. non contiguous byte stride).
-/// It may also store explicit bounds or length parameters that were specified
+/// It may also store explicit bounds or LEN parameters that were specified
 /// for the entity.
 class BoxValue : public AbstractIrBox {
 public:
@@ -287,7 +289,7 @@ public:
   // The extents member is not guaranteed to be field for arrays. It is only
   // guaranteed to be field for explicit shape arrays. In general,
   // explicit-shape will not come as descriptors, so this field will be empty in
-  // most cases. The exception are derived types with length parameters and
+  // most cases. The exception are derived types with LEN parameters and
   // polymorphic dummy argument arrays. It may be possible for the explicit
   // extents to conflict with the shape information that is in the box according
   // to 15.5.2.11 sequence association rules.
@@ -301,8 +303,8 @@ protected:
   // Verify constructor invariants.
   bool verify() const;
 
-  // Only field when the BoxValue has explicit length parameters.
-  // Otherwise, the length parameters are in the fir.box.
+  // Only field when the BoxValue has explicit LEN parameters.
+  // Otherwise, the LEN parameters are in the fir.box.
   llvm::SmallVector<mlir::Value, 2> explicitParams;
 };
 
@@ -318,7 +320,7 @@ public:
   mlir::Value addr;
   llvm::SmallVector<mlir::Value, 2> extents;
   llvm::SmallVector<mlir::Value, 2> lbounds;
-  /// Only keep track of the deferred length parameters through variables, since
+  /// Only keep track of the deferred LEN parameters through variables, since
   /// they are the only ones that can change as per the deferred type parameters
   /// definition in F2018 standard section 3.147.12.2.
   /// Non-deferred values are returned by
@@ -333,9 +335,9 @@ public:
 class MutableBoxValue : public AbstractIrBox {
 public:
   /// Create MutableBoxValue given the address \p addr of the box and the non
-  /// deferred length parameters \p lenParameters. The non deferred length
-  /// parameters must always be provided, even if they are constant and already
-  /// reflected in the address type.
+  /// deferred LEN parameters \p lenParameters. The non deferred LEN parameters
+  /// must always be provided, even if they are constant and already reflected
+  /// in the address type.
   MutableBoxValue(mlir::Value addr, mlir::ValueRange lenParameters,
                   MutableProperties mutableProperties)
       : AbstractIrBox(addr), lenParams{lenParameters.begin(),
@@ -343,7 +345,7 @@ public:
         mutableProperties{mutableProperties} {
     // Currently only accepts fir.(ref/ptr/heap)<fir.box<type>> mlir::Value for
     // the address. This may change if we accept
-    // fir.(ref/ptr/heap)<fir.heap<type>> for scalar without length parameters.
+    // fir.(ref/ptr/heap)<fir.heap<type>> for scalar without LEN parameters.
     assert(verify() &&
            "MutableBoxValue requires mem ref to fir.box<fir.[heap|ptr]<type>>");
   }
@@ -359,9 +361,9 @@ public:
   MutableBoxValue clone(mlir::Value newBox) const {
     return {newBox, lenParams, mutableProperties};
   }
-  /// Does this entity has any non deferred length parameters ?
+  /// Does this entity has any non deferred LEN parameters?
   bool hasNonDeferredLenParams() const { return !lenParams.empty(); }
-  /// Return the non deferred length parameters.
+  /// Return the non deferred LEN parameters.
   llvm::ArrayRef<mlir::Value> nonDeferredLenParams() const { return lenParams; }
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &,
                                        const MutableBoxValue &);
@@ -378,8 +380,8 @@ public:
 protected:
   /// Validate the address type form in the constructor.
   bool verify() const;
-  /// Hold the non-deferred length parameter values  (both for characters and
-  /// derived). Non-deferred length parameters cannot change dynamically, as
+  /// Hold the non-deferred LEN parameter values  (both for characters and
+  /// derived). Non-deferred LEN parameters cannot change dynamically, as
   /// opposed to deferred type parameters (3.147.12.2).
   llvm::SmallVector<mlir::Value, 2> lenParams;
   /// Set of variables holding the extents, lower bounds and
@@ -529,10 +531,9 @@ inline mlir::Type getElementTypeOf(const ExtendedValue &exv) {
   return fir::unwrapSequenceType(getBaseTypeOf(exv));
 }
 
-/// Is the extended value `exv` a derived type with length parameters ?
-inline bool isDerivedWithLengthParameters(const ExtendedValue &exv) {
-  auto record = getElementTypeOf(exv).dyn_cast<fir::RecordType>();
-  return record && record.getNumLenParams() != 0;
+/// Is the extended value `exv` a derived type with LEN parameters?
+inline bool isDerivedWithLenParameters(const ExtendedValue &exv) {
+  return fir::isRecordWithTypeParameters(getElementTypeOf(exv));
 }
 
 } // namespace fir

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -420,12 +420,6 @@ llvm::SmallVector<mlir::Value> readExtents(fir::FirOpBuilder &builder,
                                            mlir::Location loc,
                                            const fir::BoxValue &box);
 
-/// Get extents from \p box. For fir::BoxValue and
-/// fir::MutableBoxValue, this will generate code to read the extents.
-llvm::SmallVector<mlir::Value> getExtents(fir::FirOpBuilder &builder,
-                                          mlir::Location loc,
-                                          const fir::ExtendedValue &box);
-
 /// Read a fir::BoxValue into an fir::UnboxValue, a fir::ArrayBoxValue or a
 /// fir::CharArrayBoxValue. This should only be called if the fir::BoxValue is
 /// known to be contiguous given the context (or if the resulting address will

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -89,7 +89,7 @@ public:
   /// Create a sequence of `eleTy` with `rank` dimensions of unknown size.
   mlir::Type getVarLenSeqTy(mlir::Type eleTy, unsigned rank = 1);
 
-  /// Get character length type
+  /// Get character length type.
   mlir::Type getCharacterLengthType() { return getIndexType(); }
 
   /// Get the integer type whose bit width corresponds to the width of pointer
@@ -300,7 +300,8 @@ public:
   /// \p exv is an extended value holding a memory reference to the object that
   /// must be boxed. This function will crash if provided something that is not
   /// a memory reference type.
-  /// Array entities are boxed with a shape and character with their length.
+  /// Array entities are boxed with a shape and possibly a shift. Character
+  /// entities are boxed with a LEN parameter.
   mlir::Value createBox(mlir::Location loc, const fir::ExtendedValue &exv);
 
   /// Create constant i1 with value 1. if \p b is true or 0. otherwise
@@ -434,18 +435,18 @@ llvm::SmallVector<mlir::Value>
 getNonDefaultLowerBounds(fir::FirOpBuilder &builder, mlir::Location loc,
                          const fir::ExtendedValue &exv);
 
-/// Return length parameters associated to \p exv that are not deferred (that
-/// are available without having to read any fir.box values).
-/// Empty if \p exv has no length parameters or if they are all deferred.
+/// Return LEN parameters associated to \p exv that are not deferred (that are
+/// available without having to read any fir.box values). Empty if \p exv has no
+/// LEN parameters or if they are all deferred.
 llvm::SmallVector<mlir::Value>
-getNonDeferredLengthParams(const fir::ExtendedValue &exv);
+getNonDeferredLenParams(const fir::ExtendedValue &exv);
 
 //===--------------------------------------------------------------------===//
 // String literal helper helpers
 //===--------------------------------------------------------------------===//
 
-/// Create a !fir.char<1> string literal global and returns a
-/// fir::CharBoxValue with its address en length.
+/// Create a !fir.char<1> string literal global and returns a fir::CharBoxValue
+/// with its address en length.
 fir::ExtendedValue createStringLiteral(fir::FirOpBuilder &, mlir::Location,
                                        llvm::StringRef string);
 
@@ -480,9 +481,9 @@ fir::ExtendedValue componentToExtendedValue(fir::FirOpBuilder &builder,
 
 /// Given the address of an array element and the ExtendedValue describing the
 /// array, returns the ExtendedValue describing the array element. The purpose
-/// is to propagate the length parameters of the array to the element.
-/// This can be used for elements of `array` or `array(i:j:k)`. If \p element
-/// belongs to an array section `array%x` whose base is \p array,
+/// is to propagate the LEN parameters of the array to the element. This can be
+/// used for elements of `array` or `array(i:j:k)`. If \p element belongs to an
+/// array section `array%x` whose base is \p array,
 /// arraySectionElementToExtendedValue must be used instead.
 fir::ExtendedValue arrayElementToExtendedValue(fir::FirOpBuilder &builder,
                                                mlir::Location loc,

--- a/flang/include/flang/Optimizer/Builder/MutableBox.h
+++ b/flang/include/flang/Optimizer/Builder/MutableBox.h
@@ -33,7 +33,7 @@ namespace fir::factory {
 /// allocatable variable. Initialization of such variable has to be done at the
 /// beginning of the variable lifetime by storing the created box in the memory
 /// for the variable box.
-/// \p nonDeferredParams must provide the non deferred length parameters so that
+/// \p nonDeferredParams must provide the non deferred LEN parameters so that
 /// they can already be placed in the unallocated box (inquiries about these
 /// parameters are legal even in unallocated state).
 mlir::Value createUnallocatedBox(fir::FirOpBuilder &builder, mlir::Location loc,
@@ -75,13 +75,13 @@ void disassociateMutableBox(fir::FirOpBuilder &builder, mlir::Location loc,
                             const fir::MutableBoxValue &box);
 
 /// Generate code to conditionally reallocate a MutableBoxValue with a new
-/// shape, lower bounds, and length parameters if it is unallocated or if its
-/// current shape or deferred  length parameters do not match the provided ones.
+/// shape, lower bounds, and LEN parameters if it is unallocated or if its
+/// current shape or deferred  LEN parameters do not match the provided ones.
 /// Lower bounds are only used if the entity needs to be allocated, otherwise,
 /// the MutableBoxValue will keep its current lower bounds.
 /// If the MutableBoxValue is an array, the provided shape can be empty, in
 /// which case the MutableBoxValue must already be allocated at runtime and its
-/// shape and lower bounds will be kept. If \p shape is empty, only a length
+/// shape and lower bounds will be kept. If \p shape is empty, only a LEN
 /// parameter mismatch can trigger a reallocation. See Fortran 10.2.1.3 point 3
 /// that this function is implementing for more details. The polymorphic
 /// requirements are not yet covered by this function.
@@ -96,7 +96,7 @@ MutableBoxReallocation genReallocIfNeeded(fir::FirOpBuilder &builder,
                                           mlir::Location loc,
                                           const fir::MutableBoxValue &box,
                                           mlir::ValueRange shape,
-                                          mlir::ValueRange lengthParams);
+                                          mlir::ValueRange lenParams);
 
 void finalizeRealloc(fir::FirOpBuilder &builder, mlir::Location loc,
                      const fir::MutableBoxValue &box, mlir::ValueRange lbounds,

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -327,7 +327,7 @@ def fir_SaveResultOp : fir_Op<"save_result", [AttrSizedOperandSegments]> {
 
   let description = [{
     Save the result of a function returning an array, box, or record type value
-    into a memory location given the shape and length parameters of the result.
+    into a memory location given the shape and LEN parameters of the result.
 
     Function results of type fir.box, fir.array, or fir.rec are abstract values
     that require a storage to be manipulated on the caller side. This operation
@@ -336,8 +336,8 @@ def fir_SaveResultOp : fir_Op<"save_result", [AttrSizedOperandSegments]> {
     memory.
     
     For arrays, result, it is required to provide the shape of the result. For
-    character arrays and derived types with length parameters, the length
-    parameter values must be provided.
+    character arrays and derived types with LEN parameters, the LEN parameter
+    values must be provided.
 
     The fir.save_result associated to a function call must immediately follow
     the call and be in the same block.  

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -193,6 +193,11 @@ inline mlir::Type unwrapPassByRefType(mlir::Type t) {
   return t;
 }
 
+/// Unwrap all referential and sequential outer types (if any). Returns the
+/// element type. This is useful for determining the element type of any object
+/// memory reference, whether it is a single instance or a series of instances.
+mlir::Type unwrapAllRefAndSeqType(mlir::Type ty);
+
 /// Unwrap all pointer and box types and return the element type if it is a
 /// sequence type, otherwise return null.
 inline fir::SequenceType unwrapUntilSeqType(mlir::Type t) {

--- a/flang/include/flang/Optimizer/Dialect/FIRType.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRType.h
@@ -239,7 +239,7 @@ bool isRecordWithAllocatableMember(mlir::Type ty);
 /// Return true iff `ty` is a RecordType with type parameters.
 inline bool isRecordWithTypeParameters(mlir::Type ty) {
   if (auto recTy = ty.dyn_cast_or_null<fir::RecordType>())
-    return recTy.getNumLenParams() != 0;
+    return recTy.isDependentType();
   return false;
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -320,6 +320,7 @@ def fir_RecordType : FIR_Type<"Record", "type"> {
     }
     unsigned getNumFields() { return getTypeList().size(); }
     unsigned getNumLenParams() { return getLenParamList().size(); }
+    bool isDependentType() { return getNumLenParams(); }
 
     void finalize(llvm::ArrayRef<TypePair> lenPList,
                   llvm::ArrayRef<TypePair> typeList);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -442,7 +442,7 @@ public:
           // the original variable described by a fir.box.
           llvm::SmallVector<mlir::Value> extents =
               fir::factory::getExtents(loc, *builder, hexv);
-          if (box.isDerivedWithLengthParameters())
+          if (box.isDerivedWithLenParameters())
             TODO(loc, "get length parameters from derived type BoxValue");
           if (box.isCharacter()) {
             mlir::Value len = fir::factory::readCharLen(*builder, loc, box);
@@ -2152,9 +2152,9 @@ private:
                   llvm::SmallVector<mlir::Value> lengthParams;
                   if (const fir::CharBoxValue *charBox = rhs.getCharBox())
                     lengthParams.push_back(charBox->getLen());
-                  else if (fir::isDerivedWithLengthParameters(rhs))
+                  else if (fir::isDerivedWithLenParameters(rhs))
                     TODO(loc, "assignment to derived type allocatable with "
-                              "length parameters");
+                              "LEN parameters");
                   lhsRealloc = fir::factory::genReallocIfNeeded(
                       *builder, loc, *lhsMutableBox,
                       /*shape=*/llvm::None, lengthParams);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -441,7 +441,7 @@ public:
           // Create a contiguous temp with the same shape and length as
           // the original variable described by a fir.box.
           llvm::SmallVector<mlir::Value> extents =
-              fir::factory::getExtents(*builder, loc, hexv);
+              fir::factory::getExtents(loc, *builder, hexv);
           if (box.isDerivedWithLengthParameters())
             TODO(loc, "get length parameters from derived type BoxValue");
           if (box.isCharacter()) {
@@ -459,8 +459,8 @@ public:
         },
         [&](const auto &) -> fir::ExtendedValue {
           mlir::Value temp =
-              allocate(fir::factory::getExtents(*builder, loc, hexv),
-                       fir::getTypeParams(hexv));
+              allocate(fir::factory::getExtents(loc, *builder, hexv),
+                       fir::factory::getTypeParams(loc, *builder, hexv));
           return fir::substBase(hexv, temp);
         });
 

--- a/flang/lib/Lower/HostAssociations.cpp
+++ b/flang/lib/Lower/HostAssociations.cpp
@@ -223,7 +223,7 @@ public:
 
 /// Is \p sym a derived type entity with length parameters ?
 static bool
-isDerivedWithLengthParameters(const Fortran::semantics::Symbol &sym) {
+isDerivedWithLenParameters(const Fortran::semantics::Symbol &sym) {
   if (const auto *declTy = sym.GetType())
     if (const auto *derived = declTy->AsDerived())
       return Fortran::semantics::CountLenParameters(*derived) != 0;
@@ -301,7 +301,7 @@ public:
           nonDeferredLenParams.push_back(readLength());
         }
       }
-    } else if (isDerivedWithLengthParameters(sym)) {
+    } else if (isDerivedWithLenParameters(sym)) {
       TODO(loc, "host associated derived type allocatable or pointer with "
                 "length parameters");
     }
@@ -425,7 +425,7 @@ private:
     const Fortran::semantics::DeclTypeSpec *type = sym.GetType();
     bool isPolymorphic = type && type->IsPolymorphic();
     return isScalarOrContiguous && !isPolymorphic &&
-           !isDerivedWithLengthParameters(sym);
+           !isDerivedWithLenParameters(sym);
   }
 };
 
@@ -437,7 +437,7 @@ template <typename T>
 typename T::Result
 walkCaptureCategories(T visitor, Fortran::lower::AbstractConverter &converter,
                       const Fortran::semantics::Symbol &sym) {
-  if (isDerivedWithLengthParameters(sym))
+  if (isDerivedWithLenParameters(sym))
     // Should be boxed.
     TODO(converter.genLocation(sym.name()),
          "host associated derived type with length parameters");

--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -43,7 +43,8 @@ fir::ExtendedValue fir::substBase(const fir::ExtendedValue &exv,
       [=](const auto &x) { return fir::ExtendedValue(x.clone(base)); });
 }
 
-llvm::SmallVector<mlir::Value> fir::getTypeParams(const ExtendedValue &exv) {
+llvm::SmallVector<mlir::Value>
+fir::getTypeParams(const fir::ExtendedValue &exv) {
   using RT = llvm::SmallVector<mlir::Value>;
   auto baseTy = fir::getBase(exv).getType();
   if (auto t = fir::dyn_cast_ptrEleTy(baseTy))
@@ -221,10 +222,11 @@ bool fir::BoxValue::verify() const {
 
 /// Get exactly one extent for any array-like extended value, \p exv. If \p exv
 /// is not an array or has rank less then \p dim, the result will be a nullptr.
-mlir::Value fir::getExtentAtDimension(const fir::ExtendedValue &exv,
-                                      fir::FirOpBuilder &builder,
-                                      mlir::Location loc, unsigned dim) {
-  auto extents = fir::factory::getExtents(builder, loc, exv);
+mlir::Value fir::factory::getExtentAtDimension(mlir::Location loc,
+                                               fir::FirOpBuilder &builder,
+                                               const fir::ExtendedValue &exv,
+                                               unsigned dim) {
+  auto extents = fir::factory::getExtents(loc, builder, exv);
   if (dim < extents.size())
     return extents[dim];
   return {};

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -496,7 +496,7 @@ void fir::factory::associateMutableBox(fir::FirOpBuilder &builder,
           // fir.box to update the LHS.
           auto rawAddr = builder.create<fir::BoxAddrOp>(loc, arr.getMemTy(),
                                                         arr.getAddr());
-          auto extents = fir::factory::getExtents(builder, loc, source);
+          auto extents = fir::factory::getExtents(loc, builder, source);
           llvm::SmallVector<mlir::Value> lenParams;
           if (arr.isCharacter()) {
             lenParams.emplace_back(
@@ -839,7 +839,7 @@ void fir::factory::finalizeRealloc(fir::FirOpBuilder &builder,
                "reallocation of derived type entities with length parameters");
         auto lengths = getNewLengths(builder, loc, box, lenParams);
         auto heap = fir::getBase(realloc.newValue);
-        auto extents = fir::factory::getExtents(builder, loc, realloc.newValue);
+        auto extents = fir::factory::getExtents(loc, builder, realloc.newValue);
         builder.genIfThen(loc, realloc.oldAddressWasAllocated)
             .genThen(
                 [&]() { genFinalizeAndFree(builder, loc, realloc.oldAddress); })

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -66,7 +66,7 @@ static mlir::Value createNewFirBox(fir::FirOpBuilder &builder,
     cleanedAddr = builder.createConvert(loc, type, addr);
     if (charTy.getLen() == fir::CharacterType::unknownLen())
       cleanedLengths.append(lengths.begin(), lengths.end());
-  } else if (box.isDerivedWithLengthParameters()) {
+  } else if (box.isDerivedWithLenParameters()) {
     TODO(loc, "updating mutablebox of derived type with length parameters");
     cleanedLengths = lengths;
   }
@@ -164,7 +164,7 @@ public:
     extents = readShape(&lbounds);
     if (box.isCharacter())
       lengths.emplace_back(readCharacterLength());
-    else if (box.isDerivedWithLengthParameters())
+    else if (box.isDerivedWithLenParameters())
       TODO(loc, "read allocatable or pointer derived type LEN parameters");
     return readBaseAddress();
   }
@@ -306,7 +306,7 @@ private:
       for (auto [len, lenVar] :
            llvm::zip(lengths, mutableProperties.deferredParams))
         castAndStore(len, lenVar);
-    else if (box.isDerivedWithLengthParameters())
+    else if (box.isDerivedWithLenParameters())
       TODO(loc, "update allocatable derived type length parameters");
   }
   fir::FirOpBuilder &builder;
@@ -501,7 +501,7 @@ void fir::factory::associateMutableBox(fir::FirOpBuilder &builder,
           if (arr.isCharacter()) {
             lenParams.emplace_back(
                 fir::factory::readCharLen(builder, loc, source));
-          } else if (arr.isDerivedWithLengthParameters()) {
+          } else if (arr.isDerivedWithLenParameters()) {
             TODO(loc, "pointer assignment to derived with length parameters");
           }
           writer.updateMutableBox(rawAddr, newLbounds, extents, lenParams);
@@ -593,7 +593,7 @@ void fir::factory::associateMutableBoxWithRemap(
           if (arr.isCharacter()) {
             lenParams.emplace_back(
                 fir::factory::readCharLen(builder, loc, source));
-          } else if (arr.isDerivedWithLengthParameters()) {
+          } else if (arr.isDerivedWithLenParameters()) {
             TODO(loc, "pointer assignment to derived with length parameters");
           }
           writer.updateMutableBox(rawAddr, lbounds, extents, lenParams);
@@ -745,7 +745,7 @@ fir::factory::genReallocIfNeeded(fir::FirOpBuilder &builder, mlir::Location loc,
               assert(!lengthParams.empty() &&
                      "must provide length parameters for character");
               compareProperty(reader.readCharacterLength(), lengthParams[0]);
-            } else if (box.isDerivedWithLengthParameters()) {
+            } else if (box.isDerivedWithLenParameters()) {
               TODO(loc, "automatic allocation of derived type allocatable with "
                         "length parameters");
             }
@@ -808,7 +808,7 @@ fir::factory::genReallocIfNeeded(fir::FirOpBuilder &builder, mlir::Location loc,
         return fir::CharArrayBoxValue{newAddr, len, extents};
       return fir::CharBoxValue{newAddr, len};
     }
-    if (box.isDerivedWithLengthParameters())
+    if (box.isDerivedWithLenParameters())
       TODO(loc, "reallocation of derived type entities with length parameters");
     if (box.hasRank())
       return fir::ArrayBoxValue{newAddr, extents};
@@ -834,7 +834,7 @@ void fir::factory::finalizeRealloc(fir::FirOpBuilder &builder,
         llvm::SmallVector<mlir::Value> lenParams;
         if (box.isCharacter())
           lenParams.push_back(fir::getLen(realloc.newValue));
-        if (box.isDerivedWithLengthParameters())
+        if (box.isDerivedWithLenParameters())
           TODO(loc,
                "reallocation of derived type entities with length parameters");
         auto lengths = getNewLengths(builder, loc, box, lenParams);

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -283,6 +283,17 @@ bool isRecordWithAllocatableMember(mlir::Type ty) {
   return false;
 }
 
+mlir::Type unwrapAllRefAndSeqType(mlir::Type ty) {
+  while (true) {
+    mlir::Type nt = unwrapSequenceType(unwrapRefType(ty));
+    if (auto vecTy = nt.dyn_cast<fir::VectorType>())
+      nt = vecTy.getEleTy();
+    if (nt == ty)
+      return ty;
+    ty = nt;
+  }
+}
+
 } // namespace fir
 
 namespace {

--- a/flang/test/Lower/array-user-def-assignments.f90
+++ b/flang/test/Lower/array-user-def-assignments.f90
@@ -114,18 +114,21 @@ end module
 ! CHECK:         %[[VAL_3:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_2]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
 ! CHECK:         %[[VAL_4:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
 ! CHECK:         %[[VAL_5:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.array<?x!fir.char<1,?>>
-! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_8:.*]] = arith.subi %[[VAL_3]]#1, %[[VAL_6]] : index
-! CHECK:         %[[VAL_9:.*]] = fir.do_loop %[[VAL_10:.*]] = %[[VAL_7]] to %[[VAL_8]] step %[[VAL_6]] unordered iter_args(%[[VAL_11:.*]] = %[[VAL_4]]) -> (!fir.array<?xi32>) {
-! CHECK:           %[[VAL_12:.*]] = fir.array_access %[[VAL_5]], %[[VAL_10]] : (!fir.array<?x!fir.char<1,?>>, index) -> !fir.ref<!fir.char<1,?>>
-! CHECK:           %[[VAL_13:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
-! CHECK:           %[[VAL_14:.*]]:2 = fir.array_modify %[[VAL_11]], %[[VAL_10]] : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
-! CHECK:           %[[VAL_15:.*]] = fir.emboxchar %[[VAL_12]], %[[VAL_13]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-! CHECK:           fir.call @_QPsfrom_char(%[[VAL_14]]#0, %[[VAL_15]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
-! CHECK:           fir.result %[[VAL_14]]#1 : !fir.array<?xi32>
+! CHECK:         %[[VAL_6:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:         %[[VAL_7:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_8:.*]] = arith.divsi %[[VAL_6]], %[[VAL_7]] : index
+! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : index
+! CHECK:         %[[VAL_10:.*]] = arith.constant 0 : index
+! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_3]]#1, %[[VAL_9]] : index
+! CHECK:         %[[VAL_12:.*]] = fir.do_loop %[[VAL_13:.*]] = %[[VAL_10]] to %[[VAL_11]] step %[[VAL_9]] unordered iter_args(%[[VAL_14:.*]] = %[[VAL_4]]) -> (!fir.array<?xi32>) {
+! CHECK:           %[[VAL_15:.*]] = fir.array_access %[[VAL_5]], %[[VAL_13]] typeparams %[[VAL_8]] : (!fir.array<?x!fir.char<1,?>>, index, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:           %[[VAL_16:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_17:.*]]:2 = fir.array_modify %[[VAL_14]], %[[VAL_13]] : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
+! CHECK:           %[[VAL_18:.*]] = fir.emboxchar %[[VAL_15]], %[[VAL_16]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPsfrom_char(%[[VAL_17]]#0, %[[VAL_18]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:           fir.result %[[VAL_17]]#1 : !fir.array<?xi32>
 ! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_4]], %[[VAL_16:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
+! CHECK:         fir.array_merge_store %[[VAL_4]], %[[VAL_19:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -601,19 +604,22 @@ end subroutine
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i64) -> index
 ! CHECK:           %[[VAL_18:.*]] = arith.subi %[[VAL_17]], %[[VAL_14]] : index
-! CHECK:           %[[VAL_19:.*]] = fir.array_access %[[VAL_9]], %[[VAL_18]] : (!fir.array<?x!fir.char<1,?>>, index) -> !fir.ref<!fir.char<1,?>>
-! CHECK:           %[[VAL_20:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
-! CHECK:           %[[VAL_21:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_22:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (i32) -> i64
-! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (i64) -> index
-! CHECK:           %[[VAL_25:.*]] = arith.subi %[[VAL_24]], %[[VAL_21]] : index
-! CHECK:           %[[VAL_26:.*]]:2 = fir.array_modify %[[VAL_12]], %[[VAL_25]] : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
-! CHECK:           %[[VAL_27:.*]] = fir.emboxchar %[[VAL_19]], %[[VAL_20]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-! CHECK:           fir.call @_QPsfrom_char(%[[VAL_26]]#0, %[[VAL_27]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
-! CHECK:           fir.result %[[VAL_26]]#1 : !fir.array<?xi32>
+! CHECK:           %[[VAL_19:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_20:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_21:.*]] = arith.divsi %[[VAL_19]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_22:.*]] = fir.array_access %[[VAL_9]], %[[VAL_18]] typeparams %[[VAL_21]] : (!fir.array<?x!fir.char<1,?>>, index, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:           %[[VAL_23:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_24:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_25:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i32) -> i64
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (i64) -> index
+! CHECK:           %[[VAL_28:.*]] = arith.subi %[[VAL_27]], %[[VAL_24]] : index
+! CHECK:           %[[VAL_29:.*]]:2 = fir.array_modify %[[VAL_12]], %[[VAL_28]] : (!fir.array<?xi32>, index) -> (!fir.ref<i32>, !fir.array<?xi32>)
+! CHECK:           %[[VAL_30:.*]] = fir.emboxchar %[[VAL_22]], %[[VAL_23]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPsfrom_char(%[[VAL_29]]#0, %[[VAL_30]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:           fir.result %[[VAL_29]]#1 : !fir.array<?xi32>
 ! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_28:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
+! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_31:.*]] to %[[VAL_0]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.box<!fir.array<?xi32>>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -721,19 +727,22 @@ end subroutine
 ! CHECK:             %[[VAL_44:.*]] = arith.subi %[[VAL_31]], %[[VAL_31]] : index
 ! CHECK:             %[[VAL_45:.*]] = arith.muli %[[VAL_42]], %[[VAL_37]] : index
 ! CHECK:             %[[VAL_46:.*]] = arith.addi %[[VAL_44]], %[[VAL_45]] : index
-! CHECK:             %[[VAL_47:.*]] = fir.array_access %[[VAL_9]], %[[VAL_35]], %[[VAL_46]] : (!fir.array<?x?x!fir.char<1,?>>, index, index) -> !fir.ref<!fir.char<1,?>>
-! CHECK:             %[[VAL_48:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> index
-! CHECK:             %[[VAL_49:.*]] = arith.subi %[[VAL_16]], %[[VAL_16]] : index
-! CHECK:             %[[VAL_50:.*]] = arith.muli %[[VAL_42]], %[[VAL_22]] : index
-! CHECK:             %[[VAL_51:.*]] = arith.addi %[[VAL_49]], %[[VAL_50]] : index
-! CHECK:             %[[VAL_52:.*]]:2 = fir.array_modify %[[VAL_43]], %[[VAL_20]], %[[VAL_51]] : (!fir.array<?x?xi32>, index, index) -> (!fir.ref<i32>, !fir.array<?x?xi32>)
-! CHECK:             %[[VAL_53:.*]] = fir.emboxchar %[[VAL_47]], %[[VAL_48]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-! CHECK:             fir.call @_QPsfrom_char(%[[VAL_52]]#0, %[[VAL_53]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
-! CHECK:             fir.result %[[VAL_52]]#1 : !fir.array<?x?xi32>
+! CHECK:             %[[VAL_47:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> index
+! CHECK:             %[[VAL_48:.*]] = arith.constant 1 : index
+! CHECK:             %[[VAL_49:.*]] = arith.divsi %[[VAL_47]], %[[VAL_48]] : index
+! CHECK:             %[[VAL_50:.*]] = fir.array_access %[[VAL_9]], %[[VAL_35]], %[[VAL_46]] typeparams %[[VAL_49]] : (!fir.array<?x?x!fir.char<1,?>>, index, index, index) -> !fir.ref<!fir.char<1,?>>
+! CHECK:             %[[VAL_51:.*]] = fir.box_elesize %[[VAL_1]] : (!fir.box<!fir.array<?x?x!fir.char<1,?>>>) -> index
+! CHECK:             %[[VAL_52:.*]] = arith.subi %[[VAL_16]], %[[VAL_16]] : index
+! CHECK:             %[[VAL_53:.*]] = arith.muli %[[VAL_42]], %[[VAL_22]] : index
+! CHECK:             %[[VAL_54:.*]] = arith.addi %[[VAL_52]], %[[VAL_53]] : index
+! CHECK:             %[[VAL_55:.*]]:2 = fir.array_modify %[[VAL_43]], %[[VAL_20]], %[[VAL_54]] : (!fir.array<?x?xi32>, index, index) -> (!fir.ref<i32>, !fir.array<?x?xi32>)
+! CHECK:             %[[VAL_56:.*]] = fir.emboxchar %[[VAL_50]], %[[VAL_51]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:             fir.call @_QPsfrom_char(%[[VAL_55]]#0, %[[VAL_56]]) : (!fir.ref<i32>, !fir.boxchar<1>) -> ()
+! CHECK:             fir.result %[[VAL_55]]#1 : !fir.array<?x?xi32>
 ! CHECK:           }
-! CHECK:           fir.result %[[VAL_54:.*]] : !fir.array<?x?xi32>
+! CHECK:           fir.result %[[VAL_57:.*]] : !fir.array<?x?xi32>
 ! CHECK:         }
-! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_55:.*]] to %[[VAL_0]] : !fir.array<?x?xi32>, !fir.array<?x?xi32>, !fir.box<!fir.array<?x?xi32>>
+! CHECK:         fir.array_merge_store %[[VAL_8]], %[[VAL_58:.*]] to %[[VAL_0]] : !fir.array<?x?xi32>, !fir.array<?x?xi32>, !fir.box<!fir.array<?x?xi32>>
 ! CHECK:         return
 ! CHECK:       }
 

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -402,7 +402,7 @@ TEST_F(FIRBuilderTest, getExtents) {
   auto loc = builder.getUnknownLoc();
   llvm::StringRef strValue("length");
   auto strLit = fir::factory::createStringLiteral(builder, loc, strValue);
-  auto ext = fir::factory::getExtents(builder, loc, strLit);
+  auto ext = fir::factory::getExtents(loc, builder, strLit);
   EXPECT_EQ(0u, ext.size());
   auto c10 = builder.createIntegerConstant(loc, builder.getI64Type(), 10);
   auto c100 = builder.createIntegerConstant(loc, builder.getI64Type(), 100);
@@ -412,6 +412,6 @@ TEST_F(FIRBuilderTest, getExtents) {
   mlir::Value array = builder.create<fir::UndefOp>(loc, arrayTy);
   fir::ArrayBoxValue aab(array, extents, {});
   fir::ExtendedValue ex(aab);
-  auto readExtents = fir::factory::getExtents(builder, loc, ex);
+  auto readExtents = fir::factory::getExtents(loc, builder, ex);
   EXPECT_EQ(2u, readExtents.size());
 }


### PR DESCRIPTION
When dealing with values (including aggregates) that have dependent type,
FIR requires that we thread the type parameter values through the IR.
Note that boxed values contain type parameters inside the box. It is a
requirement that the type parameter(s) can be recovered from a box
value.

  - Add verifiers that determine if an Op requires type parameters or
    not and checks that the correct number of parameters is specified.
  - Fix lowering to add the proper number of type parameters.
  - Fix transformations that were losing type parameter information.

Fix code gen bug that was scaling the size of an element twice.

Fix tests to reflect these changes.
