### PR TITLE
[mlir][CSE] Remove duplicated operations with MemRead side-effect

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -258,7 +258,7 @@ def fir_FreeMemOp : fir_Op<"freemem", [MemoryEffects<[MemFree]>]> {
   let assemblyFormat = "$heapref attr-dict `:` type($heapref)";
 }
 
-def fir_LoadOp : fir_OneResultOp<"load"> {
+def fir_LoadOp : fir_OneResultOp<"load", [MemoryEffects<[MemRead]>]> {
   let summary = "load a value from a memory reference";
   let description = [{
     Load a value from a memory reference into an ssa-value (virtual register).
@@ -287,7 +287,7 @@ def fir_LoadOp : fir_OneResultOp<"load"> {
   }];
 }
 
-def fir_StoreOp : fir_Op<"store", []> {
+def fir_StoreOp : fir_Op<"store", [MemoryEffects<[MemWrite]>]> {
   let summary = "store an SSA-value to a memory location";
 
   let description = [{

--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -153,12 +153,12 @@ inline void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm) {
   // simplify the IR
   mlir::GreedyRewriteConfig config;
   config.enableRegionSimplification = false;
-  fir::addCSE(pm);
+  pm.addPass(mlir::createCSEPass());
   fir::addAVC(pm);
   pm.addNestedPass<mlir::FuncOp>(fir::createCharacterConversionPass());
   pm.addPass(mlir::createCanonicalizerPass(config));
   pm.addPass(fir::createSimplifyRegionLitePass());
-  fir::addCSE(pm);
+  pm.addPass(mlir::createCSEPass());
   fir::addMemoryAllocationOpt(pm);
 
   // The default inliner pass adds the canonicalizer pass with the default
@@ -175,7 +175,7 @@ inline void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm) {
 
   pm.addPass(mlir::createCanonicalizerPass(config));
   pm.addPass(fir::createSimplifyRegionLitePass());
-  fir::addCSE(pm);
+  pm.addPass(mlir::createCSEPass());
 }
 
 #if !defined(FLANG_EXCLUDE_CODEGEN)

--- a/flang/test/Fir/commute.fir
+++ b/flang/test/Fir/commute.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --basic-cse %s | tco | FileCheck %s
+// RUN: fir-opt %s | tco | FileCheck %s
 
 // CHECK-LABEL: define i32 @f1(i32 %0, i32 %1)
 func @f1(%a : i32, %b : i32) -> i32 {

--- a/flang/test/Fir/commute.fir
+++ b/flang/test/Fir/commute.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | tco | FileCheck %s
+// RUN: fir-opt --basic-cse %s | tco | FileCheck %s
 
 // CHECK-LABEL: define i32 @f1(i32 %0, i32 %1)
 func @f1(%a : i32, %b : i32) -> i32 {

--- a/flang/test/Fir/cse.fir
+++ b/flang/test/Fir/cse.fir
@@ -1,77 +1,57 @@
-// Test CSE pass
+// RUN: fir-opt --cse -split-input-file %s | FileCheck %s
 
-// RUN: fir-opt %s | tco | FileCheck %s
+// Check that the redundant fir.load is removed.
+func @fun(%arg0: !fir.ref<i64>) -> i64 {
+    %0 = fir.load %arg0 : !fir.ref<i64>
+    %1 = fir.load %arg0 : !fir.ref<i64>
+    %2 = arith.addi %0, %1 : i64
+    return %2 : i64
+}
 
-// CHECK-LABEL: @fun
+// CHECK-LABEL: func @fun
+// CHECK-NEXT:    %[[LOAD:.*]] = fir.load %{{.*}} : !fir.ref<i64>
+// CHECK-NEXT:    %{{.*}} = arith.addi %[[LOAD]], %[[LOAD]] : i64
+
+// -----
+
+// CHECK-LABEL: func @fun(
+// CHECK-SAME:            %[[A:.*]]: !fir.ref<i64>
 func @fun(%a : !fir.ref<i64>) -> i64 {
-  // CHECK: load i64
+  // CHECK: %[[LOAD:.*]] = fir.load %[[A]] : !fir.ref<i64>
   %1 = fir.load %a : !fir.ref<i64>
   %2 = fir.load %a : !fir.ref<i64>
-  // CHECK-NOT: load i64
-  // CHECK-COUNT-6: add i64
+  // CHECK-NEXT: %{{.*}} = arith.addi %[[LOAD]], %[[LOAD]] : i64
   %3 = arith.addi %1, %2 : i64
   %4 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: %{{.*}} = arith.addi
   %5 = arith.addi %3, %4 : i64
   %6 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: %{{.*}} = arith.addi
   %7 = arith.addi %5, %6 : i64
   %8 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: %{{.*}} = arith.addi
   %9 = arith.addi %7, %8 : i64
   %10 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: %{{.*}} = arith.addi
   %11 = arith.addi %10, %9 : i64
   %12 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: %{{.*}} = arith.addi
   %13 = arith.addi %11, %12 : i64
-  // CHECK-NEXT: ret i64
+  // CHECK-NEXT: return %{{.*}} : i64
   return %13 : i64
 }
 
-// CHECK-LABEL: @bar
-func private @bar(%a : !fir.ref<i64>) -> i64
+// -----
 
-// CHECK-LABEL: @fun2
-func @fun2(%a : !fir.ref<i64>) -> i64 {
-  // CHECK: load i64
+func @fun(%a : !fir.ref<i64>) -> i64 {
+  br ^bb1
+^bb1:
   %1 = fir.load %a : !fir.ref<i64>
-  // CHECK-NEXT: call i64
-  %2 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  // CHECK-COUNT-6: add i64
+  %2 = fir.load %a : !fir.ref<i64>
   %3 = arith.addi %1, %2 : i64
-  %4 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  %5 = arith.addi %3, %4 : i64
-  %6 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  %7 = arith.addi %5, %6 : i64
-  %8 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  %9 = arith.addi %7, %8 : i64
-  %10 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  %11 = arith.addi %10, %9 : i64
-  %12 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
-  %13 = arith.addi %11, %12 : i64
-  // CHECK-NEXT: ret i64
-  return %13 : i64
-}
-
-// Negative test: do not merge loads when an op with regions is between
-// CHECK-LABEL: @foo
-func @foo(%arg0: !fir.ref<f32>) -> f32 {
-  // CHECK: %[[var:.*]] = alloca float
-  %0 = fir.alloca f32 {name = "x"}
-  %1 = fir.load %arg0 : !fir.ref<f32>
-  fir.store %1 to %0 : !fir.ref<f32>
-  %cst = arith.constant 0.000000e+00 : f32
-  // CHECK: load float, float* %[[var]],
-  %2 = fir.load %0 : !fir.ref<f32>
-  %3 = arith.cmpf olt, %2, %cst : f32
-  fir.if %3 {
-    // CHECK: load float, float* %[[var]]
-    %7 = fir.load %0 : !fir.ref<f32>
-    %8 = arith.negf %7 : f32
-    fir.store %8 to %0 : !fir.ref<f32>
-  }
-  %cst_0 = arith.constant 1.000000e+00 : f32
-  // CHECK: load float, float* %[[var]]
-  %4 = fir.load %0 : !fir.ref<f32>
-  %5 = arith.addf %4, %cst_0 : f32
-  fir.store %5 to %0 : !fir.ref<f32>
-  // CHECK: load float, float* %[[var]]
-  %6 = fir.load %0 : !fir.ref<f32>
-  return %6 : f32
+  br ^bb2
+^bb2:
+  %4 = fir.load %a : !fir.ref<i64>
+  %5 = arith.subi %4, %4 : i64
+  return %5 : i64
 }

--- a/flang/test/Fir/fir-cse.fir
+++ b/flang/test/Fir/fir-cse.fir
@@ -1,0 +1,77 @@
+// Test the FIR CSE pass
+
+// RUN: fir-opt %s | tco | FileCheck %s
+
+// CHECK-LABEL: @fun
+func @fun(%a : !fir.ref<i64>) -> i64 {
+  // CHECK: load i64
+  %1 = fir.load %a : !fir.ref<i64>
+  %2 = fir.load %a : !fir.ref<i64>
+  // CHECK-NOT: load i64
+  // CHECK-COUNT-6: add i64
+  %3 = arith.addi %1, %2 : i64
+  %4 = fir.load %a : !fir.ref<i64>
+  %5 = arith.addi %3, %4 : i64
+  %6 = fir.load %a : !fir.ref<i64>
+  %7 = arith.addi %5, %6 : i64
+  %8 = fir.load %a : !fir.ref<i64>
+  %9 = arith.addi %7, %8 : i64
+  %10 = fir.load %a : !fir.ref<i64>
+  %11 = arith.addi %10, %9 : i64
+  %12 = fir.load %a : !fir.ref<i64>
+  %13 = arith.addi %11, %12 : i64
+  // CHECK-NEXT: ret i64
+  return %13 : i64
+}
+
+// CHECK-LABEL: @bar
+func private @bar(%a : !fir.ref<i64>) -> i64
+
+// CHECK-LABEL: @fun2
+func @fun2(%a : !fir.ref<i64>) -> i64 {
+  // CHECK: load i64
+  %1 = fir.load %a : !fir.ref<i64>
+  // CHECK-NEXT: call i64
+  %2 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  // CHECK-COUNT-6: add i64
+  %3 = arith.addi %1, %2 : i64
+  %4 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  %5 = arith.addi %3, %4 : i64
+  %6 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  %7 = arith.addi %5, %6 : i64
+  %8 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  %9 = arith.addi %7, %8 : i64
+  %10 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  %11 = arith.addi %10, %9 : i64
+  %12 = fir.call @bar(%a) { pure = true } : (!fir.ref<i64>) -> i64
+  %13 = arith.addi %11, %12 : i64
+  // CHECK-NEXT: ret i64
+  return %13 : i64
+}
+
+// Negative test: do not merge loads when an op with regions is between
+// CHECK-LABEL: @foo
+func @foo(%arg0: !fir.ref<f32>) -> f32 {
+  // CHECK: %[[var:.*]] = alloca float
+  %0 = fir.alloca f32 {name = "x"}
+  %1 = fir.load %arg0 : !fir.ref<f32>
+  fir.store %1 to %0 : !fir.ref<f32>
+  %cst = arith.constant 0.000000e+00 : f32
+  // CHECK: load float, float* %[[var]],
+  %2 = fir.load %0 : !fir.ref<f32>
+  %3 = arith.cmpf olt, %2, %cst : f32
+  fir.if %3 {
+    // CHECK: load float, float* %[[var]]
+    %7 = fir.load %0 : !fir.ref<f32>
+    %8 = arith.negf %7 : f32
+    fir.store %8 to %0 : !fir.ref<f32>
+  }
+  %cst_0 = arith.constant 1.000000e+00 : f32
+  // CHECK: load float, float* %[[var]]
+  %4 = fir.load %0 : !fir.ref<f32>
+  %5 = arith.addf %4, %cst_0 : f32
+  fir.store %5 to %0 : !fir.ref<f32>
+  // CHECK: load float, float* %[[var]]
+  %6 = fir.load %0 : !fir.ref<f32>
+  return %6 : f32
+}

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -648,8 +648,18 @@ llvm::hash_code OperationEquivalence::computeHash(
       op->getName(), op->getAttrDictionary(), op->getResultTypes());
 
   //   - Operands
-  for (Value operand : op->getOperands())
+  ValueRange operands = op->getOperands();
+  SmallVector<Value> operandStorage;
+  if (op->hasTrait<mlir::OpTrait::IsCommutative>()) {
+    operandStorage.append(operands.begin(), operands.end());
+    llvm::sort(operandStorage, [](Value a, Value b) -> bool {
+      return a.getAsOpaquePointer() < b.getAsOpaquePointer();
+    });
+    operands = operandStorage;
+  }
+  for (Value operand : operands)
     hash = llvm::hash_combine(hash, hashOperands(operand));
+
   //   - Operands
   for (Value result : op->getResults())
     hash = llvm::hash_combine(hash, hashResults(result));
@@ -725,6 +735,21 @@ bool OperationEquivalence::isEquivalentTo(
   if (!(flags & IgnoreLocations) && lhs->getLoc() != rhs->getLoc())
     return false;
 
+  ValueRange lhsOperands = lhs->getOperands(), rhsOperands = rhs->getOperands();
+  SmallVector<Value> lhsOperandStorage, rhsOperandStorage;
+  if (lhs->hasTrait<mlir::OpTrait::IsCommutative>()) {
+    lhsOperandStorage.append(lhsOperands.begin(), lhsOperands.end());
+    llvm::sort(lhsOperandStorage, [](Value a, Value b) -> bool {
+      return a.getAsOpaquePointer() < b.getAsOpaquePointer();
+    });
+    lhsOperands = lhsOperandStorage;
+
+    rhsOperandStorage.append(rhsOperands.begin(), rhsOperands.end());
+    llvm::sort(rhsOperandStorage, [](Value a, Value b) -> bool {
+      return a.getAsOpaquePointer() < b.getAsOpaquePointer();
+    });
+    rhsOperands = rhsOperandStorage;
+  }
   auto checkValueRangeMapping =
       [](ValueRange lhs, ValueRange rhs,
          function_ref<LogicalResult(Value, Value)> mapValues) {
@@ -739,8 +764,7 @@ bool OperationEquivalence::isEquivalentTo(
         return true;
       };
   // Check mapping of operands and results.
-  if (!checkValueRangeMapping(lhs->getOperands(), rhs->getOperands(),
-                              mapOperands))
+  if (!checkValueRangeMapping(lhsOperands, rhsOperands, mapOperands))
     return false;
   if (!checkValueRangeMapping(lhs->getResults(), rhs->getResults(), mapResults))
     return false;

--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -61,6 +61,14 @@ struct CSE : public CSEBase<CSE> {
   using ScopedMapTy = llvm::ScopedHashTable<Operation *, Operation *,
                                             SimpleOperationInfo, AllocatorTy>;
 
+  /// Cache holding MemoryEffects information between two operations. The first
+  /// operation is stored has the key. The second operation is stored inside a
+  /// pair in the value. The pair also hold the MemoryEffects between those
+  /// two operations. If the MemoryEffects is nullptr then we assume there is
+  /// no operation with MemoryEffects::Write between the two operations.
+  using MemEffectsCache =
+      DenseMap<Operation *, std::pair<Operation *, MemoryEffects::Effect *>>;
+
   /// Represents a single entry in the depth first traversal of a CFG.
   struct CFGStackNode {
     CFGStackNode(ScopedMapTy &knownValues, DominanceInfoNode *node)
@@ -87,11 +95,93 @@ struct CSE : public CSEBase<CSE> {
   void runOnOperation() override;
 
 private:
+  void replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
+                            Operation *existing, bool hasSSADominance);
+
+  /// Check if there is side-effecting operations other than the given effect
+  /// between the two operations.
+  bool hasOtherSideEffectingOpInBetween(Operation *fromOp, Operation *toOp);
+
   /// Operations marked as dead and to be erased.
   std::vector<Operation *> opsToErase;
   DominanceInfo *domInfo = nullptr;
+  MemEffectsCache memEffectsCache;
 };
 } // end anonymous namespace
+
+void CSE::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
+                               Operation *existing, bool hasSSADominance) {
+  // If we find one then replace all uses of the current operation with the
+  // existing one and mark it for deletion. We can only replace an operand in
+  // an operation if it has not been visited yet.
+  if (hasSSADominance) {
+    // If the region has SSA dominance, then we are guaranteed to have not
+    // visited any use of the current operation.
+    op->replaceAllUsesWith(existing);
+    opsToErase.push_back(op);
+  } else {
+    // When the region does not have SSA dominance, we need to check if we
+    // have visited a use before replacing any use.
+    for (auto it : llvm::zip(op->getResults(), existing->getResults())) {
+      std::get<0>(it).replaceUsesWithIf(
+          std::get<1>(it), [&](OpOperand &operand) {
+            return !knownValues.count(operand.getOwner());
+          });
+    }
+
+    // There may be some remaining uses of the operation.
+    if (op->use_empty())
+      opsToErase.push_back(op);
+  }
+
+  // If the existing operation has an unknown location and the current
+  // operation doesn't, then set the existing op's location to that of the
+  // current op.
+  if (existing->getLoc().isa<UnknownLoc>() && !op->getLoc().isa<UnknownLoc>())
+    existing->setLoc(op->getLoc());
+
+  ++numCSE;
+}
+
+bool CSE::hasOtherSideEffectingOpInBetween(Operation *fromOp, Operation *toOp) {
+  assert(fromOp->getBlock() == toOp->getBlock());
+  assert(
+      isa<MemoryEffectOpInterface>(fromOp) &&
+      cast<MemoryEffectOpInterface>(fromOp).hasEffect<MemoryEffects::Read>() &&
+      isa<MemoryEffectOpInterface>(toOp) &&
+      cast<MemoryEffectOpInterface>(toOp).hasEffect<MemoryEffects::Read>());
+  Operation *nextOp = fromOp->getNextNode();
+  auto result =
+      memEffectsCache.try_emplace(fromOp, std::make_pair(fromOp, nullptr));
+  if (result.second) {
+    auto memEffectsCachePair = result.first->second;
+    if (memEffectsCachePair.second == nullptr) {
+      // No MemoryEffects::Write has been detected until the cached operation.
+      // Continue looking from the cached operation to toOp.
+      nextOp = memEffectsCachePair.first;
+    } else {
+      // MemoryEffects::Write has been detected before so there is no need to
+      // check further.
+      return true;
+    }
+  }
+  while (nextOp && nextOp != toOp) {
+    auto nextOpMemEffects = dyn_cast<MemoryEffectOpInterface>(nextOp);
+    // TODO: Do we need to handle other effects generically?
+    // If the operation does not implement the MemoryEffectOpInterface we
+    // conservatively assumes it writes.
+    if ((nextOpMemEffects &&
+         nextOpMemEffects.hasEffect<MemoryEffects::Write>()) ||
+        !nextOpMemEffects) {
+      result.first->second =
+          std::make_pair(nextOp, MemoryEffects::Write::get());
+      return true;
+    }
+    nextOp = nextOp->getNextNode();
+  }
+  result.first->second = std::make_pair(toOp, nullptr);
+  return false;
+}
 
 /// Attempt to eliminate a redundant operation.
 LogicalResult CSE::simplifyOperation(ScopedMapTy &knownValues, Operation *op,
@@ -113,45 +203,34 @@ LogicalResult CSE::simplifyOperation(ScopedMapTy &knownValues, Operation *op,
   if (op->getNumRegions() != 0)
     return failure();
 
-  // TODO: We currently only eliminate non side-effecting
-  // operations.
-  if (!MemoryEffectOpInterface::hasNoEffect(op))
+  // Some simple use case of operation with memory side-effect are dealt with
+  // here. Operations with no side-effect are done after.
+  if (!MemoryEffectOpInterface::hasNoEffect(op)) {
+    auto memEffects = dyn_cast<MemoryEffectOpInterface>(op);
+    // TODO: Only basic use case for operations with MemoryEffects::Read can be
+    // eleminated now. More work needs to be done for more complicated patterns
+    // and other side-effects.
+    if (!memEffects || !memEffects.onlyHasEffect<MemoryEffects::Read>())
+      return failure();
+
+    // Look for an existing definition for the operation.
+    if (auto *existing = knownValues.lookup(op)) {
+      if (existing->getBlock() == op->getBlock() &&
+          !hasOtherSideEffectingOpInBetween(existing, op)) {
+        // The operation that can be deleted has been reach with no
+        // side-effecting operations in between the existing operation and
+        // this one so we can remove the duplicate.
+        replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
+        return success();
+      }
+    }
+    knownValues.insert(op, op);
     return failure();
+  }
 
   // Look for an existing definition for the operation.
   if (auto *existing = knownValues.lookup(op)) {
-
-    // If we find one then replace all uses of the current operation with the
-    // existing one and mark it for deletion. We can only replace an operand in
-    // an operation if it has not been visited yet.
-    if (hasSSADominance) {
-      // If the region has SSA dominance, then we are guaranteed to have not
-      // visited any use of the current operation.
-      op->replaceAllUsesWith(existing);
-      opsToErase.push_back(op);
-    } else {
-      // When the region does not have SSA dominance, we need to check if we
-      // have visited a use before replacing any use.
-      for (auto it : llvm::zip(op->getResults(), existing->getResults())) {
-        std::get<0>(it).replaceUsesWithIf(
-            std::get<1>(it), [&](OpOperand &operand) {
-              return !knownValues.count(operand.getOwner());
-            });
-      }
-
-      // There may be some remaining uses of the operation.
-      if (op->use_empty())
-        opsToErase.push_back(op);
-    }
-
-    // If the existing operation has an unknown location and the current
-    // operation doesn't, then set the existing op's location to that of the
-    // current op.
-    if (existing->getLoc().isa<UnknownLoc>() &&
-        !op->getLoc().isa<UnknownLoc>()) {
-      existing->setLoc(op->getLoc());
-    }
-
+    replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
     ++numCSE;
     return success();
   }
@@ -186,6 +265,8 @@ void CSE::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
     for (auto &region : op.getRegions())
       simplifyRegion(knownValues, region);
   }
+  // Clear the MemoryEffects cache since its usage is by block only.
+  memEffectsCache.clear();
 }
 
 void CSE::simplifyRegion(ScopedMapTy &knownValues, Region &region) {

--- a/mlir/test/Examples/Toy/Ch5/affine-lowering.mlir
+++ b/mlir/test/Examples/Toy/Ch5/affine-lowering.mlir
@@ -32,8 +32,7 @@ func @main() {
 // CHECK:         affine.for [[VAL_12:%.*]] = 0 to 3 {
 // CHECK:           affine.for [[VAL_13:%.*]] = 0 to 2 {
 // CHECK:             [[VAL_14:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_15:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_15]] : f64
+// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_14]] : f64
 // CHECK:             affine.store [[VAL_16]], [[VAL_6]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
 // CHECK:         toy.print [[VAL_6]] : memref<3x2xf64>
 // CHECK:         memref.dealloc [[VAL_8]] : memref<2x3xf64>

--- a/mlir/test/Examples/Toy/Ch6/affine-lowering.mlir
+++ b/mlir/test/Examples/Toy/Ch6/affine-lowering.mlir
@@ -32,8 +32,7 @@ func @main() {
 // CHECK:         affine.for [[VAL_12:%.*]] = 0 to 3 {
 // CHECK:           affine.for [[VAL_13:%.*]] = 0 to 2 {
 // CHECK:             [[VAL_14:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_15:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_15]] : f64
+// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_14]] : f64
 // CHECK:             affine.store [[VAL_16]], [[VAL_6]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
 // CHECK:         toy.print [[VAL_6]] : memref<3x2xf64>
 // CHECK:         memref.dealloc [[VAL_8]] : memref<2x3xf64>

--- a/mlir/test/Examples/Toy/Ch7/affine-lowering.mlir
+++ b/mlir/test/Examples/Toy/Ch7/affine-lowering.mlir
@@ -32,8 +32,7 @@ func @main() {
 // CHECK:         affine.for [[VAL_12:%.*]] = 0 to 3 {
 // CHECK:           affine.for [[VAL_13:%.*]] = 0 to 2 {
 // CHECK:             [[VAL_14:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_15:%.*]] = affine.load [[VAL_7]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
-// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_15]] : f64
+// CHECK:             [[VAL_16:%.*]] = arith.mulf [[VAL_14]], [[VAL_14]] : f64
 // CHECK:             affine.store [[VAL_16]], [[VAL_6]]{{\[}}[[VAL_12]], [[VAL_13]]] : memref<3x2xf64>
 // CHECK:         toy.print [[VAL_6]] : memref<3x2xf64>
 // CHECK:         memref.dealloc [[VAL_8]] : memref<2x3xf64>

--- a/mlir/test/Transforms/cse.mlir
+++ b/mlir/test/Transforms/cse.mlir
@@ -310,3 +310,15 @@ func @dont_remove_duplicated_read_op_with_sideeffecting() -> i32 {
   %2 = arith.addi %0, %1 : i32
   return %2 : i32
 }
+
+/// This test is checking that identical commutative operation are gracefully
+/// handled but the CSE pass.
+// CHECK-LABEL: func @check_cummutative_cse
+func @check_cummutative_cse(%a : i32, %b : i32) -> i32 {
+  // CHECK: %[[ADD1:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
+  %1 = arith.addi %a, %b : i32
+  %2 = arith.addi %b, %a : i32
+  // CHECK-NEXT:  arith.muli %[[ADD1]], %[[ADD1]] : i32
+  %3 = arith.muli %1, %2 : i32
+  return %3 : i32
+}

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2359,4 +2359,32 @@ def TestDefaultStrAttrHasValueOp : TEST_Op<"has_str_value"> {
 def : Pat<(TestDefaultStrAttrNoValueOp $value),
           (TestDefaultStrAttrHasValueOp ConstantStrAttr<StrAttr, "foo">)>;
 
+//===----------------------------------------------------------------------===//
+// Test Ops with effects
+//===----------------------------------------------------------------------===//
+
+def TestResource : Resource<"TestResource">;
+
+def TestEffectsOpA : TEST_Op<"op_with_effects_a"> {
+    let arguments = (ins
+        Arg<Variadic<AnyMemRef>, "", [MemRead]>,
+        Arg<FlatSymbolRefAttr, "", [MemRead]>:$first,
+        Arg<SymbolRefAttr, "", [MemWrite]>:$second,
+        Arg<OptionalAttr<SymbolRefAttr>, "", [MemRead]>:$optional_symbol
+        );
+
+    let results = (outs Res<AnyMemRef, "", [MemAlloc<TestResource>]>);
+}
+
+def TestEffectsOpB : TEST_Op<"op_with_effects_b",
+    [MemoryEffects<[MemWrite<TestResource>]>]>;
+
+def TestEffectsRead : TEST_Op<"op_with_memread",
+    [MemoryEffects<[MemRead]>]> {
+  let results = (outs AnyInteger);
+}
+
+def TestEffectsWrite : TEST_Op<"op_with_memwrite",
+    [MemoryEffects<[MemWrite]>]>;
+
 #endif // TEST_OPS


### PR DESCRIPTION
This patch enhances the CSE pass to deal with simple cases of duplicated
operations with MemoryEffects.

It allows the CSE pass to remove safely duplicate operations with the
MemoryEffects::Read that have no other side-effecting operations in
between. Other MemoryEffects::Read operation are allowed.

The use case is pretty simple so far so we can build on top of it to add
more features.

This patch is also meant to avoid a dedicated CSE pass in FIR and was
brought together afetr discussion on https://reviews.llvm.org/D112711.
It does not currently cover the full range of use cases described in
https://reviews.llvm.org/D112711 but the idea is to gradually enhance
the MLIR CSE pass to handle common use cases that can be used by
other dialects.

This patch takes advantage of the new CSE capabilities in Fir.

Reviewed By: mehdi_amini, rriddle, schweitz

Differential Revision: https://reviews.llvm.org/D122801