### PR TITLE
[flang] Fix "not yet implemented" message for CHARACTER MIN/MAX

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -3686,7 +3686,7 @@ static mlir::Value createExtremumCompare(mlir::Location loc,
   } else if (fir::isa_integer(type)) {
     result =
         builder.create<mlir::arith::CmpIOp>(loc, integerPredicate, left, right);
-  } else if (fir::isa_char(type)) {
+  } else if (fir::isa_char(type) || fir::isa_char(fir::unwrapRefType(type))) {
     // TODO: ! character min and max is tricky because the result
     // length is the length of the longest argument!
     // So we may need a temp.


### PR DESCRIPTION
The check to see if the arguments for the MIN/MAX intrinsics were of CHARACTER
type was not handling assumed length characters.  In this case, the FIR type is
"!fir.ref<!fir.char<1,?>>".

I fixed this by altering the check to also to see if the type was a reference
to a character type.