### PR TITLE
[flang] Fix float-number representation bug

### DIFF
--- a/flang/lib/Evaluate/real.cpp
+++ b/flang/lib/Evaluate/real.cpp
@@ -637,6 +637,9 @@ template <typename W, int P> std::string Real<W, P>::DumpHexadecimal() const {
     }
     result += 'p';
     int exponent = Exponent() - exponentBias;
+    if (intPart == '0') {
+      exponent += 1;
+    }
     result += Integer<32>{exponent}.SignedDecimal();
     return result;
   }

--- a/flang/test/Lower/intrinsic-procedures/real.f90
+++ b/flang/test/Lower/intrinsic-procedures/real.f90
@@ -1,0 +1,20 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! Tests REAL lowering
+subroutine test_real()
+  real(4) :: r4
+  real(8) :: r8
+
+  r4 = real(z'40', kind=4)
+  r8 = real(z'40', kind=8)
+
+end subroutine
+
+! CHECK-LABEL: func @_QPtest_real() {
+! CHECK:  %[[VAL_0:.*]] = fir.alloca f32 {bindc_name = "r4", uniq_name = "_QFtest_realEr4"}
+! CHECK:  %[[VAL_1:.*]] = fir.alloca f64 {bindc_name = "r8", uniq_name = "_QFtest_realEr8"}
+! CHECK:  %[[CST_0:.*]] = arith.constant 8.968310e-44 : f32
+! CHECK:  fir.store %[[CST_0]] to %[[VAL_0]] : !fir.ref<f32>
+! CHECK:  %[[CST_1:.*]] = arith.constant 3.162020e-322 : f64
+! CHECK:  fir.store %[[CST_1]] to %[[VAL_1]] : !fir.ref<f64>
+! CHECK:  return


### PR DESCRIPTION
The float number is represented as (-1)^s * 1.f * 2^(-127) for 32-bit,
where s is the signed flag, f is the mantissa. When the exponent bits
are all zeros, the float number is represented as (-1)^s * 0.f *2^(-126)
for 32-bit, in which case, the intPart is '0'.