### PR TITLE
Prefer process time over thread time in CPU_TIME

### DIFF
--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -56,10 +56,10 @@ template <typename Unused = void> double GetCpuTime(fallback_implementation) {
   return -1.0;
 }
 
-#if defined CLOCK_THREAD_CPUTIME_ID
-#define CLOCKID CLOCK_THREAD_CPUTIME_ID
-#elif defined CLOCK_PROCESS_CPUTIME_ID
+#if defined CLOCK_PROCESS_CPUTIME_ID
 #define CLOCKID CLOCK_PROCESS_CPUTIME_ID
+#elif defined CLOCK_THREAD_CPUTIME_ID
+#define CLOCKID CLOCK_THREAD_CPUTIME_ID
 #elif defined CLOCK_MONOTONIC
 #define CLOCKID CLOCK_MONOTONIC
 #else


### PR DESCRIPTION
Most Fortran compilers appear to return the process time
for calls to CPU_TIME, where the flang implementation
prior to this change was returning the time used by the
current thread. This would cause incorrect time being
reported when for example OpenMP is used to share work
across multiple CPUs.

This patch changes the order so the selection of "what
time to return" so that if there is a process time to
report, that is the reported value, and only if that is
not available, the thread time is considerd instead.