### PR TITLE
Mark region containing Fail Image Statement as unstructured

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -751,6 +751,11 @@ private:
             assert(construct && "missing EXIT construct");
             markBranchTarget(eval, *construct->constructExit);
           },
+          [&](const parser::FailImageStmt &) {
+            eval.isUnstructured = true;
+            if (eval.lexicalSuccessor->lexicalSuccessor)
+              markSuccessorAsNewBlock(eval);
+          },
           [&](const parser::GotoStmt &s) { markBranchTarget(eval, s.v); },
           [&](const parser::IfStmt &) {
             eval.lexicalSuccessor->isNewBlock = true;

--- a/flang/test/Lower/fail_image.f90
+++ b/flang/test/Lower/fail_image.f90
@@ -1,0 +1,19 @@
+! RUN: bbc -emit-fir -o - %s | FileCheck %s
+
+! CHECK-LABEL: func @_QPfail_image_test
+subroutine fail_image_test(fail)
+  logical :: fail
+! CHECK:  cond_br {{.*}}, ^[[BB1:.*]], ^[[BB2:.*]]
+! CHECK: ^[[BB1]]:
+  if (fail) then
+! CHECK:  {{.*}} = fir.call @_FortranAFailImageStatement() : () -> none
+! CHECK-NEXT:  fir.unreachable
+   FAIL IMAGE
+  end if
+! CHECK: ^[[BB2]]:
+! CHECK-NEXT:  br ^[[BB3:.*]]
+! CHECK-NEXT: ^[[BB3]]
+! CEHCK-NEXT:  return
+  return
+end subroutine
+! CHECK-LABEL: func private @_FortranAFailImageStatement() -> none attributes {fir.runtime}

--- a/flang/test/Lower/pre-fir-tree04.f90
+++ b/flang/test/Lower/pre-fir-tree04.f90
@@ -61,10 +61,10 @@ Subroutine test_coarray
   end if
   ! CHECK: <<End IfConstruct>>
 
-  ! CHECK: <<IfConstruct>>
+  ! CHECK: <<IfConstruct!>>
   if (y<0.) then
     ! CHECK: FailImageStmt
    fail image
   end if
-  ! CHECK: <<End IfConstruct>>
+  ! CHECK: <<End IfConstruct!>>
 end


### PR DESCRIPTION
Lowering of FailImage statement generates a runtime call and the
unreachable operation. The unreachable operation cannot terminate
a structured operation like the IF operation. So mark as unstructured.

This change helps to write a test case for upstreaming

Note: A previous version attempted wrapping inside an execute_region_op
which did not work.