### PR TITLE
[flang] Do not create arith.extui with same from/to type

### DIFF
--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -2610,6 +2610,8 @@ IntrinsicLibrary::genIchar(mlir::Type resultType,
   }
   LLVM_DEBUG(llvm::dbgs() << "ichar(" << charVal << ")\n");
   auto code = helper.extractCodeFromSingleton(charVal);
+  if (code.getType() == resultType)
+    return code;
   return builder.create<mlir::arith::ExtUIOp>(loc, resultType, code);
 }
 

--- a/flang/test/Lower/intrinsic-procedures/ichar.f90
+++ b/flang/test/Lower/intrinsic-procedures/ichar.f90
@@ -30,3 +30,13 @@ subroutine ichar_test(c)
   ! CHECK-NEXT: fir.call @{{.*}}EndIoStatement
   print *, iachar('X')
 end subroutine
+
+! Check that 'arith.extui' op is not generated if type are matching.
+! CHECK-LABEL: no_extui
+subroutine no_extui(ch)
+  integer, parameter :: kind = selected_char_kind('ISO_10646')
+  character(*, kind), intent(in) :: ch(:)
+  integer :: i, j 
+  ! CHECK-NOT: arith.extui
+  j = ichar(ch(i)(i:i))
+end subroutine


### PR DESCRIPTION
In some case the lowering of `ichar` is generating an `arith.extui` operation with the same from/to type. This operation do not accept from/to types to be the same. 
If the from/to types are identical, we do not generate the extra operation. 

```
error: loc("./dummy.f90":5:3): 'arith.extui' op operand type 'i32' and result type 'i32' are cast incompatible
```

